### PR TITLE
feat(grug): add `is_non_{zero,negative,positive}` methods

### DIFF
--- a/dango/bank/src/execute.rs
+++ b/dango/bank/src/execute.rs
@@ -158,7 +158,7 @@ fn increase_supply(
     denom: &Denom,
     amount: Uint128,
 ) -> StdResult<Option<Uint128>> {
-    debug_assert!(!amount.is_zero(), "increasing supply by zero");
+    debug_assert!(amount.is_non_zero(), "increasing supply by zero");
 
     SUPPLIES.update(storage, denom, |maybe_supply| {
         let supply = maybe_supply.unwrap_or(Uint128::ZERO).checked_add(amount)?;
@@ -172,7 +172,7 @@ fn decrease_supply(
     denom: &Denom,
     amount: Uint128,
 ) -> StdResult<Option<Uint128>> {
-    debug_assert!(!amount.is_zero(), "decreasing supply by zero");
+    debug_assert!(amount.is_non_zero(), "decreasing supply by zero");
 
     SUPPLIES.update(storage, denom, |maybe_supply| {
         let supply = maybe_supply.unwrap_or(Uint128::ZERO).checked_sub(amount)?;
@@ -191,7 +191,7 @@ fn increase_balance(
     denom: &Denom,
     amount: Uint128,
 ) -> StdResult<Option<Uint128>> {
-    debug_assert!(!amount.is_zero(), "increasing balance by zero");
+    debug_assert!(amount.is_non_zero(), "increasing balance by zero");
 
     BALANCES.update(storage, (address, denom), |maybe_balance| {
         let balance = maybe_balance.unwrap_or(Uint128::ZERO).checked_add(amount)?;
@@ -206,7 +206,7 @@ fn decrease_balance(
     denom: &Denom,
     amount: Uint128,
 ) -> StdResult<Option<Uint128>> {
-    debug_assert!(!amount.is_zero(), "decreasing balance by zero");
+    debug_assert!(amount.is_non_zero(), "decreasing balance by zero");
 
     BALANCES.update(storage, (address, denom), |maybe_balance| {
         let balance = maybe_balance.unwrap_or(Uint128::ZERO).checked_sub(amount)?;

--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -65,7 +65,7 @@ pub fn withhold_fee(ctx: AuthCtx, tx: Tx) -> StdResult<Response> {
     // If the sender doesn't have enough fund to cover the maximum amount of fee
     // the tx may incur, this submessage fails, causing the tx to be rejected
     // from entering the mempool.
-    let withhold_msg = if !withhold_amount.is_zero() {
+    let withhold_msg = if withhold_amount.is_non_zero() {
         // TODO: for production, we can hardcode the bank contract address
         // instead of having to make the query.
         let cfg = ctx.querier.query_config()?;
@@ -114,7 +114,7 @@ pub fn finalize_fee(ctx: AuthCtx, tx: Tx, outcome: TxOutcome) -> StdResult<Respo
     // refund the difference.
     let refund_amount = withheld_amount.saturating_sub(charge_amount);
 
-    let refund_msg = if !refund_amount.is_zero() {
+    let refund_msg = if refund_amount.is_non_zero() {
         let cfg = ctx.querier.query_config()?;
 
         Some(Message::execute(

--- a/dango/token-factory/src/execute.rs
+++ b/dango/token-factory/src/execute.rs
@@ -14,7 +14,7 @@ use {
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     ensure!(
-        !msg.denom_creation_fee.amount.is_zero(),
+        msg.denom_creation_fee.amount.is_non_zero(),
         "denom creation fee can't be zero"
     );
 

--- a/grug/math/src/is_zero.rs
+++ b/grug/math/src/is_zero.rs
@@ -3,8 +3,16 @@ use {
     bnum::types::{I256, I512, U256, U512},
 };
 
+/// Describes a number that can be compared to zero.
 pub trait IsZero {
+    /// Return true if the number is zero; false otherwise.
     fn is_zero(&self) -> bool;
+
+    /// Return true if the number is not zero; false otherwise.
+    #[inline]
+    fn is_non_zero(&self) -> bool {
+        !self.is_zero()
+    }
 }
 
 // ------------------------------------ int ------------------------------------
@@ -60,8 +68,11 @@ mod int_tests {
     int_test!( is_zero
         method = |zero: Int<_>| {
             assert!(zero.is_zero());
+            assert!(!zero.is_non_zero());
+
             let non_zero = bt(zero, Int::ONE);
             assert!(!non_zero.is_zero());
+            assert!(non_zero.is_non_zero());
         }
     );
 }
@@ -73,8 +84,11 @@ mod dec_tests {
     dec_test!( is_zero
         method = |zero: Dec<_>| {
             assert!(zero.is_zero());
+            assert!(!zero.is_non_zero());
+
             let non_zero = bt(zero, Dec::ONE);
             assert!(!non_zero.is_zero());
+            assert!(non_zero.is_non_zero());
         }
     );
 }

--- a/grug/math/src/sign.rs
+++ b/grug/math/src/sign.rs
@@ -4,13 +4,34 @@ use {
 };
 
 /// Describes a number that can take on negative values.
-/// Zero is considered non-negative, for which this should return `false`.
 pub trait Sign: Sized {
+    /// Return the number's absolute value.
+    ///
+    /// ## Note
+    ///
+    /// This method is fallible, because taking the absolute value of a
+    /// [two's complement](https://en.wikipedia.org/wiki/Two%27s_complement)
+    /// number's minimum value (i.e. the maximally negative value) leads to
+    /// overflow.
     fn checked_abs(self) -> MathResult<Self>;
 
+    /// Return true if the number is negative; false if it's zero or positive.
     fn is_negative(&self) -> bool;
 
+    /// Return true if the number is positive; false if it's zero or negative.
     fn is_positive(&self) -> bool;
+
+    /// Return true if the number is zero or positive; false if it's negative.
+    #[inline]
+    fn is_non_negative(&self) -> bool {
+        !self.is_negative()
+    }
+
+    /// Return true if the number is zero or negative; false if it's positive.
+    #[inline]
+    fn is_non_positive(&self) -> bool {
+        !self.is_positive()
+    }
 }
 
 // ------------------------------------ int ------------------------------------

--- a/grug/mock-taxman/src/execute.rs
+++ b/grug/mock-taxman/src/execute.rs
@@ -51,7 +51,7 @@ pub fn withhold_fee(ctx: AuthCtx, tx: Tx) -> StdResult<Response> {
     // Since `withhold_fee` is called during `CheckTx`, this prevents an
     // attacker from spamming txs into the mempool when he doesn't have enough
     // coins.
-    let withhold_msg = if !withhold_amount.is_zero() {
+    let withhold_msg = if withhold_amount.is_non_zero() {
         Some(Message::execute(
             cfg.bank,
             &grug_mock_bank::ExecuteMsg::ForceTransfer {
@@ -99,7 +99,7 @@ pub fn finalize_fee(ctx: AuthCtx, tx: Tx, outcome: TxOutcome) -> anyhow::Result<
     //
     // This is just a demo. In practice, it probably makes more sense to have a
     // fee distributor contract that distribute to stakers so something like that.
-    let charge_msg = if !charge_amount.is_zero() {
+    let charge_msg = if charge_amount.is_non_zero() {
         Some(Message::Transfer {
             to: cfg.owner,
             coins: Coins::one(fee_cfg.fee_denom.clone(), charge_amount)?,
@@ -108,7 +108,7 @@ pub fn finalize_fee(ctx: AuthCtx, tx: Tx, outcome: TxOutcome) -> anyhow::Result<
         None
     };
 
-    let refund_msg = if !refund_amount.is_zero() {
+    let refund_msg = if refund_amount.is_non_zero() {
         Some(Message::Transfer {
             to: tx.sender,
             coins: Coins::one(fee_cfg.fee_denom, refund_amount)?,

--- a/grug/testing/tests/taxman.rs
+++ b/grug/testing/tests/taxman.rs
@@ -38,7 +38,7 @@ mod taxman {
 
         let withhold_amount = Uint128::new(tx.gas_limit as u128).checked_mul_dec_ceil(FEE_RATE)?;
 
-        let withhold_msg = if !withhold_amount.is_zero() {
+        let withhold_msg = if withhold_amount.is_non_zero() {
             Some(Message::execute(
                 cfg.bank,
                 &grug_mock_bank::ExecuteMsg::ForceTransfer {
@@ -70,7 +70,7 @@ mod taxman {
         let charge_amount = Uint128::new(mock_gas_used as u128).checked_mul_dec_ceil(FEE_RATE)?;
         let refund_amount = withheld_amount.saturating_sub(charge_amount);
 
-        let charge_msg = if !charge_amount.is_zero() {
+        let charge_msg = if charge_amount.is_non_zero() {
             Some(Message::transfer(
                 cfg.owner,
                 Coins::one(FEE_DENOM.clone(), charge_amount)?,
@@ -79,7 +79,7 @@ mod taxman {
             None
         };
 
-        let refund_msg = if !refund_amount.is_zero() {
+        let refund_msg = if refund_amount.is_non_zero() {
             Some(Message::transfer(
                 tx.sender,
                 Coins::one(FEE_DENOM.clone(), refund_amount)?,

--- a/grug/types/src/coin_pair.rs
+++ b/grug/types/src/coin_pair.rs
@@ -178,10 +178,10 @@ impl From<CoinPair> for Coins {
         let [coin1, coin2] = pair.0;
 
         let mut map = BTreeMap::new();
-        if !coin1.amount.is_zero() {
+        if coin1.amount.is_non_zero() {
             map.insert(coin1.denom, coin1.amount);
         }
-        if !coin2.amount.is_zero() {
+        if coin2.amount.is_non_zero() {
             map.insert(coin2.denom, coin2.amount);
         }
 

--- a/grug/types/src/coins.rs
+++ b/grug/types/src/coins.rs
@@ -169,7 +169,7 @@ impl Coins {
         let Some(amount) = self.0.get_mut(&coin.denom) else {
             // If the denom doesn't exist, and we are increasing by a non-zero
             // amount: just create a new record, and we are done.
-            if !coin.amount.is_zero() {
+            if coin.amount.is_non_zero() {
                 self.0.insert(coin.denom, coin.amount);
             }
 


### PR DESCRIPTION
Using `number.is_non_{zero,negative,positive}` is exactly the same as using `!number.is_{zero,negative,positive}`, but imo it's more readable.