### PR TITLE
refactor(grug): remove excess methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "grug-jmt",
+ "grug-math",
  "grug-types",
  "serde",
  "tendermint",
@@ -1635,6 +1636,7 @@ name = "grug-jmt"
 version = "0.0.0"
 dependencies = [
  "borsh",
+ "grug-math",
  "grug-storage",
  "grug-types",
  "hex-literal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ version = "0.0.0"
 dependencies = [
  "borsh",
  "chrono",
+ "grug-math",
  "grug-storage",
  "grug-types",
  "ics23",

--- a/dango/account-factory/src/execute.rs
+++ b/dango/account-factory/src/execute.rs
@@ -213,7 +213,7 @@ fn onboard_new_user(
     }
     .into_bytes();
 
-    let address = Addr::compute(factory, code_hash, &salt);
+    let address = Addr::derive(factory, code_hash, &salt);
 
     let funds = if must_have_deposit {
         DEPOSITS.take(storage, &address)?
@@ -271,7 +271,7 @@ fn register_account(ctx: MutableCtx, params: AccountParams) -> anyhow::Result<Re
     let code_hash = CODE_HASHES.load(ctx.storage, params.ty())?;
 
     // Derive the account address.
-    let address = Addr::compute(ctx.contract, code_hash, &salt);
+    let address = Addr::derive(ctx.contract, code_hash, &salt);
 
     // Save the account info.
     let account = Account { index, params };

--- a/dango/account-factory/src/query.rs
+++ b/dango/account-factory/src/query.rs
@@ -225,10 +225,10 @@ mod tests {
         let k2 = Key::Secp256k1([2; 33].into());
         let k3 = Key::Secp256k1([3; 33].into());
 
-        let h1 = Hash160::from_array([1; 20]);
-        let h2 = Hash160::from_array([2; 20]);
-        let h3 = Hash160::from_array([3; 20]);
-        let h4 = Hash160::from_array([4; 20]);
+        let h1 = Hash160::from_inner([1; 20]);
+        let h2 = Hash160::from_inner([2; 20]);
+        let h3 = Hash160::from_inner([3; 20]);
+        let h4 = Hash160::from_inner([4; 20]);
 
         // Save the following records:
         //

--- a/dango/genesis/src/lib.rs
+++ b/dango/genesis/src/lib.rs
@@ -134,7 +134,7 @@ where
                 key_hash: user.key_hash,
             }
             .into_bytes();
-            let address = Addr::compute(account_factory, account_spot_code_hash, &salt);
+            let address = Addr::derive(account_factory, account_spot_code_hash, &salt);
             Ok((username.clone(), address))
         })
         .collect::<StdResult<BTreeMap<_, _>>>()?;
@@ -292,7 +292,7 @@ where
     S: Into<Binary>,
 {
     let salt = salt.into();
-    let address = Addr::compute(GENESIS_SENDER, code_hash, &salt);
+    let address = Addr::derive(GENESIS_SENDER, code_hash, &salt);
 
     msgs.push(Message::instantiate(
         code_hash,

--- a/dango/testing/benches/benchmarks.rs
+++ b/dango/testing/benches/benchmarks.rs
@@ -71,14 +71,14 @@ fn sends(c: &mut Criterion) {
                     .map(|i| {
                         // Predict the sender address.
                         // During genesis we created 3 accounts, so offset i by 3.
-                        let sender = Addr::compute(
+                        let sender = Addr::derive(
                             contracts.account_factory,
                             codes.account_spot.hash256(),
                             Salt { index: i + 3 }.into_bytes().as_slice(),
                         );
 
                         // Predict the receiver address.
-                        let receiver = Addr::compute(
+                        let receiver = Addr::derive(
                             contracts.account_factory,
                             codes.account_spot.hash256(),
                             Salt { index: i + 103 }.into_bytes().as_slice(),

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -74,7 +74,7 @@ impl TestAccount<Undefined<Addr>> {
             todo!("implement address prediction for not new users");
         };
 
-        let address = Addr::compute(factory, spot_code_hash, &salt);
+        let address = Addr::derive(factory, spot_code_hash, &salt);
 
         Ok(TestAccount {
             username: self.username,

--- a/dango/testing/tests/onboarding.rs
+++ b/dango/testing/tests/onboarding.rs
@@ -199,7 +199,7 @@ fn onboarding_without_deposit() -> anyhow::Result<()> {
 #[test_case(
     None,
     None,
-    Some(Hash160::from_array([0; 20]));
+    Some(Hash160::from_inner([0; 20]));
     "false key hash"
 )]
 fn false_factory_tx(

--- a/dango/testing/tests/safe.rs
+++ b/dango/testing/tests/safe.rs
@@ -96,7 +96,7 @@ fn safe() {
 
     // Derive the Safe's address.
     // We have 3 genesis users + 3 members, so the Safe's index should be 6.
-    let safe_address = Addr::compute(
+    let safe_address = Addr::derive(
         contracts.account_factory,
         codes.account_safe.to_bytes().hash256(),
         Salt { index: 6 }.into_bytes().as_slice(),

--- a/grug/app/Cargo.toml
+++ b/grug/app/Cargo.toml
@@ -17,6 +17,7 @@ tracing = ["chrono", "dep:tracing"]
 [dependencies]
 borsh            = { workspace = true }
 chrono           = { workspace = true, optional = true }
+grug-math        = { workspace = true }
 grug-storage     = { workspace = true }
 grug-types       = { workspace = true }
 ics23            = { workspace = true }

--- a/grug/app/src/abci.rs
+++ b/grug/app/src/abci.rs
@@ -1,5 +1,6 @@
 use {
     crate::{App, AppError, Db, Vm},
+    grug_math::Inner,
     grug_types::{
         Attribute, BlockInfo, Duration, Event, GenericResult, Hash256, Outcome, Timestamp,
         TxOutcome, GENESIS_BLOCK_HASH,
@@ -44,7 +45,7 @@ where
                 data: env!("CARGO_PKG_NAME").into(),
                 version: env!("CARGO_PKG_VERSION").into(),
                 app_version: 1,
-                last_block_app_hash: last_block_version.into_vec().into(),
+                last_block_app_hash: last_block_version.into_inner().to_vec().into(),
                 last_block_height: last_block_height as i64,
             },
             Err(err) => panic!("failed to get info: {err}"),
@@ -67,7 +68,7 @@ where
             Ok(app_hash) => ResponseInitChain {
                 consensus_params: req.consensus_params,
                 validators: req.validators,
-                app_hash: app_hash.into_vec().into(),
+                app_hash: app_hash.into_inner().to_vec().into(),
             },
             Err(err) => panic!("failed to init chain: {err}"),
         }
@@ -95,7 +96,7 @@ where
                     .collect();
 
                 ResponseFinalizeBlock {
-                    app_hash: outcome.app_hash.into_vec().into(),
+                    app_hash: outcome.app_hash.into_inner().to_vec().into(),
                     events,
                     tx_results,
                     // We haven't implemented any mechanism to alter the

--- a/grug/app/src/execute.rs
+++ b/grug/app/src/execute.rs
@@ -369,7 +369,7 @@ where
 
     // Compute the contract address, and make sure there isn't already a
     // contract of the same address.
-    let address = Addr::compute(sender, code_hash, &salt);
+    let address = Addr::derive(sender, code_hash, &salt);
     if CONTRACTS.has(&storage, address) {
         return Err(AppError::AccountExists { address });
     }

--- a/grug/app/src/execute.rs
+++ b/grug/app/src/execute.rs
@@ -133,12 +133,14 @@ fn _do_upload(
 ) -> AppResult<(Event, Hash256)> {
     // Make sure the user has the permission to upload contracts
     let cfg = CONFIG.load_with_gas(storage, gas_tracker.clone())?;
+
     if !has_permission(&cfg.permissions.upload, cfg.owner, uploader) {
         return Err(AppError::Unauthorized);
     }
 
     // Make sure that the same code isn't already uploaded
     let code_hash = code.hash256();
+
     if CODES.has_with_gas(storage, gas_tracker.clone(), code_hash)? {
         return Err(AppError::CodeExists { code_hash });
     }
@@ -230,6 +232,7 @@ where
         funds: None,
         mode: None,
     };
+
     let msg = BankMsg { from, to, coins };
 
     let mut events = call_in_1_out_1_handle_response(
@@ -273,6 +276,7 @@ where
 {
     let chain_id = CHAIN_ID.load(&storage)?;
     let code_hash = CONTRACTS.load(&storage, msg.to)?.code_hash;
+
     let ctx = Context {
         chain_id,
         block,
@@ -363,6 +367,7 @@ where
 
     // Make sure the user has the permission to instantiate contracts
     let cfg = CONFIG.load(&storage)?;
+
     if !has_permission(&cfg.permissions.instantiate, cfg.owner, sender) {
         return Err(AppError::Unauthorized);
     }
@@ -370,16 +375,19 @@ where
     // Compute the contract address, and make sure there isn't already a
     // contract of the same address.
     let address = Addr::derive(sender, code_hash, &salt);
+
     if CONTRACTS.has(&storage, address) {
         return Err(AppError::AccountExists { address });
     }
 
     // Save the contract info
     let contract = ContractInfo { code_hash, admin };
+
     CONTRACTS.save(&mut storage, address, &contract)?;
 
     // Make the fund transfer
     let mut events = vec![];
+
     if !funds.is_empty() {
         events.extend(_do_transfer(
             vm.clone(),
@@ -483,6 +491,7 @@ where
 
     // Make the fund transfer
     let mut events = vec![];
+
     if !funds.is_empty() {
         events.extend(_do_transfer(
             vm.clone(),
@@ -588,6 +597,7 @@ where
     let Some(admin) = &contract_info.admin else {
         return Err(AppError::AdminNotSet);
     };
+
     if sender != admin {
         return Err(AppError::NotAdmin {
             sender,
@@ -597,6 +607,7 @@ where
 
     // Update account info and save
     contract_info.code_hash = new_code_hash;
+
     CONTRACTS.save(&mut storage, contract, &contract_info)?;
 
     let ctx = Context {
@@ -679,6 +690,7 @@ where
 {
     let chain_id = CHAIN_ID.load(&storage)?;
     let code_hash = CONTRACTS.load(&storage, contract)?.code_hash;
+
     let ctx = Context {
         chain_id,
         block,
@@ -719,6 +731,7 @@ where
 {
     let chain_id = CHAIN_ID.load(&storage)?;
     let code_hash = CONTRACTS.load(&storage, tx.sender)?.code_hash;
+
     let ctx = Context {
         chain_id,
         block,
@@ -787,6 +800,7 @@ where
 {
     let chain_id = CHAIN_ID.load(&storage)?;
     let code_hash = CONTRACTS.load(&storage, tx.sender)?.code_hash;
+
     let ctx = Context {
         chain_id,
         block,

--- a/grug/client/Cargo.toml
+++ b/grug/client/Cargo.toml
@@ -13,6 +13,7 @@ categories    = { workspace = true }
 [dependencies]
 anyhow         = { workspace = true }
 grug-jmt       = { workspace = true }
+grug-math      = { workspace = true }
 grug-types     = { workspace = true }
 serde          = { workspace = true }
 tendermint     = { workspace = true }

--- a/grug/client/src/client.rs
+++ b/grug/client/src/client.rs
@@ -2,6 +2,7 @@ use {
     crate::{AdminOption, GasOption, SigningOption},
     anyhow::{bail, ensure},
     grug_jmt::Proof,
+    grug_math::Inner,
     grug_types::{
         Addr, AsyncSigner, Binary, Coin, Coins, Config, ConfigUpdates, ContractInfo, Denom,
         GenericResult, Hash256, HashExt, Json, JsonDeExt, JsonSerExt, Message, Op, Query,
@@ -42,7 +43,7 @@ impl Client {
     pub async fn query_tx(&self, hash: Hash256) -> anyhow::Result<tx::Response> {
         Ok(self
             .inner
-            .tx(TmHash::Sha256(hash.into_array()), false)
+            .tx(TmHash::Sha256(hash.into_inner()), false)
             .await?)
     }
 

--- a/grug/client/src/client.rs
+++ b/grug/client/src/client.rs
@@ -518,7 +518,7 @@ impl Client {
         StdError: From<C::Error>,
     {
         let salt = salt.into();
-        let address = Addr::compute(sign_opt.sender, code_hash, &salt);
+        let address = Addr::derive(sign_opt.sender, code_hash, &salt);
         let admin = admin_opt.decide(address);
 
         let msg = Message::instantiate(code_hash, msg, salt, funds, admin)?;
@@ -552,7 +552,7 @@ impl Client {
         let code = code.into();
         let code_hash = code.hash256();
         let salt = salt.into();
-        let address = Addr::compute(sign_opt.sender, code_hash, &salt);
+        let address = Addr::derive(sign_opt.sender, code_hash, &salt);
         let admin = admin_opt.decide(address);
 
         let msgs = vec![

--- a/grug/db-disk/src/db.rs
+++ b/grug/db-disk/src/db.rs
@@ -766,25 +766,25 @@ mod tests {
     mod v0 {
         use super::*;
 
-        pub const ROOT_HASH: Hash256 = Hash256::from_array(hex!(
+        pub const ROOT_HASH: Hash256 = Hash256::from_inner(hex!(
             "1712a8d4c9896a8cadb4e13592bd9e2713a16d0bf5572a8bf540eb568cb30b64"
         ));
-        pub const HASH_0: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_0: Hash256 = Hash256::from_inner(hex!(
             "4d28a7511b5df59d1cdab1ace2314ba10f4637d0b51cac24ad0dbf199f7333ad"
         ));
-        pub const HASH_00: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_00: Hash256 = Hash256::from_inner(hex!(
             "01d2b46c3dd0180a5e8236137b4ada8ae6c9ca7c8799ecf7932d1320c9dfbf3b"
         ));
-        pub const HASH_01: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_01: Hash256 = Hash256::from_inner(hex!(
             "248f2dfa7cd94e3856e5a6978e500e6d9528837cd0c64187b937455f8d865baf"
         ));
-        pub const HASH_010: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_010: Hash256 = Hash256::from_inner(hex!(
             "8fb3cdb9c15244dc8b7f701bb08640389dcde92a3b85277348ca1ec839d2a575"
         ));
-        pub const HASH_011: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_011: Hash256 = Hash256::from_inner(hex!(
             "3b640fe6cffebfa7c2ba388b66aa3a4978c2221799ef9316e059eed2e656511a"
         ));
-        pub const HASH_1: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_1: Hash256 = Hash256::from_inner(hex!(
             "8358fe5d68c2d969c72b67ccffef68e2bf3b2edb200c0a7731e9bf131be11394"
         ));
     }
@@ -833,25 +833,25 @@ mod tests {
     mod v1 {
         use super::*;
 
-        pub const ROOT_HASH: Hash256 = Hash256::from_array(hex!(
+        pub const ROOT_HASH: Hash256 = Hash256::from_inner(hex!(
             "05c5d1c5e433ed85c4b5c42d4da7adf6d204d3c1af37cac316f47b042c154eb4"
         ));
-        pub const HASH_0: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_0: Hash256 = Hash256::from_inner(hex!(
             "7ce76869da6e1ff26f873924e6667e131761ef9075aebd6bba7c48663696f402"
         ));
-        pub const HASH_00: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_00: Hash256 = Hash256::from_inner(hex!(
             "01d2b46c3dd0180a5e8236137b4ada8ae6c9ca7c8799ecf7932d1320c9dfbf3b"
         ));
-        pub const HASH_01: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_01: Hash256 = Hash256::from_inner(hex!(
             "44cb87f51dbe89d482329a5cc71fadf6758d3c3f7a46b8e03efbc9354e4b5be7"
         ));
-        pub const HASH_1: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_1: Hash256 = Hash256::from_inner(hex!(
             "9445f09716426120318220f103d9925c8a73155cf561ed4440b3d1fdc1f1153f"
         ));
-        pub const HASH_110: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_110: Hash256 = Hash256::from_inner(hex!(
             "8358fe5d68c2d969c72b67ccffef68e2bf3b2edb200c0a7731e9bf131be11394"
         ));
-        pub const HASH_111: Hash256 = Hash256::from_array(hex!(
+        pub const HASH_111: Hash256 = Hash256::from_inner(hex!(
             "a2cb2e0c6a5b3717d5355d1e8d046f305f7bd9730cf94434b51063209664f9c6"
         ));
     }

--- a/grug/jellyfish-merkle/Cargo.toml
+++ b/grug/jellyfish-merkle/Cargo.toml
@@ -19,6 +19,7 @@ ics23 = ["dep:ics23"]
 
 [dependencies]
 borsh        = { workspace = true, features = ["derive", "de_strict_order"] }
+grug-math    = { workspace = true }
 grug-storage = { workspace = true }
 grug-types   = { workspace = true }
 ics23        = { workspace = true, optional = true }

--- a/grug/jellyfish-merkle/src/bitarray.rs
+++ b/grug/jellyfish-merkle/src/bitarray.rs
@@ -1,4 +1,5 @@
 use {
+    grug_math::Inner,
     grug_storage::PrimaryKey,
     grug_types::{split_one_key, Hash256, Order, StdResult},
     std::{borrow::Cow, fmt},
@@ -153,7 +154,7 @@ impl From<Hash256> for BitArray {
     fn from(hash: Hash256) -> Self {
         Self {
             num_bits: Self::MAX_BIT_LENGTH,
-            bytes: hash.into_array(),
+            bytes: hash.into_inner(),
         }
     }
 }

--- a/grug/jellyfish-merkle/src/proof.rs
+++ b/grug/jellyfish-merkle/src/proof.rs
@@ -180,34 +180,34 @@ mod tests {
     };
 
     // use the same test case as in tree.rs
-    const HASH_ROOT: Hash256 = Hash256::from_array(hex!(
+    const HASH_ROOT: Hash256 = Hash256::from_inner(hex!(
         "ae08c246d53a8ff3572a68d5bba4d610aaaa765e3ef535320c5653969aaa031b"
     ));
-    const HASH_0: Hash256 = Hash256::from_array(hex!(
+    const HASH_0: Hash256 = Hash256::from_inner(hex!(
         "b843a96765fc40641227234e9f9a2736c2e0cdf8fb2dc54e358bb4fa29a61042"
     ));
-    const HASH_1: Hash256 = Hash256::from_array(hex!(
+    const HASH_1: Hash256 = Hash256::from_inner(hex!(
         "cb640e68682628445a3e0713fafe91b9cefe4f81c2337e9d3df201d81ae70222"
     ));
-    const HASH_01: Hash256 = Hash256::from_array(hex!(
+    const HASH_01: Hash256 = Hash256::from_inner(hex!(
         "521de0a3ef2b7791666435a872ca9ec402ce886aff07bb4401de28bfdde4a13b"
     ));
-    const HASH_010: Hash256 = Hash256::from_array(hex!(
+    const HASH_010: Hash256 = Hash256::from_inner(hex!(
         "c8348e9a7a327e8b76e97096c362a1f87071ee4108b565d1f409529c189cb684"
     ));
-    const HASH_011: Hash256 = Hash256::from_array(hex!(
+    const HASH_011: Hash256 = Hash256::from_inner(hex!(
         "e104e2bcf24027af737c021033cb9d8cbd710a463f54ae6f2ff9eb06c784c744"
     ));
-    const HASH_0110: Hash256 = Hash256::from_array(hex!(
+    const HASH_0110: Hash256 = Hash256::from_inner(hex!(
         "fd34e3f8d9840e7f6d6f639435b6f9b67732fc5e3d5288e268021aeab873f280"
     ));
-    const HASH_0111: Hash256 = Hash256::from_array(hex!(
+    const HASH_0111: Hash256 = Hash256::from_inner(hex!(
         "412341380b1e171077dd9da9af936ae2126ede2dd91dc5acb0f77363d46eb76b"
     ));
-    const HASH_M: Hash256 = Hash256::from_array(hex!(
+    const HASH_M: Hash256 = Hash256::from_inner(hex!(
         "62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a"
     ));
-    const HASH_BAR: Hash256 = Hash256::from_array(hex!(
+    const HASH_BAR: Hash256 = Hash256::from_inner(hex!(
         "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
     ));
 

--- a/grug/jellyfish-merkle/src/tree.rs
+++ b/grug/jellyfish-merkle/src/tree.rs
@@ -736,34 +736,34 @@ mod tests {
 
     const TREE: MerkleTree = MerkleTree::new_default();
 
-    const HASH_ROOT: Hash256 = Hash256::from_array(hex!(
+    const HASH_ROOT: Hash256 = Hash256::from_inner(hex!(
         "ae08c246d53a8ff3572a68d5bba4d610aaaa765e3ef535320c5653969aaa031b"
     ));
-    const HASH_0: Hash256 = Hash256::from_array(hex!(
+    const HASH_0: Hash256 = Hash256::from_inner(hex!(
         "b843a96765fc40641227234e9f9a2736c2e0cdf8fb2dc54e358bb4fa29a61042"
     ));
-    const HASH_1: Hash256 = Hash256::from_array(hex!(
+    const HASH_1: Hash256 = Hash256::from_inner(hex!(
         "cb640e68682628445a3e0713fafe91b9cefe4f81c2337e9d3df201d81ae70222"
     ));
-    const HASH_01: Hash256 = Hash256::from_array(hex!(
+    const HASH_01: Hash256 = Hash256::from_inner(hex!(
         "521de0a3ef2b7791666435a872ca9ec402ce886aff07bb4401de28bfdde4a13b"
     ));
-    const HASH_010: Hash256 = Hash256::from_array(hex!(
+    const HASH_010: Hash256 = Hash256::from_inner(hex!(
         "c8348e9a7a327e8b76e97096c362a1f87071ee4108b565d1f409529c189cb684"
     ));
-    const HASH_011: Hash256 = Hash256::from_array(hex!(
+    const HASH_011: Hash256 = Hash256::from_inner(hex!(
         "e104e2bcf24027af737c021033cb9d8cbd710a463f54ae6f2ff9eb06c784c744"
     ));
-    const HASH_0110: Hash256 = Hash256::from_array(hex!(
+    const HASH_0110: Hash256 = Hash256::from_inner(hex!(
         "fd34e3f8d9840e7f6d6f639435b6f9b67732fc5e3d5288e268021aeab873f280"
     ));
-    const HASH_0111: Hash256 = Hash256::from_array(hex!(
+    const HASH_0111: Hash256 = Hash256::from_inner(hex!(
         "412341380b1e171077dd9da9af936ae2126ede2dd91dc5acb0f77363d46eb76b"
     ));
-    const HASH_M: Hash256 = Hash256::from_array(hex!(
+    const HASH_M: Hash256 = Hash256::from_inner(hex!(
         "62c66a7a5dd70c3146618063c344e531e6d4b59e379808443ce962b3abd63c5a"
     ));
-    const HASH_BAR: Hash256 = Hash256::from_array(hex!(
+    const HASH_BAR: Hash256 = Hash256::from_inner(hex!(
         "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
     ));
 
@@ -825,7 +825,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             new_root_hash,
-            Some(Hash256::from_array(hex!(
+            Some(Hash256::from_inner(hex!(
                 "b3e4002b2d95d57ab44bbf64c8cfb04904c02fb2df9c859a75d82b02fd087dbf"
             )))
         );

--- a/grug/std/tests/queries.rs
+++ b/grug/std/tests/queries.rs
@@ -30,7 +30,7 @@ mod query_maker {
                 fuzz.to_json_value()
             },
             QueryMsg::Buzz => {
-                let buzz = Hash256::from_array([1; 32]);
+                let buzz = Hash256::from_inner([1; 32]);
                 buzz.to_json_value()
             },
         }
@@ -76,5 +76,5 @@ fn query_super_smart() {
     // Similarly, for unit variant `Buzz`.
     suite
         .query_wasm_smart(contract, query_maker::QueryBuzzRequest)
-        .should_succeed_and_equal(Hash256::from_array([1; 32]));
+        .should_succeed_and_equal(Hash256::from_inner([1; 32]));
 }

--- a/grug/storage/src/key.rs
+++ b/grug/storage/src/key.rs
@@ -223,8 +223,8 @@ impl<const N: usize> PrimaryKey for Hash<N> {
     }
 
     fn from_slice(bytes: &[u8]) -> StdResult<Self::Output> {
-        let array = bytes.try_into()?;
-        Ok(Hash::from_array(array))
+        let inner = bytes.try_into()?;
+        Ok(Hash::from_inner(inner))
     }
 }
 
@@ -815,12 +815,12 @@ mod tests {
         "borrow_addr"
     )]
     #[test_case(
-        Hash::<32>::from_array([1;32]),
+        Hash::<32>::from_inner([1;32]),
         &[1; 32];
         "hash"
     )]
     #[test_case(
-        &Hash::<20>::from_array([2;20]),
+        &Hash::<20>::from_inner([2;20]),
         &[2; 20];
         "borrow_hash"
     )]

--- a/grug/storage/src/key.rs
+++ b/grug/storage/src/key.rs
@@ -206,8 +206,8 @@ impl PrimaryKey for Addr {
     }
 
     fn from_slice(bytes: &[u8]) -> StdResult<Self::Output> {
-        let array = bytes.try_into()?;
-        Ok(Addr::from_array(array))
+        let inner = bytes.try_into()?;
+        Ok(Addr::from_inner(inner))
     }
 }
 
@@ -805,12 +805,12 @@ mod tests {
         "string"
     )]
     #[test_case(
-        Addr::from_array(*b"ThisIsAValidAddress-"),
+        Addr::from_inner(*b"ThisIsAValidAddress-"),
         b"ThisIsAValidAddress-";
         "addr"
     )]
     #[test_case(
-        &Addr::from_array(*b"ThisIsAValidAddress-"),
+        &Addr::from_inner(*b"ThisIsAValidAddress-"),
         b"ThisIsAValidAddress-";
         "borrow_addr"
     )]

--- a/grug/testing/src/account.rs
+++ b/grug/testing/src/account.rs
@@ -25,7 +25,7 @@ impl TestAccount {
     /// The address is predicted with the given code hash and salt, assuming the
     /// account is to be instantiated during genesis.
     pub fn new_random(code_hash: Hash256, salt: &[u8]) -> Self {
-        let address = Addr::compute(GENESIS_SENDER, code_hash, salt);
+        let address = Addr::derive(GENESIS_SENDER, code_hash, salt);
         let sk = SigningKey::random(&mut OsRng);
         let pk = sk
             .verifying_key()

--- a/grug/testing/src/builder.rs
+++ b/grug/testing/src/builder.rs
@@ -542,14 +542,14 @@ where
         }
 
         // Predict bank contract address
-        let bank = Addr::compute(
+        let bank = Addr::derive(
             GENESIS_SENDER,
             self.bank_opt.code.hash256(),
             DEFAULT_BANK_SALT,
         );
 
         // Prefict taxman contract address
-        let taxman = Addr::compute(
+        let taxman = Addr::derive(
             GENESIS_SENDER,
             self.taxman_opt.code.hash256(),
             DEFAULT_TAXMAN_SALT,

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -282,7 +282,7 @@ where
         B: Into<Binary>,
     {
         let code = code.into();
-        let code_hash = Hash256::from_array(sha2_256(&code));
+        let code_hash = Hash256::from_inner(sha2_256(&code));
 
         self.send_message_with_gas(signer, gas_limit, Message::upload(code))?
             .result
@@ -379,7 +379,7 @@ where
         StdError: From<C::Error>,
     {
         let code = code.into();
-        let code_hash = Hash256::from_array(sha2_256(&code));
+        let code_hash = Hash256::from_inner(sha2_256(&code));
         let salt = salt.into();
         let address = Addr::compute(signer.address(), code_hash, &salt);
 

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -327,7 +327,7 @@ where
         StdError: From<C::Error>,
     {
         let salt = salt.into();
-        let address = Addr::compute(signer.address(), code_hash, &salt);
+        let address = Addr::derive(signer.address(), code_hash, &salt);
 
         self.send_message_with_gas(
             signer,
@@ -381,7 +381,7 @@ where
         let code = code.into();
         let code_hash = Hash256::from_inner(sha2_256(&code));
         let salt = salt.into();
-        let address = Addr::compute(signer.address(), code_hash, &salt);
+        let address = Addr::derive(signer.address(), code_hash, &salt);
 
         self.send_messages_with_gas(signer, gas_limit, vec![
             Message::upload(code),

--- a/grug/types/src/address.rs
+++ b/grug/types/src/address.rs
@@ -26,11 +26,6 @@ pub type Addr = EncodedBytes<[u8; 20], AddrEncoder>;
 impl Addr {
     pub const LENGTH: usize = 20;
 
-    /// Create a new address from a 32-byte byte slice.
-    pub const fn from_array(array: [u8; Self::LENGTH]) -> Self {
-        Self::from_inner(array)
-    }
-
     /// Generate a mock address from use in testing.
     pub const fn mock(index: u8) -> Self {
         let mut bytes = [0; Self::LENGTH];

--- a/grug/types/src/address.rs
+++ b/grug/types/src/address.rs
@@ -33,7 +33,7 @@ impl Addr {
         Self::from_inner(bytes)
     }
 
-    /// Compute a contract address as:
+    /// Derive a contract address as:
     ///
     /// ```plain
     /// address := ripemd160(sha256(deployer_addr | code_hash | salt))
@@ -43,7 +43,7 @@ impl Addr {
     ///
     /// The double hash the same as used by Bitcoin, for [preventing length
     /// extension attacks](https://bitcoin.stackexchange.com/questions/8443/where-is-double-hashing-performed-in-bitcoin).
-    pub fn compute(deployer: Addr, code_hash: Hash256, salt: &[u8]) -> Self {
+    pub fn derive(deployer: Addr, code_hash: Hash256, salt: &[u8]) -> Self {
         let mut preimage = Vec::with_capacity(Self::LENGTH + Hash256::LENGTH + salt.len());
         preimage.extend_from_slice(deployer.as_ref());
         preimage.extend_from_slice(code_hash.as_ref());

--- a/grug/types/src/app.rs
+++ b/grug/types/src/app.rs
@@ -21,7 +21,7 @@ pub const GENESIS_SENDER: Addr = Addr::from_inner(hex!("114af6e7a822df07328fba90
 /// this as a mock up.
 ///
 /// This is the SHA-256 hash of the UTF-8 string `"hash"`.
-pub const GENESIS_BLOCK_HASH: Hash256 = Hash256::from_array(hex!(
+pub const GENESIS_BLOCK_HASH: Hash256 = Hash256::from_inner(hex!(
     "d04b98f48e8f8bcc15c6ae5ac050801cd6dcfd428fb5f9e65c4e16e7807340fa"
 ));
 

--- a/grug/types/src/app.rs
+++ b/grug/types/src/app.rs
@@ -13,7 +13,7 @@ use {
 /// We use this as a mock up.
 ///
 /// This is the RIPEMD-160 hash of the UTF-8 string `"sender"`.
-pub const GENESIS_SENDER: Addr = Addr::from_array(hex!("114af6e7a822df07328fba90e1546b5c2b00703f"));
+pub const GENESIS_SENDER: Addr = Addr::from_inner(hex!("114af6e7a822df07328fba90e1546b5c2b00703f"));
 
 /// The mock up block hash used for executing genesis messages.
 ///

--- a/grug/types/src/hash.rs
+++ b/grug/types/src/hash.rs
@@ -1,7 +1,4 @@
-use {
-    crate::{EncodedBytes, HashEncoder},
-    grug_math::Inner,
-};
+use crate::{EncodedBytes, HashEncoder};
 
 /// A hash of a fixed length, in uppercase hex encoding.
 pub type Hash<const N: usize> = EncodedBytes<[u8; N], HashEncoder>;
@@ -26,9 +23,4 @@ impl<const N: usize> Hash<N> {
     pub const LENGTH: usize = N;
     /// A zeroed-out hash. Useful as mockups or placeholders.
     pub const ZERO: Self = Self::from_inner([0; N]);
-
-    /// Cast the hash into a byte vector.
-    pub fn into_vec(self) -> Vec<u8> {
-        self.inner().to_vec()
-    }
 }

--- a/grug/types/src/hash.rs
+++ b/grug/types/src/hash.rs
@@ -25,12 +25,7 @@ impl<const N: usize> Hash<N> {
     /// ASCII length should be 64.
     pub const LENGTH: usize = N;
     /// A zeroed-out hash. Useful as mockups or placeholders.
-    pub const ZERO: Self = Self::from_array([0; N]);
-
-    /// Create a new hash from a byte array of the correct length.
-    pub const fn from_array(array: [u8; N]) -> Self {
-        Self::from_inner(array)
-    }
+    pub const ZERO: Self = Self::from_inner([0; N]);
 
     /// Cast the hash into a byte array.
     pub fn into_array(self) -> [u8; N] {

--- a/grug/types/src/hash.rs
+++ b/grug/types/src/hash.rs
@@ -27,11 +27,6 @@ impl<const N: usize> Hash<N> {
     /// A zeroed-out hash. Useful as mockups or placeholders.
     pub const ZERO: Self = Self::from_inner([0; N]);
 
-    /// Cast the hash into a byte array.
-    pub fn into_array(self) -> [u8; N] {
-        self.into_inner()
-    }
-
     /// Cast the hash into a byte vector.
     pub fn into_vec(self) -> Vec<u8> {
         self.inner().to_vec()

--- a/grug/types/src/hashers.rs
+++ b/grug/types/src/hashers.rs
@@ -23,12 +23,12 @@ where
     fn hash160(&self) -> Hash160 {
         let mut hasher = Ripemd160::new();
         hasher.update(self.as_ref());
-        Hash160::from_array(hasher.finalize().into())
+        Hash160::from_inner(hasher.finalize().into())
     }
 
     fn hash256(&self) -> Hash256 {
         let mut hasher = Sha256::new();
         hasher.update(self.as_ref());
-        Hash256::from_array(hasher.finalize().into())
+        Hash256::from_inner(hasher.finalize().into())
     }
 }

--- a/grug/vm-wasm/benches/benchmarks.rs
+++ b/grug/vm-wasm/benches/benchmarks.rs
@@ -58,7 +58,7 @@ fn looping(c: &mut Criterion) {
                         let instance = vm
                             .build_instance(
                                 BENCHMARKER_CODE,
-                                Hash::from_array(sha2_256(BENCHMARKER_CODE)),
+                                Hash::from_inner(sha2_256(BENCHMARKER_CODE)),
                                 storage,
                                 true,
                                 querier,

--- a/sdk/packages/sdk/src/actions/public/computeAddress.ts
+++ b/sdk/packages/sdk/src/actions/public/computeAddress.ts
@@ -14,7 +14,7 @@ export type ComputeAddressReturnType = Address;
  * Given parameters used while instantiating a new contract, compute what the
  * contract address would be.
  *
- * Mirrors that Rust function: `grug::Addr::compute`.
+ * Mirrors that Rust function: `grug::Addr::derive`.
  * @param parameters
  * @param parameters.deployer Address of the deployer, that it,
  * the account that sends the `Message::Instantiate`.


### PR DESCRIPTION
Delete the following methods:

- `Addr::from_array`
- `Hash::{from_array,into_array,into_vec}`

Because you can already do the same with methods such as `from_inner`, `into_inner`.

Ideally, there is only one way to do something.

I didn't remove these in previous PRs because I want to keep diffs small.