### PR TITLE
feat(grug): Result `Outcome` and `Suite` improvements

### DIFF
--- a/dango/testing/benches/benchmarks.rs
+++ b/dango/testing/benches/benchmarks.rs
@@ -62,7 +62,6 @@ fn sends(c: &mut Criterion) {
                 suite
                     .send_messages_with_gas(&mut accounts.relayer, 50_000_000, msgs)
                     .unwrap()
-                    .result
                     .should_succeed();
 
                 // Make a block that contains 100 transactions.

--- a/dango/testing/tests/amm.rs
+++ b/dango/testing/tests/amm.rs
@@ -54,7 +54,6 @@ fn amm() {
             .unwrap(),
         ])
         .unwrap()
-        .result
         .should_succeed();
 
     // Check the pools.
@@ -212,7 +211,6 @@ fn amm() {
             .unwrap(),
         ])
         .unwrap()
-        .result
         .should_succeed();
 
     // Check pool states should have been updated.

--- a/dango/testing/tests/onboarding.rs
+++ b/dango/testing/tests/onboarding.rs
@@ -139,7 +139,6 @@ fn onboarding_existing_user() -> anyhow::Result<()> {
     // Attempt to register the same username again, should fail.
     suite
         .check_tx(tx)?
-        .result
         .should_fail_with_error("username `user` already exists");
 
     Ok(())
@@ -175,7 +174,6 @@ fn onboarding_without_deposit() -> anyhow::Result<()> {
             data: Json::Null,
             credential: Json::Null,
         })?
-        .result
         .should_fail_with_error("data not found!");
 
     Ok(())

--- a/dango/testing/tests/onboarding.rs
+++ b/dango/testing/tests/onboarding.rs
@@ -237,7 +237,6 @@ fn false_factory_tx(
                 Coins::new(),
             )?,
         )?
-        .result
         .should_fail_with_error("data not found!");
 
     Ok(())

--- a/dango/testing/tests/safe.rs
+++ b/dango/testing/tests/safe.rs
@@ -353,6 +353,5 @@ fn safe() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("proposal isn't passed or timelock hasn't elapsed");
 }

--- a/dango/testing/tests/token_factory.rs
+++ b/dango/testing/tests/token_factory.rs
@@ -32,7 +32,6 @@ fn token_factory() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("invalid payment: expecting 1 coins, found 0");
 
     // Attempt to create a denom with more fee than needed. Should fail.
@@ -51,7 +50,6 @@ fn token_factory() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("incorrect denom creation fee!");
 
     // Attempt to create a denom for another username. Should fail.
@@ -70,7 +68,6 @@ fn token_factory() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("isn't associated with username");
 
     // Finally, correctly create a denom.
@@ -103,7 +100,6 @@ fn token_factory() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("already exists");
 
     // ----------------------------- Token minting -----------------------------
@@ -132,7 +128,6 @@ fn token_factory() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("sender isn't the admin of denom");
 
     // Attempt to mint a non-existent token. Should fail.
@@ -156,7 +151,6 @@ fn token_factory() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("data not found");
 
     // Correctly mint a token.
@@ -196,7 +190,6 @@ fn token_factory() {
             .unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("subtraction overflow");
 
     // Properly burn the token.

--- a/grug/std/tests/queries.rs
+++ b/grug/std/tests/queries.rs
@@ -52,9 +52,9 @@ fn query_super_smart() {
         .with_query(Box::new(query_maker::query))
         .build();
 
-    let (_, contract) = suite
+    let contract = suite
         .upload_and_instantiate(
-            accounts.get_mut("larry").unwrap(),
+            &mut accounts["larry"],
             code,
             &Empty {},
             "contract",
@@ -62,7 +62,8 @@ fn query_super_smart() {
             None,
             Coins::new(),
         )
-        .unwrap();
+        .unwrap()
+        .address;
 
     // Here, the compiler should be able to infer the type of the response as
     // `String` based on the request type `QueryFooRequest`.

--- a/grug/testing/src/account.rs
+++ b/grug/testing/src/account.rs
@@ -13,6 +13,8 @@ use {
     },
 };
 
+// ---------------------------------- account ----------------------------------
+
 /// A signer that tracks a sequence number and signs transactions in a way
 /// corresponding to the mock account used in Grug test suite.
 pub struct TestAccount {
@@ -100,13 +102,24 @@ impl Signer for TestAccount {
     }
 }
 
-#[derive(Default)]
-pub struct TestAccounts(InnerTestAccounts);
+// --------------------------------- accounts ----------------------------------
 
-type InnerTestAccounts = HashMap<&'static str, TestAccount>;
+/// A set of test accounts, indexed by names.
+///
+/// ## Note
+///
+/// Why not just use a `HashMap`?
+///
+/// The Rust `HashMap` doesn't implement `IndexMut`, so we can't index into it
+/// like `&mut accounts["name"]`. We have to do `accounts.get_mut("name").unwrap()`
+/// instead which is quite verbose.
+///
+/// To fix this, we make a wrapper over `HashMap` and implement `IndexMut` ourselves.
+#[derive(Default)]
+pub struct TestAccounts(HashMap<&'static str, TestAccount>);
 
 impl Deref for TestAccounts {
-    type Target = InnerTestAccounts;
+    type Target = HashMap<&'static str, TestAccount>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -136,11 +149,5 @@ where
 {
     fn index_mut(&mut self, index: S) -> &mut Self::Output {
         self.get_mut(index.as_ref()).expect("account not found")
-    }
-}
-
-impl From<InnerTestAccounts> for TestAccounts {
-    fn from(accounts: InnerTestAccounts) -> Self {
-        Self(accounts)
     }
 }

--- a/grug/testing/src/builder.rs
+++ b/grug/testing/src/builder.rs
@@ -13,6 +13,7 @@ use {
     serde::Serialize,
     std::{
         collections::BTreeMap,
+        ops::Deref,
         str::FromStr,
         time::{SystemTime, UNIX_EPOCH},
     },
@@ -533,7 +534,7 @@ where
         ];
 
         // Instantiate accounts
-        for (name, account) in self.accounts.inner() {
+        for (name, account) in self.accounts.inner().deref() {
             msgs.push(Message::instantiate(
                 self.account_opt.code.hash256(),
                 &(self.account_opt.msg_builder)(account.pk),

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -7,12 +7,28 @@ use {
     grug_types::{
         Addr, Addressable, Binary, BlockInfo, BlockOutcome, Coins, Config, ConfigUpdates,
         ContractInfo, Denom, Duration, GenesisState, Hash256, Json, JsonDeExt, JsonSerExt, Message,
-        Op, Outcome, Query, QueryRequest, ResultExt, Signer, StdError, Tx, TxOutcome, UnsignedTx,
+        Op, Outcome, Query, QueryRequest, Signer, StdError, Tx, TxOutcome, UnsignedTx,
     },
     grug_vm_rust::RustVm,
     serde::{de::DeserializeOwned, ser::Serialize},
     std::{collections::BTreeMap, error::Error, fmt::Debug},
 };
+
+pub struct InstantiateOutcome {
+    pub address: Addr,
+    pub tx_outcome: TxOutcome,
+}
+
+pub struct UploadOutcome {
+    pub code_hash: Hash256,
+    pub tx_outcome: TxOutcome,
+}
+
+pub struct UploadAndInstantiateOutcome {
+    pub address: Addr,
+    pub code_hash: Hash256,
+    pub tx_outcome: TxOutcome,
+}
 
 pub struct TestSuite<DB = MemDb, VM = RustVm>
 where
@@ -216,7 +232,7 @@ where
         signer: &mut dyn Signer,
         updates: ConfigUpdates,
         app_updates: BTreeMap<String, Op<Json>>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<TxOutcome> {
         self.configure_with_gas(signer, self.default_gas_limit, updates, app_updates)
     }
 
@@ -227,16 +243,17 @@ where
         gas_limit: u64,
         updates: ConfigUpdates,
         app_updates: BTreeMap<String, Op<Json>>,
-    ) -> anyhow::Result<()> {
-        self.send_message_with_gas(signer, gas_limit, Message::configure(updates, app_updates))?
-            .result
-            .should_succeed();
-
-        Ok(())
+    ) -> anyhow::Result<TxOutcome> {
+        self.send_message_with_gas(signer, gas_limit, Message::configure(updates, app_updates))
     }
 
     /// Make a transfer of tokens.
-    pub fn transfer<C>(&mut self, signer: &mut dyn Signer, to: Addr, coins: C) -> anyhow::Result<()>
+    pub fn transfer<C>(
+        &mut self,
+        signer: &mut dyn Signer,
+        to: Addr,
+        coins: C,
+    ) -> anyhow::Result<TxOutcome>
     where
         C: TryInto<Coins>,
         StdError: From<C::Error>,
@@ -251,20 +268,16 @@ where
         gas_limit: u64,
         to: Addr,
         coins: C,
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<TxOutcome>
     where
         C: TryInto<Coins>,
         StdError: From<C::Error>,
     {
-        self.send_message_with_gas(signer, gas_limit, Message::transfer(to, coins)?)?
-            .result
-            .should_succeed();
-
-        Ok(())
+        self.send_message_with_gas(signer, gas_limit, Message::transfer(to, coins)?)
     }
 
     /// Upload a code. Return the code's hash.
-    pub fn upload<B>(&mut self, signer: &mut dyn Signer, code: B) -> anyhow::Result<Hash256>
+    pub fn upload<B>(&mut self, signer: &mut dyn Signer, code: B) -> anyhow::Result<UploadOutcome>
     where
         B: Into<Binary>,
     {
@@ -277,18 +290,19 @@ where
         signer: &mut dyn Signer,
         gas_limit: u64,
         code: B,
-    ) -> anyhow::Result<Hash256>
+    ) -> anyhow::Result<UploadOutcome>
     where
         B: Into<Binary>,
     {
         let code = code.into();
         let code_hash = Hash256::from_inner(sha2_256(&code));
 
-        self.send_message_with_gas(signer, gas_limit, Message::upload(code))?
-            .result
-            .should_succeed();
+        let tx_outcome = self.send_message_with_gas(signer, gas_limit, Message::upload(code))?;
 
-        Ok(code_hash)
+        Ok(UploadOutcome {
+            code_hash,
+            tx_outcome,
+        })
     }
 
     /// Instantiate a contract. Return the contract's address.
@@ -301,7 +315,7 @@ where
         label: Option<L>,
         admin: Option<Addr>,
         funds: C,
-    ) -> anyhow::Result<Addr>
+    ) -> anyhow::Result<InstantiateOutcome>
     where
         M: Serialize,
         S: Into<Binary>,
@@ -333,7 +347,7 @@ where
         label: Option<L>,
         admin: Option<Addr>,
         funds: C,
-    ) -> anyhow::Result<Addr>
+    ) -> anyhow::Result<InstantiateOutcome>
     where
         M: Serialize,
         S: Into<Binary>,
@@ -344,15 +358,16 @@ where
         let salt = salt.into();
         let address = Addr::derive(signer.address(), code_hash, &salt);
 
-        self.send_message_with_gas(
+        let tx_outcome = self.send_message_with_gas(
             signer,
             gas_limit,
             Message::instantiate(code_hash, msg, salt, label, admin, funds)?,
-        )?
-        .result
-        .should_succeed();
+        )?;
 
-        Ok(address)
+        Ok(InstantiateOutcome {
+            address,
+            tx_outcome,
+        })
     }
 
     /// Upload a code and instantiate a contract with it in one go. Return the
@@ -366,7 +381,7 @@ where
         label: Option<L>,
         admin: Option<Addr>,
         funds: C,
-    ) -> anyhow::Result<(Hash256, Addr)>
+    ) -> anyhow::Result<UploadAndInstantiateOutcome>
     where
         M: Serialize,
         B: Into<Binary>,
@@ -399,7 +414,7 @@ where
         label: Option<L>,
         admin: Option<Addr>,
         funds: C,
-    ) -> anyhow::Result<(Hash256, Addr)>
+    ) -> anyhow::Result<UploadAndInstantiateOutcome>
     where
         M: Serialize,
         B: Into<Binary>,
@@ -413,14 +428,16 @@ where
         let salt = salt.into();
         let address = Addr::derive(signer.address(), code_hash, &salt);
 
-        self.send_messages_with_gas(signer, gas_limit, vec![
+        let tx_outcome = self.send_messages_with_gas(signer, gas_limit, vec![
             Message::upload(code),
             Message::instantiate(code_hash, msg, salt, label, admin, funds)?,
-        ])?
-        .result
-        .should_succeed();
+        ])?;
 
-        Ok((code_hash, address))
+        Ok(UploadAndInstantiateOutcome {
+            address,
+            code_hash,
+            tx_outcome,
+        })
     }
 
     /// Execute a contrat.
@@ -430,7 +447,7 @@ where
         contract: Addr,
         msg: &M,
         funds: C,
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<TxOutcome>
     where
         M: Serialize,
         C: TryInto<Coins>,
@@ -447,17 +464,13 @@ where
         contract: Addr,
         msg: &M,
         funds: C,
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<TxOutcome>
     where
         M: Serialize,
         C: TryInto<Coins>,
         StdError: From<C::Error>,
     {
-        self.send_message_with_gas(signer, gas_limit, Message::execute(contract, msg, funds)?)?
-            .result
-            .should_succeed();
-
-        Ok(())
+        self.send_message_with_gas(signer, gas_limit, Message::execute(contract, msg, funds)?)
     }
 
     /// Migrate a contract to a new code hash.
@@ -467,7 +480,7 @@ where
         contract: Addr,
         new_code_hash: Hash256,
         msg: &M,
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<TxOutcome>
     where
         M: Serialize,
     {
@@ -482,7 +495,7 @@ where
         contract: Addr,
         new_code_hash: Hash256,
         msg: &M,
-    ) -> anyhow::Result<()>
+    ) -> anyhow::Result<TxOutcome>
     where
         M: Serialize,
     {
@@ -490,11 +503,7 @@ where
             signer,
             gas_limit,
             Message::migrate(contract, new_code_hash, msg)?,
-        )?
-        .result
-        .should_succeed();
-
-        Ok(())
+        )
     }
 
     pub fn query_config(&self) -> anyhow::Result<Config> {

--- a/grug/testing/tests/account.rs
+++ b/grug/testing/tests/account.rs
@@ -27,7 +27,7 @@ fn check_tx_and_finalize() {
 
     // Create a tx to set sequence to 1.
     suite
-        .send_message(accounts.get_mut("rhaki").unwrap(), transfer_msg.clone())
+        .send_message(&mut accounts["rhaki"], transfer_msg.clone())
         .unwrap();
 
     // Create a tx with sequence 0, 1, 2, 4.
@@ -98,9 +98,9 @@ fn check_tx_and_finalize() {
     // The tx with sequence 4 should fail.
     let result = suite.make_block(txs).unwrap();
 
-    result.tx_outcomes[0].result.clone().should_succeed();
-    result.tx_outcomes[1].result.clone().should_succeed();
-    result.tx_outcomes[2].result.clone().should_fail();
+    result.tx_outcomes[0].clone().should_succeed();
+    result.tx_outcomes[1].clone().should_succeed();
+    result.tx_outcomes[2].clone().should_fail();
 
     suite
         .query_balance(&accounts["rhaki"], "uatom")
@@ -115,7 +115,6 @@ fn check_tx_and_finalize() {
         .unwrap();
 
     suite.make_block(vec![tx]).unwrap().tx_outcomes[0]
-        .result
         .clone()
         .should_succeed();
 
@@ -196,7 +195,7 @@ fn backrunning_works() {
     // Attempt to send a transaction
     suite
         .transfer(
-            accounts.get_mut("sender").unwrap(),
+            &mut accounts["sender"],
             receiver,
             Coins::one("ugrug", 123).unwrap(),
         )
@@ -241,11 +240,10 @@ fn backrunning_with_error() {
     // Attempt to make a transfer; should fail.
     suite
         .send_message(
-            accounts.get_mut("sender").unwrap(),
+            &mut accounts["sender"],
             Message::transfer(receiver, Coins::one("ugrug", 123).unwrap()).unwrap(),
         )
         .unwrap()
-        .result
         .should_fail_with_error("division by zero: 1 / 0");
 
     // Transfer should have been reverted, and sender doesn't get bad kids.

--- a/grug/testing/tests/cron.rs
+++ b/grug/testing/tests/cron.rs
@@ -69,8 +69,9 @@ fn cronjob_works() {
     //
     // Upload the tester contract code.
     let tester_code_hash = suite
-        .upload(accounts.get_mut("larry").unwrap(), tester_code)
-        .unwrap();
+        .upload(&mut accounts["larry"], tester_code)
+        .unwrap()
+        .code_hash;
 
     // Block time: 2
     //
@@ -78,7 +79,7 @@ fn cronjob_works() {
     // Each contract is given an initial coin balance.
     let cron1 = suite
         .instantiate(
-            accounts.get_mut("larry").unwrap(),
+            &mut accounts["larry"],
             tester_code_hash,
             &tester::Job {
                 receiver,
@@ -89,12 +90,13 @@ fn cronjob_works() {
             None,
             Coins::one("uatom", 3).unwrap(),
         )
-        .unwrap();
+        .unwrap()
+        .address;
 
     // Block time: 3
     let cron2 = suite
         .instantiate(
-            accounts.get_mut("larry").unwrap(),
+            &mut accounts["larry"],
             tester_code_hash,
             &tester::Job {
                 receiver,
@@ -105,12 +107,13 @@ fn cronjob_works() {
             None,
             Coins::one("uosmo", 3).unwrap(),
         )
-        .unwrap();
+        .unwrap()
+        .address;
 
     // Block time: 4
     let cron3 = suite
         .instantiate(
-            accounts.get_mut("larry").unwrap(),
+            &mut accounts["larry"],
             tester_code_hash,
             &tester::Job {
                 receiver,
@@ -121,7 +124,8 @@ fn cronjob_works() {
             None,
             Coins::one("umars", 3).unwrap(),
         )
-        .unwrap();
+        .unwrap()
+        .address;
 
     // Block time: 5
     //
@@ -140,7 +144,7 @@ fn cronjob_works() {
     // cron2 scheduled at 7
     // cron3 scheduled at 8
     suite
-        .configure(accounts.get_mut("larry").unwrap(), updates, BTreeMap::new())
+        .configure(&mut accounts["larry"], updates, BTreeMap::new())
         .unwrap();
 
     // Make some blocks.

--- a/grug/testing/tests/queries.rs
+++ b/grug/testing/tests/queries.rs
@@ -49,7 +49,7 @@ fn handling_multi_query() {
     // If the contract successfully deploys, the multi query must have worked.
     suite
         .upload_and_instantiate(
-            accounts.get_mut("larry").unwrap(),
+            &mut accounts["larry"],
             query_maker_code,
             &Empty {},
             "query_maker",

--- a/grug/testing/tests/taxman.rs
+++ b/grug/testing/tests/taxman.rs
@@ -1,7 +1,7 @@
 use {
     grug_math::{NumberConst, Uint128},
     grug_testing::TestBuilder,
-    grug_types::{Coins, Empty, Message, ResultExt, TxOutcome},
+    grug_types::{Coins, Empty, Message, ResultExt},
     grug_vm_rust::ContractBuilder,
     test_case::test_case,
 };
@@ -186,7 +186,7 @@ fn withholding_and_finalizing_fee_works(
 
     let outcome = suite
         .send_message_with_gas(
-            accounts.get_mut("sender").unwrap(),
+            &mut accounts["sender"],
             gas_limit,
             Message::transfer(
                 to,
@@ -198,10 +198,10 @@ fn withholding_and_finalizing_fee_works(
 
     match maybe_err {
         Some(err) => {
-            outcome.result.should_fail_with_error(err);
+            outcome.should_fail_with_error(err);
         },
         None => {
-            outcome.result.should_succeed();
+            outcome.should_succeed();
         },
     }
 
@@ -250,19 +250,19 @@ fn finalizing_fee_erroring() {
     // Send a transaction with a single message.
     // `withhold_fee` must pass, which should be the case as we're requesting
     // zero gas limit.
-    let TxOutcome { events, result, .. } = suite
+    let outcome = suite
         .send_message_with_gas(
-            accounts.get_mut("sender").unwrap(),
+            &mut accounts["sender"],
             0,
             Message::transfer(to, Coins::new()).unwrap(),
         )
         .unwrap();
 
     // Result should be an error.
-    result.should_fail_with_error("division by zero: 1 / 0");
+    let failing = outcome.should_fail_with_error("division by zero: 1 / 0");
 
     // All events should have been discarded.
-    assert!(events.is_empty());
+    assert!(failing.events.is_empty());
 
     // Owner and sender's balances shouldn't have changed, since state changes
     // are discarded.

--- a/grug/types/src/app.rs
+++ b/grug/types/src/app.rs
@@ -131,6 +131,20 @@ pub struct Outcome {
     pub result: GenericResult<Vec<Event>>,
 }
 
+impl Outcome {
+    pub fn as_success(self) {
+        if let GenericResult::Err(err) = self.result {
+            panic!("expected success, got error: {err}");
+        }
+    }
+
+    pub fn as_error(self) -> String {
+        match self.result {
+            GenericResult::Ok(_) => panic!("expected error, got success"),
+            GenericResult::Err(error) => error,
+        }
+    }
+}
 /// Outcome of processing a transaction.
 ///
 /// Different from `Outcome`, which can either succeed or fail, a transaction

--- a/grug/types/src/app.rs
+++ b/grug/types/src/app.rs
@@ -154,6 +154,46 @@ pub struct TxOutcome {
     pub result: GenericResult<()>,
 }
 
+impl TxOutcome {
+    pub fn as_success(self) -> TxSuccess {
+        match self.result {
+            GenericResult::Ok(_) => TxSuccess {
+                gas_limit: self.gas_limit,
+                gas_used: self.gas_used,
+                events: self.events,
+            },
+            GenericResult::Err(err) => panic!("expected success, got error: {err}"),
+        }
+    }
+
+    pub fn as_error(self) -> TxError {
+        match self.result {
+            GenericResult::Ok(_) => panic!("expected error, got success"),
+            GenericResult::Err(error) => TxError {
+                gas_limit: self.gas_limit,
+                gas_used: self.gas_used,
+                error,
+                events: self.events,
+            },
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TxSuccess {
+    pub gas_limit: u64,
+    pub gas_used: u64,
+    pub events: Vec<Event>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TxError {
+    pub gas_limit: u64,
+    pub gas_used: u64,
+    pub error: String,
+    pub events: Vec<Event>,
+}
+
 #[derive(Debug)]
 /// Outcome of executing a block.
 pub struct BlockOutcome {

--- a/grug/types/src/result.rs
+++ b/grug/types/src/result.rs
@@ -1,8 +1,11 @@
 use {
-    crate::{Event, StdError, StdResult},
+    crate::{Event, StdError, StdResult, TxError, TxOutcome, TxSuccess},
     borsh::{BorshDeserialize, BorshSerialize},
     serde::{Deserialize, Serialize},
-    std::fmt::{Debug, Display},
+    std::{
+        fmt::{Debug, Display},
+        ops::Deref,
+    },
 };
 
 /// The result for executing a submessage, provided to the contract in the `reply`
@@ -75,49 +78,52 @@ where
 
 /// Addition methods for result types.
 /// Useful for testing, improving code readability.
-pub trait ResultExt<T, E>: Sized {
+pub trait ResultExt: Sized {
+    type Success;
+    type Error;
+
     /// Ensure the result satisfies the given predicate.
     fn should<F>(self, predicate: F)
     where
         F: FnOnce(Self) -> bool;
 
     /// Ensure the result is ok; return the value.
-    fn should_succeed(self) -> T;
+    fn should_succeed(self) -> Self::Success;
 
     /// Ensure the result is ok, and the value satisfies the given predicate.
-    fn should_succeed_and<F>(self, predicate: F)
+    fn should_succeed_and<F>(self, predicate: F) -> Self::Success
     where
-        F: FnOnce(T) -> bool;
+        F: FnOnce(&Self::Success) -> bool;
 
     /// Ensure the result is ok, and matches the expect value.
-    fn should_succeed_and_equal<U>(self, expect: U)
+    fn should_succeed_and_equal<U>(self, expect: U) -> Self::Success
     where
-        T: PartialEq<U>,
+        Self::Success: PartialEq<U>,
         U: Debug;
 
     /// Ensure the result is ok, but the value doesn't equal the given value.
-    fn should_succeed_but_not_equal<U>(self, expect: U)
+    fn should_succeed_but_not_equal<U>(self, expect: U) -> Self::Success
     where
-        T: PartialEq<U>,
+        Self::Success: PartialEq<U>,
         U: Debug;
 
     /// Ensure the result is error; return the error message;
-    fn should_fail(self) -> E;
+    fn should_fail(self) -> Self::Error;
 
     /// Ensure the result is error, and the error satisfies the given predicate.
-    fn should_fail_and<F>(self, predicate: F)
+    fn should_fail_and<F>(self, predicate: F) -> Self::Error
     where
-        F: FnOnce(E) -> bool;
+        F: FnOnce(&Self::Error) -> bool;
 
     /// Ensure the result is error, and contains the given substring.
-    fn should_fail_with_error<M>(self, msg: M)
+    fn should_fail_with_error<M>(self, msg: M) -> Self::Error
     where
         M: ToString;
 
     /// Ensure the result matches the given result.
     fn should_match<U>(self, expect: GenericResult<U>)
     where
-        T: PartialEq<U>,
+        Self::Success: PartialEq<U>,
         U: Debug;
 }
 
@@ -233,17 +239,225 @@ macro_rules! impl_result_ext {
     };
 }
 
-impl<T, E> ResultExt<T, E> for Result<T, E>
+impl<T, E> ResultExt for Result<T, E>
 where
     T: Debug,
     E: Display,
 {
-    impl_result_ext!(Result, E);
+    type Error = E;
+    type Success = T;
+
+    fn should<F>(self, predicate: F)
+    where
+        F: FnOnce(Self) -> bool,
+    {
+        assert!(predicate(self), "result does not satisfy predicte!");
+    }
+
+    fn should_succeed(self) -> Self::Success {
+        match self {
+            Self::Ok(value) => value,
+            Self::Err(err) => panic!("expecting ok, got error: {err}"),
+        }
+    }
+
+    fn should_succeed_and<F>(self, predicate: F) -> Self::Success
+    where
+        F: FnOnce(&Self::Success) -> bool,
+    {
+        match self {
+            Self::Ok(value) => {
+                assert!(predicate(&value), "value does not satisfy predicate!");
+                value
+            },
+            Self::Err(err) => panic!("expecting ok, got error: {err}"),
+        }
+    }
+
+    fn should_succeed_and_equal<U>(self, expect: U) -> Self::Success
+    where
+        Self::Success: PartialEq<U>,
+        U: Debug,
+    {
+        match self {
+            Self::Ok(value) => {
+                assert_eq!(value, expect, "wrong value!");
+                value
+            },
+            Self::Err(err) => panic!("expecting ok, got error: {err}"),
+        }
+    }
+
+    fn should_succeed_but_not_equal<U>(self, expect: U) -> Self::Success
+    where
+        Self::Success: PartialEq<U>,
+        U: Debug,
+    {
+        match self {
+            Self::Ok(value) => {
+                assert_ne!(value, expect, "wrong value!");
+                value
+            },
+            Self::Err(err) => panic!("expecting ok, got error: {err}"),
+        }
+    }
+
+    fn should_fail(self) -> Self::Error {
+        match self {
+            Self::Err(err) => err,
+            Self::Ok(value) => panic!("expecting error, got ok: {value:?}"),
+        }
+    }
+
+    fn should_fail_and<F>(self, predicate: F) -> Self::Error
+    where
+        F: FnOnce(&Self::Error) -> bool,
+    {
+        match self {
+            Self::Err(err) => {
+                assert!(predicate(&err), "error does not satisfy predicate!");
+                err
+            },
+            Self::Ok(value) => panic!("expecting error, got ok: {value:?}"),
+        }
+    }
+
+    fn should_fail_with_error<M>(self, msg: M) -> Self::Error
+    where
+        M: ToString,
+    {
+        match self {
+            Self::Err(err) => {
+                let expect = msg.to_string();
+                let actual = err.to_string();
+                assert!(
+                    actual.contains(&expect),
+                    "wrong error! expecting: {expect}, got: {actual}"
+                );
+
+                err
+            },
+            Self::Ok(value) => panic!("expecting error, got ok: {value:?}"),
+        }
+    }
+
+    fn should_match<U>(self, expect: GenericResult<U>)
+    where
+        Self::Success: PartialEq<U>,
+        U: Debug,
+    {
+        match (self, expect) {
+            (Self::Ok(actual), GenericResult::Ok(expect)) => {
+                assert_eq!(actual, expect, "wrong value!");
+            },
+            (Self::Err(actual), GenericResult::Err(expect)) => {
+                assert!(
+                    actual.to_string().contains(&expect),
+                    "wrong error! expecting: {expect}, got {actual}"
+                );
+            },
+            (Self::Ok(value), GenericResult::Err(_)) => {
+                panic!("expecting error, got ok: {value:?}");
+            },
+            (Self::Err(err), GenericResult::Ok(_)) => {
+                panic!("expecting ok, got error: {err}");
+            },
+        }
+    }
 }
 
-impl<T> ResultExt<T, String> for GenericResult<T>
-where
-    T: Debug,
-{
-    impl_result_ext!(GenericResult, String);
+impl ResultExt for TxOutcome {
+    type Error = TxError;
+    type Success = TxSuccess;
+
+    fn should<F>(self, predicate: F)
+    where
+        F: FnOnce(Self) -> bool,
+    {
+        assert!(predicate(self), "result does not satisfy predicte!");
+    }
+
+    fn should_succeed(self) -> TxSuccess {
+        self.as_success()
+    }
+
+    fn should_succeed_and<F>(self, predicate: F) -> TxSuccess
+    where
+        F: FnOnce(&TxSuccess) -> bool,
+    {
+        let success = self.as_success();
+        assert!(predicate(&success), "value does not satisfy predicate!");
+        success
+    }
+
+    fn should_succeed_and_equal<U>(self, expect: U) -> TxSuccess
+    where
+        TxSuccess: PartialEq<U>,
+        U: Debug,
+    {
+        let success = self.as_success();
+        assert_eq!(success, expect, "wrong value!");
+        success
+    }
+
+    fn should_succeed_but_not_equal<U>(self, expect: U) -> TxSuccess
+    where
+        TxSuccess: PartialEq<U>,
+        U: Debug,
+    {
+        let success = self.as_success();
+        assert_ne!(success, expect, "wrong value!");
+        success
+    }
+
+    fn should_fail(self) -> TxError {
+        self.as_error()
+    }
+
+    fn should_fail_and<F>(self, predicate: F) -> TxError
+    where
+        F: FnOnce(&TxError) -> bool,
+    {
+        let error = self.as_error();
+        assert!(predicate(&error), "error does not satisfy predicate!");
+        error
+    }
+
+    fn should_fail_with_error<M>(self, msg: M) -> TxError
+    where
+        M: ToString,
+    {
+        let error = self.as_error();
+        let expect = msg.to_string();
+        let actual = error.error.deref();
+        assert!(
+            &error.error.contains(&expect),
+            "wrong error! expecting: {expect}, got: {actual}"
+        );
+        error
+    }
+
+    fn should_match<U>(self, expect: GenericResult<U>)
+    where
+        TxSuccess: PartialEq<U>,
+        U: Debug,
+    {
+        match (&self.result, expect) {
+            (GenericResult::Ok(_), GenericResult::Ok(expect)) => {
+                assert_eq!(self.as_success(), expect, "wrong events!")
+            },
+            (GenericResult::Err(actual), GenericResult::Err(expect)) => {
+                assert_eq!(*actual, expect, "wrong error!")
+            },
+            (GenericResult::Ok(_), GenericResult::Err(expect)) => {
+                panic!(
+                    "expecting error: {expect}, got ok: {:#?}",
+                    self.as_success()
+                )
+            },
+            (GenericResult::Err(err), GenericResult::Ok(ok)) => {
+                panic!("expecting ok: {:#?}, got error: {err:?}", ok)
+            },
+        }
+    }
 }

--- a/grug/vm-rust/tests/transfer.rs
+++ b/grug/vm-rust/tests/transfer.rs
@@ -31,7 +31,7 @@ fn transfers() {
 
     // Sender sends 70 ugrug to the receiver across multiple messages
     suite
-        .send_messages(accounts.get_mut("sender").unwrap(), vec![
+        .send_messages(&mut accounts["sender"], vec![
             Message::Transfer {
                 to,
                 coins: Coins::one(DENOM.clone(), 10).unwrap(),
@@ -50,7 +50,6 @@ fn transfers() {
             },
         ])
         .unwrap()
-        .result
         .should_succeed();
 
     // Check balances again

--- a/grug/vm-wasm/tests/transfer.rs
+++ b/grug/vm-wasm/tests/transfer.rs
@@ -41,7 +41,7 @@ fn transfers() {
 
     // Sender sends 70 ugrug to the receiver across multiple messages
     let outcome = suite
-        .send_messages_with_gas(accounts.get_mut("sender").unwrap(), 2_500_000, vec![
+        .send_messages_with_gas(&mut accounts["sender"], 2_500_000, vec![
             Message::Transfer {
                 to,
                 coins: Coins::one(DENOM.clone(), 10).unwrap(),
@@ -61,7 +61,7 @@ fn transfers() {
         ])
         .unwrap();
 
-    outcome.result.should_succeed();
+    outcome.clone().should_succeed();
 
     // Sender remaining balance should be 300k - 70 - withhold + (withhold - charge).
     // = 300k - 70 - charge
@@ -120,17 +120,13 @@ fn transfers_with_insufficient_gas_limit() {
     // say that the error has to be one of the two. Therefore, we simply ensure
     // the error message contains the word "gas".
     let outcome = suite
-        .send_message_with_gas(
-            accounts.get_mut("sender").unwrap(),
-            100_000,
-            Message::Transfer {
-                to,
-                coins: Coins::one(DENOM.clone(), 10).unwrap(),
-            },
-        )
+        .send_message_with_gas(&mut accounts["sender"], 100_000, Message::Transfer {
+            to,
+            coins: Coins::one(DENOM.clone(), 10).unwrap(),
+        })
         .unwrap();
 
-    outcome.result.should_fail();
+    outcome.clone().should_fail();
 
     // The transfer should have failed, but gas fee already spent is still charged.
     let fee = Uint128::new(outcome.gas_used as u128)


### PR DESCRIPTION
### Outcome:
- `ResultExt` now require associated type over generics;
- `TxOutcome` impls`ResultExt`;
- `Outcome` impls`ResultExt`;
- remove `ResultExt` for `GenericResult`.

### Suite:
- `TestAccounts` now are a wrapper struct over `HashMap<&'static str, TestAccount>`;
- `instantiate` methods now return `InstantiateOutcome`;
- `upload` methods now return `UploadOutcome`;
- `upload_and_instantiate` methods now return `UploadAndInstantiateOutcome`.