### PR TITLE
refractor(grug): use `Option<&str>` instead of generic for label

### DIFF
--- a/grug/client/src/client.rs
+++ b/grug/client/src/client.rs
@@ -500,12 +500,12 @@ impl Client {
     /// Send a transaction with a single [`Message::Instantiate`](grug_types::Message::Instantiate).
     ///
     /// Return the deployed contract's address.
-    pub async fn instantiate<M, S, L, C, T>(
+    pub async fn instantiate<M, S, C, T>(
         &self,
         code_hash: Hash256,
         msg: &M,
         salt: S,
-        label: Option<L>,
+        label: Option<&str>,
         funds: C,
         gas_opt: GasOption,
         sign_opt: SigningOption<'_, T>,
@@ -514,7 +514,6 @@ impl Client {
     where
         M: Serialize,
         S: Into<Binary>,
-        L: Into<String>,
         C: TryInto<Coins>,
         T: AsyncSigner,
         StdError: From<C::Error>,
@@ -533,12 +532,12 @@ impl Client {
     /// with the code in one go.
     ///
     /// Return the code hash, and the deployed contract's address.
-    pub async fn upload_and_instantiate<M, B, S, L, C, T>(
+    pub async fn upload_and_instantiate<M, B, S, C, T>(
         &self,
         code: B,
         msg: &M,
         salt: S,
-        label: Option<L>,
+        label: Option<&str>,
         funds: C,
         gas_opt: GasOption,
         sign_opt: SigningOption<'_, T>,
@@ -548,7 +547,6 @@ impl Client {
         M: Serialize,
         B: Into<Binary>,
         S: Into<Binary>,
-        L: Into<String>,
         C: TryInto<Coins>,
         T: AsyncSigner,
         StdError: From<C::Error>,

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -383,20 +383,19 @@ where
     }
 
     /// Instantiate a contract. Return the contract's address.
-    pub fn instantiate<M, S, C, L>(
+    pub fn instantiate<M, S, C>(
         &mut self,
         signer: &mut dyn Signer,
         code_hash: Hash256,
         msg: &M,
         salt: S,
-        label: Option<L>,
+        label: Option<&str>,
         admin: Option<Addr>,
         funds: C,
     ) -> InstantiateOutcome
     where
         M: Serialize,
         S: Into<Binary>,
-        L: Into<String>,
         C: TryInto<Coins>,
         StdError: From<C::Error>,
     {
@@ -414,21 +413,20 @@ where
 
     /// Instantiate a contract under the given gas limit. Return the contract's
     /// address.
-    pub fn instantiate_with_gas<M, S, L, C>(
+    pub fn instantiate_with_gas<M, S, C>(
         &mut self,
         signer: &mut dyn Signer,
         gas_limit: u64,
         code_hash: Hash256,
         msg: &M,
         salt: S,
-        label: Option<L>,
+        label: Option<&str>,
         admin: Option<Addr>,
         funds: C,
     ) -> InstantiateOutcome
     where
         M: Serialize,
         S: Into<Binary>,
-        L: Into<String>,
         C: TryInto<Coins>,
         StdError: From<C::Error>,
     {


### PR DESCRIPTION
…tion<Into<String>> for label