### PR TITLE
refactor: rename UpdateConfig to Configure

### DIFF
--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -22,12 +22,12 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
-        ExecuteMsg::UpdateConfig { new_cfg } => update_config(ctx, new_cfg),
+        ExecuteMsg::Configure { new_cfg } => configure(ctx, new_cfg),
         ExecuteMsg::Pay { payer } => pay(ctx, payer),
     }
 }
 
-fn update_config(ctx: MutableCtx, new_cfg: Config) -> anyhow::Result<Response> {
+fn configure(ctx: MutableCtx, new_cfg: Config) -> anyhow::Result<Response> {
     let cfg = ctx.querier.query_config()?;
 
     // Only the chain's owner can update fee config.

--- a/dango/types/src/taxman.rs
+++ b/dango/types/src/taxman.rs
@@ -15,7 +15,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     /// Update the fee configurations.
     /// Can only be called by the chain's owner.
-    UpdateConfig { new_cfg: Config },
+    Configure { new_cfg: Config },
     /// Forward protocol fee to the taxman.
     Pay { payer: Addr },
 }

--- a/grug/mock-taxman/src/execute.rs
+++ b/grug/mock-taxman/src/execute.rs
@@ -13,7 +13,7 @@ pub fn initialize_config(storage: &mut dyn Storage, cfg: &Config) -> StdResult<R
     Ok(Response::new())
 }
 
-pub fn update_config(ctx: MutableCtx, new_cfg: &Config) -> anyhow::Result<Response> {
+pub fn configure(ctx: MutableCtx, new_cfg: &Config) -> anyhow::Result<Response> {
     let cfg = ctx.querier.query_config()?;
 
     // Only the chain's owner can update fee config.

--- a/grug/mock-taxman/src/exports.rs
+++ b/grug/mock-taxman/src/exports.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{initialize_config, query_config, update_config, ExecuteMsg, InstantiateMsg, QueryMsg},
+    crate::{configure, initialize_config, query_config, ExecuteMsg, InstantiateMsg, QueryMsg},
     grug_types::{ImmutableCtx, Json, JsonSerExt, MutableCtx, Response, StdResult},
 };
 
@@ -39,7 +39,7 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> 
 
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
-        ExecuteMsg::UpdateConfig { new_cfg } => update_config(ctx, &new_cfg),
+        ExecuteMsg::Configure { new_cfg } => configure(ctx, &new_cfg),
     }
 }
 

--- a/grug/mock-taxman/src/types.rs
+++ b/grug/mock-taxman/src/types.rs
@@ -21,7 +21,7 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename = "snake_case")]
 pub enum ExecuteMsg {
-    UpdateConfig { new_cfg: Config },
+    Configure { new_cfg: Config },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/sdk/packages/encoding/src/binary.spec.ts
+++ b/sdk/packages/encoding/src/binary.spec.ts
@@ -13,7 +13,7 @@ describe("serializing and deserializing complex types", () => {
           },
         },
       },
-      '{"update_config":{"new_cfg":{"bank":"0xccf2d114c23acb6735aa28418310cb20f042f1d2c3974969ac103376dae70838"}}}',
+      '{"configure":{"new_cfg":{"bank":"0xccf2d114c23acb6735aa28418310cb20f042f1d2c3974969ac103376dae70838"}}}',
     ],
     [
       "query balances request",

--- a/sdk/packages/types/src/index.ts
+++ b/sdk/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export type {
   MsgMigrate,
   MsgStoreCode,
   MsgTransfer,
-  MsgUpdateConfig,
+  MsgConfigure,
   Tx,
   TxParameters,
   UnsignedTx,

--- a/sdk/packages/types/src/tx.ts
+++ b/sdk/packages/types/src/tx.ts
@@ -20,14 +20,14 @@ export type Tx = {
 export type UnsignedTx = Pick<Tx, "sender" | "msgs">;
 
 export type Message =
-  | { configure: MsgUpdateConfig }
+  | { configure: MsgConfigure }
   | { transfer: MsgTransfer }
   | { upload: MsgStoreCode }
   | { instantiate: MsgInstantiate }
   | { execute: MsgExecute }
   | { migrate: MsgMigrate };
 
-export type MsgUpdateConfig = {
+export type MsgConfigure = {
   updates: ConfigUpdate;
   appUpdates: Record<string, Json>;
 };


### PR DESCRIPTION
Consistent naming. Prefer a single verb over a phrase.