### PR TITLE
fix: small build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Prerequisites:
 - [Rust](https://rustup.rs/) with `wasm32-unknown-unknown` target
 - [Just](https://just.systems/man/en/)
 - [Docker](https://docs.docker.com/engine/install/)
+- [Node.js](https://nodejs.org/en/download/) v20.18.0 LTS
 - [pnpm](https://pnpm.io/)
 
 We use [VS Code](https://code.visualstudio.com/) as text editor with the following plugins:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prerequisites:
 - [Rust](https://rustup.rs/) with `wasm32-unknown-unknown` target
 - [Just](https://just.systems/man/en/)
 - [Docker](https://docs.docker.com/engine/install/)
-- [Node.js](https://nodejs.org/en/download/) v20.18.0 LTS
+- [Node.js](https://nodejs.org/en/download/) [version 18+](https://github.com/left-curve/left-curve/blob/main/sdk/README.md?plain=1#L62)
 - [pnpm](https://pnpm.io/)
 
 We use [VS Code](https://code.visualstudio.com/) as text editor with the following plugins:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  devnet:
+    build:
+      context: ./docker/devnet
+    ports:
+      - "26656:26656"
+      - "26657:26657"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3.8"
-services:
-  devnet:
-    build:
-      context: ./docker/devnet
-    ports:
-      - "26656:26656"
-      - "26657:26657"

--- a/docker/devnet/Dockerfile
+++ b/docker/devnet/Dockerfile
@@ -74,10 +74,11 @@ RUN cd left-curve \
   && cat artifacts/checksum.txt
 
 # Create genesis file.
-# Edit cometbft config such that Tendermint RPC accepts queries from all hosts.
+# Edit cometbft config such that Tendermint RPC accepts queries from all hosts and allows CORS from any origin.
 RUN cd left-curve \
   && cometbft init \
   && sed -i 's|laddr = "tcp://127.0.0.1:26657"|laddr = "tcp://0.0.0.0:26657"|g' ~/.cometbft/config/config.toml \
+  && sed -i 's|cors_allowed_origins = \[\]|cors_allowed_origins = ["*"]|g' ~/.cometbft/config/config.toml \
   && cargo run -p dango-genesis --example build_genesis -- ${CHAIN_ID} ${GENESIS_TIME} \
   && cat ~/.cometbft/config/genesis.json
 

--- a/justfile
+++ b/justfile
@@ -79,8 +79,12 @@ docker-build-devnet:
 
 # Start a devnet from genesis
 start-devnet:
-  docker run -it -p 26657:26657 -p 26656:26656 {{DEVNET_NAME}}:{{DEVNET_VERSION}}
+  docker run --name devnet -it -p 26657:26657 -p 26656:26656 {{DEVNET_NAME}}:{{DEVNET_VERSION}}
 
 # Restart a devnet that have been previous stopped
-restart-devnet container_id:
-  docker start -i $1
+restart-devnet:
+  docker start -i devnet
+
+# Remove a devnet
+remove-devnet:
+  docker rm -f devnet

--- a/justfile
+++ b/justfile
@@ -79,12 +79,12 @@ docker-build-devnet:
 
 # Start a devnet from genesis
 start-devnet:
-  docker run --name devnet -it -p 26657:26657 -p 26656:26656 {{DEVNET_NAME}}:{{DEVNET_VERSION}}
+  docker run --name {{DEVNET_CHAIN_ID}} -it -p 26657:26657 -p 26656:26656 {{DEVNET_NAME}}:{{DEVNET_VERSION}}
 
 # Restart a devnet that have been previous stopped
 restart-devnet:
-  docker start -i devnet
+  docker start -i {{DEVNET_CHAIN_ID}}
 
 # Remove a devnet
 remove-devnet:
-  docker rm -f devnet
+  docker rm -f {{DEVNET_CHAIN_ID}}


### PR DESCRIPTION
Ran into some issues when trying to run devnet and frontend. Fixes applied:

- Add prerequisite to have Node.js v20.18.0. I was on 16 or 18 (can't recall) and it only worked once upgraded to 20.18.0. Perhaps some lesser version works, but not sure.
- Allow CORS from any origin in devnet. Otherwise frontend can't connect to RPC node in docker container.
- Add docker compose file for easy launch of devnet with `docker compose up` and `docker compose rm` to reset.