### PR TITLE
feat(dango): oracle contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dango-oracle"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "dango-types",
+ "grug",
+]
+
+[[package]]
 name = "dango-taxman"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ dango-auth            = { path = "dango/auth" }
 dango-bank            = { path = "dango/bank" }
 dango-genesis         = { path = "dango/genesis" }
 dango-ibc-transfer    = { path = "dango/ibc-transfer" }
+dango-oracle          = { path = "dango/oracle" }
 dango-taxman          = { path = "dango/taxman" }
 dango-testing         = { path = "dango/testing" }
 dango-token-factory   = { path = "dango/token-factory" }

--- a/dango/oracle/Cargo.toml
+++ b/dango/oracle/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name          = "dango-oracle"
+version       = { workspace = true }
+authors       = { workspace = true }
+edition       = { workspace = true }
+rust-version  = { workspace = true }
+documentation = { workspace = true }
+repository    = { workspace = true }
+license       = { workspace = true }
+categories    = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# If enabled, Wasm exports won't be created. This allows this contract to be
+# imported into other contracts as a library.
+library = []
+
+[dependencies]
+anyhow      = { workspace = true }
+dango-types = { workspace = true }
+grug        = { workspace = true }
+
+[dev-dependencies]

--- a/dango/oracle/src/execute.rs
+++ b/dango/oracle/src/execute.rs
@@ -1,0 +1,100 @@
+use {
+    crate::{CONFIG, GUARDIANS, PRICES, PRICE_FEEDS},
+    anyhow::ensure,
+    dango_types::oracle::{ExecuteMsg, InstantiateMsg, Price},
+    grug::{Denom, Integer, MutableCtx, Number, Order, Response, StdResult, SudoCtx, Udec128},
+    std::collections::BTreeMap,
+};
+
+#[cfg_attr(not(feature = "library"), grug::export)]
+pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> {
+    CONFIG.save(ctx.storage, &msg.config)?;
+
+    for guardian in msg.guardians {
+        GUARDIANS.insert(ctx.storage, guardian)?;
+    }
+
+    Ok(Response::new())
+}
+
+#[cfg_attr(not(feature = "library"), grug::export)]
+pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
+    match msg {
+        ExecuteMsg::FeedPrices(feeds) => feed_prices(ctx, feeds),
+    }
+}
+
+fn feed_prices(ctx: MutableCtx, feeds: BTreeMap<Denom, Udec128>) -> anyhow::Result<Response> {
+    // Only guardians can feed prices.
+    ensure!(
+        GUARDIANS.has(ctx.storage, ctx.sender),
+        "you don't have the right, O you don't have the right"
+    );
+
+    // Save the prices in storage.
+    // If the guardian has fed prices before in the same epoch, the older feeds
+    // are simply overwritten.
+    for (denom, feed) in feeds {
+        PRICE_FEEDS.save(ctx.storage, (&denom, ctx.sender), &feed)?;
+    }
+
+    Ok(Response::new())
+}
+
+#[cfg_attr(not(feature = "library"), grug::export)]
+pub fn cron_execute(ctx: SudoCtx) -> StdResult<Response> {
+    let cfg = CONFIG.load(ctx.storage)?;
+
+    let mut denom_feeds = BTreeMap::<Denom, Vec<Udec128>>::new();
+
+    // Load all feeds submitted by guardians since the last cron execute.
+    for res in PRICE_FEEDS.prefix_range(ctx.storage, None, None, Order::Ascending) {
+        let ((denom, _guardian), feed) = res?;
+        // We expect there to be ~20 guardians, so pre-allocate a vector
+        // with capacity of 20.
+        denom_feeds
+            .entry(denom)
+            .or_insert_with(|| Vec::with_capacity(20))
+            .push(feed);
+    }
+
+    // Compute price for each denom based on the feeds.
+    for (denom, mut feeds) in denom_feeds {
+        let num_feeds = feeds.len();
+
+        // If there's not enough feeds, then don't compute the median.
+        if num_feeds < cfg.quorum as usize {
+            continue;
+        }
+
+        // The price feeds must be sorted in order to find the median.
+        feeds.sort();
+
+        // Find the median price.
+        let median = if num_feeds % 2 == 0 {
+            // If there's an even number of feeds, take the average of the two
+            // middle ones.
+            let feed1 = feeds[num_feeds / 2 - 1];
+            let feed2 = feeds[num_feeds / 2];
+
+            // A little optimization: use bit shift instead of division.
+            feed1
+                .numerator()
+                .checked_add(*feed2.numerator())?
+                .checked_shr(1)
+                .map(Udec128::raw)?
+        } else {
+            feeds[num_feeds / 2]
+        };
+
+        PRICES.save(ctx.storage, &denom, &Price {
+            price: median,
+            timestamp: ctx.block.timestamp,
+        })?;
+    }
+
+    // Delete all feeds.
+    PRICE_FEEDS.clear(ctx.storage, None, None);
+
+    Ok(Response::new())
+}

--- a/dango/oracle/src/lib.rs
+++ b/dango/oracle/src/lib.rs
@@ -1,0 +1,5 @@
+mod execute;
+mod query;
+mod state;
+
+pub use {execute::*, query::*, state::*};

--- a/dango/oracle/src/query.rs
+++ b/dango/oracle/src/query.rs
@@ -1,0 +1,90 @@
+use {
+    crate::{CONFIG, GUARDIANS, PRICES, PRICE_FEEDS},
+    dango_types::oracle::{Config, Price, QueryMsg},
+    grug::{Addr, Bound, Denom, ImmutableCtx, Json, JsonSerExt, Order, StdResult, Udec128},
+    std::collections::BTreeSet,
+};
+
+const DEFAULT_PAGE_LIMIT: u32 = 30;
+
+#[cfg_attr(not(feature = "library"), grug::export)]
+pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
+    match msg {
+        QueryMsg::Config {} => {
+            let res = query_config(ctx)?;
+            res.to_json_value()
+        },
+        QueryMsg::Guardians {} => {
+            let res = query_guardians(ctx)?;
+            res.to_json_value()
+        },
+        QueryMsg::Price { denom } => {
+            let res = query_price(ctx, denom)?;
+            res.to_json_value()
+        },
+        QueryMsg::Prices { start_after, limit } => {
+            let res = query_prices(ctx, start_after, limit)?;
+            res.to_json_value()
+        },
+        QueryMsg::PriceFeed { denom, guardian } => {
+            let res = query_price_feed(ctx, denom, guardian)?;
+            res.to_json_value()
+        },
+        QueryMsg::PriceFeeds {
+            denom,
+            start_after,
+            limit,
+        } => {
+            let res = query_price_feeds(ctx, denom, start_after, limit)?;
+            res.to_json_value()
+        },
+    }
+}
+
+fn query_config(ctx: ImmutableCtx) -> StdResult<Config> {
+    CONFIG.load(ctx.storage)
+}
+
+fn query_guardians(ctx: ImmutableCtx) -> StdResult<BTreeSet<Addr>> {
+    GUARDIANS
+        .range(ctx.storage, None, None, Order::Ascending)
+        .collect()
+}
+
+fn query_price(ctx: ImmutableCtx, denom: Denom) -> StdResult<Price> {
+    PRICES.load(ctx.storage, &denom)
+}
+
+fn query_prices(
+    ctx: ImmutableCtx,
+    start_after: Option<Denom>,
+    limit: Option<u32>,
+) -> StdResult<Vec<(Denom, Price)>> {
+    let start_after = start_after.as_ref().map(Bound::Exclusive);
+    let limit = limit.unwrap_or(DEFAULT_PAGE_LIMIT);
+
+    PRICES
+        .range(ctx.storage, start_after, None, Order::Ascending)
+        .take(limit as usize)
+        .collect()
+}
+
+fn query_price_feed(ctx: ImmutableCtx, denom: Denom, guardian: Addr) -> StdResult<Udec128> {
+    PRICE_FEEDS.load(ctx.storage, (&denom, guardian))
+}
+
+fn query_price_feeds(
+    ctx: ImmutableCtx,
+    denom: Denom,
+    start_after: Option<Addr>,
+    limit: Option<u32>,
+) -> StdResult<Vec<(Addr, Udec128)>> {
+    let start_after = start_after.map(Bound::Exclusive);
+    let limit = limit.unwrap_or(DEFAULT_PAGE_LIMIT);
+
+    PRICE_FEEDS
+        .prefix(&denom)
+        .range(ctx.storage, start_after, None, Order::Ascending)
+        .take(limit as usize)
+        .collect()
+}

--- a/dango/oracle/src/state.rs
+++ b/dango/oracle/src/state.rs
@@ -1,0 +1,12 @@
+use {
+    dango_types::oracle::{Config, Price},
+    grug::{Addr, Denom, Item, Map, Set, Udec128},
+};
+
+pub const CONFIG: Item<Config> = Item::new("config");
+
+pub const GUARDIANS: Set<Addr> = Set::new("guardian");
+
+pub const PRICES: Map<&Denom, Price> = Map::new("price");
+
+pub const PRICE_FEEDS: Map<(&Denom, Addr), Udec128> = Map::new("price_feed");

--- a/dango/types/src/lib.rs
+++ b/dango/types/src/lib.rs
@@ -5,5 +5,6 @@ pub mod auth;
 pub mod bank;
 pub mod config;
 pub mod mock_ibc_transfer;
+pub mod oracle;
 pub mod taxman;
 pub mod token_factory;

--- a/dango/types/src/oracle.rs
+++ b/dango/types/src/oracle.rs
@@ -1,0 +1,62 @@
+use {
+    grug::{Addr, Denom, Timestamp, Udec128},
+    std::collections::{BTreeMap, BTreeSet},
+};
+
+#[grug::derive(Serde, Borsh)]
+pub struct Config {
+    /// The minimum number of guardians that must have voted on the price in
+    /// order for it to be considered valid and votes tallied.
+    pub quorum: u32,
+}
+
+#[grug::derive(Serde, Borsh)]
+pub struct Price {
+    pub price: Udec128,
+    /// The time this price was computed.
+    ///
+    /// Contracts that query the price should check this timestamp to make sure
+    /// it's not too old before using it in business logic.
+    pub timestamp: Timestamp,
+}
+
+#[grug::derive(Serde)]
+pub struct InstantiateMsg {
+    pub config: Config,
+    pub guardians: BTreeSet<Addr>,
+}
+
+#[grug::derive(Serde)]
+pub enum ExecuteMsg {
+    /// Provides price feed for a list of denoms. Called by guardians.
+    FeedPrices(BTreeMap<Denom, Udec128>),
+}
+
+#[grug::derive(Serde, QueryRequest)]
+pub enum QueryMsg {
+    /// Query the oracle configurations.
+    #[returns(Config)]
+    Config {},
+    /// Query the guardian set.
+    #[returns(BTreeSet<Addr>)]
+    Guardians {},
+    /// Query the price of a specific denom.
+    #[returns(Price)]
+    Price { denom: Denom },
+    /// Enumerate the prices of all denoms.
+    #[returns(BTreeMap<Denom, Price>)]
+    Prices {
+        start_after: Option<Denom>,
+        limit: Option<u32>,
+    },
+    /// Query the price feed of a given denom from a specific guardian.
+    #[returns(Udec128)]
+    PriceFeed { denom: Denom, guardian: Addr },
+    /// Enumerate the price feeds of a denom from all guardians.
+    #[returns(BTreeMap<Addr, Udec128>)]
+    PriceFeeds {
+        denom: Denom,
+        start_after: Option<Addr>,
+        limit: Option<u32>,
+    },
+}

--- a/dango/types/src/oracle.rs
+++ b/dango/types/src/oracle.rs
@@ -5,8 +5,8 @@ use {
 
 #[grug::derive(Serde, Borsh)]
 pub struct Config {
-    /// The minimum number of guardians that must have voted on the price in
-    /// order for it to be considered valid and votes tallied.
+    /// The minimum number of price feeds that must have been submitted during
+    /// the epoch in order for the price to be considered valid.
     pub quorum: u32,
 }
 


### PR DESCRIPTION
the way this oracle contract works:

- it is to be defined as a cronjob. let's call the time interval it's execute the **epoch** (say, every 30 seconds)
- during an epoch, a set of **guardians** submit prices
- at the end of each epoch, the oracle contract computes the median price of each denom

a few remaining issues:

- add exponential moving average (EMA)
- how to deal with AMM LP tokens? compute them onchain or have guardians submit the prices as well?
- chain owner should be able to add/remove guardians
- handle the case of possible chain halt - oracle should exclude feeds that are too old