### PR TITLE
feature(grug): typed `GasTracker`

### DIFF
--- a/grug/app/src/context.rs
+++ b/grug/app/src/context.rs
@@ -1,28 +1,42 @@
 use {
-    crate::GasTracker,
+    crate::{GasModeLimitLess, GasModeLimited, GasTracker},
     grug_types::{BlockInfo, Storage, Undefined},
-    std::mem,
 };
 
 /// The context under which app functions are executed.
 ///
 /// Includes the virtual machine used, and key-value storage being operated on,
 /// gas tracker, block, and so on.
-#[derive(Clone)]
-pub struct AppCtx<VM = Undefined, S = Box<dyn Storage>> {
+pub struct AppCtx<VM = Undefined, S = Box<dyn Storage>, G = Undefined> {
     pub vm: VM,
     pub storage: S,
-    pub gas_tracker: GasTracker,
+    pub gas_tracker: GasTracker<G>,
     pub chain_id: String,
     pub block: BlockInfo,
 }
 
-impl<VM, S> AppCtx<VM, S> {
+impl<VM, S, G> Clone for AppCtx<VM, S, G>
+where
+    VM: Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            vm: self.vm.clone(),
+            storage: self.storage.clone(),
+            gas_tracker: self.gas_tracker.clone(),
+            chain_id: self.chain_id.clone(),
+            block: self.block,
+        }
+    }
+}
+
+impl<VM, S, G> AppCtx<VM, S, G> {
     /// Create a new context.
     pub fn new<C>(
         vm: VM,
         storage: S,
-        gas_tracker: GasTracker,
+        gas_tracker: GasTracker<G>,
         chain_id: C,
         block: BlockInfo,
     ) -> Self
@@ -38,16 +52,32 @@ impl<VM, S> AppCtx<VM, S> {
         }
     }
 
-    /// Replace the gas tracker with a new one; return the old one.
-    pub fn replace_gas_tracker(&mut self, gas_tracker: GasTracker) -> GasTracker {
-        mem::replace(&mut self.gas_tracker, gas_tracker)
+    /// Create a new instance of `AppCtx`, returning also the current `gas_tracker`.
+    ///
+    /// Is not possible to take `&mut self`, because `G1` and `G` are different types.
+    pub fn with_gas_tracker<G1>(
+        self,
+        gas_tracker: GasTracker<G1>,
+    ) -> (AppCtx<VM, S, G1>, GasTracker<G>) {
+        let old_gas_tracker = self.gas_tracker;
+
+        (
+            AppCtx {
+                vm: self.vm,
+                storage: self.storage,
+                gas_tracker,
+                chain_id: self.chain_id,
+                block: self.block,
+            },
+            old_gas_tracker,
+        )
     }
 
     /// Cast the context to a variant where the VM is undefined.
     ///
     /// Used for methods that don't require a VM, such as updating chain config
     /// or uploading a code.
-    pub fn downcast(self) -> AppCtx<Undefined, S> {
+    pub fn downcast(self) -> AppCtx<Undefined, S, G> {
         AppCtx {
             vm: Undefined::default(),
             storage: self.storage,
@@ -58,12 +88,12 @@ impl<VM, S> AppCtx<VM, S> {
     }
 }
 
-impl<VM, S> AppCtx<VM, S>
+impl<VM, S, G> AppCtx<VM, S, G>
 where
     VM: Clone,
 {
     /// Clone the context, at the same time replacing the storage with a new one.
-    pub fn clone_with_storage<S1>(&self, storage: S1) -> AppCtx<VM, S1> {
+    pub fn clone_with_storage<S1>(&self, storage: S1) -> AppCtx<VM, S1, G> {
         AppCtx {
             vm: self.vm.clone(),
             storage,
@@ -74,18 +104,42 @@ where
     }
 }
 
-impl<VM, S> AppCtx<VM, S>
+impl<VM, S, G> AppCtx<VM, S, G>
 where
     VM: Clone,
     S: Storage + Clone + 'static,
 {
     /// Clone the context, at the same time put the storage in a `Box`.
-    pub fn clone_boxing_storage(&self) -> AppCtx<VM, Box<dyn Storage>> {
+    pub fn clone_boxing_storage(&self) -> AppCtx<VM, Box<dyn Storage>, G> {
         AppCtx {
             vm: self.vm.clone(),
             storage: Box::new(self.storage.clone()),
             gas_tracker: self.gas_tracker.clone(),
             chain_id: self.chain_id.clone(),
+            block: self.block,
+        }
+    }
+}
+
+impl<VM, S> AppCtx<VM, S, GasModeLimitLess> {
+    pub fn unbound(self) -> AppCtx<VM, S, Undefined> {
+        AppCtx {
+            vm: self.vm,
+            storage: self.storage,
+            gas_tracker: self.gas_tracker.to_undefined(),
+            chain_id: self.chain_id,
+            block: self.block,
+        }
+    }
+}
+
+impl<VM, S> AppCtx<VM, S, GasModeLimited> {
+    pub fn unbound(self) -> AppCtx<VM, S, Undefined> {
+        AppCtx {
+            vm: self.vm,
+            storage: self.storage,
+            gas_tracker: self.gas_tracker.to_undefined(),
+            chain_id: self.chain_id,
             block: self.block,
         }
     }

--- a/grug/app/src/gas/tracker.rs
+++ b/grug/app/src/gas/tracker.rs
@@ -35,17 +35,6 @@ impl<T> Clone for GasTracker<T> {
 }
 
 impl GasTracker {
-    /// Create a new gas tracker, with or without a gas limit.
-    // pub fn new(maybe_limit: Option<u64>) -> GasTracker<GasModeUndefined> {
-    //     GasTracker {
-    //         inner: Shared::new(GasTrackerInner {
-    //             limit: maybe_limit,
-    //             used: 0,
-    //         }),
-    //         phantom: std::marker::PhantomData,
-    //     }
-    // }
-
     /// Create a new gas tracker without a gas limit.
     pub fn new_limitless() -> GasTracker<GasModeLimitLess> {
         GasTracker {

--- a/grug/types/src/builder.rs
+++ b/grug/types/src/builder.rs
@@ -6,7 +6,7 @@
 use std::{fmt::Debug, marker::PhantomData};
 
 /// Represents a builder parameter that has not yet been provided.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Undefined<T = ()>(PhantomData<T>);
 
 impl<T> Default for Undefined<T> {

--- a/grug/vm-rust/src/vm.rs
+++ b/grug/vm-rust/src/vm.rs
@@ -325,7 +325,7 @@ mod tests {
             hash: Hash::ZERO,
         };
 
-        let gas_tracker = GasTracker::new_limitless();
+        let gas_tracker = GasTracker::new_limitless().to_undefined();
 
         let querier_provider = QuerierProvider::new(AppCtx::new(
             vm.clone(),

--- a/grug/vm-wasm/benches/benchmarks.rs
+++ b/grug/vm-wasm/benches/benchmarks.rs
@@ -45,7 +45,7 @@ fn looping(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let storage = Box::new(MockStorage::new());
-                        let gas_tracker = GasTracker::new_limitless();
+                        let gas_tracker = GasTracker::new_limitless().to_undefined();
 
                         let querier = QuerierProvider::new(AppCtx::new(
                             vm.clone(),

--- a/grug/vm-wasm/src/imports.rs
+++ b/grug/vm-wasm/src/imports.rs
@@ -475,7 +475,7 @@ mod tests {
 
     fn setup_test() -> Suite {
         let gas_checkpoint = u64::MAX;
-        let gas_tracker = GasTracker::new_limitless();
+        let gas_tracker = GasTracker::new_limitless().to_undefined();
         // Compile the contract; create Wasmer store and instance.
         let (mut store, instance) = {
             let mut compiler = Singlepass::new();

--- a/grug/vm-wasm/src/vm.rs
+++ b/grug/vm-wasm/src/vm.rs
@@ -98,7 +98,7 @@ impl Vm for WasmVm {
         // would be the `authenticate` call) will have the limit as X. Suppose
         // this call consumed Y gas points, the next call will have its limit as
         // (X-Y); so on.
-        let gas_remaining = gas_tracker.remaining().unwrap_or(u64::MAX);
+        let gas_remaining = gas_tracker.maybe_remaining().unwrap_or(u64::MAX);
 
         // Create the Wasmer store, function environment, and register import
         // functions.


### PR DESCRIPTION
`GasTracker` now includes a generic parameter, allowing it to be defined as either `Limited`, `Limitless`, or `Undefined` in specific functions.