### PR TITLE
feat(dango): signdoc with sender

### DIFF
--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -162,6 +162,7 @@ pub fn authenticate_tx(
 
                     let sign_bytes = ctx.api.sha2_256(
                         &SignDoc {
+                            sender: tx.sender,
                             messages: tx.msgs,
                             chain_id: ctx.chain_id,
                             sequence: metadata.sequence,
@@ -197,6 +198,7 @@ pub fn authenticate_tx(
             (Key::Secp256k1(pk), Credential::Secp256k1(sig)) => {
                 let sign_bytes = ctx.api.sha2_256(
                     &SignDoc {
+                        sender: tx.sender,
                         messages: tx.msgs,
                         chain_id: ctx.chain_id,
                         sequence: metadata.sequence,

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -233,29 +233,29 @@ mod tests {
 
     #[test]
     fn passkey_authentication() {
-        let user_address = Addr::from_str("0x93841114860ba74d0a9fa88962268aff17365fc9").unwrap();
-        let user_username = Username::from_str("test4").unwrap();
-        let user_keyhash = Hash160::from_str("4466B77A86FB18EBA97080D56398B61470148059").unwrap();
+        let user_address = Addr::from_str("0x0e6d8a14f8e200f060ef35514c8184d54042e811").unwrap();
+        let user_username = Username::from_str("test200").unwrap();
+        let user_keyhash = Hash160::from_str("8BFF03014982A50218CE139F1FAC0B1897DEDEF9").unwrap();
         let user_key = Key::Secp256r1(
             [
-                3, 32, 23, 59, 89, 52, 51, 126, 80, 201, 159, 243, 253, 222, 209, 56, 72, 217, 193,
-                1, 195, 12, 83, 16, 188, 138, 208, 246, 53, 238, 156, 133, 163,
+                3, 190, 24, 244, 141, 90, 188, 110, 30, 146, 69, 153, 207, 241, 45, 19, 100, 19,
+                164, 93, 119, 95, 139, 59, 198, 252, 5, 5, 129, 204, 10, 136, 15,
             ]
             .into(),
         );
 
         let tx = r#"{
-          "sender": "0x93841114860ba74d0a9fa88962268aff17365fc9",
+          "sender": "0x0e6d8a14f8e200f060ef35514c8184d54042e811",
           "credential": {
             "passkey": {
-              "sig": "BqtWfd8nTuTIiVipr/OcbeiBjsWmAp8e3VitWD+AekOmAPs/4dJkgjt7p+dB3ZJpqg6LHP+RX9bvALfgMoYh2Q==",
-              "client_data": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQmN3X1JrUDdDc3EtZWVFemw0ZWxFSWxTZXN0b055VVA1b21tUFJkU3VJQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTA4MCIsImNyb3NzT3JpZ2luIjpmYWxzZX0=",
+              "sig": "Ni2ljMLszTN+iL9lXPzPMo7klwVFUsK3SBCFnsYNdDOkN03/T2Es/7zTZ4CyJGQGcIeAzM4/fO+XbIASu92Q4w==",
+              "client_data": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoidXYya01mUllmUDJ2cXFGSGxBT0xsVlotTTItYWQtM3kyaVlNVVY1MGJqWSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTA4MCIsImNyb3NzT3JpZ2luIjpmYWxzZX0=",
               "authenticator_data": "SZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2MZAAAAAA=="
             }
           },
           "data": {
-            "key_hash": "4466B77A86FB18EBA97080D56398B61470148059",
-            "username": "test4",
+            "key_hash": "8BFF03014982A50218CE139F1FAC0B1897DEDEF9",
+            "username": "test200",
             "sequence": 0
           },
           "msgs": [
@@ -263,12 +263,12 @@ mod tests {
               "transfer": {
                 "to": "0x123559ca94d734111f32cc7d603c3341c4d29a84",
                 "coins": {
-                  "uusdc": "5"
+                  "uusdc": "1000000"
                 }
               }
             }
           ],
-          "gas_limit": 1116375
+          "gas_limit": 1116937
         }"#;
 
         let querier = MockQuerier::new()
@@ -363,11 +363,11 @@ mod tests {
     fn secp256k1_authentication() {
         let user_address = Addr::from_str("0x93841114860ba74d0a9fa88962268aff17365fc9").unwrap();
         let user_username = Username::from_str("owner").unwrap();
-        let user_keyhash = Hash160::from_str("CB8E23B4BE5F8386E68AEDC900C9BFDA26519FDB").unwrap();
+        let user_keyhash = Hash160::from_str("46DDF382989C9B321428A688032BC9F2A34F6BCD").unwrap();
         let user_key = Key::Secp256k1(
             [
-                2, 111, 13, 75, 148, 145, 161, 77, 233, 136, 36, 236, 240, 231, 244, 217, 82, 186,
-                93, 163, 132, 66, 35, 3, 19, 17, 197, 180, 52, 200, 219, 178, 97,
+                3, 124, 218, 165, 96, 43, 172, 215, 28, 79, 219, 96, 16, 200, 82, 173, 128, 6, 111,
+                33, 56, 47, 216, 47, 135, 163, 94, 250, 183, 130, 253, 241, 70,
             ]
             .into(),
         );
@@ -375,10 +375,10 @@ mod tests {
         let tx = r#"{
           "sender": "0x93841114860ba74d0a9fa88962268aff17365fc9",
           "credential": {
-            "secp256k1": "GkkfQb81pEZJISbqAhJOZuZ5wgRyN0Q4HABD9HDAkxB516nV5d0UjRciNhh3RIg2Hh8nmS3jHFVl3NO34PVLNA=="
+            "secp256k1": "W+kfvnD23DMencrjT3/OLVfNkwYQTNcVsP2WHzIGj4ZizYAIpMslIiqE25vSDG3E634w4V+ppHIutqLZMY6sLg=="
           },
           "data": {
-            "key_hash": "CB8E23B4BE5F8386E68AEDC900C9BFDA26519FDB",
+            "key_hash": "46DDF382989C9B321428A688032BC9F2A34F6BCD",
             "username": "owner",
             "sequence": 0
           },

--- a/dango/testing/benches/benchmarks.rs
+++ b/dango/testing/benches/benchmarks.rs
@@ -87,7 +87,12 @@ fn sends(c: &mut Criterion) {
 
                         let (data, credential) = accounts
                             .owner
-                            .sign_transaction_with_sequence(vec![msg.clone()], &suite.chain_id, 0)
+                            .sign_transaction_with_sequence(
+                                sender,
+                                vec![msg.clone()],
+                                &suite.chain_id,
+                                0,
+                            )
                             .unwrap();
 
                         Tx {

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -106,11 +106,13 @@ where
 {
     pub fn sign_transaction_with_sequence(
         &self,
+        sender: Addr,
         msgs: Vec<Message>,
         chain_id: &str,
         sequence: u32,
     ) -> StdResult<(Metadata, Credential)> {
         let sign_bytes = SignDoc {
+            sender,
             messages: msgs.clone(),
             chain_id: chain_id.to_string(),
             sequence,
@@ -146,8 +148,12 @@ impl Signer for TestAccount<Defined<Addr>> {
         chain_id: &str,
         gas_limit: u64,
     ) -> StdResult<Tx> {
-        let (data, credential) =
-            self.sign_transaction_with_sequence(msgs.clone(), chain_id, self.sequence)?;
+        let (data, credential) = self.sign_transaction_with_sequence(
+            self.address(),
+            msgs.clone(),
+            chain_id,
+            self.sequence,
+        )?;
 
         // Increment the internally tracked sequence.
         self.sequence += 1;
@@ -243,7 +249,12 @@ impl<'a> Signer for Safe<'a> {
         let (data, credential) = self
             .signer
             .expect("[Safe]: signer not set")
-            .sign_transaction_with_sequence(msgs.clone(), chain_id, self.sequence)?;
+            .sign_transaction_with_sequence(
+                self.address(),
+                msgs.clone(),
+                chain_id,
+                self.sequence,
+            )?;
 
         // Increment the internally tracked sequence.
         self.sequence += 1;

--- a/dango/types/src/auth.rs
+++ b/dango/types/src/auth.rs
@@ -1,6 +1,6 @@
 use {
     crate::account_factory::Username,
-    grug::{Binary, ByteArray, Hash160, Message},
+    grug::{Addr, Binary, ByteArray, Hash160, Message},
 };
 
 /// A public key that can be associated with a [`Username`](crate::auth::Username).
@@ -28,9 +28,10 @@ pub enum Credential {
 /// Data that a transaction's sender must sign with their private key.
 ///
 /// This includes the messages to be included in the transaction, as well as
-/// chain ID and account sequence number for replay protection.
+/// chain ID, sender and account sequence number for replay protection.
 #[grug::derive(Serde)]
 pub struct SignDoc {
+    pub sender: Addr,
     pub messages: Vec<Message>,
     pub chain_id: String,
     pub sequence: u32,

--- a/sdk/packages/connect-kit/src/connectors/passkey.ts
+++ b/sdk/packages/connect-kit/src/connectors/passkey.ts
@@ -93,8 +93,8 @@ export function passkey(parameters: PasskeyConnectorParameters = {}) {
         return _isAuthorized;
       },
       async requestSignature(signDoc) {
-        const { messages, chainId, sequence } = signDoc;
-        const bytes = sha256(serialize({ messages, chainId, sequence }));
+        const { sender, messages, chainId, sequence } = signDoc;
+        const bytes = sha256(serialize({ sender, messages, chainId, sequence }));
 
         const {
           webauthn,

--- a/sdk/packages/core/src/signers/privateKey.ts
+++ b/sdk/packages/core/src/signers/privateKey.ts
@@ -63,8 +63,8 @@ export class PrivateKeySigner implements Signer {
   }
 
   async signTx(signDoc: SignDoc) {
-    const { messages, chainId, sequence } = signDoc;
-    const tx = sha256(serialize({ messages, chainId, sequence }));
+    const { messages, chainId, sequence, sender } = signDoc;
+    const tx = sha256(serialize({ sender, messages, chainId, sequence }));
 
     const signature = await this.signBytes(tx);
 


### PR DESCRIPTION
We've added the sender to `SignDoc` struct to enhance user protection against replay attacks. Previously, since the same key could be used across different accounts, there was a risk of the same transaction being submitted in a particular sequence on another account. By including the sender, we ensure the transaction cannot be reused in a different account, even with the same key.