### PR TITLE
feat(sdk): update ts reference real time

### DIFF
--- a/sdk/packages/config/ts/common.json
+++ b/sdk/packages/config/ts/common.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "composite": true,
     "allowJs": true,
     "declaration": true,
     "declarationMap": true,

--- a/sdk/packages/config/tsup/common.json
+++ b/sdk/packages/config/tsup/common.json
@@ -1,5 +1,9 @@
 {
-  "dts": true,
+  "dts": {
+    "compilerOptions": {
+      "composite": false
+    }
+  },
   "bundle": true,
   "outDir": "build",
   "platform": "neutral",

--- a/sdk/packages/connect-kit/tsconfig.json
+++ b/sdk/packages/connect-kit/tsconfig.json
@@ -6,5 +6,22 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "build"]
+  "exclude": ["node_modules", "build"],
+  "references": [
+    {
+      "path": "../utils"
+    },
+    {
+      "path": "../types"
+    },
+    {
+      "path": "../crypto"
+    },
+    {
+      "path": "../encoding"
+    },
+    {
+      "path": "../core"
+    }
+  ]
 }

--- a/sdk/packages/core/tsconfig.json
+++ b/sdk/packages/core/tsconfig.json
@@ -6,5 +6,19 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "build"]
+  "exclude": ["node_modules", "build"],
+  "references": [
+    {
+      "path": "../types"
+    },
+    {
+      "path": "../utils"
+    },
+    {
+      "path": "../crypto"
+    },
+    {
+      "path": "../encoding"
+    }
+  ]
 }

--- a/sdk/packages/crypto/tsconfig.json
+++ b/sdk/packages/crypto/tsconfig.json
@@ -6,5 +6,13 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "build"]
+  "exclude": ["node_modules", "build"],
+  "references": [
+    {
+      "path": "../types"
+    },
+    {
+      "path": "../encoding"
+    }
+  ]
 }

--- a/sdk/packages/encoding/tsconfig.json
+++ b/sdk/packages/encoding/tsconfig.json
@@ -6,5 +6,13 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "build"]
+  "exclude": ["node_modules", "build"],
+  "references": [
+    {
+      "path": "../types"
+    },
+    {
+      "path": "../utils"
+    }
+  ]
 }

--- a/sdk/packages/react/tsconfig.json
+++ b/sdk/packages/react/tsconfig.json
@@ -6,5 +6,22 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../utils"
+    },
+    {
+      "path": "../types"
+    },
+    {
+      "path": "../crypto"
+    },
+    {
+      "path": "../encoding"
+    },
+    {
+      "path": "../connect-kit"
+    }
+  ]
 }

--- a/sdk/packages/utils/tsconfig.json
+++ b/sdk/packages/utils/tsconfig.json
@@ -6,5 +6,10 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "build"]
+  "exclude": ["node_modules", "build"],
+  "references": [
+    {
+      "path": "../types"
+    }
+  ]
 }

--- a/ui/portal/tsconfig.json
+++ b/ui/portal/tsconfig.json
@@ -6,5 +6,28 @@
     }
   },
   "include": ["**/*.ts", "**/*.tsx", "env.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../shared"
+    },
+    {
+      "path": "../../sdk/packages/types"
+    },
+    {
+      "path": "../../sdk/packages/connect-kit"
+    },
+    {
+      "path": "../../sdk/packages/crypto"
+    },
+    {
+      "path": "../../sdk/packages/utils"
+    },
+    {
+      "path": "../../sdk/packages/core"
+    },
+    {
+      "path": "../../sdk/packages/react"
+    }
+  ]
 }

--- a/ui/shared/tsconfig.json
+++ b/ui/shared/tsconfig.json
@@ -6,5 +6,19 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../../sdk/packages/types"
+    },
+    {
+      "path": "../../sdk/packages/core"
+    },
+    {
+      "path": "../../sdk/packages/utils"
+    },
+    {
+      "path": "../../sdk/packages/react"
+    }
+  ]
 }

--- a/ui/workers/mock-ibc/tsconfig.json
+++ b/ui/workers/mock-ibc/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "@leftcurve/config/ts/common.json",
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "references": [
+    {
+      "path": "../../../sdk/packages/types"
+    },
+    {
+      "path": "../../../sdk/packages/core"
+    }
+  ]
 }


### PR DESCRIPTION
We're adding the composite and reference options into the tsconfig. When developing this makes possible to refresh the types right at the moment. Before it was necessary to restart VS Code ts-server in order to get the latest version.

We disable composite option in tsup, it uses rollup-plugin-dts to output .d.ts files and doesn't support composite.