### PR TITLE
spec: run formatter and address linter issues in JMT spec

### DIFF
--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -74,7 +74,7 @@ jobs:
           node-version: "18"
       - run: npm install -g @informalsystems/quint
       - run: quint test --max-samples=$MAX_SAMPLES quint/test/test_all.qnt
-  
+
   quint-simulations-fancy:
     name: Simulate fancy
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
           node-version: "18"
       - run: npm install -g @informalsystems/quint
       - run: quint run --max-samples=$MAX_SAMPLES --max-steps=$MAX_STEPS --invariant=allInvariants --step=step_fancy apply_state_machine.qnt
-    
+
   quint-simulations-simple:
     name: Simulate simple
     runs-on: ubuntu-latest
@@ -125,7 +125,7 @@ jobs:
           node-version: "18"
       - run: npm install -g @informalsystems/quint
       - run: quint run --max-samples=$MAX_SAMPLES --max-steps=$MAX_STEPS --invariant=allInvariants --step=step_simple pruning_state_machine.qnt
-  
+
   quint-simulations-prune-fancy:
     name: Simulate fancy pruning
     runs-on: ubuntu-latest

--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -1,4 +1,4 @@
-name: Quint checks
+name: Quint
 
 on:
   push:

--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -17,33 +17,33 @@ jobs:
       run:
         working-directory: ./grug/jellyfish-merkle/spec
     steps:
-    # Step 1: Checkout the repository
-    - name: Checkout code
-      uses: actions/checkout@v3
+      # Step 1: Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    # Step 2: Install Go
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.20' # Replace with the required Go version
+      # Step 2: Install Go
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20' # Replace with the required Go version
 
-    # Step 3: Clone and build `lmt`
-    - name: Build LMT
-      run: |
-        go install github.com/driusan/lmt@latest
-        export PATH=$PATH:$(go env GOPATH)/bin
+      # Step 3: Clone and build `lmt`
+      - name: Build LMT
+        run: |
+          go install github.com/driusan/lmt@latest
+          export PATH=$PATH:$(go env GOPATH)/bin
 
-    # Step 4: Run `lmt` and fail if differences are detected
-    - name: Run LMT
-      run: |
-        lmt docs/proofs.md
-        lmt docs/invariants.md
-        lmt docs/tree_manipulation.md
-        lmt docs/grug_ics23.md
-        lmt docs/proof_types.md
-        # Check that it is up to date
-        git diff --exit-code \
-          || ( echo ">>> ERROR: Tangled files are out of sync." &&  exit 1)
+      # Step 4: Run `lmt` and fail if differences are detected
+      - name: Run LMT
+        run: |
+          lmt docs/proofs.md
+          lmt docs/invariants.md
+          lmt docs/tree_manipulation.md
+          lmt docs/grug_ics23.md
+          lmt docs/proof_types.md
+          # Check that it is up to date
+          git diff --exit-code \
+            || ( echo ">>> ERROR: Tangled files are out of sync." &&  exit 1)
 
   quint-typecheck:
     name: Typecheck

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,14 @@
 {
+  "emphasis-style": {
+    "style": "underscore"
+  },
+  "strong-style": {
+    "style": "asterisk"
+  },
   "first-line-heading": false,
   "heading-increment": false,
   "line-length": false,
   "no-alt-text": false,
+  "no-bare-urls": false,
   "no-inline-html": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-  "rust-analyzer.check.command": "clippy",
-  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
   "[json]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
@@ -42,5 +40,8 @@
     "timelock",
     "timelocked",
     "uusdc"
-  ]
+  ],
+  "markdown.extension.toc.updateOnSave": false,
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"]
 }

--- a/grug/jellyfish-merkle/spec/README.md
+++ b/grug/jellyfish-merkle/spec/README.md
@@ -1,6 +1,6 @@
 # Grug JellyFish Merkle Tree Quint specification
 
-*This document and specs were prepared by the [Informal Systems security team](https://informal.systems/security)*
+_This document and specs were prepared by the [Informal Systems security team](https://informal.systems/security)_
 
 This is a Quint model of a Grug Jellyfish Merkle Tree implemented in Rust. The primary objective of this specification is to formalize the design of the Grug Jellyfish Merkle Tree. The design is described using Quint along with the correctness conditions in the form of invariants and tests.
 

--- a/grug/jellyfish-merkle/spec/docs/grug_ics23.md
+++ b/grug/jellyfish-merkle/spec/docs/grug_ics23.md
@@ -91,7 +91,7 @@ pub struct InnerSpec {
 
 ```bluespec "definitions" +=
 type InnerSpec = {
-  min_prefix_length: int, 
+  min_prefix_length: int,
   max_prefix_length: int,
   child_size: int,
   empty_child: Term,
@@ -339,7 +339,7 @@ pub fn apply_leaf<H: HostFunctionsProvider>(
 ```
 
 ```bluespec "definitions" +=
-  val leafHash = hashLeafNode({ key_hash: p.key, value_hash: p.value})    
+  val leafHash = hashLeafNode({ key_hash: p.key, value_hash: p.value})
 ```
 
 After getting the hash of the leaf, it concatanates hashes of other nodes that are in `path`. This part emulates the [`apply_inner`](https://github.com/cosmos/ics23/blob/a31bd4d9ca77beca7218299727db5ad59e65f5b8/rust/src/ops.rs#L8-L14) Rust function.
@@ -481,7 +481,7 @@ Here is the snippet from the Rust implementation.
   proof.left != None implies {
     pure val left = proof.left.unwrap()
     and {
-      verify_existence(left, root, left.key, left.value), 
+      verify_existence(left, root, left.key, left.value),
       key.greater_than(left.key),
     }
   },
@@ -519,7 +519,7 @@ Since Quint's matching is not as powerful as Rust's, we had to find a work-aroun
         (Some(left), Some(right)) => ensure_left_neighbor(inner, &left.path, &right.path),
         ...
     }
-  } 
+  }
 ```
 
 ```bluespec "definitions" +=
@@ -634,7 +634,7 @@ pure def get_padding(spec: InnerSpec, branch: int): Option[Padding] = {
 Based on the `branch` value, which will be either `0` or `1`.
 
 - In the case when `branch = 0`, padding will look like this:
-  
+
   ```bluespec
   {
     min_prefix: spec.min_prefix_length,   // 1
@@ -644,7 +644,7 @@ Based on the `branch` value, which will be either `0` or `1`.
   ```
 
 - In the case when `branch = 1`, padding will look like this:
-  
+
   ```bluespec
   {
     min_prefix: spec.min_prefix_length + spec.child_size,   // 1 + 32 = 33
@@ -1101,7 +1101,7 @@ fn ensure_left_neighbor(
 }
 ```
 
-This uses mutable values and a `while` statement to search for the part of the left and right paths that don't share a prefix and a suffix, while their successors still do. In other words, we need to find the smallest indexes `li` and `ri` where the paths at the respective indexes don't match while they do match for `li + k` and `ri + k` for all positive `k`s in range. The Quint definition uses `exists` to search for this indexes in a less performant but more declarative way: 
+This uses mutable values and a `while` statement to search for the part of the left and right paths that don't share a prefix and a suffix, while their successors still do. In other words, we need to find the smallest indexes `li` and `ri` where the paths at the respective indexes don't match while they do match for `li + k` and `ri + k` for all positive `k`s in range. The Quint definition uses `exists` to search for this indexes in a less performant but more declarative way:
 
 ```bluespec "definitions" +=
 pure def is_left_neighbor(spec: InnerSpec, left: List[InnerOp], right: List[InnerOp]): bool = {
@@ -1139,7 +1139,7 @@ This part emulates the first part of `ensure_left_neighbor` Rust function:
       top_right = mut_right.pop().unwrap();
   }
 ```
-<!--- 
+<!---
 ```bluespec "definitions" +=
       // Now topleft and topright are the first divergent nodes
       // make sure they are left and right of each other.
@@ -1167,7 +1167,7 @@ Since we have wrapped all checks in one _big_ `and`, we can just call `is_left_s
 is_left_step(spec, left[li], right[ri]),
 ```
 
-<!--- 
+<!---
 ```bluespec "extensionLeftNeighbor" +=
 // left and right are remaining children below the split,
 // ensure left child is the rightmost path, and visa versa
@@ -1184,7 +1184,7 @@ ensure_left_most(spec, &mut_right)?;
 is_right_most(spec, left.slice(0, li)),
 is_left_most(spec, right.slice(0, ri)),
 ```
-<!--- 
+<!---
 ```bluespec "definitions" +=
     })
   )

--- a/grug/jellyfish-merkle/spec/docs/grug_ics23.md
+++ b/grug/jellyfish-merkle/spec/docs/grug_ics23.md
@@ -1,6 +1,6 @@
 # Grug ICS23 proof verification
 
-*This document was prepared by the [Informal Systems security team](https://informal.systems/security)*
+_This document was prepared by the [Informal Systems security team](https://informal.systems/security)_
 
 This document describes how ICS23 proof verification was modelled in Quint, and how everything corresponds to the Rust implementation. In this version of the Quint model, we tried to make things as close to the Rust implementation as possible.
 
@@ -13,18 +13,22 @@ This document covers main verification functions:
 
 And other helper functions that are used:
 
-- [`verify_existence`](#verifying-existence)
-- [`exists_calculate`](#calculating-root-hash-from-existence-proof)
-- [`verify_non_existence`](#verifying-nonexistence)
-- [`get_padding`](#get-padding)
-- [`is_left_most`](#is-left-most)
-- [`is_right_most`](#is-right-most)
-- [`has_padding`](#has-padding)
-- [`order_from_padding`](#order-from-padding)
-- [`left_branches_are_empty`](#left-branches-empty)
-- [`right_branches_are_empty`](#right-branches-empty)
-- [`is_left_step`](#is-left-step)
-- [`is_left_neighbor`](#is-left-neighbor)
+- [Grug ICS23 proof verification](#grug-ics23-proof-verification)
+  - [Types](#types)
+  - [Verifying Membership Proof](#verifying-membership-proof)
+  - [Verifying existence](#verifying-existence)
+  - [Calculating root hash from existence proof](#calculating-root-hash-from-existence-proof)
+  - [Verifying NonMembership proof](#verifying-nonmembership-proof)
+  - [Verifying NonExistence](#verifying-nonexistence)
+  - [Get Padding](#get-padding)
+  - [Is Left Most](#is-left-most)
+  - [Is Right Most](#is-right-most)
+  - [Has Padding](#has-padding)
+  - [Order from padding](#order-from-padding)
+  - [Left Branches Empty](#left-branches-empty)
+  - [Right Branches Empty](#right-branches-empty)
+  - [Is Left Step](#is-left-step)
+  - [Is Left Neighbor](#is-left-neighbor)
 
 > [!TIP]
 > This markdown file contains some metadata and comments that enable it to be tangled to a full Quint file (using [lmt](https://github.com/driusan/lmt)). The Quint file can be found at [grug_ics23.qnt](../quint/grug_ics23.qnt).

--- a/grug/jellyfish-merkle/spec/docs/grug_ics23.md
+++ b/grug/jellyfish-merkle/spec/docs/grug_ics23.md
@@ -13,22 +13,18 @@ This document covers main verification functions:
 
 And other helper functions that are used:
 
-- [Grug ICS23 proof verification](#grug-ics23-proof-verification)
-  - [Types](#types)
-  - [Verifying Membership Proof](#verifying-membership-proof)
-  - [Verifying existence](#verifying-existence)
-  - [Calculating root hash from existence proof](#calculating-root-hash-from-existence-proof)
-  - [Verifying NonMembership proof](#verifying-nonmembership-proof)
-  - [Verifying NonExistence](#verifying-nonexistence)
-  - [Get Padding](#get-padding)
-  - [Is Left Most](#is-left-most)
-  - [Is Right Most](#is-right-most)
-  - [Has Padding](#has-padding)
-  - [Order from padding](#order-from-padding)
-  - [Left Branches Empty](#left-branches-empty)
-  - [Right Branches Empty](#right-branches-empty)
-  - [Is Left Step](#is-left-step)
-  - [Is Left Neighbor](#is-left-neighbor)
+- [`verify_existence`](#verifying-existence)
+- [`exists_calculate`](#calculating-root-hash-from-existence-proof)
+- [`verify_non_existence`](#verifying-nonexistence)
+- [`get_padding`](#get-padding)
+- [`is_left_most`](#is-left-most)
+- [`is_right_most`](#is-right-most)
+- [`has_padding`](#has-padding)
+- [`order_from_padding`](#order-from-padding)
+- [`left_branches_are_empty`](#left-branches-empty)
+- [`right_branches_are_empty`](#right-branches-empty)
+- [`is_left_step`](#is-left-step)
+- [`is_left_neighbor`](#is-left-neighbor)
 
 > [!TIP]
 > This markdown file contains some metadata and comments that enable it to be tangled to a full Quint file (using [lmt](https://github.com/driusan/lmt)). The Quint file can be found at [grug_ics23.qnt](../quint/grug_ics23.qnt).

--- a/grug/jellyfish-merkle/spec/docs/invariants.md
+++ b/grug/jellyfish-merkle/spec/docs/invariants.md
@@ -1,6 +1,6 @@
 # Invariants
 
-*This document was prepared by the [Informal Systems security team](https://informal.systems/security)*
+_This document was prepared by the [Informal Systems security team](https://informal.systems/security)_
 
 This part of the document describes invariants of Grug's JellyFish Merkle Tree manipulation. The snippets in here get tangled into a Quint file for verification.
 
@@ -180,7 +180,7 @@ This inserts a line break that is not rendered in the markdown
 
 In a tree, all nodes except from the root should have a parent. There should be no dangling nodes. If we find a node with key 1001, there should be a node for 100. At some other iteration, we'll also check that 100 has a parent (that is, 10), and so on.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// Make sure the tree encoded in the map forms a tree (everyone has a parent, except for the root)
@@ -208,7 +208,7 @@ This inserts a line break that is not rendered in the markdown
 
 For any pair of leafs on the tree, there should be another node such that its key hash is the common prefix of the key hashes of both leafs.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// Invariant that checks that for any two leaf nodes, there is a nodeId in the
@@ -240,7 +240,7 @@ This inserts a line break that is not rendered in the markdown
 
 Leafs should never be in the middle of a tree. If a there is a node with a key hash that is a prefix of the key hash of a leaf, then this is not a proper tree.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// Make sure that the map encodes a tree. In particular, there is no internal node
@@ -270,7 +270,7 @@ This inserts a line break that is not rendered in the markdown
 
 Internal nodes can have 1 or 2 children, but never 0. Otherwise, they would be a leaf with no value.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// All nodes of type Internal have a child which is not None
@@ -304,7 +304,7 @@ This checks that collapsing works properly: there should never be an internal no
 
 This also means that the three is dense, not sparse.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// If a node has exactly one child, the child is an internal node
@@ -342,7 +342,7 @@ This inserts a line break that is not rendered in the markdown
 
 When nodes are updated (inserted, deleted) they are given a new version, and so are all the predecessors in the tree. At the same time, subtrees that are not touched by an update maintain their version. As a result, if the tree is properly maintained, the parent of a node, should have a version that is greater than or equal to the version of the node.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// Invariant: For every node has predecessors with higer (or equal) version
@@ -373,7 +373,7 @@ Given the explanation around `versionInv` from above, we had the (wrong) intuiti
 - in the case of applying an empty batch, where we get a new root node at the new version, but the root node's subtrees are unchanged.
 However, for reference, we keep the formula here as it might be useful for understanding in the future.
 
-*Status:* FALSE
+_Status:_ FALSE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// Every internal node must have at least one child with the same version
@@ -412,7 +412,7 @@ This inserts a line break that is not rendered in the markdown
 
 Orphans are used for state pruning. The implicit intuition is that orphaned nodes can be pruned as they are not needed for any tree operation (including proof construction or verification) for versions after they became orphans. This invariant makes it explicit why it is safe to prune orphans: No orphan is part of a tree at a version after it became orphaned.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// Orphan should not be at one of the version trees after it gets orphaned
@@ -434,7 +434,7 @@ This inserts a line break that is not rendered in the markdown
 
 For all internal nodes, for each existing child, the hash should match the result of hashing the subtree under that child's key hash.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// Check that for all internal nodes, if they have a hash stored for a child,
@@ -473,7 +473,7 @@ This inserts a line break that is not rendered in the markdown
 
 We use an implementation of hashes that ensure no collision, since no collision of hashes is an assumption we can make. This invariant is a sanity check that the hashes that get saved in the child nodes are unique.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// All children in the tree should have different hashes
@@ -515,7 +515,7 @@ This inserts a line break that is not rendered in the markdown
 
 While the overall tree receives an entry for the same `key_hash` whenever the corresponding value changes in a new version; in the versioned tree, each node should contain at most one entry for each `key_hash`.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// The treemaps we use in the invariants should have unique key_hashes
@@ -540,7 +540,7 @@ This inserts a line break that is not rendered in the markdown
 Just as `key_hashes` in the invariant above, all nodes saved in the values of a tree map should be unique. This also mean that the mapping between node ids and nodes is bijective.
 We can simply check that the sizes of keys and values is the same, since keys are already guaranteed to be unique by Quint's `Map` data structure.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   /// TreeMap is a bijection: we can map keys to values but also values to keys
@@ -564,7 +564,7 @@ This inserts a line break that is not rendered in the markdown
 
 TODO: describe
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   val operationSuccessInv: bool =
@@ -602,17 +602,17 @@ These are invariants for completeness and soundness of both membership and non-m
 
 Completeness:
 
-  - Membership: If a node exists, we should be able to get an existence proof for it and verify that proof against the tree root
-  - Non-Membership: If a node does not exist, we should be able to get a non-existence proof for it and verify that proof against the tree root
+- Membership: If a node exists, we should be able to get an existence proof for it and verify that proof against the tree root
+- Non-Membership: If a node does not exist, we should be able to get a non-existence proof for it and verify that proof against the tree root
 
 Soundness:
 
-  - Membership: If we can get an existence proof for a key_hash, there should be a leaf in the tree with that key hash.
-  - Non-Membership: If we can get a non-existence proof for a key_hash, there should not be a leaf in the tree with that key hash.
+- Membership: If we can get an existence proof for a key_hash, there should be a leaf in the tree with that key hash.
+- Non-Membership: If we can get a non-existence proof for a key_hash, there should not be a leaf in the tree with that key hash.
 
 See [completeness.qnt](../quint/completeness.qnt) and [soundness.qnt](../quint/soundness.qnt) for the formal definitions.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   val membershipCompletenessInv = versionsToCheck.forall(v => membershipCompleteness(tree, v))
@@ -640,7 +640,7 @@ we consider all possible values for `value_hash`. If there is a leaf in the tree
   - It should be verified for the `key_hash` it was proved with
   - It should not be verified with any of the `key_hash`es in the tree.
 
-*Status:* TRUE
+_Status:_ TRUE
 
 ```bluespec quint/apply_state_machine.qnt +=
   val verifyMembershipInv = {
@@ -730,11 +730,11 @@ This inserts a line break that is not rendered in the markdown
 ```
 -->
 
-# Tests
+## Tests
 
 This part of the document describes relevant tests for tree manipulation and ICS23 proofs of Grug's JellyFish Merkle Tree manipulation. The snippets in here get tangled into a Quint files for verification.
 
-## Testing functional equivalence
+### Testing functional equivalence
 
 We defined two runs that are verifying the functional equivalence of [`apply_fancy`](../quint/apply_fancy.qnt) and [`apply_simple`](../quint/apply_simple.qnt) algorithms:
 
@@ -840,7 +840,7 @@ Then we update the state using operator `all`, which means that everyhing wrappe
 }))
 ```
 
-## Testing proofs
+### Testing proofs
 
 We defined several interesting scenarios in order to test proofs.
 <!---

--- a/grug/jellyfish-merkle/spec/docs/invariants.md
+++ b/grug/jellyfish-merkle/spec/docs/invariants.md
@@ -741,7 +741,7 @@ We defined two runs that are verifying the functional equivalence of [`apply_fan
 - [`simpleVsFancyTest`](#simple-vs-fancy-test)
 - [`simpleVsFancyMultipleRepsTest`](#simple-vs-fancy-multiple-reps-test)
 
-<!--- 
+<!---
 ```bluespec quint/test/tree_test.qnt +=
 // -*- mode: Bluespec; -*-
 
@@ -776,7 +776,7 @@ Then we create a batch of randomly picked operations to apply on both trees.
   nondet kms_with_value = all_key_hashes.setOfMaps(VALUES).oneOf()
   pure val ops = kms_with_value.to_operations()
 ```
-<!--- 
+<!---
 ```bluespec "tests" +=
 
 ```
@@ -793,7 +793,7 @@ Then, we assert their equivalence.
 ```bluespec "tests" +=
   assert(reference == result)
 ```
-<!--- 
+<!---
 ```bluespec "tests" +=
 
 ```
@@ -814,7 +814,7 @@ After that, we repeat the following set of operations three times. First we pick
   nondet kms_with_value = all_key_hashes.setOfMaps(VALUES).oneOf()
   pure val ops = kms_with_value.to_operations()
 ```
-<!--- 
+<!---
 ```bluespec "tests" +=
 
 ```
@@ -843,7 +843,7 @@ Then we update the state using operator `all`, which means that everyhing wrappe
 ## Testing proofs
 
 We defined several interesting scenarios in order to test proofs.
-<!--- 
+<!---
 ```bluespec quint/test/proofs_test.qnt +=
 // -*- mode: Bluespec; -*-
 
@@ -1067,7 +1067,7 @@ pure def assert_proof_on_different_trees(t1: Tree, t2: Tree, leaf: LeafNode, ver
   }
 }
 ```
-<!--- 
+<!---
 ```bluespec "proofs_helpers" +=
 
 ```
@@ -1102,7 +1102,7 @@ pure def assert_proof_on_equivalent_trees(t1: Tree, t2: Tree, leaf: LeafNode, ve
   }
 }
 ```
-<!--- 
+<!---
 ```bluespec "proofs_helpers" +=
 
 ```
@@ -1118,7 +1118,7 @@ run generate_one_tree = ({
   T1::step
 }))
 ```
-<!--- 
+<!---
 ```bluespec "proofs_helpers" +=
 
 ```
@@ -1134,7 +1134,7 @@ run generate_two_trees = (all {
   T2::step,
 }))
 ```
-<!--- 
+<!---
 ```bluespec "proofs_helpers" +=
 
 // Some values to make tests easier to read
@@ -1147,7 +1147,7 @@ val tree1 = T1::tree
 val tree2 = T2::tree
 val max_version = T1::version - 1
 ```
-<!--- 
+<!---
 ```bluespec "proofs_helpers" +=
 
 ```

--- a/grug/jellyfish-merkle/spec/docs/proof_types.md
+++ b/grug/jellyfish-merkle/spec/docs/proof_types.md
@@ -4,11 +4,13 @@
 
 This document describes how we defined proof types, and how everything corresponds to the Rust implementation. In this version of the Quint model, we tried to make things as close to the Rust implementation as possible. We defined types:
 
-- [`LeafOp`](#leafop)
-- [`InnerOp`](#innerop)
-- [`ExistenceProof`](#existenceproof)
-- [`NonExistenceProof`](#nonexistenceproof)
-- [`CommitmentProof`](#commitmentproof)
+- [Proof types](#proof-types)
+  - [LeafOp](#leafop)
+  - [InnerOp](#innerop)
+  - [ExistenceProof](#existenceproof)
+  - [NonExistenceProof](#nonexistenceproof)
+  - [CommitmentProof](#commitmentproof)
+
 Types used are similar to the original Rust implementation. There are some minor differences, but those will be addressed in detail here. We based our types on [`cosmos.ics23.v1.rs`](https://github.com/cosmos/ics23/blob/master/rust/src/cosmos.ics23.v1.rs) file.
 
 <!-- Boilerplate: tangled from comment to avoid markdown rendering

--- a/grug/jellyfish-merkle/spec/docs/proof_types.md
+++ b/grug/jellyfish-merkle/spec/docs/proof_types.md
@@ -4,12 +4,11 @@ _This document was prepared by the [Informal Systems security team](https://info
 
 This document describes how we defined proof types, and how everything corresponds to the Rust implementation. In this version of the Quint model, we tried to make things as close to the Rust implementation as possible. We defined types:
 
-- [Proof types](#proof-types)
-  - [LeafOp](#leafop)
-  - [InnerOp](#innerop)
-  - [ExistenceProof](#existenceproof)
-  - [NonExistenceProof](#nonexistenceproof)
-  - [CommitmentProof](#commitmentproof)
+- [`LeafOp`](#leafop)
+- [`InnerOp`](#innerop)
+- [`ExistenceProof`](#existenceproof)
+- [`NonExistenceProof`](#nonexistenceproof)
+- [`CommitmentProof`](#commitmentproof)
 
 Types used are similar to the original Rust implementation. There are some minor differences, but those will be addressed in detail here. We based our types on [`cosmos.ics23.v1.rs`](https://github.com/cosmos/ics23/blob/master/rust/src/cosmos.ics23.v1.rs) file.
 

--- a/grug/jellyfish-merkle/spec/docs/proof_types.md
+++ b/grug/jellyfish-merkle/spec/docs/proof_types.md
@@ -1,6 +1,6 @@
 # Proof types
 
-*This document was prepared by the [Informal Systems security team](https://informal.systems/security)*
+_This document was prepared by the [Informal Systems security team](https://informal.systems/security)_
 
 This document describes how we defined proof types, and how everything corresponds to the Rust implementation. In this version of the Quint model, we tried to make things as close to the Rust implementation as possible. We defined types:
 

--- a/grug/jellyfish-merkle/spec/docs/proofs.md
+++ b/grug/jellyfish-merkle/spec/docs/proofs.md
@@ -1,6 +1,6 @@
 # Proofs
 
-*This document was prepared by the [Informal Systems security team](https://informal.systems/security)*
+_This document was prepared by the [Informal Systems security team](https://informal.systems/security)_
 
 This document describes how ICS23 proof generation was modelled in Quint, and how everything corresponds to the Rust implementation. In this version of the Quint model, we tried to make things as close to the Rust implementation as possible. However, since Quint does not support hashing, there were some challenges.
 
@@ -8,10 +8,11 @@ Most of the correspondance is shown by comparing the Rust code with Quint code s
 
 This document covers:
 
-- [`ics23_prove_existence`](#ics23-proving-existence)
-- [`leftNeighbor`](#get-left-neighbor)
-- [`rightNeighbor`](#get-right-neighbor)
-- [`ics23_prove`](#generating-commitment-proof)
+- [Proofs](#proofs)
+  - [ICS23 proving existence](#ics23-proving-existence)
+  - [Get left neighbor](#get-left-neighbor)
+  - [Get right neighbor](#get-right-neighbor)
+  - [Generating commitment proof](#generating-commitment-proof)
 
 > [!TIP]
 > This markdown file contains some metadata and comments that enable it to be tangled to a full Quint file (using [lmt](https://github.com/driusan/lmt)). The Quint file can be found at [proofs.qnt](../quint/proofs.qnt).

--- a/grug/jellyfish-merkle/spec/docs/proofs.md
+++ b/grug/jellyfish-merkle/spec/docs/proofs.md
@@ -8,11 +8,10 @@ Most of the correspondance is shown by comparing the Rust code with Quint code s
 
 This document covers:
 
-- [Proofs](#proofs)
-  - [ICS23 proving existence](#ics23-proving-existence)
-  - [Get left neighbor](#get-left-neighbor)
-  - [Get right neighbor](#get-right-neighbor)
-  - [Generating commitment proof](#generating-commitment-proof)
+- [`ics23_prove_existence`](#ics23-proving-existence)
+- [`leftNeighbor`](#get-left-neighbor)
+- [`rightNeighbor`](#get-right-neighbor)
+- [`ics23_prove`](#generating-commitment-proof)
 
 > [!TIP]
 > This markdown file contains some metadata and comments that enable it to be tangled to a full Quint file (using [lmt](https://github.com/driusan/lmt)). The Quint file can be found at [proofs.qnt](../quint/proofs.qnt).

--- a/grug/jellyfish-merkle/spec/docs/simulation_and_model_checking.md
+++ b/grug/jellyfish-merkle/spec/docs/simulation_and_model_checking.md
@@ -6,7 +6,7 @@ In order to obtain confidence that the model is correct, in respect to the invar
 
 ## Summary of Simualation
 | Simulation Type                                                        | Time Taken | Parallel Instances | Max Steps | Samples per Command | Total Samples | Key Hash Length | Commit                                                                                                                |
-|------------------------------------------------------------------------|------------|--------------------|-----------|---------------------|---------------|-----------------|-----------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------------------------------------------- | ---------- | ------------------ | --------- | ------------------- | ------------- | --------------- | --------------------------------------------------------------------------------------------------------------------- |
 | [Tree manipulation](#simulating-tree-manipulation)                     | 16 hours   | 12                 | 3         | 100k                | 1.2M          | 6               | [25e3960](https://github.com/informalsystems/left-curve-jmt/commit/25e3960869e5a200253c6def80ce0c19cdd0dff7)          |
 | [Proofs (First simulation)](#simulating-proofs-and-proof-verification) | 17 hours   | 12                 | 3         | 15k                 | 180k          | 4               | [30a7013](https://github.com/informalsystems/left-curve-jmt/pull/58/commits/30a70137328040e865a530295477359be90cd5b4) |
 | [Proofs (Second simulation)](#second-simulation)                       | 8 hours    | 12                 | 3         | 20k                 | 240k          | 4               | [be6b33b](https://github.com/informalsystems/left-curve-jmt/commit/be6b33ba547901ab7e5bb4863dd54b03d4baf0ac)          |
@@ -16,14 +16,14 @@ In order to obtain confidence that the model is correct, in respect to the invar
 ## Summary of Testing
 
 | Test Type                                                                               | Time Taken | Parallel Instances | Samples per Command | Total Samples | Test File                                        | Commit                                                                                                       |
-|-----------------------------------------------------------------------------------------|------------|--------------------|---------------------|---------------|--------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| --------------------------------------------------------------------------------------- | ---------- | ------------------ | ------------------- | ------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | [Simple apply vs Fancy apply](#simple-apply-vs-fancy-apply)                             | 6 hours    | 8                  | 10k                 | 80k           | [tree_test.qnt](../quint/test/tree_test.qnt)     | [7081237](https://github.com/informalsystems/left-curve-jmt/commit/7081237fdc646ebb4d3b4128be01286089e2ac27) |
 | [Proof verification across different trees](#proof-verification-across-different-trees) | 3 hours    | 10                 | 4k                  | 40k           | [proofs_test.qnt](../quint/test/proofs_test.qnt) | [93e2359](https://github.com/informalsystems/left-curve-jmt/commit/93e235970a6c1f85b398133bf54928e8ffb5c32e) |
 
 ## Summary of Model Checking
 
 | Setup               | Key Hash Length | Steps | Distinct States Found | Depth of State Graph | Time Taken | Commit                                                                                                       |
-|---------------------|-----------------|-------|-----------------------|----------------------|------------|--------------------------------------------------------------------------------------------------------------|
+| ------------------- | --------------- | ----- | --------------------- | -------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
 | [Setup A](#setup-a) | 3               | 1     | 16,777,472            | 2                    | 1h 55min   | [5b99741](https://github.com/informalsystems/left-curve-jmt/commit/5b997412efd1de6663204a96612b618f8baefc7f) |
 | [Setup B](#setup-b) | 2               | 2     | 1,052,688             | 3                    | 2min 46s   | [5b99741](https://github.com/informalsystems/left-curve-jmt/commit/5b997412efd1de6663204a96612b618f8baefc7f) |
 
@@ -115,7 +115,7 @@ ok leafNotExistsThenExistsTest passed 4000 test(s)
 ok leafExistsThenNotExistsTest passed 4000 test(s)
 ```
 
-Commit for this experiment: [93e2359](https://github.com/informalsystems/left-curve-jmt/commit/93e235970a6c1f85b398133bf54928e8ffb5c32e) 
+Commit for this experiment: [93e2359](https://github.com/informalsystems/left-curve-jmt/commit/93e235970a6c1f85b398133bf54928e8ffb5c32e)
 
 ## **Model Checking**
 

--- a/grug/jellyfish-merkle/spec/docs/simulation_and_model_checking.md
+++ b/grug/jellyfish-merkle/spec/docs/simulation_and_model_checking.md
@@ -1,10 +1,11 @@
 # Simulations and Model Checking
 
-*This document was prepared by the [Informal Systems security team](https://informal.systems/security)*
+_This document was prepared by the [Informal Systems security team](https://informal.systems/security)_
 
 In order to obtain confidence that the model is correct, in respect to the invariants and tests described in [invariants.md](./invariants.md), we run random simulations (on bigger scopes) and model checking (on smaller scopes). We used the **Quint simulator** for simulations, which runs a kind of Depth First Search (DFS) on the state space with a max-depth (`--max-steps`) defined by us; and the **TLC model checker** for model checking, which runs a kind of Breadth First Search (BFS) on the complete state space, which requires that we refine our model to a state-space small enough for this to run in the time we had available.
 
 ## Summary of Simualation
+
 | Simulation Type                                                        | Time Taken | Parallel Instances | Max Steps | Samples per Command | Total Samples | Key Hash Length | Commit                                                                                                                |
 | ---------------------------------------------------------------------- | ---------- | ------------------ | --------- | ------------------- | ------------- | --------------- | --------------------------------------------------------------------------------------------------------------------- |
 | [Tree manipulation](#simulating-tree-manipulation)                     | 16 hours   | 12                 | 3         | 100k                | 1.2M          | 6               | [25e3960](https://github.com/informalsystems/left-curve-jmt/commit/25e3960869e5a200253c6def80ce0c19cdd0dff7)          |
@@ -33,27 +34,29 @@ Simulations were the main tool we used while iterating over the model. It helped
 
 Once the model and invariants are stable, and we don't get violations from the simulator on a few minutes, we can set up longer runs, which serve to increase our confidence on the model. The first one was run once our model and invariants for tree manipulation were stable, and the other ones were done after the model and invariants for proofs and proof verification were stable.
 
-### **Simulating tree manipulation**
+### Simulating tree manipulation
 
 At the point in time where we finished tree manipulation, we ran a **16-hour simulation** with **12 parallel instances** of the simulator, each with `max-steps=3`, and **100k samples per command**. This gave us a total of **1.2M samples**. For this simulation, we limited batches to have at most 5 operations, and used `key_hash`es of length 6.
 
-### **Simulating proofs and proof verification**
+### Simulating proofs and proof verification
 
 The invariants for producing and verifying proofs are quite heavy performance-wise, as they check lots of combinations of keys to generate proofs for and trees and values to check the proof against. This means that the total number of samples we can check is much lower in relation to what we check for tree manipulation, but the number of checks per sample is very high.
 
-#### **First simulation**
+#### First simulation
 
 We ran a **17-hour simulation** with **12 parallel instances** of the simulator, each with `max-steps=3`, and **15k samples per command**. This gave us a total of **180k samples**. For this simulation, we limited batches to have at most 5 operations, and used `key_hash`es of length 4, and used the pruning state machine. In this experiment, we only checked the proof-related invariants (completeness, soundness and the `verifyMembershipInv`). This was run at [30a7013](https://github.com/informalsystems/left-curve-jmt/pull/58/commits/30a70137328040e865a530295477359be90cd5b4).
 
-#### **Second simulation**
+#### Second simulation
 
 Before running the next experiment, we want to try to improve two things:
+
 1. **Performance of the invariants**
 2. **Distribution of batches**
 
-##### **Performance of the invariants**
+##### Performance of the invariants
 
 There were some straightforward improvements that were made, but made a small compromise in favor of enabling more verification. For many invariants, we had a quantifier over all active (not pruned) tree versions. However, invariants are checked of every single state, which means that, for three steps, we had something like this:
+
 1. Check invariant for state 0, which has an empty tree
 2. Take a step and check invariant for state 1, which has one tree version
 3. Take a step and check invariant for state 2, which has two different tree versions
@@ -65,47 +68,53 @@ This means that the tree at version 1 was checked three times at (2), (3) and (4
 
 We went with this assumption and remove the quantification over active versions from invariants that had it.
 
-##### **Distribution of batches**
+##### Distribution of batches
 
 The strategy used to generate non-deterministic batches was much more likely to generate medium-sized batches than batches with no operation, a single operation or all possible operations. At this point, we had use two different batch generation strategies:
+
 1. Produce a power set over the set of operations and pick one.
-  - In this power set, there are much more big sets than small sets, which means that we are more likely to pick a big set.
+
+   - In this power set, there are much more big sets than small sets, which means that we are more likely to pick a big set.
+
 2. For each `key_hash`, non-deterministically pick if we want to include it in the batch or not.
-  - This has a central tendency issue, where we are more likely to pick a batch with half of the operations than with no operations or all operations.
+
+   - This has a central tendency issue, where we are more likely to pick a batch with half of the operations than with no operations or all operations.
 
 What we believed would be ideal is that chances of batches of different sizes are all the same. So we changed this to first non-deterministically pick the size of the batch, and then non-deterministically pick the operations to include in the batch. This way, we have a uniform distribution of batch sizes.
 
 We also removed the limit of 5 operations per batch, and reduced the set from which value hashes are picked from to have only two potential values, increasing the chances of collision (having an insert operation for a key that was inserted with the same value before).
 
-##### **Simulation itself**
+##### Simulation itself
 
 We ran an **8-hour simulation** with **12 parallel instances** of the simulator, each with `max-steps=3`, and **20k samples per command**. This gave us a total of **240k samples**. We used `key_hash`es of length 4. In this experiment, we checked all invariants, including the proof-related ones, except for pruning, as we used the regular state machine for performance reasons. This was run at [be6b33b](https://github.com/informalsystems/left-curve-jmt/commit/be6b33ba547901ab7e5bb4863dd54b03d4baf0ac).
 
-### **Final simulation results**
+### Final simulation results
 
 After all this iteration, we ran two final simulations with the latest version ([28ac5e5](https://github.com/informalsystems/left-curve-jmt/commit/7081237fdc646ebb4d3b4128be01286089e2ac27)), only differing by the invariants we check in each of them. We checked consecutive "fancy" apply operations on top of an empty tree for 3 steps. This was run for **66 hours**, with **6 parallel instances** per command.
+
 - Invariant: `treeInvariants` (all tree manipulation invariants): Total samples = 1.8M
 - Invariant: `proofInvariants` (all proof-related invariants): Total samples = 2.3M
 
-### **Testing**
+### Testing
 
 Another way to use the Quint random simulator is to run tests, which work like property-based testing. The tests can have non-deterministic values, so we can run many samples to get more confidence that the property stated by the tests holds. We focus the long-running testing on the more interesting ones:
 
-#### **Simple apply vs Fancy apply**
+#### Simple apply vs Fancy apply
 
 We ran an **6-hour** test with **8 parallel instances** of the test simulator, and **10k samples per command**. This gave us a total of **80k samples** for each test. It was run for the [tree_test.qnt](../quint/test/tree_test.qnt) file which includes two tests:
-```
+
+```plain
 ok simpleVsFancyTest passed 10000 test(s)
 ok simpleVsFancyMultipleRepsTest passed 10000 test(s)
 ```
 
 Commit for this experiment: [7081237](https://github.com/informalsystems/left-curve-jmt/commit/7081237fdc646ebb4d3b4128be01286089e2ac27).
 
-#### **Proof verification across different trees**
+#### Proof verification across different trees
 
 We ran a **3-hour** test with **10 parallel instances** of the test simulator, and **4k samples per command**. This gave us a total of **40k samples** for each test. It was run for the [proofs_test.qnt](../quint/test/proofs_test.qnt) file which includes the following:
 
-```
+```plain
 ok twoDifferentTreesTest passed 4000 test(s)
 ok twoDifferentTreesByOnlyValuesTest passed 4000 test(s)
 ok twoDifferentTreesByOnlyOneValueTest passed 4000 test(s)
@@ -117,20 +126,21 @@ ok leafExistsThenNotExistsTest passed 4000 test(s)
 
 Commit for this experiment: [93e2359](https://github.com/informalsystems/left-curve-jmt/commit/93e235970a6c1f85b398133bf54928e8ffb5c32e)
 
-## **Model Checking**
+## Model Checking
 
 We were able to run the TLC model checker for two different setups. We were not able to run Apalache, as it quickly ran out of memory before the model checking started (to be investigated). In order to run TLC, we transpile Quint to TLA+ and then run the model checker on the TLA+ model.
 
-### **Generating the TLA+ model**
+### Generating the TLA+ model
 
 There are still some integration issues between Quint and Apalache, which is used to generate TLA+ out of Quint. We had to circumvent this, introducing non-disruptive changes:
+
 - Some new Quint built-ins (`getOnlyElement` and `allListsUpTo`) are not supported for translation yet, so we replaced those with a non-built-in version. Same for `foldr` which we adapted to use `foldl` which is supported.
 - There were many issues translating polymorphic Quint operators into Apalache's representation, so we did some adaptations to avoid some instances of polymorphism, mostly regarding polymorphic usage of the `None` constructor inside the same operator.
 - Many issues could only be fixed on Apalache's side, which we did. See the [PR](https://github.com/apalache-mc/apalache/pull/3041). We used a version of Apalache with these fixes in order to generate the TLA+ model.
 
 The generated TLA+ models are available in the [quint/tla folder](../quint/tla) together with instructions on how to run them.
 
-### **Initial states for model checking**
+### Initial states for model checking
 
 With the goal of optimizing the state space as much as possible for model checking, we define a special case for the initial state. Instead of always starting with an empty tree and applying any operation, we consider a symmetry property of trees and operations, where any scenario arising from applying two sets of operations of value hashes `[1]` or `[2]` on top of an empty tree should be reproducible by applying first a set of operations with only value hash `[1]` and then the second set with `[1]` or `[2]`. This reduces the number of operation combinations to consider, while maintaining the same coverage.
 
@@ -138,12 +148,12 @@ Therefore, we change the `init` definition to start with the result of applying 
 
 This also means that performing a single step in this state machine is similar to performing two steps in the original state machine that always started with an empty tree, as we are now also applying one batch of operations on the initial state.
 
-### **Setup A**
+### Setup A
 
 - The key hash length is 3
 - The state machine performs a single step
 
-```
+```plain
 Model checking completed. No error has been found.
   Estimates of the probability that TLC did not check all reachable states
   because two distinct states had the same fingerprint:
@@ -158,21 +168,23 @@ Finished in 01h 55min at (2024-12-05 22:58:14)
 - Running this with key hash length of 4 instead of 3 would increase the state space to **281 474 976 710 656 states**
 
 An inductive interpretation of this result is:
+
 - **Base case:** All possible trees with `value_hash` being `[1]` and version being `1`.
 - **Induction step:** All possible operations with `value_hash` being `[1]` (same as a potentially existing leaf) or `[2]` (different from a potentially existing leaf), from version `1` to version `2`.
 
 This check is a valid inductive proof for the real tree manipulation algorithm if and only if the following assumptions hold:
+
 - Any violation for key hashes of length 256 can be reproduced with key hashes of length 3
 - Any violation for value hashes of length 256 can be reproduced using only two value hashes (specifically `[1]` and [`2`])
 - Any violation that happens in multiple steps/versions can be reproduced in a single step/version change (specifically from version `1` to version `2`). See Setup B for more coverage on this.
 - Our model is equivalent to the algorithm. Model-based testing can help obtain confidence on this.
 
-### **Setup B**
+### Setup B
 
 - The key hash length is 2
 - The state machine performs 2 steps
 
-```
+```plain
 Model checking completed. No error has been found.
   Estimates of the probability that TLC did not check all reachable states
   because two distinct states had the same fingerprint:
@@ -188,10 +200,12 @@ Finished in 02min 46s at (2024-12-05 20:53:41)
 - Running this with 4 steps instead of 3 would increase the state space to **68 988 964 880 states**
 
 An inductive interpretation of this result is:
+
 - **Base case:** All possible trees that can be generated using all possible combinations of operations with `value_hash` being `[1]` or `[2]`, and versions being 1 and 2.
 - **Induction step:** All possible operations with `value_hash` being `[1]` (same as a potentially existing leaf) or `[2]` (different from a potentially existing leaf), from version `2` to version `3`.
 
 This check is a valid inductive proof for the real tree manipulation algorithm if and only if the following assumptions hold:
+
 - Any violation for key hashes of length 256 can be reproduced with key hashes of length 2
 - Any violation for value hashes of length 256 can be reproduced using only two value hashes (specifically `[1]` and [`2`])
 - Any violation that happens in multiple steps/versions can be reproduced with 2 steps/versions

--- a/grug/jellyfish-merkle/spec/docs/tree_manipulation.md
+++ b/grug/jellyfish-merkle/spec/docs/tree_manipulation.md
@@ -44,7 +44,7 @@ module apply_fancy {
   import basicSpells.* from "./spells/basicSpells"
   import commonSpells.* from "./spells/commonSpells"
   import rareSpells.* from "./spells/rareSpells"
-  
+
   <<<definitions>>>
 }
 ```
@@ -245,7 +245,7 @@ Lastly, we make the recursive call
 As explained, we call `pre_compute_apply_at` to prepare for the recursion from calling `apply_at`.
 - `memo`, the result from the pre-computation, is given to `apply_at` so it uses it instead of doing recursion.
 - The result obtained from `apply_at` includes mutations to be made to the tree (`nodes_to_add` and `orphans_to_add`). We produce a new tree (`new_tree`) with those changes applied.
-- Then, we just need to match, in a less powerful but similar pattern matching. 
+- Then, we just need to match, in a less powerful but similar pattern matching.
 
 ```bluespec "definitions" +=
   pure val memo = pre_compute_apply_at(tree_1, new_version, batch)
@@ -469,7 +469,7 @@ In the rust code so far, we had potential mutations:
 - Calls to `apply_at_child` can add orhpans
 - The checks on the block above can add orphans
 
-We set up a result value that include this initial changes, to be used by most cases below. In the cases where we need to make more mutations on top of these, those are added to this initial result value. 
+We set up a result value that include this initial changes, to be used by most cases below. In the cases where we need to make more mutations on top of these, those are added to this initial result value.
 
 ```bluespec "definitions" +=
   pure val orphans_from_children =
@@ -796,7 +796,7 @@ pure def apply_at_child(
 ): ApplyResult = {
 ```
 
-Once again, Rust uses a `match`, and Quint will use a combination of `if` and `match` instead due to less powerful pattern matching. 
+Once again, Rust uses a `match`, and Quint will use a combination of `if` and `match` instead due to less powerful pattern matching.
 ```rust
     match (batch.is_empty(), child) {
 ```
@@ -919,7 +919,7 @@ We start by preparing the batch:
 -->
 
 And again, we have a `match`:
-  
+
 ```rust
     match (batch.is_empty(), op) {
 ```
@@ -1029,7 +1029,7 @@ fn partition_batch<T>(
 }
 ```
 
-In Quint, we do a simpler partition using a fold and list access for bits. 
+In Quint, we do a simpler partition using a fold and list access for bits.
 
 ```bluespec "definitions" +=
 pure def partition_batch(
@@ -1073,7 +1073,7 @@ fn partition_leaf(leaf: Option<LeafNode>, bits: BitArray) -> (Option<LeafNode>, 
 }
 ```
 
-Replacing `if let` with a `match` and `bit_at_index` with simple list access, we have: 
+Replacing `if let` with a `match` and `bit_at_index` with simple list access, we have:
 
 ```bluespec "definitions" +=
 pure def partition_leaf(leaf: Option[LeafNode], bits: BitArray): (Option[LeafNode], Option[LeafNode]) = {
@@ -1138,7 +1138,7 @@ pure def prepare_batch_for_subtree(
 }
 ```
 
-The way to write this in Quint that keeps tighter correspondance is to break down how we find `maybe_op` and `filtered_batch` into two different iterations. This happens because we can't have a mutable `maybe_op` as in Rust, and doing it all on a single iteration would require a more complicated fold. We favor cognitive correspondance over performance. 
+The way to write this in Quint that keeps tighter correspondance is to break down how we find `maybe_op` and `filtered_batch` into two different iterations. This happens because we can't have a mutable `maybe_op` as in Rust, and doing it all on a single iteration would require a more complicated fold. We favor cognitive correspondance over performance.
 
 For `maybe_op`:
 
@@ -1315,7 +1315,7 @@ Then we start the translation from the body of `create_subtree` in Rust:
     match (batch.len(), existing_leaf) {
 ```
 
-In Quint, this `match` will be if-else branches. 
+In Quint, this `match` will be if-else branches.
 
 First case:
 ```rust

--- a/grug/jellyfish-merkle/spec/docs/tree_manipulation.md
+++ b/grug/jellyfish-merkle/spec/docs/tree_manipulation.md
@@ -14,24 +14,15 @@ Most of the correspondance is shown by comparing the Rust code with Quint code s
 
 This document covers the correspondance of all the `apply_*` functions and their main helper functions, including:
 
-- [Tree manipulation](#tree-manipulation)
-  - [Types](#types)
-  - [Recursion emulation for `apply_at`](#recursion-emulation-for-apply_at)
-    - [Concrete example](#concrete-example)
-    - [Memoization](#memoization)
-  - [Apply operators](#apply-operators)
-    - [Top level apply](#top-level-apply)
-    - [Apply At](#apply-at)
-    - [Apply At Internal](#apply-at-internal)
-    - [Apply At Child](#apply-at-child)
-    - [Apply at Leaf](#apply-at-leaf)
-  - [Auxiliary functions](#auxiliary-functions)
-    - [Partition Batch](#partition-batch)
-    - [Partition Leaf](#partition-leaf)
-    - [Prepare Batch for Subtree](#prepare-batch-for-subtree)
-  - [Create Subtree](#create-subtree)
-    - [Recursion emulation for `create_subtree`](#recursion-emulation-for-create_subtree)
-    - [Create subtree operator](#create-subtree-operator)
+- [`apply`](#top-level-apply)
+- [`apply_at`](#apply-at)
+- [`apply_at_internal`](#apply-at-internal)
+- [`apply_at_child`](#apply-at-child)
+- [`apply_at_leaf`](#apply-at-leaf)
+- [`partition_batch`](#partition-batch)
+- [`partition_leaf`](#partition-leaf)
+- [`prepare_batch_for_subtree`](#prepare-batch-for-subtree)
+- [`create_subtree`](#create-subtree)
 
 > [!TIP]
 > This markdown file contains some metadata and comments that enable it to be tangled to a full Quint file (using [lmt](https://github.com/driusan/lmt)). The Quint file can be found at [apply_fancy.qnt](../quint/apply_fancy.qnt).

--- a/grug/jellyfish-merkle/spec/quint/apply_fancy.qnt
+++ b/grug/jellyfish-merkle/spec/quint/apply_fancy.qnt
@@ -15,7 +15,7 @@ module apply_fancy {
   import basicSpells.* from "./spells/basicSpells"
   import commonSpells.* from "./spells/commonSpells"
   import rareSpells.* from "./spells/rareSpells"
-  
+
   /// The return type of apply_* functions, as some of them modify the tree
   type ApplyResult = { outcome: Outcome, orphans_to_add: Set[OrphanId], nodes_to_add: Set[(NodeId, Node)] }
 

--- a/grug/jellyfish-merkle/spec/quint/apply_simple.qnt
+++ b/grug/jellyfish-merkle/spec/quint/apply_simple.qnt
@@ -7,10 +7,10 @@ module apply_simple {
   import hashes.* from "./hashes"
   import utils.* from "./utils"
 
-  pure def apply(tree: Tree, old_version: Version, new_version: Version, batch: Set[OperationOnKey]): Tree = 
+  pure def apply(tree: Tree, old_version: Version, new_version: Version, batch: Set[OperationOnKey]): Tree =
     simple_apply(tree, old_version, new_version, batch)
-  
-  pure def extractOrphansFromNewVersion(oldTree: Tree, updatedTree: Tree, old_version: Version, new_version: Version) : Set[OrphanId] = 
+
+  pure def extractOrphansFromNewVersion(oldTree: Tree, updatedTree: Tree, old_version: Version, new_version: Version) : Set[OrphanId] =
     pure val nodes_at_old = updatedTree.treeAtVersion(old_version).keys()
     pure val nodes_at_new = updatedTree.treeAtVersion(new_version).keys()
     pure val orphaned_nodes = nodes_at_old.exclude(nodes_at_new)
@@ -22,25 +22,25 @@ module apply_simple {
     oldTree.orphans.union(new_orphans)
 
 
-  pure def unpackChild(child: Option[Child]) : Child = 
+  pure def unpackChild(child: Option[Child]) : Child =
     pure val EMPTY_MAP = Map()
     match child {
       | Some(c) => { version: c.version, hash: c.hash }
       | None => { version: -1, hash: EMPTY_MAP }
     }
   pure def unpackInternalNode(internal: InternalNode) : { left: Child, right: Child } =
-    { left: internal.left_child.unpackChild(), 
+    { left: internal.left_child.unpackChild(),
       right: internal.right_child.unpackChild() }
 
-  pure def cmpInternalAndNode(internal : InternalNode, internalOldVersion: InternalNode) : bool = 
+  pure def cmpInternalAndNode(internal : InternalNode, internalOldVersion: InternalNode) : bool =
     pure val unpackedNew = internal.unpackInternalNode()
     pure val unpackedOld = internalOldVersion.unpackInternalNode()
     unpackedNew.left.hash == unpackedOld.left.hash and unpackedNew.right.hash == unpackedOld.right.hash
-  
-  pure def updateChildVersions(nodes: NodeId->Node, old_version_nodes: TreeMap, new_version: Version) : NodeId->Node = 
+
+  pure def updateChildVersions(nodes: NodeId->Node, old_version_nodes: TreeMap, new_version: Version) : NodeId->Node =
     val internalNodes = allInternals(nodes)
     val internalNodesOld = allInternals(old_version_nodes)
-    
+
     internalNodesOld.keys().fold(nodes, (nodes, key) =>
         if (new_version > key.version and internalNodes.has({...key, version: new_version}))
           val internalOld = internalNodes.get(key)
@@ -63,13 +63,13 @@ module apply_simple {
           else if ( unpackedNew.right.hash == unpackedOld.right.hash and unpackedNew.right.version != unpackedOld.right.version )
             nodes.set({ ...key, version: new_version }, Internal({ ...internalNew, right_child: Some( unpackedOld.right) }))
           else nodes
-        else 
+        else
         nodes
       )
 
 
-  pure def removeDuplicateEntries(nodes: TreeMap, old_version_nodes: TreeMap, current_version: Version) : NodeId->Node = 
-    old_version_nodes.keys().fold(nodes, (nodes, key) => 
+  pure def removeDuplicateEntries(nodes: TreeMap, old_version_nodes: TreeMap, current_version: Version) : NodeId->Node =
+    old_version_nodes.keys().fold(nodes, (nodes, key) =>
       if(current_version > key.version and nodes.keys().contains({...key, version: current_version}))
         val nodeForKey = nodes.get(key)
         val nodeForKeyWithNewVersion = nodes.get({...key, version: current_version})
@@ -77,9 +77,9 @@ module apply_simple {
           nodes.mapRemove({...key, version: current_version})
         else
             match nodeForKeyWithNewVersion {
-             | Internal(internalNewVersion) 
+             | Internal(internalNewVersion)
                 => match nodeForKey {
-                  | Internal(internalOldVersion) =>  
+                  | Internal(internalOldVersion) =>
                     if(cmpInternalAndNode(internalNewVersion, internalOldVersion)
                         and not(key.isRoot()))
                       nodes.mapRemove({...key, version: current_version})
@@ -88,7 +88,7 @@ module apply_simple {
                 }
              | Leaf(_) => nodes
            }
-      else 
+      else
         nodes
     )
 
@@ -104,8 +104,8 @@ module apply_simple {
 
       pure val keys_with_values_without_new =  existing_keys_with_values
                                   .filter(x => not(batch.map(op => op.key_hash).contains(x.key_hash)))
-      
-      val keys_and_values_and_op = batch.fold(keys_with_values_without_new, (kv_set, op) => 
+
+      val keys_and_values_and_op = batch.fold(keys_with_values_without_new, (kv_set, op) =>
           match op.op {
             | Insert(value_hash) => kv_set.union(Set({key_hash: op.key_hash, value_hash: value_hash}))
             | Delete => kv_set
@@ -204,14 +204,14 @@ module apply_simple {
         (acc._1.union(queue_2), queue_2)
       })
     })
-    
+
     val nodes = result._2.map(kv => ({version: new_version, key_hash: kv.key_hash}, kv.node))
                       .fold(tree.nodes, (nodes, kv) => nodes.put(kv._1, kv._2))
                       .removeDuplicateEntries(treeAtVersion(tree, old_version), new_version)
                       .updateChildVersions(treeAtVersion(tree, old_version), new_version)
-    
+
     val orphans = extractOrphansFromNewVersion(tree, { nodes: nodes, orphans: Set() },
                                                old_version, new_version)
-      
+
     { nodes: nodes, orphans: orphans }
 }

--- a/grug/jellyfish-merkle/spec/quint/completeness.qnt
+++ b/grug/jellyfish-merkle/spec/quint/completeness.qnt
@@ -29,7 +29,7 @@ module completeness {
       )
 
   /// For each key_hash that is not in the version of the tree,
-  /// ics23_prove returns a non-existence proof, and the proof 
+  /// ics23_prove returns a non-existence proof, and the proof
   /// can be verified against the root hash
   pure def nonMembershipCompleteness(tree: Tree, v: Version): bool =
     // Tree needs to have a root at this version

--- a/grug/jellyfish-merkle/spec/quint/grug_ics23.qnt
+++ b/grug/jellyfish-merkle/spec/quint/grug_ics23.qnt
@@ -23,7 +23,7 @@ module grug_ics23 {
   import utils.* from "./utils"
 
   type InnerSpec = {
-    min_prefix_length: int, 
+    min_prefix_length: int,
     max_prefix_length: int,
     child_size: int,
     empty_child: Term,
@@ -65,7 +65,7 @@ module grug_ics23 {
 
   /// calculate a hash from an exists proof
   pure def exists_calculate(p: ExistenceProof): Term =
-    val leafHash = hashLeafNode({ key_hash: p.key, value_hash: p.value})    
+    val leafHash = hashLeafNode({ key_hash: p.key, value_hash: p.value})
     // the inner node nodeHashes are concatenated and hashed upwards
     p.path.foldl(leafHash,
       (child, inner) =>
@@ -90,7 +90,7 @@ module grug_ics23 {
     proof.left != None implies {
       pure val left = proof.left.unwrap()
       and {
-        verify_existence(left, root, left.key, left.value), 
+        verify_existence(left, root, left.key, left.value),
         key.greater_than(left.key),
       }
     },

--- a/grug/jellyfish-merkle/spec/quint/hashes.qnt
+++ b/grug/jellyfish-merkle/spec/quint/hashes.qnt
@@ -163,9 +163,9 @@ module hashes {
   /// Slice a raw sequence represented by a term.
   /// Non-raw sequences are returned unmodified.
   pure def termSlice(term: Term, start: int, end: int): Term = {
-    if (size(keys(term)) != 1) 
+    if (size(keys(term)) != 1)
       term
-    else 
+    else
       pure val first = term.get([ 0 ])
       match first {
         | Raw(bytes) => raw(bytes.slice(start, end))

--- a/grug/jellyfish-merkle/spec/quint/proofs.qnt
+++ b/grug/jellyfish-merkle/spec/quint/proofs.qnt
@@ -16,37 +16,37 @@ module proofs {
   import utils.* from "./utils"
 
   /// Returns optional list of InnerOps as a path to the leaf with particular key_hash
-  pure def ics23_prove_existence(t: Tree, version: Version, key_hash: BitArray) 
+  pure def ics23_prove_existence(t: Tree, version: Version, key_hash: BitArray)
   : Option[List[InnerOp]] =
     val prefixes_list = 0.to(key_hash.length()).map( i => key_hash.slice(0,i)).toList(listCompare)
-    val r = prefixes_list.foldl({ path: List(), i: 0, found: false, child_version: version}, (iterator, key_prefix) => 
-      if (iterator.found or not(t.nodes.keys().contains({key_hash: key_prefix, version: iterator.child_version}))) 
-        iterator 
+    val r = prefixes_list.foldl({ path: List(), i: 0, found: false, child_version: version}, (iterator, key_prefix) =>
+      if (iterator.found or not(t.nodes.keys().contains({key_hash: key_prefix, version: iterator.child_version})))
+        iterator
       else
         val node = t.nodes.get({key_hash: key_prefix, version: iterator.child_version})
         match node {
-          | Leaf(l) => { ...iterator, i: iterator.i + 1, 
+          | Leaf(l) => { ...iterator, i: iterator.i + 1,
                                     found: l.key_hash == key_hash }
-          | Internal(internal) => 
+          | Internal(internal) =>
             val next_bit_0 = key_prefix.append(0)
-            val child_version = if(prefixes_list[iterator.i + 1] == next_bit_0) 
+            val child_version = if(prefixes_list[iterator.i + 1] == next_bit_0)
                                   internal.left_child.unwrap().version
-                                else 
+                                else
                                   internal.right_child.unwrap().version
-            val innerOp = 
-              if(prefixes_list[iterator.i + 1] == next_bit_0) 
-                { prefix: InternalNodeHashPrefix, 
+            val innerOp =
+              if(prefixes_list[iterator.i + 1] == next_bit_0)
+                { prefix: InternalNodeHashPrefix,
                   suffix: match internal.right_child {
                             | None => Hash256_ZERO
                             | Some(c) => c.hash} }
-              else 
+              else
                 { prefix: InternalNodeHashPrefix
                             .termConcat(match internal.left_child {
                                           | None => Hash256_ZERO
-                                          | Some(c) => c.hash}), 
+                                          | Some(c) => c.hash}),
                   suffix: Map() }
 
-            { ...iterator, path: iterator.path.append(innerOp),  
+            { ...iterator, path: iterator.path.append(innerOp),
               i: iterator.i + 1, child_version: child_version }
         }
     )
@@ -60,20 +60,20 @@ module proofs {
     val smallerKeyNodes = t.values().filter(n => match n {
       | Leaf(l) => less_than(l.key_hash, k)
       | Internal(_) => false
-    }) 
-    if(smallerKeyNodes.empty()) None else 
-      val someLeaf = smallerKeyNodes.fold({key_hash: [], value_hash: []}, (s, x) => 
+    })
+    if(smallerKeyNodes.empty()) None else
+      val someLeaf = smallerKeyNodes.fold({key_hash: [], value_hash: []}, (s, x) =>
         match x {
-          | Leaf(l) =>  
+          | Leaf(l) =>
                 l
           | Internal(_) => s
         })
       Some(smallerKeyNodes.fold( someLeaf, (s,x) =>
         match x {
-          | Leaf(l) =>  
+          | Leaf(l) =>
               if (less_than(s.key_hash, l.key_hash))
                 l
-              else 
+              else
                 s
           | Internal(_) => s
         }
@@ -84,26 +84,26 @@ module proofs {
     val largerKeyNodes = t.values().filter(n => match n {
       | Leaf(l) => less_than(k, l.key_hash)
       | Internal(_) => false
-    }) 
-    if(largerKeyNodes.empty()) None else 
-      val someLeaf = largerKeyNodes.fold({key_hash: [], value_hash: []}, (s, x) => 
+    })
+    if(largerKeyNodes.empty()) None else
+      val someLeaf = largerKeyNodes.fold({key_hash: [], value_hash: []}, (s, x) =>
         match x {
-          | Leaf(l) =>  
+          | Leaf(l) =>
                 l
           | Internal(_) => s
           })
       Some(largerKeyNodes.fold(someLeaf, (s, x) =>
         match x {
-          | Leaf(l) =>  
+          | Leaf(l) =>
               if (less_than(l.key_hash, s.key_hash) )
                 l
-              else 
+              else
                 s
           | Internal(_) => s
         }
       ))
 
-  /// Returns optional CommitmentProof based for the given key_hash. 
+  /// Returns optional CommitmentProof based for the given key_hash.
   /// In implementation the key is passed instead of the key_hash.
   pure def ics23_prove(t: Tree, key_hash: BitArray, version: Version): Option[CommitmentProof] =
     val optionalValueForKey = t.treeAtVersion(version)
@@ -127,7 +127,7 @@ module proofs {
       | None =>
         val lneighborOption: Option[LeafNode] = leftNeighbor(t.treeAtVersion(version), key_hash)
         val leftNeighborExistenceProof: Option[ExistenceProof] = match lneighborOption {
-          | Some(lneighbor) => 
+          | Some(lneighbor) =>
             val pathOption = ics23_prove_existence(t, version, lneighbor.key_hash)
             match pathOption {
               | Some(path) => Some({
@@ -142,7 +142,7 @@ module proofs {
         }
         val rneighborOption: Option[LeafNode]  = rightNeighbor(t.treeAtVersion(version), key_hash)
         val rightNeighborExistenceProof: Option[ExistenceProof] = match rneighborOption {
-          | Some(rneighbor) => 
+          | Some(rneighbor) =>
             val pathOption = ics23_prove_existence(t,version, rneighbor.key_hash)
             match pathOption {
               | Some(path) => Some({

--- a/grug/jellyfish-merkle/spec/quint/spells/commonSpells.qnt
+++ b/grug/jellyfish-merkle/spec/quint/spells/commonSpells.qnt
@@ -38,11 +38,11 @@ module commonSpells {
   /// - @param __list a list
   /// - @param __elem an element
   /// - @returns true if the element is in the list, false otherwise
-  pure def listContains(__list: List[a], __elem: a): bool = 
+  pure def listContains(__list: List[a], __elem: a): bool =
     __list.foldl(
-      false, 
+      false,
       (__acc, __i) => __acc or __i == __elem)
-    
+
   run listContainsTest = all {
     assert(listContains([], 1) == false),
     assert(listContains([1, 2, 3], 1) == true),

--- a/grug/jellyfish-merkle/spec/quint/spells/rareSpells.qnt
+++ b/grug/jellyfish-merkle/spec/quint/spells/rareSpells.qnt
@@ -28,8 +28,8 @@ module rareSpells {
     else
       { EQ }
   }
-  type NodeIdToCompare = { 
-    version: int, 
+  type NodeIdToCompare = {
+    version: int,
     key_hash: List[int]
   }
 
@@ -129,7 +129,7 @@ module rareSpells {
   run toListAndSetTest =
   all {
       assert(Set(4, 2, 1, 55, 23, 3).toList(intCompare).toSet() == Set(1, 2, 3, 4, 23, 55)),
-      assert(Set({version:0, key_hash: []}, {version:0, key_hash: [1,0,1]}, {version:0, key_hash: [1,0,1,1]},{version:0, key_hash: [1,0]},{version:0, key_hash: [1]}).toList(nodeCompare) 
+      assert(Set({version:0, key_hash: []}, {version:0, key_hash: [1,0,1]}, {version:0, key_hash: [1,0,1,1]},{version:0, key_hash: [1,0]},{version:0, key_hash: [1]}).toList(nodeCompare)
             == List({version:0, key_hash: [1,0,1,1]},{version:0, key_hash: [1,0,1]}, {version:0, key_hash: [1,0]}, {version:0, key_hash: [1]}, {version:0, key_hash: []})),
       assert(List(2,3,1).toSet() == Set(1, 2, 3)),
       assert(List(2,3,1).toSet() == List(3,2,1).toSet()),

--- a/grug/jellyfish-merkle/spec/quint/test/apply_simple_test.qnt
+++ b/grug/jellyfish-merkle/spec/quint/test/apply_simple_test.qnt
@@ -32,7 +32,7 @@ module apply_simple_test {
     pure val internal_height_3 = Internal({
       left_child: Some({ version: 2, hash: expected_leaf_1.hash() }),
       right_child: Some({ version: 2, hash: expected_leaf_2.hash() })})
-    
+
     pure val internal_height_2 = Internal({
       left_child: None,
       right_child: Some({ version: 2, hash: internal_height_3.hash() })
@@ -605,11 +605,11 @@ module apply_simple_test {
     val t1 = empty_tree.apply(0,1,op1)
     val t2 = t1.apply(1,2, op2)
 
-    val super_simple =  { nodes: 
+    val super_simple =  { nodes:
                             Map({ key_hash: [], version: 1 } -> Leaf({ key_hash: [1, 0, 0, 0], value_hash: [13] })),
                           orphans: Set({ key_hash: [], orphaned_since_version: 2, version: 1 })
                         }
-    val fancy = { nodes: 
+    val fancy = { nodes:
                     Map(
                         { key_hash: [], version: 1 } -> Leaf({ key_hash: [1, 0, 0, 0], value_hash: [13] }),
                         { key_hash: [], version: 2 } -> Leaf({ key_hash: [1, 0, 0, 0], value_hash: [13] })),

--- a/grug/jellyfish-merkle/spec/quint/test/node_test.qnt
+++ b/grug/jellyfish-merkle/spec/quint/test/node_test.qnt
@@ -24,21 +24,21 @@ module node_test {
     val left_leaf_hash = hashLeafNode(left_leaf)
     val right_leaf_hash = hashLeafNode(right_leaf)
 
-    val expected_left_hash =  Map([0] -> Hash, 
+    val expected_left_hash =  Map([0] -> Hash,
                                   [0,0] -> Raw(LeafNodeIdentifier.concat(left_child_key).append(left_child_value)))
     val expected_right_hash = Map([0] -> Hash,
                                   [0,0] -> Raw(LeafNodeIdentifier.concat(right_child_key).append(right_child_value)))
-                            
+
     val internal_node = {
         left_child: Some({version: 1, hash: left_leaf_hash}),
         right_child: Some({version: 1, hash: right_leaf_hash})
     }
     val hashed_internal_node = hash(Internal(internal_node))
     val expected_internal_node_hash =  Map( [0] -> Hash,
-                                            [0, 0] -> Raw(InternalNodeIdentifier), 
-                                            [0, 1, 0] -> Raw(LeafNodeIdentifier.concat(left_child_key).append(left_child_value)), 
-                                            [0, 1] -> Hash, 
-                                            [0, 2, 0] -> Raw(LeafNodeIdentifier.concat(right_child_key).append(right_child_value)), 
+                                            [0, 0] -> Raw(InternalNodeIdentifier),
+                                            [0, 1, 0] -> Raw(LeafNodeIdentifier.concat(left_child_key).append(left_child_value)),
+                                            [0, 1] -> Hash,
+                                            [0, 2, 0] -> Raw(LeafNodeIdentifier.concat(right_child_key).append(right_child_value)),
                                             [0, 2] -> Hash
                                           )
    assert(all{

--- a/grug/jellyfish-merkle/spec/quint/tla/README.md
+++ b/grug/jellyfish-merkle/spec/quint/tla/README.md
@@ -5,7 +5,7 @@ This folder contains TLA+ generated files used to run TLC over the model. See th
 The files were generated with the command:
 
 ``` sh
-$ quint compile --target=tlaplus apply_state_machine.qnt  --step=step_fancy --invariant=allInvariants > apply_state_machine.tla
+quint compile --target=tlaplus apply_state_machine.qnt  --step=step_fancy --invariant=allInvariants > apply_state_machine.tla
 ```
 
 but not before making some adjustments to the Quint spec to handle some integration issues. Some adjustments are in the process of being incorporated into the integrated tools (Apalache and Quint), and others that don't have fixes yet, along with some optimizations for model checking, can be found in a `.patch` file in the respective folders.
@@ -15,13 +15,14 @@ After generating the TLA+ file, we also manually fixed the `init` definitions, a
 ## Using TLC to model check
 
 Dependencies:
+
 - Install [TLC](https://github.com/tlaplus/tlaplus) (requires Java)
 - Install [Quint](https://quint-lang.org/docs/getting-started)
 
 You'll need to run some instance of `quint verify` as that command installs apalache for you, which you'll need for the command below. Go to the folder above this one with all the quint files and run (PS: this command will fail, it is fine):
 
 ``` sh
-$ quint verify apply_state_machine.qnt --step=step_fancy --max-steps=0
+quint verify apply_state_machine.qnt --step=step_fancy --max-steps=0
 ```
 
 Now, Quint should have downloaded Apalache into `~/.quint/`. Check if it's there:

--- a/grug/jellyfish-merkle/spec/quint/tla/setupA/changes.patch
+++ b/grug/jellyfish-merkle/spec/quint/tla/setupA/changes.patch
@@ -5,24 +5,24 @@ index e2adafa..af8582e 100644
 @@ -12,42 +12,48 @@ module apply_state_machine {
    import grug_ics23.* from "./grug_ics23"
    import proofs.* from "./proofs"
- 
+
 -  import apply_simple as simple from "./apply_simple"
 +  // import apply_simple as simple from "./apply_simple"
    import apply_fancy as fancy from "./apply_fancy"
- 
+
    import completeness.* from "./completeness"
    import soundness.* from "./soundness"
- 
+
 -  pure val VALUES = Set(Insert([1]), Insert([2]), Delete)
 +  // Try to pick values with a balanced chance of collision
 +  pure val INIT_VALUES = Set(Some(Insert([1])), None)
 +  pure val VALUES = Set(Some(Insert([1])), Some(Insert([2])), Some(Delete), None)
- 
+
    var tree: Tree
    var version: int
    var smallest_unpruned_version: int
    var ops_history: List[Set[OperationOnKey]]
- 
+
 -  action init = all {
 -    // For now, we always start with an empty tree
 -    tree' = { nodes: Map(), orphans: Set() },
@@ -39,7 +39,7 @@ index e2adafa..af8582e 100644
 +      ops_history' = [ops],
 +    }
    }
- 
+
 -  pure def to_operations(nondet_value: BitArray -> Operation): Set[OperationOnKey] = {
 -    nondet_value.mapToTuples().map(((key_hash, op)) => {
 -      { key_hash: key_hash, op: op }
@@ -51,7 +51,7 @@ index e2adafa..af8582e 100644
 +      }
      })
    }
- 
+
    action step_parametrized(
      apply_op: (Tree, int, int, Set[OperationOnKey]) => Tree,
      assign_result: (Set[OperationOnKey], Tree) => bool
@@ -65,17 +65,17 @@ index e2adafa..af8582e 100644
 -    pure val ops = all_ops.indices().filter(i => i < threshold).map(i => all_ops[i])
 +    pure val ops = kms_with_value.to_operations()
      pure val new_tree = apply_op(tree, version - 1, version, ops)
- 
+
      assign_result(ops, new_tree)
 @@ -61,7 +67,7 @@ module apply_state_machine {
    }
- 
+
    action step_fancy = step_parametrized(fancy::apply, assign_result)
 -  action step_simple = step_parametrized(simple::apply, assign_result)
 +  // action step_simple = step_parametrized(simple::apply, assign_result)
- 
+
    /********* INVARIANTS ***********/
- 
+
 diff --git a/quint/tree.qnt b/quint/tree.qnt
 index 9973972..ecbeecd 100644
 --- a/quint/tree.qnt
@@ -83,10 +83,10 @@ index 9973972..ecbeecd 100644
 @@ -9,7 +9,7 @@ module tree {
    export hashes.*
    import utils.* from "./utils"
- 
+
 -  pure val MAX_HASH_LENGTH = 4
 +  pure val MAX_HASH_LENGTH = 3
- 
+
    // For types like -> batch: Vec<(Hash256, Op<Hash256>)>,
    type OperationOnKey = { key_hash: BitArray, op: Operation }
 diff --git a/quint/utils.qnt b/quint/utils.qnt
@@ -99,6 +99,6 @@ index 79efce6..e9474a6 100644
    import hashes.* from "./hashes"
 -  val keylength = 4
 +  val keylength = 3
- 
+
    pure val DEBUG_ENABLED = false
- 
+

--- a/grug/jellyfish-merkle/spec/quint/tla/setupB/changes.patch
+++ b/grug/jellyfish-merkle/spec/quint/tla/setupB/changes.patch
@@ -5,24 +5,24 @@ index e2adafa..5d44f07 100644
 @@ -12,42 +12,48 @@ module apply_state_machine {
    import grug_ics23.* from "./grug_ics23"
    import proofs.* from "./proofs"
- 
+
 -  import apply_simple as simple from "./apply_simple"
 +  // import apply_simple as simple from "./apply_simple"
    import apply_fancy as fancy from "./apply_fancy"
- 
+
    import completeness.* from "./completeness"
    import soundness.* from "./soundness"
- 
+
 -  pure val VALUES = Set(Insert([1]), Insert([2]), Delete)
 +  // Try to pick values with a balanced chance of collision
 +  pure val INIT_VALUES = Set(Some(Insert([1])), None)
 +  pure val VALUES = Set(Some(Insert([1])), Some(Insert([2])), Some(Delete), None)
- 
+
    var tree: Tree
    var version: int
    var smallest_unpruned_version: int
    var ops_history: List[Set[OperationOnKey]]
- 
+
 -  action init = all {
 -    // For now, we always start with an empty tree
 -    tree' = { nodes: Map(), orphans: Set() },
@@ -39,7 +39,7 @@ index e2adafa..5d44f07 100644
 +      ops_history' = [ops],
 +    }
    }
- 
+
 -  pure def to_operations(nondet_value: BitArray -> Operation): Set[OperationOnKey] = {
 -    nondet_value.mapToTuples().map(((key_hash, op)) => {
 -      { key_hash: key_hash, op: op }
@@ -51,7 +51,7 @@ index e2adafa..5d44f07 100644
 +      }
      })
    }
- 
+
    action step_parametrized(
      apply_op: (Tree, int, int, Set[OperationOnKey]) => Tree,
      assign_result: (Set[OperationOnKey], Tree) => bool
@@ -65,17 +65,17 @@ index e2adafa..5d44f07 100644
 -    pure val ops = all_ops.indices().filter(i => i < threshold).map(i => all_ops[i])
 +    pure val ops = kms_with_value.to_operations()
      pure val new_tree = apply_op(tree, version - 1, version, ops)
- 
+
      assign_result(ops, new_tree)
 @@ -61,7 +67,7 @@ module apply_state_machine {
    }
- 
+
    action step_fancy = step_parametrized(fancy::apply, assign_result)
 -  action step_simple = step_parametrized(simple::apply, assign_result)
 +  // action step_simple = step_parametrized(simple::apply, assign_result)
- 
+
    /********* INVARIANTS ***********/
- 
+
 diff --git a/quint/tree.qnt b/quint/tree.qnt
 index 9973972..e71ab49 100644
 --- a/quint/tree.qnt
@@ -83,10 +83,10 @@ index 9973972..e71ab49 100644
 @@ -9,7 +9,7 @@ module tree {
    export hashes.*
    import utils.* from "./utils"
- 
+
 -  pure val MAX_HASH_LENGTH = 4
 +  pure val MAX_HASH_LENGTH = 2
- 
+
    // For types like -> batch: Vec<(Hash256, Op<Hash256>)>,
    type OperationOnKey = { key_hash: BitArray, op: Operation }
 diff --git a/quint/utils.qnt b/quint/utils.qnt
@@ -99,6 +99,6 @@ index 79efce6..420fb42 100644
    import hashes.* from "./hashes"
 -  val keylength = 4
 +  val keylength = 2
- 
+
    pure val DEBUG_ENABLED = false
- 
+

--- a/grug/jellyfish-merkle/spec/quint/tree.qnt
+++ b/grug/jellyfish-merkle/spec/quint/tree.qnt
@@ -47,7 +47,7 @@ module tree {
   pure def is_node_orphaned(nodeId: NodeId, orphans: Set[OrphanId]): bool = {
     orphans.exists(el => (el.version == nodeId.version and el.key_hash == nodeId.key_hash))
   }
-  
+
   pure def isRoot(key: NodeId) : bool = key.key_hash == ROOT_BITS
 
   pure def prune(tree: Tree, up_to_version: Version): Tree = {
@@ -72,14 +72,14 @@ module tree {
       | Leaf(x) => s.union(Set(x))
     })
   }
-  
-  pure def allInternals(t: TreeMap): NodeId -> InternalNode = 
-    t.keys().fold(Map(), (internals, key) => 
+
+  pure def allInternals(t: TreeMap): NodeId -> InternalNode =
+    t.keys().fold(Map(), (internals, key) =>
       match t.get(key) {
       | Internal(x) => internals.put(key, x)
       | Leaf(_) => internals
     })
-  
+
   pure def treeVersion(t: Tree): int =
     t.nodes.keys()
      .filter(nId => nId.key_hash == [])
@@ -175,7 +175,7 @@ module tree {
   }
 
   pure val all_value_hashes = Set([0], [1])
-  
+
   pure def add_nodes(nodes: NodeId -> Node, new_nodes: Set[(NodeId, Node)]): NodeId -> Node = {
     new_nodes.fold(nodes, (nodes, new_node) => nodes.put(new_node._1, new_node._2))
   }

--- a/grug/jellyfish-merkle/spec/quint/utils.qnt
+++ b/grug/jellyfish-merkle/spec/quint/utils.qnt
@@ -34,16 +34,16 @@ module utils {
 
   pure def commonPrefixBetweenKeys(a: List[int], b: List[int]) : List[int] =
     val indList = range(1, keylength + 1)
-    indList.foldl([], (s, x) => if (a.slice(0, x) == b.slice(0, x)) 
-                                    b.slice(0, x) 
+    indList.foldl([], (s, x) => if (a.slice(0, x) == b.slice(0, x))
+                                    b.slice(0, x)
                                 else s )
 
   pure def commonPrefix(a: LeafNode, b: LeafNode) : Bytes =
     val indList = range(1, keylength + 1)
-    indList.foldl([], (s, x) => if (a.key_hash.slice(0, x) == b.key_hash.slice(0, x)) 
-                                    b.key_hash.slice(0, x) 
+    indList.foldl([], (s, x) => if (a.key_hash.slice(0, x) == b.key_hash.slice(0, x))
+                                    b.key_hash.slice(0, x)
                                 else s )
-  
+
   pure def prefix_of(l1: List[a], l2: List[b]): bool = and {
     l1.length() <= l2.length(),
     l1.indices().forall(i => l1[i] == l2[i])

--- a/grug/jellyfish-merkle/spec/scripts/quint-forall.sh
+++ b/grug/jellyfish-merkle/spec/scripts/quint-forall.sh
@@ -9,7 +9,7 @@ UNDERLINE=$(tput smul)
 info()
 {
   echo "${BLUE}[INFO] $*${RESET}"
-} 
+}
 
 # [ERROR] message in red
 error()


### PR DESCRIPTION
- run formatters (editorconfig and markdown-all-in-one)
- address markdownlint issues