### PR TITLE
refactor(grug): make ICS-23 optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
           toolchain: stable
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --all-features
         env:
           RUST_BACKTRACE: 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,7 +2787,6 @@ dependencies = [
  "grug-app",
  "grug-jmt",
  "grug-types",
- "ics23",
  "thiserror 2.0.9",
 ]
 

--- a/grug/app/Cargo.toml
+++ b/grug/app/Cargo.toml
@@ -11,6 +11,7 @@ version       = { workspace = true }
 
 [features]
 abci    = ["data-encoding", "tower", "tower-abci"]
+ibc     = ["dep:ics23"]
 tracing = ["chrono", "dep:tracing"]
 
 [dependencies]
@@ -20,7 +21,7 @@ data-encoding = { workspace = true, optional = true }
 grug-math     = { workspace = true }
 grug-storage  = { workspace = true }
 grug-types    = { workspace = true }
-ics23         = { workspace = true }
+ics23         = { workspace = true, optional = true }
 prost         = { workspace = true }
 serde         = { workspace = true }
 tendermint    = { workspace = true }

--- a/grug/app/Cargo.toml
+++ b/grug/app/Cargo.toml
@@ -11,7 +11,7 @@ version       = { workspace = true }
 
 [features]
 abci    = ["data-encoding", "tower", "tower-abci"]
-ibc     = ["dep:ics23"]
+ibc     = ["ics23"]
 tracing = ["chrono", "dep:tracing"]
 
 [dependencies]

--- a/grug/db/disk/Cargo.toml
+++ b/grug/db/disk/Cargo.toml
@@ -9,11 +9,14 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
+[features]
+ibc = ["grug-app/ibc", "grug-jmt/ibc", "ics23"]
+
 [dependencies]
 grug-app   = { workspace = true }
-grug-jmt   = { workspace = true, features = ["ics23"] }
+grug-jmt   = { workspace = true }
 grug-types = { workspace = true }
-ics23      = { workspace = true }
+ics23      = { workspace = true, optional = true }
 rocksdb    = { workspace = true }
 tempfile   = { workspace = true }
 thiserror  = { workspace = true }

--- a/grug/db/disk/src/db.rs
+++ b/grug/db/disk/src/db.rs
@@ -1,15 +1,11 @@
 use {
     crate::{DbError, DbResult, U64Comparator, U64Timestamp},
     grug_app::{Buffer, Db, PrunableDb},
-    grug_jmt::{MerkleTree, Proof, ICS23_PROOF_SPEC},
+    grug_jmt::{MerkleTree, Proof},
     grug_types::{Batch, Hash256, HashExt, Op, Order, Record, Storage},
-    ics23::{
-        commitment_proof::Proof as CommitmentProofInner, CommitmentProof, ExistenceProof,
-        NonExistenceProof,
-    },
     rocksdb::{
-        BoundColumnFamily, DBWithThreadMode, Direction, IteratorMode, MultiThreaded, Options,
-        ReadOptions, WriteBatch,
+        BoundColumnFamily, DBWithThreadMode, IteratorMode, MultiThreaded, Options, ReadOptions,
+        WriteBatch,
     },
     std::{
         path::Path,
@@ -50,7 +46,7 @@ const LATEST_VERSION_KEY: &[u8] = b"latest_version";
 const OLDEST_VERSION_KEY: &[u8] = b"oldest_version";
 
 /// Jellyfish Merkle tree (JMT) using default namespaces.
-const MERKLE_TREE: MerkleTree = MerkleTree::new_default();
+pub(crate) const MERKLE_TREE: MerkleTree = MerkleTree::new_default();
 
 /// The base storage primitive.
 ///
@@ -80,11 +76,11 @@ const MERKLE_TREE: MerkleTree = MerkleTree::new_default();
 /// have time to look into those advanced features yet. We will keep experimenting
 /// and maybe our implementation will converge with Sei's some time later.
 pub struct DiskDb {
-    inner: Arc<DiskDbInner>,
+    pub(crate) inner: Arc<DiskDbInner>,
 }
 
-struct DiskDbInner {
-    db: DBWithThreadMode<MultiThreaded>,
+pub(crate) struct DiskDbInner {
+    pub db: DBWithThreadMode<MultiThreaded>,
     // Data that are ready to be persisted to the physical database.
     // Ideally we want to just use a `rocksdb::WriteBatch` here, but it's not
     // thread-safe.
@@ -206,78 +202,6 @@ impl Db for DiskDb {
     fn prove(&self, key: &[u8], version: Option<u64>) -> DbResult<Proof> {
         let version = version.unwrap_or_else(|| self.latest_version().unwrap_or(0));
         Ok(MERKLE_TREE.prove(&self.state_commitment(), key.hash256(), version)?)
-    }
-
-    fn ics23_prove(
-        &self,
-        key: Vec<u8>,
-        version: Option<u64>,
-    ) -> Result<CommitmentProof, Self::Error> {
-        let version = version.unwrap_or_else(|| self.latest_version().unwrap_or(0));
-        let state_storage = self.state_storage(Some(version))?;
-        let state_commitment = self.state_commitment();
-
-        let generate_existence_proof = |key: Vec<u8>, value| -> DbResult<_> {
-            let key_hash = key.hash256();
-            let path = MERKLE_TREE.ics23_prove_existence(&state_commitment, version, key_hash)?;
-
-            Ok(ExistenceProof {
-                key,
-                value,
-                leaf: ICS23_PROOF_SPEC.leaf_spec.clone(),
-                path,
-            })
-        };
-
-        let proof = match state_storage.read(&key) {
-            // Value is found. Generate an ICS-23 existence proof.
-            Some(value) => CommitmentProofInner::Exist(generate_existence_proof(key, value)?),
-            // Value is not found.
-            //
-            // Here, unlike Diem or Penumbra's implementation, which walks the
-            // tree to find the left and right neighbors, we use an approach
-            // similar to SeiDB's:
-            // https://github.com/sei-protocol/sei-db/blob/v0.0.43/sc/memiavl/proof.go#L41-L76
-            //
-            // We simply look up the state storage to find the left and right
-            // neighbors, and generate existence proof of them.
-            None => {
-                let cf = cf_preimages(&self.inner.db);
-                let key_hash = key.hash256();
-
-                let opts = new_read_options(Some(version), None, None);
-                let mode = IteratorMode::From(&key_hash, Direction::Reverse);
-                let left = self
-                    .inner
-                    .db
-                    .iterator_cf_opt(&cf, opts, mode)
-                    .next()
-                    .map(|res| {
-                        let (_, key) = res?;
-                        let value = state_storage.read(&key).unwrap();
-                        generate_existence_proof(key.to_vec(), value)
-                    })
-                    .transpose()?;
-
-                let opts = new_read_options(Some(version), None, None);
-                let mode = IteratorMode::From(&key_hash, Direction::Forward);
-                let right = self
-                    .inner
-                    .db
-                    .iterator_cf_opt(&cf, opts, mode)
-                    .next()
-                    .map(|res| {
-                        let (_, key) = res?;
-                        let value = state_storage.read(&key).unwrap();
-                        generate_existence_proof(key.to_vec(), value)
-                    })
-                    .transpose()?;
-
-                CommitmentProofInner::Nonexist(NonExistenceProof { key, left, right })
-            },
-        };
-
-        Ok(CommitmentProof { proof: Some(proof) })
     }
 
     fn flush_but_not_commit(&self, batch: Batch) -> DbResult<(u64, Option<Hash256>)> {
@@ -652,7 +576,7 @@ fn new_cf_options_with_ts() -> Options {
     opts
 }
 
-fn new_read_options(
+pub(crate) fn new_read_options(
     version: Option<u64>,
     iterate_lower_bound: Option<&[u8]>,
     iterate_upper_bound: Option<&[u8]>,
@@ -676,7 +600,7 @@ fn cf_default(db: &DBWithThreadMode<MultiThreaded>) -> Arc<BoundColumnFamily> {
     })
 }
 
-fn cf_preimages(db: &DBWithThreadMode<MultiThreaded>) -> Arc<BoundColumnFamily> {
+pub(crate) fn cf_preimages(db: &DBWithThreadMode<MultiThreaded>) -> Arc<BoundColumnFamily> {
     db.cf_handle(CF_NAME_PREIMAGES).unwrap_or_else(|| {
         panic!("failed to find default column family");
     })
@@ -701,14 +625,9 @@ mod tests {
     use {
         crate::{DiskDb, TempDataDir},
         grug_app::{Db, PrunableDb},
-        grug_jmt::{
-            verify_proof, MembershipProof, NonMembershipProof, Proof, ProofNode, ICS23_PROOF_SPEC,
-        },
+        grug_jmt::{verify_proof, MembershipProof, NonMembershipProof, Proof, ProofNode},
         grug_types::{Batch, Hash256, HashExt, Op, Order, Storage},
         hex_literal::hex,
-        ics23::HostFunctionsManager,
-        proptest::prelude::*,
-        std::collections::BTreeMap,
     };
 
     // Using the same test case as in our rust-rocksdb fork:
@@ -1102,254 +1021,6 @@ mod tests {
                 err.to_string()
                     .contains("data not found! type: grug_jmt::node::Node")
             }));
-        }
-    }
-
-    #[test]
-    fn ics23_prove_works() {
-        let path = TempDataDir::new("_grug_disk_db_ics23_proving_works");
-        let db = DiskDb::open(&path).unwrap();
-
-        // Same test data as used in JMT crate.
-        let (_, maybe_root) = db
-            .flush_and_commit(Batch::from([
-                (b"r".to_vec(), Op::Insert(b"foo".to_vec())),
-                (b"m".to_vec(), Op::Insert(b"bar".to_vec())),
-                (b"L".to_vec(), Op::Insert(b"fuzz".to_vec())),
-                (b"a".to_vec(), Op::Insert(b"buzz".to_vec())),
-            ]))
-            .unwrap();
-        let root = maybe_root.unwrap().to_vec();
-
-        // Prove existing keys, and verify those proofs.
-        for (key, value) in [("r", "foo"), ("m", "bar"), ("L", "fuzz"), ("a", "buzz")] {
-            let proof = db.ics23_prove(key.as_bytes().to_vec(), None).unwrap();
-            assert!(
-                ics23::verify_membership::<HostFunctionsManager>(
-                    &proof,
-                    &ICS23_PROOF_SPEC,
-                    &root,
-                    key.as_bytes(),
-                    value.as_bytes(),
-                ),
-                "inclusion verification failed for key `{key}` and value `{value}`"
-            );
-        }
-
-        // Prove non-existing keys, and verify those proofs.
-        for key in ["b", "o"] {
-            let proof = db.ics23_prove(key.as_bytes().to_vec(), None).unwrap();
-            assert!(
-                ics23::verify_non_membership::<HostFunctionsManager>(
-                    &proof,
-                    &ICS23_PROOF_SPEC,
-                    &root,
-                    key.as_bytes()
-                ),
-                "exclusion verification failed for key `{key}`"
-            );
-        }
-    }
-
-    /// Testing a coding mistake found in the Zellic audit (finding 3.1).
-    ///
-    /// If a batch contains deletions, we forgot to also delete the keys from
-    /// the preimages map.
-    ///
-    /// In this example,
-    ///
-    /// - We build the tree at version 0 with two keys: "b" and "a".
-    /// - Then, at version 1, we delete "a".
-    /// - Then, we prove the non-existence of "L" at version 1.
-    ///
-    /// Hashes:
-    ///
-    /// - sha256("m") = 0110...
-    /// - sha256("L") = 0111...
-    /// - sha256("a") = 1100...
-    ///
-    /// Their relation is:
-    ///
-    /// > "m" < "L" < "a"
-    ///
-    /// At version 1, we expect the ICS-23 proof to contain a left neighbor ("m")
-    /// and no right neighbor.
-    ///
-    /// However, since we don't to delete the preimage of "a", the function
-    /// incorrectly thinks "a" exists as the right neighbor.
-    ///
-    /// When loading the key from state storage, it panics.
-    #[test]
-    fn ics23_prove_after_deletion() {
-        let path = TempDataDir::new("__grug_disk_db_ics23_prove_after_deletion");
-        let db = DiskDb::open(&path).unwrap();
-
-        // Apply batch at version 0.
-        let _ = db
-            .flush_and_commit(Batch::from([
-                (b"b".to_vec(), Op::Insert(b"buzz".to_vec())),
-                (b"a".to_vec(), Op::Insert(b"fuzz".to_vec())),
-            ]))
-            .unwrap();
-
-        // Apply batch at version 1.
-        let (version, maybe_root) = db
-            .flush_and_commit(Batch::from([(b"a".to_vec(), Op::Delete)]))
-            .unwrap();
-
-        // Generate and verify non-existence proof of "L" at version 1.
-        let key = b"L".to_vec();
-        let proof = db.ics23_prove(key.clone(), Some(version)).unwrap();
-        assert!(ics23::verify_non_membership::<HostFunctionsManager>(
-            &proof,
-            &ICS23_PROOF_SPEC,
-            &maybe_root.unwrap().to_vec(),
-            &key,
-        ));
-    }
-
-    proptest! {
-        /// Apply three batches as follows:
-        ///
-        /// 1. Insertions only.
-        /// 2. Deletions only.
-        /// 3. Both insertions and deletions.
-        ///
-        /// After each batch, generate and verify ICS-23 proofs.
-        #[test]
-        fn proptest_ics23_prove_works(
-            (inserts1, deletes1) in prop::collection::hash_map("[a-z]{1,10}", "[a-z]{1,10}", 1..100).prop_flat_map(|kvs| {
-                let len = kvs.len();
-                (Just(kvs), prop::collection::vec(any::<prop::sample::Selector>(), 0..len))
-            }),
-            inserts2 in prop::collection::hash_map("[a-z]{1,10}", "[a-z]{1,10}", 1..100),
-            deletes2 in prop::collection::vec(any::<prop::sample::Selector>(), 0..50)
-        ) {
-            let path = TempDataDir::new("_grug_disk_db_ics23_proving_works");
-            let db = DiskDb::open(&path).unwrap();
-            let mut state = BTreeMap::new();
-
-            // --------------------------- version 0 ---------------------------
-
-            let batch0 = inserts1
-                .into_iter()
-                .map(|(k, v)| (k.into_bytes(), Op::Insert(v.into_bytes())))
-                .collect::<Batch>();
-            let (version0, maybe_root) = db.flush_and_commit(batch0.clone()).unwrap();
-            let root0 = maybe_root.unwrap().to_vec();
-            assert_eq!(version0, 0);
-
-            // Update state mirroring version 0.
-            for (k, v) in &batch0 {
-                state.insert(k.clone(), v.clone().into_option().unwrap());
-            }
-
-            // Generate and verify membership proofs for each key in the state of
-            // version 0.
-            for (k, v) in &state {
-                let proof = db.ics23_prove(k.clone(), Some(version0)).unwrap();
-                assert!(ics23::verify_membership::<HostFunctionsManager>(
-                    &proof,
-                    &ICS23_PROOF_SPEC,
-                    &root0,
-                    k,
-                    v,
-                ));
-            }
-
-            // --------------------------- version 1 ---------------------------
-
-            let batch1 = deletes1
-                .into_iter()
-                .map(|s| {
-                    let (k, _) = s.select(&batch0);
-                    (k.clone(), Op::Delete)
-                })
-                .collect::<Batch>();
-            let (version1, maybe_root) = db.flush_and_commit(batch1.clone()).unwrap();
-            let root1 = maybe_root.unwrap().to_vec();
-            assert_eq!(version1, 1);
-
-            // For each key in this batch,
-            // - generate and verify membership proof at verson 0, when the key
-            //   still existsed in the state;
-            // - generate and verify non-membership proof at version 1, after the
-            //   key has been deleted.
-            // Also update the state.
-            for k in batch1.keys() {
-                // Prove in version 0
-                let proof = db.ics23_prove(k.clone(), Some(version0)).unwrap();
-                assert!(ics23::verify_membership::<HostFunctionsManager>(
-                    &proof,
-                    &ICS23_PROOF_SPEC,
-                    &root0,
-                    k,
-                    state.get(k).unwrap(),
-                ));
-
-                // Prove in version 1
-                let proof = db.ics23_prove(k.clone(), Some(version1)).unwrap();
-                assert!(ics23::verify_non_membership::<HostFunctionsManager>(
-                    &proof,
-                    &ICS23_PROOF_SPEC,
-                    &root1,
-                    k,
-                ));
-
-                // Update the state mirroring version 1.
-                state.remove(k);
-            }
-
-            // --------------------------- version 2 ---------------------------
-
-            let deletes2 = deletes2
-                .into_iter()
-                .map(|s| {
-                    let (k, _) = s.select(&batch0);
-                    (k.clone(), Op::Delete)
-                })
-                .collect::<Batch>();
-            let batch2 = inserts2
-                .into_iter()
-                .map(|(k, v)| (k.into_bytes(), Op::Insert(v.into_bytes())))
-                .chain(deletes2.clone())
-                .collect::<Batch>();
-            let (version2, maybe_root) = db.flush_and_commit(batch2.clone()).unwrap();
-            let root2 = maybe_root.unwrap().to_vec();
-            assert_eq!(version2, 2);
-
-            // Update the state mirroring version 2.
-            for (k, op) in batch2 {
-                match op {
-                    Op::Insert(v) => {
-                        state.insert(k.clone(), v);
-                    },
-                    Op::Delete => {
-                        state.remove(&k);
-                    },
-                }
-            }
-
-            // Generate and verify proofs at version 2.
-            for (k, v) in &state {
-                let proof = db.ics23_prove(k.clone(), Some(version2)).unwrap();
-                assert!(ics23::verify_membership::<HostFunctionsManager>(
-                    &proof,
-                    &ICS23_PROOF_SPEC,
-                    &root2,
-                    k,
-                    v,
-                ));
-            }
-            for k in deletes2.keys() {
-                let proof = db.ics23_prove(k.clone(), Some(version2)).unwrap();
-                assert!(ics23::verify_non_membership::<HostFunctionsManager>(
-                    &proof,
-                    &ICS23_PROOF_SPEC,
-                    &root2,
-                    k,
-                ));
-            }
         }
     }
 }

--- a/grug/db/disk/src/ics23.rs
+++ b/grug/db/disk/src/ics23.rs
@@ -1,0 +1,347 @@
+use {
+    crate::{cf_preimages, new_read_options, DbResult, DiskDb, MERKLE_TREE},
+    grug_app::{Db, IbcDb},
+    grug_jmt::ICS23_PROOF_SPEC,
+    grug_types::{HashExt, Storage},
+    ics23::{
+        commitment_proof::Proof as CommitmentProofInner, CommitmentProof, ExistenceProof,
+        NonExistenceProof,
+    },
+    rocksdb::{Direction, IteratorMode},
+};
+
+impl IbcDb for DiskDb {
+    fn ics23_prove(
+        &self,
+        key: Vec<u8>,
+        version: Option<u64>,
+    ) -> Result<CommitmentProof, Self::Error> {
+        let version = version.unwrap_or_else(|| self.latest_version().unwrap_or(0));
+        let state_storage = self.state_storage(Some(version))?;
+        let state_commitment = self.state_commitment();
+
+        let generate_existence_proof = |key: Vec<u8>, value| -> DbResult<_> {
+            let key_hash = key.hash256();
+            let path = MERKLE_TREE.ics23_prove_existence(&state_commitment, version, key_hash)?;
+
+            Ok(ExistenceProof {
+                key,
+                value,
+                leaf: ICS23_PROOF_SPEC.leaf_spec.clone(),
+                path,
+            })
+        };
+
+        let proof = match state_storage.read(&key) {
+            // Value is found. Generate an ICS-23 existence proof.
+            Some(value) => CommitmentProofInner::Exist(generate_existence_proof(key, value)?),
+            // Value is not found.
+            //
+            // Here, unlike Diem or Penumbra's implementation, which walks the
+            // tree to find the left and right neighbors, we use an approach
+            // similar to SeiDB's:
+            // https://github.com/sei-protocol/sei-db/blob/v0.0.43/sc/memiavl/proof.go#L41-L76
+            //
+            // We simply look up the state storage to find the left and right
+            // neighbors, and generate existence proof of them.
+            None => {
+                let cf = cf_preimages(&self.inner.db);
+                let key_hash = key.hash256();
+
+                let opts = new_read_options(Some(version), None, None);
+                let mode = IteratorMode::From(&key_hash, Direction::Reverse);
+                let left = self
+                    .inner
+                    .db
+                    .iterator_cf_opt(&cf, opts, mode)
+                    .next()
+                    .map(|res| {
+                        let (_, key) = res?;
+                        let value = state_storage.read(&key).unwrap();
+                        generate_existence_proof(key.to_vec(), value)
+                    })
+                    .transpose()?;
+
+                let opts = new_read_options(Some(version), None, None);
+                let mode = IteratorMode::From(&key_hash, Direction::Forward);
+                let right = self
+                    .inner
+                    .db
+                    .iterator_cf_opt(&cf, opts, mode)
+                    .next()
+                    .map(|res| {
+                        let (_, key) = res?;
+                        let value = state_storage.read(&key).unwrap();
+                        generate_existence_proof(key.to_vec(), value)
+                    })
+                    .transpose()?;
+
+                CommitmentProofInner::Nonexist(NonExistenceProof { key, left, right })
+            },
+        };
+
+        Ok(CommitmentProof { proof: Some(proof) })
+    }
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::TempDataDir,
+        grug_types::{Batch, Op},
+        ics23::HostFunctionsManager,
+        proptest::prelude::*,
+        std::collections::BTreeMap,
+    };
+
+    #[test]
+    fn ics23_prove_works() {
+        let path = TempDataDir::new("_grug_disk_db_ics23_proving_works");
+        let db = DiskDb::open(&path).unwrap();
+
+        // Same test data as used in JMT crate.
+        let (_, maybe_root) = db
+            .flush_and_commit(Batch::from([
+                (b"r".to_vec(), Op::Insert(b"foo".to_vec())),
+                (b"m".to_vec(), Op::Insert(b"bar".to_vec())),
+                (b"L".to_vec(), Op::Insert(b"fuzz".to_vec())),
+                (b"a".to_vec(), Op::Insert(b"buzz".to_vec())),
+            ]))
+            .unwrap();
+        let root = maybe_root.unwrap().to_vec();
+
+        // Prove existing keys, and verify those proofs.
+        for (key, value) in [("r", "foo"), ("m", "bar"), ("L", "fuzz"), ("a", "buzz")] {
+            let proof = db.ics23_prove(key.as_bytes().to_vec(), None).unwrap();
+            assert!(
+                ics23::verify_membership::<HostFunctionsManager>(
+                    &proof,
+                    &ICS23_PROOF_SPEC,
+                    &root,
+                    key.as_bytes(),
+                    value.as_bytes(),
+                ),
+                "inclusion verification failed for key `{key}` and value `{value}`"
+            );
+        }
+
+        // Prove non-existing keys, and verify those proofs.
+        for key in ["b", "o"] {
+            let proof = db.ics23_prove(key.as_bytes().to_vec(), None).unwrap();
+            assert!(
+                ics23::verify_non_membership::<HostFunctionsManager>(
+                    &proof,
+                    &ICS23_PROOF_SPEC,
+                    &root,
+                    key.as_bytes()
+                ),
+                "exclusion verification failed for key `{key}`"
+            );
+        }
+    }
+
+    /// Testing a coding mistake found in the Zellic audit (finding 3.1).
+    ///
+    /// If a batch contains deletions, we forgot to also delete the keys from
+    /// the preimages map.
+    ///
+    /// In this example,
+    ///
+    /// - We build the tree at version 0 with two keys: "b" and "a".
+    /// - Then, at version 1, we delete "a".
+    /// - Then, we prove the non-existence of "L" at version 1.
+    ///
+    /// Hashes:
+    ///
+    /// - sha256("m") = 0110...
+    /// - sha256("L") = 0111...
+    /// - sha256("a") = 1100...
+    ///
+    /// Their relation is:
+    ///
+    /// > "m" < "L" < "a"
+    ///
+    /// At version 1, we expect the ICS-23 proof to contain a left neighbor ("m")
+    /// and no right neighbor.
+    ///
+    /// However, since we don't to delete the preimage of "a", the function
+    /// incorrectly thinks "a" exists as the right neighbor.
+    ///
+    /// When loading the key from state storage, it panics.
+    #[test]
+    fn ics23_prove_after_deletion() {
+        let path = TempDataDir::new("__grug_disk_db_ics23_prove_after_deletion");
+        let db = DiskDb::open(&path).unwrap();
+
+        // Apply batch at version 0.
+        let _ = db
+            .flush_and_commit(Batch::from([
+                (b"b".to_vec(), Op::Insert(b"buzz".to_vec())),
+                (b"a".to_vec(), Op::Insert(b"fuzz".to_vec())),
+            ]))
+            .unwrap();
+
+        // Apply batch at version 1.
+        let (version, maybe_root) = db
+            .flush_and_commit(Batch::from([(b"a".to_vec(), Op::Delete)]))
+            .unwrap();
+
+        // Generate and verify non-existence proof of "L" at version 1.
+        let key = b"L".to_vec();
+        let proof = db.ics23_prove(key.clone(), Some(version)).unwrap();
+        assert!(ics23::verify_non_membership::<HostFunctionsManager>(
+            &proof,
+            &ICS23_PROOF_SPEC,
+            &maybe_root.unwrap().to_vec(),
+            &key,
+        ));
+    }
+
+    proptest! {
+        /// Apply three batches as follows:
+        ///
+        /// 1. Insertions only.
+        /// 2. Deletions only.
+        /// 3. Both insertions and deletions.
+        ///
+        /// After each batch, generate and verify ICS-23 proofs.
+        #[test]
+        fn proptest_ics23_prove_works(
+            (inserts1, deletes1) in prop::collection::hash_map("[a-z]{1,10}", "[a-z]{1,10}", 1..100).prop_flat_map(|kvs| {
+                let len = kvs.len();
+                (Just(kvs), prop::collection::vec(any::<prop::sample::Selector>(), 0..len))
+            }),
+            inserts2 in prop::collection::hash_map("[a-z]{1,10}", "[a-z]{1,10}", 1..100),
+            deletes2 in prop::collection::vec(any::<prop::sample::Selector>(), 0..50)
+        ) {
+            let path = TempDataDir::new("_grug_disk_db_ics23_proving_works");
+            let db = DiskDb::open(&path).unwrap();
+            let mut state = BTreeMap::new();
+
+            // --------------------------- version 0 ---------------------------
+
+            let batch0 = inserts1
+                .into_iter()
+                .map(|(k, v)| (k.into_bytes(), Op::Insert(v.into_bytes())))
+                .collect::<Batch>();
+            let (version0, maybe_root) = db.flush_and_commit(batch0.clone()).unwrap();
+            let root0 = maybe_root.unwrap().to_vec();
+            assert_eq!(version0, 0);
+
+            // Update state mirroring version 0.
+            for (k, v) in &batch0 {
+                state.insert(k.clone(), v.clone().into_option().unwrap());
+            }
+
+            // Generate and verify membership proofs for each key in the state of
+            // version 0.
+            for (k, v) in &state {
+                let proof = db.ics23_prove(k.clone(), Some(version0)).unwrap();
+                assert!(ics23::verify_membership::<HostFunctionsManager>(
+                    &proof,
+                    &ICS23_PROOF_SPEC,
+                    &root0,
+                    k,
+                    v,
+                ));
+            }
+
+            // --------------------------- version 1 ---------------------------
+
+            let batch1 = deletes1
+                .into_iter()
+                .map(|s| {
+                    let (k, _) = s.select(&batch0);
+                    (k.clone(), Op::Delete)
+                })
+                .collect::<Batch>();
+            let (version1, maybe_root) = db.flush_and_commit(batch1.clone()).unwrap();
+            let root1 = maybe_root.unwrap().to_vec();
+            assert_eq!(version1, 1);
+
+            // For each key in this batch,
+            // - generate and verify membership proof at verson 0, when the key
+            //   still existsed in the state;
+            // - generate and verify non-membership proof at version 1, after the
+            //   key has been deleted.
+            // Also update the state.
+            for k in batch1.keys() {
+                // Prove in version 0
+                let proof = db.ics23_prove(k.clone(), Some(version0)).unwrap();
+                assert!(ics23::verify_membership::<HostFunctionsManager>(
+                    &proof,
+                    &ICS23_PROOF_SPEC,
+                    &root0,
+                    k,
+                    state.get(k).unwrap(),
+                ));
+
+                // Prove in version 1
+                let proof = db.ics23_prove(k.clone(), Some(version1)).unwrap();
+                assert!(ics23::verify_non_membership::<HostFunctionsManager>(
+                    &proof,
+                    &ICS23_PROOF_SPEC,
+                    &root1,
+                    k,
+                ));
+
+                // Update the state mirroring version 1.
+                state.remove(k);
+            }
+
+            // --------------------------- version 2 ---------------------------
+
+            let deletes2 = deletes2
+                .into_iter()
+                .map(|s| {
+                    let (k, _) = s.select(&batch0);
+                    (k.clone(), Op::Delete)
+                })
+                .collect::<Batch>();
+            let batch2 = inserts2
+                .into_iter()
+                .map(|(k, v)| (k.into_bytes(), Op::Insert(v.into_bytes())))
+                .chain(deletes2.clone())
+                .collect::<Batch>();
+            let (version2, maybe_root) = db.flush_and_commit(batch2.clone()).unwrap();
+            let root2 = maybe_root.unwrap().to_vec();
+            assert_eq!(version2, 2);
+
+            // Update the state mirroring version 2.
+            for (k, op) in batch2 {
+                match op {
+                    Op::Insert(v) => {
+                        state.insert(k.clone(), v);
+                    },
+                    Op::Delete => {
+                        state.remove(&k);
+                    },
+                }
+            }
+
+            // Generate and verify proofs at version 2.
+            for (k, v) in &state {
+                let proof = db.ics23_prove(k.clone(), Some(version2)).unwrap();
+                assert!(ics23::verify_membership::<HostFunctionsManager>(
+                    &proof,
+                    &ICS23_PROOF_SPEC,
+                    &root2,
+                    k,
+                    v,
+                ));
+            }
+            for k in deletes2.keys() {
+                let proof = db.ics23_prove(k.clone(), Some(version2)).unwrap();
+                assert!(ics23::verify_non_membership::<HostFunctionsManager>(
+                    &proof,
+                    &ICS23_PROOF_SPEC,
+                    &root2,
+                    k,
+                ));
+            }
+        }
+    }
+}

--- a/grug/db/disk/src/lib.rs
+++ b/grug/db/disk/src/lib.rs
@@ -1,5 +1,7 @@
 mod db;
 mod error;
+#[cfg(feature = "ibc")]
+mod ics23;
 mod testing;
 mod timestamp;
 

--- a/grug/db/memory/Cargo.toml
+++ b/grug/db/memory/Cargo.toml
@@ -13,7 +13,6 @@ version       = { workspace = true }
 grug-app   = { workspace = true }
 grug-jmt   = { workspace = true }
 grug-types = { workspace = true }
-ics23      = { workspace = true }
 thiserror  = { workspace = true }
 
 [dev-dependencies]

--- a/grug/db/memory/src/db.rs
+++ b/grug/db/memory/src/db.rs
@@ -3,7 +3,6 @@ use {
     grug_app::{Buffer, Db},
     grug_jmt::{MerkleTree, Proof},
     grug_types::{Batch, Hash256, HashExt, Op, Order, Record, Storage},
-    ics23::CommitmentProof,
     std::{
         collections::HashMap,
         ops::Bound,
@@ -115,14 +114,6 @@ impl Db for MemDb {
     fn prove(&self, key: &[u8], version: Option<u64>) -> DbResult<Proof> {
         let version = version.unwrap_or_else(|| self.latest_version().unwrap_or(0));
         Ok(MERKLE_TREE.prove(&self.state_commitment(), key.hash256(), version)?)
-    }
-
-    fn ics23_prove(
-        &self,
-        _key: Vec<u8>,
-        _version: Option<u64>,
-    ) -> Result<CommitmentProof, Self::Error> {
-        unimplemented!("don't need this for testing")
     }
 
     // Note on implementing this function: We must make sure that we don't

--- a/grug/jellyfish-merkle/Cargo.toml
+++ b/grug/jellyfish-merkle/Cargo.toml
@@ -11,11 +11,10 @@ rust-version  = { workspace = true }
 version       = { workspace = true }
 
 [features]
-default = ["ics23"]
 # Include fuzzing test, which can take a long time to run.
 fuzzing = []
 # Include a method to generate ICS-23 compatible proofs.
-ics23 = ["dep:ics23"]
+ibc = ["ics23"]
 
 [dependencies]
 borsh        = { workspace = true, features = ["de_strict_order", "derive"] }

--- a/grug/jellyfish-merkle/src/lib.rs
+++ b/grug/jellyfish-merkle/src/lib.rs
@@ -1,10 +1,10 @@
 mod bitarray;
-#[cfg(feature = "ics23")]
+#[cfg(feature = "ibc")]
 mod ics23;
 mod node;
 mod proof;
 mod tree;
 
-#[cfg(feature = "ics23")]
+#[cfg(feature = "ibc")]
 pub use crate::ics23::*;
 pub use crate::{bitarray::*, node::*, proof::*, tree::*};


### PR DESCRIPTION
we no longer use IBC, so ICS-23 related stuff can be made optional.