### PR TITLE
lint(grug): more fixes related to optional dependencies in grug-app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,7 +2722,6 @@ dependencies = [
  "grug-types",
  "ics23",
  "prost",
- "serde",
  "tendermint",
  "thiserror 2.0.9",
  "tower 0.5.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,6 @@ dependencies = [
  "hex-literal",
  "ics23",
  "proptest",
- "rand",
  "serde",
  "test-case",
  "thiserror 2.0.9",

--- a/grug/app/Cargo.toml
+++ b/grug/app/Cargo.toml
@@ -10,7 +10,7 @@ rust-version  = { workspace = true }
 version       = { workspace = true }
 
 [features]
-abci    = ["data-encoding", "tower", "tower-abci"]
+abci    = ["data-encoding", "tendermint", "tower", "tower-abci"]
 ibc     = ["ics23"]
 tracing = ["chrono", "dep:tracing"]
 
@@ -23,8 +23,7 @@ grug-storage  = { workspace = true }
 grug-types    = { workspace = true }
 ics23         = { workspace = true, optional = true }
 prost         = { workspace = true }
-serde         = { workspace = true }
-tendermint    = { workspace = true }
+tendermint    = { workspace = true, optional = true }
 thiserror     = { workspace = true }
 tower         = { workspace = true, optional = true }
 tower-abci    = { workspace = true, optional = true }

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -1,3 +1,9 @@
+#[cfg(all(feature = "abci", feature = "tracing"))]
+use data_encoding::BASE64;
+#[cfg(feature = "abci")]
+use grug_types::JsonDeExt;
+#[cfg(any(feature = "abci", feature = "tracing"))]
+use grug_types::JsonSerExt;
 use {
     crate::{
         catch_and_append_event, catch_and_update_event, do_authenticate, do_backrun, do_configure,
@@ -18,11 +24,6 @@ use {
         TxOutcome, UnsignedTx, GENESIS_SENDER,
     },
     prost::bytes::Bytes,
-};
-#[cfg(feature = "abci")]
-use {
-    data_encoding::BASE64,
-    grug_types::{JsonDeExt, JsonSerExt},
 };
 
 /// The ABCI application.

--- a/grug/jellyfish-merkle/Cargo.toml
+++ b/grug/jellyfish-merkle/Cargo.toml
@@ -11,8 +11,6 @@ rust-version  = { workspace = true }
 version       = { workspace = true }
 
 [features]
-# Include fuzzing test, which can take a long time to run.
-fuzzing = []
 # Include a method to generate ICS-23 compatible proofs.
 ibc = ["ics23"]
 
@@ -28,5 +26,4 @@ thiserror    = { workspace = true }
 [dev-dependencies]
 hex-literal = { workspace = true }
 proptest    = { workspace = true }
-rand        = { workspace = true }
 test-case   = { workspace = true }


### PR DESCRIPTION
use the following commands to make sure:

```
cargo clippy -p grug-app --no-default-features
cargo clippy -p grug-app --no-default-features --features abci
cargo clippy -p grug-app --no-default-features --features tracing
cargo clippy -p grug-app --no-default-features --features abci,tracing
```