### PR TITLE
feat(grug): Contract Event Trait

### DIFF
--- a/dango/account/margin/src/execute.rs
+++ b/dango/account/margin/src/execute.rs
@@ -218,7 +218,7 @@ pub fn liquidate(ctx: MutableCtx, liquidation_denom: Denom) -> anyhow::Result<Re
     Ok(Response::new()
         .add_message(repay_msg)
         .add_message(send_msg)
-        .add_event("liquidate", Liquidate {
+        .add_event(Liquidate {
             liquidation_denom,
             repay_coins,
             refunds,

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -111,18 +111,16 @@ fn submit_order(
         },
     )?;
 
-    Ok(
-        Response::new().add_event("order_submitted", OrderSubmitted {
-            order_id,
-            user: ctx.sender,
-            base_denom,
-            quote_denom,
-            direction,
-            price,
-            amount,
-            deposit,
-        })?,
-    )
+    Ok(Response::new().add_event(OrderSubmitted {
+        order_id,
+        user: ctx.sender,
+        base_denom,
+        quote_denom,
+        direction,
+        price,
+        amount,
+        deposit,
+    })?)
 }
 
 #[inline]

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -46,6 +46,7 @@ pub enum QueryMsg {
 }
 
 #[grug::derive(Serde)]
+#[grug::event("liquidate")]
 pub struct Liquidate {
     pub liquidation_denom: Denom,
     pub repay_coins: Coins,

--- a/dango/types/src/dex.rs
+++ b/dango/types/src/dex.rs
@@ -143,6 +143,7 @@ pub enum QueryMsg {
 // ---------------------------------- events -----------------------------------
 
 #[grug::derive(Serde)]
+#[grug::event("order_submitted")]
 pub struct OrderSubmitted {
     pub order_id: OrderId,
     pub user: Addr,
@@ -155,6 +156,7 @@ pub struct OrderSubmitted {
 }
 
 #[grug::derive(Serde)]
+#[grug::event("order_canceled")]
 pub struct OrderCanceled {
     pub order_id: OrderId,
     pub remaining: Uint128,
@@ -162,6 +164,7 @@ pub struct OrderCanceled {
 }
 
 #[grug::derive(Serde)]
+#[grug::event("orders_matched")]
 pub struct OrdersMatched {
     pub base_denom: Denom,
     pub quote_denom: Denom,
@@ -170,6 +173,7 @@ pub struct OrdersMatched {
 }
 
 #[grug::derive(Serde)]
+#[grug::event("order_filled")]
 pub struct OrderFilled {
     pub order_id: OrderId,
     /// The price at which the order was executed.

--- a/dango/types/src/warp.rs
+++ b/dango/types/src/warp.rs
@@ -168,6 +168,7 @@ pub struct QueryRoutesResponseItem {
 // ---------------------------------- events -----------------------------------
 
 #[grug::derive(Serde)]
+#[grug::event("transfer_remote")]
 pub struct TransferRemote {
     pub sender: Addr,
     pub destination_domain: Domain,
@@ -179,6 +180,7 @@ pub struct TransferRemote {
 }
 
 #[grug::derive(Serde)]
+#[grug::event("handle")]
 pub struct Handle {
     pub recipient: Addr32,
     pub token: Denom,

--- a/dango/warp/src/execute.rs
+++ b/dango/warp/src/execute.rs
@@ -131,7 +131,7 @@ fn transfer_remote(
                 }
             },
         )?)
-        .add_event("transfer_remote", &TransferRemote {
+        .add_event(TransferRemote {
             sender: ctx.sender,
             destination_domain,
             recipient,
@@ -180,7 +180,7 @@ fn handle(
                 amount: body.amount,
             })?
         })
-        .add_event("handle", &Handle {
+        .add_event(Handle {
             recipient: body.recipient,
             token: denom,
             amount: body.amount,

--- a/grug/macros/src/event.rs
+++ b/grug/macros/src/event.rs
@@ -30,7 +30,7 @@ pub fn process(attr: TokenStream, input: TokenStream) -> TokenStream {
     quote::quote! {
         #input
 
-        impl grug::AsContractEvent for #input_name {
+        impl grug::EventName for #input_name {
             const NAME: &'static str = #name;
         }
     }

--- a/grug/macros/src/event.rs
+++ b/grug/macros/src/event.rs
@@ -1,0 +1,38 @@
+use {
+    proc_macro::TokenStream,
+    syn::{
+        parse::{Parse, ParseStream},
+        parse_macro_input, DeriveInput, LitStr,
+    },
+};
+
+struct Args(String);
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse::<LitStr>()?;
+
+        if !input.is_empty() {
+            return Err(input.error("expected only a single identifier"));
+        }
+
+        Ok(Self(name.value()))
+    }
+}
+
+pub fn process(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attrs = parse_macro_input!(attr as Args);
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = attrs.0;
+    let input_name = input.ident.clone();
+
+    quote::quote! {
+        #input
+
+        impl grug::AsContractEvent for #input_name {
+            const NAME: &'static str = #name;
+        }
+    }
+    .into()
+}

--- a/grug/macros/src/lib.rs
+++ b/grug/macros/src/lib.rs
@@ -1,9 +1,15 @@
 mod derive;
+mod event;
 mod export;
 mod index_list;
 mod query;
 
 use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn event(attr: TokenStream, input: TokenStream) -> TokenStream {
+    event::process(attr, input)
+}
 
 #[proc_macro_attribute]
 pub fn derive(attr: TokenStream, input: TokenStream) -> TokenStream {

--- a/grug/types/src/events.rs
+++ b/grug/types/src/events.rs
@@ -1,8 +1,9 @@
 mod as_variant;
+mod contract_event;
 mod filter;
 mod flat;
 mod flatten;
 mod nested;
 mod search;
 
-pub use {as_variant::*, filter::*, flat::*, flatten::*, nested::*, search::*};
+pub use {as_variant::*, contract_event::*, filter::*, flat::*, flatten::*, nested::*, search::*};

--- a/grug/types/src/events/contract_event.rs
+++ b/grug/types/src/events/contract_event.rs
@@ -1,0 +1,5 @@
+use serde::Serialize;
+
+pub trait AsContractEvent: Serialize {
+    const NAME: &'static str;
+}

--- a/grug/types/src/events/contract_event.rs
+++ b/grug/types/src/events/contract_event.rs
@@ -1,5 +1,8 @@
 use serde::Serialize;
 
-pub trait AsContractEvent: Serialize {
+/// Represents a custom event that contracts may emit.
+///
+/// It must be serializable to JSON and has a string name.
+pub trait EventName: Serialize {
     const NAME: &'static str;
 }

--- a/grug/types/src/response.rs
+++ b/grug/types/src/response.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Json, JsonSerExt, Message, StdResult},
+    crate::{AsContractEvent, Json, JsonSerExt, Message, StdResult},
     borsh::{BorshDeserialize, BorshSerialize},
     serde::{Deserialize, Serialize},
 };
@@ -65,12 +65,11 @@ impl Response {
         self
     }
 
-    pub fn add_event<T, U>(mut self, ty: T, data: U) -> StdResult<Self>
+    pub fn add_event<E>(mut self, event: E) -> StdResult<Self>
     where
-        T: Into<String>,
-        U: Serialize,
+        E: AsContractEvent,
     {
-        self.subevents.push(ContractEvent::new(ty, data)?);
+        self.subevents.push(ContractEvent::new(E::NAME, event)?);
         Ok(self)
     }
 
@@ -153,12 +152,11 @@ impl AuthResponse {
         self
     }
 
-    pub fn add_event<T, U>(mut self, ty: T, data: U) -> StdResult<Self>
+    pub fn add_event<E>(mut self, event: E) -> StdResult<Self>
     where
-        T: Into<String>,
-        U: Serialize,
+        E: AsContractEvent,
     {
-        self.response = self.response.add_event(ty, data)?;
+        self.response = self.response.add_event(event)?;
         Ok(self)
     }
 

--- a/grug/types/src/response.rs
+++ b/grug/types/src/response.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{AsContractEvent, Json, JsonSerExt, Message, StdResult},
+    crate::{EventName, Json, JsonSerExt, Message, StdResult},
     borsh::{BorshDeserialize, BorshSerialize},
     serde::{Deserialize, Serialize},
 };
@@ -67,7 +67,7 @@ impl Response {
 
     pub fn add_event<E>(mut self, event: E) -> StdResult<Self>
     where
-        E: AsContractEvent,
+        E: EventName,
     {
         self.subevents.push(ContractEvent::new(E::NAME, event)?);
         Ok(self)
@@ -154,7 +154,7 @@ impl AuthResponse {
 
     pub fn add_event<E>(mut self, event: E) -> StdResult<Self>
     where
-        E: AsContractEvent,
+        E: EventName,
     {
         self.response = self.response.add_event(event)?;
         Ok(self)

--- a/hyperlane/grug/hooks/merkle/src/execute.rs
+++ b/hyperlane/grug/hooks/merkle/src/execute.rs
@@ -50,11 +50,11 @@ fn post_dispatch(ctx: MutableCtx, raw_message: HexBinary) -> anyhow::Result<Resp
     })?;
 
     Ok(Response::new()
-        .add_event("post_dispatch", PostDispatch {
+        .add_event(PostDispatch {
             message_id,
             index: tree.count - 1,
         })?
-        .add_event("inserted_into_tree", InsertedIntoTree {
+        .add_event(InsertedIntoTree {
             index: tree.count - 1,
         })?)
 }

--- a/hyperlane/grug/mailbox/src/execute.rs
+++ b/hyperlane/grug/mailbox/src/execute.rs
@@ -105,13 +105,13 @@ fn dispatch(
             }),
             ctx.funds,
         )?)
-        .add_event("mailbox_dispatch", &Dispatch {
+        .add_event(Dispatch {
             sender: message.sender,
             destination_domain: message.destination_domain,
             recipient: message.recipient,
             message: message.body,
         })?
-        .add_event("mailbox_dispatch_id", &DispatchId { message_id })?)
+        .add_event(DispatchId { message_id })?)
 }
 
 #[inline]
@@ -183,10 +183,10 @@ fn process(
             }),
             Coins::new(),
         )?)
-        .add_event("mailbox_process", &Process {
+        .add_event(Process {
             origin_domain: message.origin_domain,
             sender: message.sender,
             recipient: message.recipient,
         })?
-        .add_event("mailbox_process_id", &ProcessId { message_id })?)
+        .add_event(ProcessId { message_id })?)
 }

--- a/hyperlane/grug/types/src/hooks/merkle.rs
+++ b/hyperlane/grug/types/src/hooks/merkle.rs
@@ -36,12 +36,14 @@ pub enum QueryMsg {
 // ---------------------------------- events -----------------------------------
 
 #[grug::derive(Serde)]
+#[grug::event("post_dispatch")]
 pub struct PostDispatch {
     pub message_id: Hash256,
     pub index: u128,
 }
 
 #[grug::derive(Serde)]
+#[grug::event("inserted_into_tree")]
 pub struct InsertedIntoTree {
     pub index: u128,
 }

--- a/hyperlane/grug/types/src/mailbox.rs
+++ b/hyperlane/grug/types/src/mailbox.rs
@@ -109,6 +109,7 @@ pub enum QueryMsg {
 // ---------------------------------- events -----------------------------------
 
 #[grug::derive(Serde)]
+#[grug::event("mailbox_dispatch")]
 pub struct Dispatch {
     pub sender: Addr32,
     pub destination_domain: Domain,
@@ -117,11 +118,13 @@ pub struct Dispatch {
 }
 
 #[grug::derive(Serde)]
+#[grug::event("mailbox_dispatch_id")]
 pub struct DispatchId {
     pub message_id: Hash256,
 }
 
 #[grug::derive(Serde)]
+#[grug::event("mailbox_process")]
 pub struct Process {
     pub origin_domain: Domain,
     pub sender: Addr32,
@@ -129,6 +132,7 @@ pub struct Process {
 }
 
 #[grug::derive(Serde)]
+#[grug::event("mailbox_process_id")]
 pub struct ProcessId {
     pub message_id: Hash256,
 }


### PR DESCRIPTION
Instead of manually adding the string type of a event into the `Response` via `Response::add_event(ty: impl Into<String>, event: impl Serialize)`,  `add_event` require now a single param `E: impl AsContractEvent`
```rust
pub trait AsContractEvent: Serialize {
    const NAME: &'static str;
}
```
The trait `AsContractEvent` can be implemented with a new `proc_macro_attribute`
```rust
#[grug::derive(Serde)]
#[grug::event("handle")]
pub struct Handle {
    pub recipient: Addr32,
    pub token: Denom,
    pub amount: Uint128,
}
```
