### PR TITLE
feat(dango): permissioned creation of DEX pairs

### DIFF
--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -1,20 +1,20 @@
 use {
     crate::{
         fill_orders, match_orders, FillingOutcome, MatchingOutcome, Order, NEW_ORDER_COUNTS,
-        NEXT_ORDER_ID, ORDERS,
+        NEXT_ORDER_ID, ORDERS, PAIRS,
     },
     anyhow::ensure,
     dango_types::{
         bank,
         dex::{
             Direction, ExecuteMsg, InstantiateMsg, OrderCanceled, OrderFilled, OrderId,
-            OrderSubmitted, OrdersMatched,
+            OrderSubmitted, OrdersMatched, PairUpdate, PairUpdated,
         },
     },
     grug::{
-        Addr, Coin, Coins, ContractEvent, Denom, Message, MultiplyFraction, MutableCtx, Number,
-        Order as IterationOrder, QuerierExt, Response, StdResult, Storage, SudoCtx, Udec128,
-        Uint128,
+        Addr, Coin, Coins, ContractEvent, Denom, EventName, Message, MultiplyFraction, MutableCtx,
+        Number, Order as IterationOrder, QuerierExt, Response, StdResult, Storage, SudoCtx,
+        Udec128, Uint128,
     },
     std::collections::{BTreeMap, BTreeSet},
 };
@@ -22,13 +22,21 @@ use {
 const HALF: Udec128 = Udec128::new_percent(50);
 
 #[cfg_attr(not(feature = "library"), grug::export)]
-pub fn instantiate(_ctx: MutableCtx, _msg: InstantiateMsg) -> StdResult<Response> {
-    Ok(Response::new())
+pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
+    batch_update_pairs(ctx, msg.pairs)
 }
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
+        ExecuteMsg::BatchUpdatePairs(updates) => {
+            ensure!(
+                ctx.sender == ctx.querier.query_owner()?,
+                "only the owner can update a trading pair parameters"
+            );
+
+            batch_update_pairs(ctx, updates)
+        },
         ExecuteMsg::SubmitOrder {
             base_denom,
             quote_denom,
@@ -41,6 +49,26 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
 }
 
 #[inline]
+fn batch_update_pairs(ctx: MutableCtx, updates: Vec<PairUpdate>) -> anyhow::Result<Response> {
+    let mut events = Vec::with_capacity(updates.len());
+
+    for update in updates {
+        PAIRS.save(
+            ctx.storage,
+            (&update.base_denom, &update.quote_denom),
+            &update.params,
+        )?;
+
+        events.push(ContractEvent::new(PairUpdated::NAME, PairUpdated {
+            base_denom: update.base_denom,
+            quote_denom: update.quote_denom,
+        })?);
+    }
+
+    Ok(Response::new().add_subevents(events))
+}
+
+#[inline]
 fn submit_order(
     ctx: MutableCtx,
     base_denom: Denom,
@@ -49,6 +77,11 @@ fn submit_order(
     amount: Uint128,
     price: Udec128,
 ) -> anyhow::Result<Response> {
+    ensure!(
+        PAIRS.has(ctx.storage, (&base_denom, &quote_denom)),
+        "pair not found with base `{base_denom}` and quote `{quote_denom}`"
+    );
+
     let deposit = ctx.funds.into_one_coin()?;
 
     match direction {

--- a/dango/dex/src/state.rs
+++ b/dango/dex/src/state.rs
@@ -1,7 +1,10 @@
 use {
-    dango_types::dex::{Direction, OrderId},
-    grug::{Addr, Counter, Counters, Denom, IndexedMap, Udec128, Uint128, UniqueIndex},
+    dango_types::dex::{Direction, OrderId, PairParams},
+    grug::{Addr, Counter, Counters, Denom, IndexedMap, Map, Udec128, Uint128, UniqueIndex},
 };
+
+// (base_denom, quote_denom) => params
+pub const PAIRS: Map<(&Denom, &Denom), PairParams> = Map::new("pair");
 
 /// The number of new orders that each trading pair has received during the
 /// current block.

--- a/dango/genesis/examples/build_genesis.rs
+++ b/dango/genesis/examples/build_genesis.rs
@@ -3,7 +3,11 @@ use {
     dango_types::{
         account_factory::Username,
         auth::Key,
-        constants::{DANGO_DENOM, GUARDIAN_SETS, PYTH_PRICE_SOURCES, USDC_DENOM},
+        constants::{
+            BTC_DENOM, DANGO_DENOM, ETH_DENOM, GUARDIAN_SETS, PYTH_PRICE_SOURCES, SOL_DENOM,
+            USDC_DENOM,
+        },
+        dex::{PairParams, PairUpdate},
         taxman,
     },
     grug::{
@@ -111,6 +115,28 @@ fn main() {
         },
         max_orphan_age: Duration::from_weeks(1),
         metadatas: btree_map! {},
+        pairs: vec![
+            PairUpdate {
+                base_denom: DANGO_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+            PairUpdate {
+                base_denom: BTC_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+            PairUpdate {
+                base_denom: ETH_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+            PairUpdate {
+                base_denom: SOL_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+        ],
         markets: btree_map! {},
         price_sources: PYTH_PRICE_SOURCES.clone(),
         unlocking_cliff: Duration::from_weeks(4 * 9), // ~9 months

--- a/dango/genesis/src/lib.rs
+++ b/dango/genesis/src/lib.rs
@@ -4,7 +4,8 @@ use {
         auth::Key,
         bank,
         config::{AppAddresses, AppConfig},
-        dex, ibc,
+        dex::{self, PairUpdate},
+        ibc,
         lending::{self, MarketUpdates},
         oracle::{self, GuardianSet, GuardianSetIndex, PriceSource},
         taxman, vesting, warp,
@@ -92,6 +93,8 @@ pub struct GenesisConfig<T> {
     pub max_orphan_age: Duration,
     /// Metadata of tokens.
     pub metadatas: BTreeMap<Denom, bank::Metadata>,
+    /// Initial Dango DEX trading pairs.
+    pub pairs: Vec<PairUpdate>,
     /// Initial Dango lending markets.
     pub markets: BTreeMap<Denom, MarketUpdates>,
     /// Oracle price sources.
@@ -288,6 +291,7 @@ pub fn build_genesis<T>(
         fee_cfg,
         max_orphan_age,
         metadatas,
+        pairs,
         markets,
         price_sources,
         unlocking_cliff,
@@ -444,7 +448,7 @@ where
     let dex = instantiate(
         &mut msgs,
         dex_code_hash,
-        &dex::InstantiateMsg {},
+        &dex::InstantiateMsg { pairs },
         "dango/dex",
         "dango/dex",
     )?;

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -7,8 +7,10 @@ use {
     },
     dango_types::{
         constants::{
-            DANGO_DENOM, ETH_DENOM, GUARDIAN_SETS, PYTH_PRICE_SOURCES, USDC_DENOM, WBTC_DENOM,
+            BTC_DENOM, DANGO_DENOM, ETH_DENOM, GUARDIAN_SETS, PYTH_PRICE_SOURCES, SOL_DENOM,
+            USDC_DENOM, WBTC_DENOM,
         },
+        dex::{PairParams, PairUpdate},
         lending::MarketUpdates,
         taxman,
     },
@@ -312,6 +314,28 @@ where
         },
         max_orphan_age: Duration::from_seconds(7 * 24 * 60 * 60),
         metadatas: btree_map! {},
+        pairs: vec![
+            PairUpdate {
+                base_denom: DANGO_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+            PairUpdate {
+                base_denom: BTC_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+            PairUpdate {
+                base_denom: ETH_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+            PairUpdate {
+                base_denom: SOL_DENOM.clone(),
+                quote_denom: USDC_DENOM.clone(),
+                params: PairParams {},
+            },
+        ],
         markets: btree_map! {
             USDC_DENOM.clone() => MarketUpdates {},
             WBTC_DENOM.clone() => MarketUpdates {},


### PR DESCRIPTION
necessary 1) for preventing spam orders, and 2) for implementing passive liquidity pools.

see #439