### PR TITLE
feat(grug): native multi send

### DIFF
--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -385,14 +385,7 @@ pub fn cron_execute(ctx: SudoCtx) -> StdResult<Response> {
     }
 
     Ok(Response::new()
-        .add_message({
-            let bank = ctx.querier.query_bank()?;
-            Message::execute(
-                bank,
-                &bank::ExecuteMsg::BatchTransfer(refunds),
-                Coins::new(),
-            )?
-        })
+        .add_message(Message::batch_transfer(refunds)?)
         .add_events(events))
 }
 

--- a/dango/indexer/sql/src/hooks.rs
+++ b/dango/indexer/sql/src/hooks.rs
@@ -72,22 +72,26 @@ impl Hooks {
             .into_iter()
             .flat_map(|(flat_transfer_event, te)| {
                 flat_transfer_event
-                    .coins
-                    .inner()
+                    .transfers
                     .iter()
-                    .map(|(denom, amount)| {
-                        let res = entity::transfers::ActiveModel {
-                            id: Set(Uuid::new_v4()),
-                            idx: Set(idx),
-                            block_height: Set(te.block_height),
-                            created_at: Set(te.created_at),
-                            from_address: Set(flat_transfer_event.sender.to_string()),
-                            to_address: Set(flat_transfer_event.recipient.to_string()),
-                            amount: Set(amount.to_string()),
-                            denom: Set(denom.to_string()),
-                        };
-                        idx += 1;
-                        res
+                    .flat_map(|(recipient, coins)| {
+                        coins
+                            .into_iter()
+                            .map(|coin| {
+                                let res = entity::transfers::ActiveModel {
+                                    id: Set(Uuid::new_v4()),
+                                    idx: Set(idx),
+                                    block_height: Set(te.block_height),
+                                    created_at: Set(te.created_at),
+                                    from_address: Set(flat_transfer_event.sender.to_string()),
+                                    to_address: Set(recipient.to_string()),
+                                    amount: Set(coin.amount.to_string()),
+                                    denom: Set(coin.denom.to_string()),
+                                };
+                                idx += 1;
+                                res
+                            })
+                            .collect::<Vec<_>>()
                     })
                     .collect::<Vec<_>>()
             })

--- a/dango/testing/tests/lending.rs
+++ b/dango/testing/tests/lending.rs
@@ -14,9 +14,9 @@ use {
         oracle::{self, PriceSource},
     },
     grug::{
-        btree_map, Addressable, Binary, Coins, Denom, Duration, JsonSerExt, Message, MsgConfigure,
-        MsgTransfer, MultiplyFraction, NonEmpty, NumberConst, QuerierExt, ResultExt, Sign, Udec128,
-        Udec256, Uint128,
+        btree_map, coins, Addressable, Binary, Coins, Denom, Duration, JsonSerExt, Message,
+        MsgConfigure, MultiplyFraction, NonEmpty, NumberConst, QuerierExt, ResultExt, Sign,
+        Udec128, Udec256, Uint128,
     },
     grug_app::NaiveProposalPreparer,
     grug_vm_rust::VmError,
@@ -96,10 +96,7 @@ fn cant_transfer_to_lending() {
     suite
         .send_message(
             &mut accounts.user1,
-            Message::Transfer(MsgTransfer {
-                to: contracts.lending,
-                coins: Coins::one(USDC_DENOM.clone(), 123).unwrap(),
-            }),
+            Message::transfer(contracts.lending, coins! { USDC_DENOM.clone() => 123 }).unwrap(),
         )
         .should_fail_with_error(VmError::function_not_found("receive"));
 }

--- a/dango/types/src/bank/msgs.rs
+++ b/dango/types/src/bank/msgs.rs
@@ -58,8 +58,6 @@ pub enum ExecuteMsg {
         denom: Denom,
         amount: Uint128,
     },
-    /// Transfer coins to multiple recipients at once.
-    BatchTransfer(BTreeMap<Addr, Coins>),
     /// Retrieve funds sent to a non-existing recipient.
     RecoverTransfer { sender: Addr, recipient: Addr },
 }

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -4,9 +4,10 @@ use data_encoding::BASE64;
 use grug_types::JsonSerExt;
 #[cfg(feature = "abci")]
 use grug_types::{HashExt, JsonDeExt};
+
 use {
     crate::{
-        catch_and_append_event, catch_and_update_event, do_authenticate, do_backrun, do_configure,
+        catch_and_push_event, catch_and_update_event, do_authenticate, do_backrun, do_configure,
         do_cron_execute, do_execute, do_finalize_fee, do_instantiate, do_migrate, do_transfer,
         do_upload, do_withhold_fee, query_app_config, query_balance, query_balances, query_code,
         query_codes, query_config, query_contract, query_contracts, query_supplies, query_supply,
@@ -819,7 +820,7 @@ where
         #[cfg(feature = "tracing")]
         tracing::debug!(idx = _idx, "Processing message");
 
-        catch_and_append_event! {
+        catch_and_push_event! {
             process_msg(
                 vm.clone(),
                 Box::new(buffer.clone()),
@@ -829,7 +830,8 @@ where
                 tx.sender,
                 msg.clone(),
             ),
-            evt
+            evt,
+            msgs
         }
     }
 

--- a/grug/app/src/execute/execute.rs
+++ b/grug/app/src/execute/execute.rs
@@ -3,7 +3,7 @@ use {
         call_in_1_out_1_handle_response, catch_and_update_event, catch_event, AppError,
         EventResult, GasTracker, Vm, _do_transfer, CHAIN_ID, CONTRACTS,
     },
-    grug_types::{Addr, BlockInfo, Context, EvtExecute, MsgExecute, MsgTransfer, Storage},
+    grug_types::{btree_map, Addr, BlockInfo, Context, EvtExecute, MsgExecute, Storage},
 };
 
 pub fn do_execute<VM>(
@@ -74,10 +74,7 @@ where
                 block,
                 msg_depth,
                 sender,
-                MsgTransfer {
-                    to: msg.contract,
-                    coins: msg.funds.clone(),
-                },
+                btree_map! { msg.contract => msg.funds.clone() },
                 false,
             ),
             evt => transfer_event

--- a/grug/app/src/execute/instantiate.rs
+++ b/grug/app/src/execute/instantiate.rs
@@ -4,8 +4,8 @@ use {
         AppError, EventResult, GasTracker, Vm, _do_transfer, CHAIN_ID, CODES, CONFIG, CONTRACTS,
     },
     grug_types::{
-        Addr, BlockInfo, CodeStatus, Context, ContractInfo, EvtInstantiate, MsgInstantiate,
-        MsgTransfer, StdResult, Storage,
+        btree_map, Addr, BlockInfo, CodeStatus, Context, ContractInfo, EvtInstantiate,
+        MsgInstantiate, StdResult, Storage,
     },
 };
 
@@ -112,10 +112,7 @@ where
                 block,
                 msg_depth,
                 sender,
-                MsgTransfer {
-                    to: address,
-                    coins: msg.funds.clone(),
-                },
+                btree_map! { address => msg.funds.clone() },
                 false,
             ),
             evt => transfer_event

--- a/grug/app/src/execute/transfer.rs
+++ b/grug/app/src/execute/transfer.rs
@@ -1,7 +1,8 @@
 use {
     crate::{
-        call_in_0_out_1_handle_response, call_in_1_out_1_handle_response, catch_and_update_event,
-        catch_event, AppError, EventResult, GasTracker, Vm, CHAIN_ID, CONFIG, CONTRACTS,
+        call_in_0_out_1_handle_response, call_in_1_out_1_handle_response, catch_and_insert_event,
+        catch_and_update_event, catch_event, AppError, EventResult, GasTracker, Vm, CHAIN_ID,
+        CONFIG, CONTRACTS,
     },
     grug_types::{
         Addr, BankMsg, BlockInfo, Coins, Context, EvtGuest, EvtTransfer, Hash256, MsgTransfer,
@@ -114,7 +115,7 @@ where
         for (to, coins) in msg.transfers {
             // If recipient does not exist, skip the `_do_receive` call.
             if let Ok(Some(contract_info)) = CONTRACTS.may_load(&storage, to) {
-                catch_and_update_event! {
+                catch_and_insert_event! {
                     _do_receive(
                         vm.clone(),
                         storage.clone(),
@@ -126,7 +127,9 @@ where
                         coins,
                         contract_info.code_hash,
                     ),
-                    evt => receive_guest
+                    evt,
+                    receive_guests,
+                    key: to
                 }
             }
         }

--- a/grug/app/src/execute/transfer.rs
+++ b/grug/app/src/execute/transfer.rs
@@ -4,7 +4,8 @@ use {
         catch_event, AppError, EventResult, GasTracker, Vm, CHAIN_ID, CONFIG, CONTRACTS,
     },
     grug_types::{
-        Addr, BankMsg, BlockInfo, Context, EvtGuest, EvtTransfer, Hash256, MsgTransfer, Storage,
+        Addr, BankMsg, BlockInfo, Coins, Context, EvtGuest, EvtTransfer, Hash256, MsgTransfer,
+        Storage,
     },
 };
 
@@ -38,8 +39,7 @@ where
         |_| {
             tracing::info!(
                 from = sender.to_string(),
-                to = msg.to.to_string(),
-                coins = msg.coins.to_string(),
+                transfers = ?msg,
                 "Transferred coins"
             );
         },
@@ -67,7 +67,7 @@ where
     VM: Vm + Clone + 'static,
     AppError: From<VM::Error>,
 {
-    let mut evt = EvtTransfer::base(sender, msg.to, msg.coins.clone());
+    let mut evt = EvtTransfer::base(sender, msg.clone());
 
     let (cfg, code_hash, chain_id) = catch_event! {
         {
@@ -91,8 +91,7 @@ where
 
     let msg = BankMsg {
         from: sender,
-        to: msg.to,
-        coins: msg.coins.clone(),
+        transfers: msg,
     };
 
     catch_and_update_event! {
@@ -112,19 +111,23 @@ where
     }
 
     if do_receive {
-        // If recipient does not exist, skip the `_do_receive` call.
-        if let Ok(Some(contract_info)) = CONTRACTS.may_load(&storage, msg.to) {
-            catch_and_update_event! {
-                _do_receive(
-                    vm,
-                    storage,
-                    gas_tracker,
-                    block,
-                    msg_depth,
-                    msg,
-                    contract_info.code_hash,
-                ),
-                evt => receive_guest
+        for (to, coins) in msg.transfers {
+            // If recipient does not exist, skip the `_do_receive` call.
+            if let Ok(Some(contract_info)) = CONTRACTS.may_load(&storage, to) {
+                catch_and_update_event! {
+                    _do_receive(
+                        vm.clone(),
+                        storage.clone(),
+                        gas_tracker.clone(),
+                        block,
+                        msg_depth,
+                        msg.from,
+                        to,
+                        coins,
+                        contract_info.code_hash,
+                    ),
+                    evt => receive_guest
+                }
             }
         }
     };
@@ -138,7 +141,9 @@ fn _do_receive<VM>(
     gas_tracker: GasTracker,
     block: BlockInfo,
     msg_depth: usize,
-    msg: BankMsg,
+    from: Addr,
+    to: Addr,
+    coins: Coins,
     code_hash: Hash256,
 ) -> EventResult<EvtGuest>
 where
@@ -150,15 +155,15 @@ where
         {
             CHAIN_ID.load(&storage).map_err(Into::into)
         },
-        EvtGuest::base(msg.to, "receive")
+        EvtGuest::base(to, "receive")
     };
 
     let ctx = Context {
         chain_id,
         block,
-        contract: msg.to,
-        sender: Some(msg.from),
-        funds: Some(msg.coins),
+        contract: to,
+        sender: Some(from),
+        funds: Some(coins),
         mode: None,
     };
 

--- a/grug/app/src/macros.rs
+++ b/grug/app/src/macros.rs
@@ -38,14 +38,14 @@ macro_rules! catch_and_update_event {
 }
 
 #[macro_export]
-macro_rules! catch_and_append_event {
-    ($result:expr, $evt:expr) => {
+macro_rules! catch_and_push_event {
+    ($result:expr, $evt:expr, $field:ident) => {
         match $result {
             EventResult::Ok(i) => {
-                $evt.msgs.push(grug_types::EventStatus::Ok(i));
+                $evt.$field.push(grug_types::EventStatus::Ok(i));
             },
             EventResult::Err { event, error } => {
-                $evt.msgs.push(grug_types::EventStatus::Failed {
+                $evt.$field.push(grug_types::EventStatus::Failed {
                     event,
                     error: error.to_string(),
                 });
@@ -53,7 +53,31 @@ macro_rules! catch_and_append_event {
                 return EventResult::NestedErr { event: $evt, error };
             },
             EventResult::NestedErr { event, error } => {
-                $evt.msgs.push(grug_types::EventStatus::NestedFailed(event));
+                $evt.$field.push(grug_types::EventStatus::NestedFailed(event));
+
+                return EventResult::NestedErr { event: $evt, error };
+            },
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! catch_and_insert_event {
+    ($result:expr, $evt:expr, $field:ident, key:$key:expr) => {
+        match $result {
+            EventResult::Ok(i) => {
+                $evt.$field.insert($key, grug_types::EventStatus::Ok(i));
+            },
+            EventResult::Err { event, error } => {
+                $evt.$field.insert($key, grug_types::EventStatus::Failed {
+                    event,
+                    error: error.to_string(),
+                });
+
+                return EventResult::NestedErr { event: $evt, error };
+            },
+            EventResult::NestedErr { event, error } => {
+                $evt.$field.insert($key, grug_types::EventStatus::NestedFailed(event));
 
                 return EventResult::NestedErr { event: $evt, error };
             },

--- a/grug/mocks/bank/src/execute.rs
+++ b/grug/mocks/bank/src/execute.rs
@@ -98,18 +98,13 @@ pub fn force_transfer(
 }
 
 /// Transfer tokens from one account to another.
-pub fn transfer(
-    storage: &mut dyn Storage,
-    from: Addr,
-    to: Addr,
-    coins: &Coins,
-) -> StdResult<Response> {
+pub fn transfer(storage: &mut dyn Storage, from: Addr, to: Addr, coins: &Coins) -> StdResult<()> {
     for coin in coins {
         decrease_balance(storage, from, coin.denom, *coin.amount)?;
         increase_balance(storage, to, coin.denom, *coin.amount)?;
     }
 
-    Ok(Response::new())
+    Ok(())
 }
 
 /// Increase the total supply of a token by the given amount.

--- a/grug/mocks/bank/src/exports.rs
+++ b/grug/mocks/bank/src/exports.rs
@@ -83,7 +83,11 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
 }
 
 pub fn bank_execute(ctx: SudoCtx, msg: BankMsg) -> StdResult<Response> {
-    transfer(ctx.storage, msg.from, msg.to, &msg.coins)
+    for (to, coins) in msg.transfers {
+        transfer(ctx.storage, msg.from, to, &coins)?;
+    }
+
+    Ok(Response::new())
 }
 
 #[rustfmt::skip]

--- a/grug/types/src/bank.rs
+++ b/grug/types/src/bank.rs
@@ -7,6 +7,7 @@ use {
     paste::paste,
     serde::{Deserialize, Serialize},
     serde_with::skip_serializing_none,
+    std::collections::BTreeMap,
 };
 
 /// The execute message that the host provides the bank contract during the
@@ -14,8 +15,7 @@ use {
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BankMsg {
     pub from: Addr,
-    pub to: Addr,
-    pub coins: Coins,
+    pub transfers: BTreeMap<Addr, Coins>,
 }
 
 /// The query message that the host provides the bank contract during the

--- a/grug/types/src/events/builder.rs
+++ b/grug/types/src/events/builder.rs
@@ -24,6 +24,17 @@ impl EventBuilder {
         self.events.push(event.try_into()?);
         Ok(self)
     }
+
+    pub fn may_push<T>(&mut self, maybe_event: Option<T>) -> Result<&mut Self, T::Error>
+    where
+        T: TryInto<ContractEvent>,
+    {
+        if let Some(event) = maybe_event {
+            self.events.push(event.try_into()?);
+        }
+
+        Ok(self)
+    }
 }
 
 impl IntoIterator for EventBuilder {

--- a/grug/types/src/events/flat.rs
+++ b/grug/types/src/events/flat.rs
@@ -6,6 +6,7 @@ use {
     },
     borsh::{BorshDeserialize, BorshSerialize},
     serde::{Deserialize, Serialize},
+    std::collections::BTreeMap,
     strum_macros::{Display, EnumDiscriminants},
 };
 
@@ -185,8 +186,7 @@ pub enum FlatEvent {
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FlatEvtTransfer {
     pub sender: Addr,
-    pub recipient: Addr,
-    pub coins: Coins,
+    pub transfers: BTreeMap<Addr, Coins>,
 }
 
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]

--- a/grug/types/src/events/flatten.rs
+++ b/grug/types/src/events/flatten.rs
@@ -206,11 +206,11 @@ impl Flatten for EvtTransfer {
 
         events.extend(bank_guest);
 
-        let receive_guest = self
-            .receive_guest
-            .flatten_status(parent_id, next_id, commitment);
-
-        events.extend(receive_guest);
+        for event in self.receive_guests.into_values() {
+            let receive_guest = event.flatten_status(parent_id, next_id, commitment.clone());
+            next_id.increment_idx(&receive_guest);
+            events.extend(receive_guest);
+        }
 
         events
     }

--- a/grug/types/src/events/flatten.rs
+++ b/grug/types/src/events/flatten.rs
@@ -192,8 +192,7 @@ impl Flatten for EvtTransfer {
             event_status: status,
             event: FlatEvent::Transfer(FlatEvtTransfer {
                 sender: self.sender,
-                recipient: self.recipient,
-                coins: self.coins,
+                transfers: self.transfers,
             }),
         }];
 

--- a/grug/types/src/events/nested.rs
+++ b/grug/types/src/events/nested.rs
@@ -6,6 +6,7 @@ use {
     paste::paste,
     serde::{Deserialize, Serialize},
     serde_with::skip_serializing_none,
+    std::collections::BTreeMap,
 };
 
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
@@ -110,18 +111,16 @@ pub struct EvtConfigure {
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct EvtTransfer {
     pub sender: Addr,
-    pub recipient: Addr,
-    pub coins: Coins,
+    pub transfers: BTreeMap<Addr, Coins>,
     pub bank_guest: EventStatus<EvtGuest>,
     pub receive_guest: EventStatus<EvtGuest>,
 }
 
 impl EvtTransfer {
-    pub fn base(sender: Addr, recipient: Addr, coins: Coins) -> Self {
+    pub fn base(sender: Addr, transfers: BTreeMap<Addr, Coins>) -> Self {
         Self {
             sender,
-            recipient,
-            coins,
+            transfers,
             bank_guest: EventStatus::NotReached,
             receive_guest: EventStatus::NotReached,
         }

--- a/grug/types/src/events/nested.rs
+++ b/grug/types/src/events/nested.rs
@@ -113,16 +113,19 @@ pub struct EvtTransfer {
     pub sender: Addr,
     pub transfers: BTreeMap<Addr, Coins>,
     pub bank_guest: EventStatus<EvtGuest>,
-    pub receive_guest: EventStatus<EvtGuest>,
+    pub receive_guests: BTreeMap<Addr, EventStatus<EvtGuest>>,
 }
 
 impl EvtTransfer {
     pub fn base(sender: Addr, transfers: BTreeMap<Addr, Coins>) -> Self {
         Self {
             sender,
+            receive_guests: transfers
+                .keys()
+                .map(|addr| (*addr, EventStatus::NotReached))
+                .collect(),
             transfers,
             bank_guest: EventStatus::NotReached,
-            receive_guest: EventStatus::NotReached,
         }
     }
 }

--- a/grug/types/src/tx.rs
+++ b/grug/types/src/tx.rs
@@ -1,11 +1,12 @@
 use {
     crate::{
-        Addr, Binary, Coins, Config, Hash256, HashExt, Json, JsonSerExt, LengthBounded, MaxLength,
-        NonEmpty, StdError, StdResult,
+        btree_map, Addr, Binary, Coins, Config, Hash256, HashExt, Json, JsonSerExt, LengthBounded,
+        MaxLength, NonEmpty, StdError, StdResult,
     },
     borsh::{BorshDeserialize, BorshSerialize},
     serde::{Deserialize, Serialize},
     serde_with::skip_serializing_none,
+    std::collections::BTreeMap,
 };
 
 /// An arbitrary binary data used for deriving address when instantiating a
@@ -82,11 +83,23 @@ impl Message {
         C: TryInto<Coins>,
         StdError: From<C::Error>,
     {
-        Ok(MsgTransfer {
-            to,
-            coins: coins.try_into()?,
-        }
-        .into())
+        Ok(Message::Transfer(btree_map! { to => coins.try_into()? }))
+    }
+
+    pub fn batch_transfer<I, C>(transfers: I) -> StdResult<Self>
+    where
+        I: IntoIterator<Item = (Addr, C)>,
+        C: TryInto<Coins>,
+        StdError: From<C::Error>,
+    {
+        transfers
+            .into_iter()
+            .map(|(to, coins)| {
+                let coins = coins.try_into()?;
+                Ok((to, coins))
+            })
+            .collect::<StdResult<_>>()
+            .map(Message::Transfer)
     }
 
     pub fn upload<B>(code: B) -> Self
@@ -156,12 +169,8 @@ pub struct MsgConfigure {
     pub new_app_cfg: Option<Json>,
 }
 
-#[skip_serializing_none]
-#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
-pub struct MsgTransfer {
-    pub to: Addr,
-    pub coins: Coins,
-}
+// recipient => coins
+pub type MsgTransfer = BTreeMap<Addr, Coins>;
 
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
this PR makes `grug_types::Message::Transfer` multi-send.

removes `dango_types::bank::Message::BatchTransfer` because it's no longer needed.