### PR TITLE
fix(dango/auth): ensure chain ID matches

### DIFF
--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -105,6 +105,14 @@ pub fn verify_nonce_and_signature(
         tx.data.deserialize_json()?
     };
 
+    // Ensure the chain ID in metadata matches the context.
+    ensure!(
+        metadata.chain_id == ctx.chain_id,
+        "chain ID mismatch: expecting `{}`, got `{}`",
+        ctx.chain_id,
+        metadata.chain_id
+    );
+
     let sign_doc = SignDoc {
         gas_limit: tx.gas_limit,
         sender: ctx.contract,

--- a/dango/client/src/signer.rs
+++ b/dango/client/src/signer.rs
@@ -240,6 +240,7 @@ mod tests {
             .unwrap();
 
         let mut mock_ctx = MockContext::default()
+            .with_chain_id("dango-1")
             .with_querier(mock_querier)
             .with_mode(AuthMode::Finalize);
 


### PR DESCRIPTION
we forgot to check `ctx.chain_id == metadata.chain_id`