### PR TITLE
refractor(graphql): Better queries interface

### DIFF
--- a/indexer/httpd/src/graphql/query/grug.rs
+++ b/indexer/httpd/src/graphql/query/grug.rs
@@ -1,9 +1,6 @@
 use {
-    super::super::types::status::Status,
-    async_graphql::*,
-    grug_math::Inner,
-    grug_types::{HexBinary, JsonSerExt},
-    std::str::FromStr,
+    super::super::types::status::Status, crate::graphql::types::store::Store, async_graphql::*,
+    grug_math::Inner, grug_types::Binary, std::str::FromStr,
 };
 
 #[derive(Default, Debug)]
@@ -15,29 +12,38 @@ impl GrugQuery {
         &self,
         ctx: &async_graphql::Context<'_>,
         #[graphql(desc = "Request as JSON string")] request: String,
-        height: u64,
-        #[graphql(default = false)] prove: bool,
+        height: Option<u64>,
     ) -> Result<String, Error> {
         let app_ctx = ctx.data::<crate::context::Context>()?;
 
-        Ok(app_ctx.grug_app.query_app(request, height, prove)?)
+        Ok(app_ctx.grug_app.query_app(request, height)?)
     }
 
     async fn query_store(
         &self,
         ctx: &async_graphql::Context<'_>,
-        #[graphql(desc = "Key as Hex string")] key: String,
-        height: u64,
+        #[graphql(desc = "Key as B64 string")] key: String,
+        height: Option<u64>,
         #[graphql(default = false)] prove: bool,
-    ) -> Result<String, Error> {
+    ) -> Result<Store, Error> {
         let app_ctx = ctx.data::<crate::context::Context>()?;
-        let key = HexBinary::from_str(&key)?;
+        let key = Binary::from_str(&key)?;
 
-        app_ctx
-            .grug_app
-            .query_store(key.inner(), height, prove)?
-            .to_json_string()
-            .map_err(Into::into)
+        let (value, proof) = app_ctx.grug_app.query_store(key.inner(), height, prove)?;
+
+        let value = if let Some(value) = value {
+            Binary::from(value).to_string()
+        } else {
+            return Err(Error::new(&format!("Key not found: {}", key)));
+        };
+
+        let proof = if let Some(proof) = proof {
+            Some(Binary::from(proof).to_string())
+        } else {
+            None
+        };
+
+        Ok(Store { value, proof })
     }
 
     async fn query_status(&self, ctx: &async_graphql::Context<'_>) -> Result<Status, Error> {
@@ -55,11 +61,9 @@ impl GrugQuery {
         &self,
         ctx: &async_graphql::Context<'_>,
         #[graphql(desc = "Transaction as Json string")] tx: String,
-        height: u64,
-        #[graphql(default = false)] prove: bool,
     ) -> Result<String, Error> {
         let app_ctx = ctx.data::<crate::context::Context>()?;
 
-        Ok(app_ctx.grug_app.simulate(tx, height, prove)?)
+        Ok(app_ctx.grug_app.simulate(tx)?)
     }
 }

--- a/indexer/httpd/src/graphql/query/grug.rs
+++ b/indexer/httpd/src/graphql/query/grug.rs
@@ -34,16 +34,13 @@ impl GrugQuery {
         let value = if let Some(value) = value {
             Binary::from(value).to_string()
         } else {
-            return Err(Error::new(&format!("Key not found: {}", key)));
+            return Err(Error::new(format!("Key not found: {}", key)));
         };
 
-        let proof = if let Some(proof) = proof {
-            Some(Binary::from(proof).to_string())
-        } else {
-            None
-        };
-
-        Ok(Store { value, proof })
+        Ok(Store {
+            value,
+            proof: proof.map(|proof| Binary::from(proof).to_string()),
+        })
     }
 
     async fn query_status(&self, ctx: &async_graphql::Context<'_>) -> Result<Status, Error> {

--- a/indexer/httpd/src/graphql/types.rs
+++ b/indexer/httpd/src/graphql/types.rs
@@ -2,5 +2,6 @@ pub mod block;
 pub mod event;
 pub mod message;
 pub mod status;
+pub mod store;
 pub mod tendermint;
 pub mod transaction;

--- a/indexer/httpd/src/graphql/types/store.rs
+++ b/indexer/httpd/src/graphql/types/store.rs
@@ -1,0 +1,9 @@
+use async_graphql::SimpleObject;
+
+#[derive(SimpleObject)]
+pub struct Store {
+    /// The base64 encoded value
+    pub value: String,
+    /// The base64 encoded proof
+    pub proof: Option<String>,
+}


### PR DESCRIPTION
- `queryApp` 
   - height is now optional:
   - proof is removed (proof is supported only for `queryStore`).
- `queryStore`:
   - return a dedicated schema with field in B64;
   - key is now in B64.
- `simulate`
   - removed height (cannot simulate at past height);
   - proof is removed (proof is supported only for `queryStore`).
