### PR TITLE
fix(dango/dex): only transfer if refunds in non-empty

### DIFF
--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -385,7 +385,11 @@ pub fn cron_execute(ctx: SudoCtx) -> StdResult<Response> {
     }
 
     Ok(Response::new()
-        .add_message(Message::batch_transfer(refunds)?)
+        .may_add_message(if !refunds.is_empty() {
+            Some(Message::batch_transfer(refunds)?)
+        } else {
+            None
+        })
         .add_events(events))
 }
 


### PR DESCRIPTION
no need to call `transfer` if the coins are empty.