### PR TITLE
refactor: `SignData` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "dango-account-factory",
  "dango-types",
  "grug",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3480,7 +3481,7 @@ dependencies = [
  "paste",
  "pyth-types",
  "serde",
- "serde_json",
+ "sha2 0.10.8",
  "thiserror 2.0.12",
  "tokio",
 ]
@@ -4549,6 +4550,7 @@ dependencies = [
  "grug-storage",
  "grug-types",
  "serde",
+ "sha2 0.10.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,6 +3439,7 @@ dependencies = [
  "dango-proposal-preparer",
  "dango-types",
  "dango-warp",
+ "digest 0.10.7",
  "grug",
  "grug-app",
  "grug-crypto",

--- a/dango/auth/Cargo.toml
+++ b/dango/auth/Cargo.toml
@@ -16,5 +16,6 @@ base64                = { workspace = true }
 dango-account-factory = { workspace = true, features = ["library"] }
 dango-types           = { workspace = true }
 grug                  = { workspace = true }
+sha2                  = { workspace = true }
 
 [dev-dependencies]

--- a/dango/client/src/signer.rs
+++ b/dango/client/src/signer.rs
@@ -7,8 +7,8 @@ use {
         auth::{Credential, Key, Metadata, Nonce, SignDoc, Signature, StandardCredential},
     },
     grug::{
-        Addr, Addressable, ByteArray, Client, Defined, Hash256, HashExt, Inner, JsonSerExt,
-        MaybeDefined, Message, NonEmpty, Signer, StdResult, Tx, Undefined, UnsignedTx,
+        Addr, Addressable, ByteArray, Client, Defined, Hash256, HashExt, JsonSerExt, MaybeDefined,
+        Message, NonEmpty, SignData, Signer, StdResult, Tx, Undefined, UnsignedTx,
     },
     std::str::FromStr,
 };
@@ -166,15 +166,12 @@ impl Signer for SingleSigner<Defined<u32>> {
             sender: self.address,
             messages: msgs.clone(),
             data: metadata.clone(),
-        }
-        .to_json_value()? // convert to JSON value first, so that the fields are sorted alphabetically
-        .to_json_vec()?
-        .hash256()
-        .into_inner();
+        };
+        let sign_data = sign_doc.to_sign_data()?;
 
         let credential = Credential::Standard(StandardCredential {
             key_hash: self.key_hash,
-            signature: Signature::Secp256k1(self.sk.sign_digest(sign_doc).into()),
+            signature: Signature::Secp256k1(self.sk.sign_digest(sign_data.into()).into()),
         });
 
         Ok(Tx {

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -18,6 +18,7 @@ dango-httpd             = { workspace = true }
 dango-indexer-sql       = { workspace = true, features = ["tracing"] }
 dango-proposal-preparer = { workspace = true }
 dango-types             = { workspace = true }
+digest                  = { workspace = true }
 grug                    = { workspace = true }
 grug-app                = { workspace = true }
 grug-crypto             = { workspace = true }

--- a/dango/testing/src/crypto.rs
+++ b/dango/testing/src/crypto.rs
@@ -26,5 +26,5 @@ pub fn create_signature(sk: &SigningKey, sign_data: GenericArray<u8, U32>) -> By
     let sign_data = Identity256::from_inner(sign_data);
     let signature: Signature = sk.sign_digest(sign_data);
 
-    signature.to_bytes().as_slice().try_into().unwrap()
+    ByteArray::from_inner(signature.to_bytes().into())
 }

--- a/dango/testing/src/crypto.rs
+++ b/dango/testing/src/crypto.rs
@@ -19,10 +19,11 @@ pub fn generate_random_key() -> (SigningKey, ByteArray<33>) {
     (sk, pk)
 }
 
-pub fn create_signature(sk: &SigningKey, sign_bytes: &[u8]) -> ByteArray<64> {
-    // This hashes `sign_bytes` with SHA2-256. If we eventually choose to use a
-    // different hash, it's necessary to update this.
-    let signature: Signature = sk.sign(sign_bytes);
+/// Note: This function expects the _prehash_ bytes.
+pub fn create_signature(sk: &SigningKey, prehash_sign_data: &[u8]) -> ByteArray<64> {
+    // This hashes `prehash_sign_data` with SHA2-256. If we eventually choose to
+    // use a different hash, it's necessary to update this.
+    let signature: Signature = sk.sign(prehash_sign_data);
 
     signature.to_bytes().as_slice().try_into().unwrap()
 }

--- a/dango/testing/src/crypto.rs
+++ b/dango/testing/src/crypto.rs
@@ -1,7 +1,9 @@
 use {
+    digest::{consts::U32, generic_array::GenericArray},
     grug::ByteArray,
+    grug_crypto::Identity256,
     k256::{
-        ecdsa::{Signature, SigningKey, signature::Signer},
+        ecdsa::{Signature, SigningKey, signature::DigestSigner},
         elliptic_curve::rand_core::OsRng,
     },
 };
@@ -19,11 +21,10 @@ pub fn generate_random_key() -> (SigningKey, ByteArray<33>) {
     (sk, pk)
 }
 
-/// Note: This function expects the _prehash_ bytes.
-pub fn create_signature(sk: &SigningKey, prehash_sign_data: &[u8]) -> ByteArray<64> {
-    // This hashes `prehash_sign_data` with SHA2-256. If we eventually choose to
-    // use a different hash, it's necessary to update this.
-    let signature: Signature = sk.sign(prehash_sign_data);
+/// Note: This function expects the _hashed_ sign data.
+pub fn create_signature(sk: &SigningKey, sign_data: GenericArray<u8, U32>) -> ByteArray<64> {
+    let sign_data = Identity256::from_inner(sign_data);
+    let signature: Signature = sk.sign_digest(sign_data);
 
     signature.to_bytes().as_slice().try_into().unwrap()
 }

--- a/dango/testing/tests/session_key.rs
+++ b/dango/testing/tests/session_key.rs
@@ -92,8 +92,8 @@ mod session_account {
                 expire_at,
             };
 
-            let prehash_sign_data = session_info.to_prehash_sign_data()?;
-            let credential = self.account.create_standard_credential(&prehash_sign_data);
+            let sign_data = session_info.to_sign_data()?;
+            let credential = self.account.create_standard_credential(sign_data);
 
             let session_buffer = SessionInfoBuffer {
                 session_info,
@@ -158,14 +158,13 @@ mod session_account {
                 data: data.clone(),
             };
 
-            let prehash_sign_data = sign_doc.to_prehash_sign_data()?;
+            let sign_data = sign_doc.to_sign_data()?;
+            let session_signature = create_signature(&self.session_sk, sign_data);
 
             let standard_credential = StandardCredential {
                 key_hash: self.sign_with(),
                 signature: self.session_buffer.inner().sign_info_signature.clone(),
             };
-
-            let session_signature = create_signature(&self.session_sk, &prehash_sign_data);
 
             let credential = Credential::Session(SessionCredential {
                 session_info: self.session_buffer.inner().session_info.clone(),

--- a/dango/testing/tests/session_key.rs
+++ b/dango/testing/tests/session_key.rs
@@ -18,7 +18,7 @@ mod session_account {
             StandardCredential,
         },
         grug::{
-            Addr, Addressable, ByteArray, Defined, JsonSerExt, Message, NonEmpty, Signer,
+            Addr, Addressable, ByteArray, Defined, JsonSerExt, Message, NonEmpty, SignData, Signer,
             StdResult, Timestamp, Tx, Undefined, UnsignedTx,
         },
         k256::ecdsa::SigningKey,
@@ -92,10 +92,8 @@ mod session_account {
                 expire_at,
             };
 
-            // Convert to JSON value first such that the struct fields are sorted alphabetically.
-            let sign_bytes = session_info.to_json_value()?.to_json_vec()?;
-
-            let credential = self.account.create_standard_credential(&sign_bytes);
+            let prehash_sign_data = session_info.to_prehash_sign_data()?;
+            let credential = self.account.create_standard_credential(&prehash_sign_data);
 
             let session_buffer = SessionInfoBuffer {
                 session_info,
@@ -160,15 +158,14 @@ mod session_account {
                 data: data.clone(),
             };
 
-            // Convert to JSON value first such that the struct fields are sorted alphabetically.
-            let sign_bytes = sign_doc.to_json_value()?.to_json_vec()?;
+            let prehash_sign_data = sign_doc.to_prehash_sign_data()?;
 
             let standard_credential = StandardCredential {
                 key_hash: self.sign_with(),
                 signature: self.session_buffer.inner().sign_info_signature.clone(),
             };
 
-            let session_signature = create_signature(&self.session_sk, &sign_bytes);
+            let session_signature = create_signature(&self.session_sk, &prehash_sign_data);
 
             let credential = Credential::Session(SessionCredential {
                 session_info: self.session_buffer.inner().session_info.clone(),

--- a/dango/types/Cargo.toml
+++ b/dango/types/Cargo.toml
@@ -19,7 +19,7 @@ hyperlane-types = { workspace = true }
 paste           = { workspace = true }
 pyth-types      = { workspace = true }
 serde           = { workspace = true, features = ["derive"] }
-serde_json      = { workspace = true }
+sha2            = { workspace = true }
 thiserror       = { workspace = true }
 
 [dev-dependencies]

--- a/dango/types/src/auth.rs
+++ b/dango/types/src/auth.rs
@@ -1,6 +1,10 @@
 use {
     crate::account_factory::Username,
-    grug::{Addr, Binary, ByteArray, Hash256, Message, NonEmpty, Timestamp},
+    grug::{
+        Addr, Binary, ByteArray, Hash256, JsonSerExt, Message, NonEmpty, SignData, StdError,
+        Timestamp,
+    },
+    sha2::Sha256,
 };
 
 /// A number that included in each transaction's sign doc for the purpose of
@@ -61,6 +65,17 @@ pub struct SessionInfo {
     pub expire_at: Timestamp,
 }
 
+impl SignData for SessionInfo {
+    type Error = StdError;
+    type Hasher = Sha256;
+
+    fn to_prehash_sign_data(&self) -> Result<Vec<u8>, Self::Error> {
+        // Convert to JSON value first, then to bytes, such that the struct fields
+        // are ordered alphabetically.
+        self.to_json_value()?.to_json_vec()
+    }
+}
+
 /// Data that a transaction's sender must sign with their private key.
 ///
 /// This includes the messages to be included in the transaction, as well as
@@ -71,6 +86,17 @@ pub struct SignDoc {
     pub gas_limit: u64,
     pub messages: NonEmpty<Vec<Message>>,
     pub data: Metadata,
+}
+
+impl SignData for SignDoc {
+    type Error = StdError;
+    type Hasher = Sha256;
+
+    fn to_prehash_sign_data(&self) -> Result<Vec<u8>, Self::Error> {
+        // Convert to JSON value first, then to bytes, such that the struct fields
+        // are ordered alphabetically.
+        self.to_json_value()?.to_json_vec()
+    }
 }
 
 /// Data that the account expects for the transaction's [`data`](grug::Tx::data)

--- a/grug/crypto/src/identity_digest.rs
+++ b/grug/crypto/src/identity_digest.rs
@@ -52,6 +52,10 @@ macro_rules! identity {
         }
 
         impl $name {
+            pub const fn from_inner(bytes: GenericArray<u8, $array_len>) -> Self {
+                Self { bytes }
+            }
+
             pub fn into_bytes(self) -> [u8; $len] {
                 self.bytes.into()
             }

--- a/grug/mocks/account/Cargo.toml
+++ b/grug/mocks/account/Cargo.toml
@@ -27,3 +27,4 @@ grug-ffi     = { workspace = true }
 grug-storage = { workspace = true }
 grug-types   = { workspace = true }
 serde        = { workspace = true, features = ["derive"] }
+sha2         = { workspace = true }

--- a/grug/mocks/account/src/types.rs
+++ b/grug/mocks/account/src/types.rs
@@ -1,6 +1,7 @@
 use {
-    grug_types::ByteArray,
+    grug_types::{Addr, ByteArray, JsonSerExt, Message, StdError, StdResult},
     serde::{Deserialize, Serialize},
+    sha2::Sha256,
 };
 
 /// An Secp256k1 public key in compressed form.
@@ -8,6 +9,48 @@ pub type PublicKey = ByteArray<33>;
 
 /// An Secp256k1 signature.
 pub type Signature = ByteArray<64>;
+
+pub struct SignDoc<'a> {
+    pub sender: Addr,
+    pub msgs: &'a [Message],
+    pub chain_id: &'a str,
+    pub sequence: u32,
+}
+
+// Generate the bytes that the sender of a transaction needs to sign.
+//
+// The bytes are defined as:
+//
+// ```plain
+// bytes := hasher(json(msgs) | sender | chain_id | sequence)
+// ```
+//
+// Parameters:
+//
+// - `hasher` is a hash function; this account implementation uses SHA2-256;
+// - `msgs` is the list of messages in the transaction;
+// - `sender` is a 32 bytes address of the sender;
+// - `chain_id` is the chain ID in UTF-8 encoding;
+// - `sequence` is the sender account's sequence in 32-bit big endian encoding.
+//
+// Chain ID and sequence are included in the sign bytes, as they are necessary
+// for preventing replat attacks (e.g. user signs a transaction for chain A;
+// attacker uses the signature to broadcast another transaction on chain B.)
+impl grug_types::SignData for SignDoc<'_> {
+    type Error = StdError;
+    type Hasher = Sha256;
+
+    fn to_prehash_sign_data(&self) -> StdResult<Vec<u8>> {
+        let mut prehash = Vec::new();
+        // That there are multiple valid ways that the messages can be serialized
+        // into JSON. Here we use `grug::to_json_vec` as the source of truth.
+        prehash.extend(self.msgs.to_json_vec()?);
+        prehash.extend(self.sender.as_ref());
+        prehash.extend(self.chain_id.as_bytes());
+        prehash.extend(self.sequence.to_be_bytes());
+        Ok(prehash)
+    }
+}
 
 /// Schema for the account credentials expected in [`Tx::credential`](grug_types::Tx::credential).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/grug/types/src/signer.rs
+++ b/grug/types/src/signer.rs
@@ -1,4 +1,7 @@
-use crate::{Addr, Message, NonEmpty, StdResult, Tx, UnsignedTx};
+use {
+    crate::{Addr, Message, NonEmpty, StdResult, Tx, UnsignedTx},
+    digest::{Digest, OutputSizeUser, generic_array::GenericArray},
+};
 
 /// Represents an object that has an onchain address.
 pub trait Addressable {
@@ -33,4 +36,21 @@ pub trait Signer: Addressable {
         chain_id: &str,
         gas_limit: u64,
     ) -> StdResult<Tx>;
+}
+
+/// Represents an object that can be converted to a fixed length byte array for
+/// the purpose of cryptographic signing.
+pub trait SignData {
+    type Error;
+    type Hasher: Digest;
+
+    fn to_prehash_sign_data(&self) -> Result<Vec<u8>, Self::Error>;
+
+    fn to_sign_data(
+        &self,
+    ) -> Result<GenericArray<u8, <Self::Hasher as OutputSizeUser>::OutputSize>, Self::Error> {
+        let mut hasher = Self::Hasher::new();
+        hasher.update(self.to_prehash_sign_data()?);
+        Ok(hasher.finalize())
+    }
 }


### PR DESCRIPTION
Follow up to #566 and #567.

This PR adds a new `SignData` trait, so that for each structure that needs to be signed (e.g. `dango_types::auth::SignDoc` and `SessionInfo`) there's a single source of truth on how to convert this structure to raw bytes, and which hash function to use.