### PR TITLE
refactor(dango): add ethereum address as a key type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "dango-account-factory",
  "dango-types",
  "grug",
+ "hex",
  "sha2 0.10.8",
 ]
 

--- a/dango/auth/Cargo.toml
+++ b/dango/auth/Cargo.toml
@@ -16,6 +16,7 @@ base64                = { workspace = true }
 dango-account-factory = { workspace = true, features = ["library"] }
 dango-types           = { workspace = true }
 grug                  = { workspace = true }
+hex                   = { workspace = true }
 sha2                  = { workspace = true }
 
 [dev-dependencies]

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -283,14 +283,17 @@ fn verify_signature(
             }
             .eip712_signing_hash()?;
 
-            // Recover the Ethereum public key from the signature.
             // The first 64 bytes of the Ethereum signature is the typical
             // Secp256k1 signature, while the last byte is the recovery ID.
-            // In Ethereum, the recovery ID is usually 27 or 28
-            // instead of the standard 0 or 1 used in raw ECDSA recoverable signatures.
-            // To use it with standard crypto libraries, we subtract 27 to normalize it.
+            //
+            // In Ethereum, the recovery ID is usually 27 or 28, instead of the
+            // standard 0 or 1 used in raw ECDSA recoverable signatures.
+            // However, our `Api` implementation should handle this, so no action
+            // is needed here.
             let signature = &cred.sig[0..64];
-            let recovery_id = cred.sig[64] - 27;
+            let recovery_id = cred.sig[64];
+
+            // Recover the Ethereum public key from the signature.
             let pk = api.secp256k1_pubkey_recover(&sign_bytes.0, signature, recovery_id, false)?;
 
             // Derive Ethereum address from the public key.

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -286,8 +286,11 @@ fn verify_signature(
             // Recover the Ethereum public key from the signature.
             // The first 64 bytes of the Ethereum signature is the typical
             // Secp256k1 signature, while the last byte is the recovery ID.
+            // In Ethereum, the recovery ID is usually 27 or 28
+            // instead of the standard 0 or 1 used in raw ECDSA recoverable signatures.
+            // To use it with standard crypto libraries, we subtract 27 to normalize it.
             let signature = &cred.sig[0..64];
-            let recovery_id = cred.sig[64];
+            let recovery_id = cred.sig[64] - 27;
             let pk = api.secp256k1_pubkey_recover(&sign_bytes.0, signature, recovery_id, false)?;
 
             // Derive Ethereum address from the public key.
@@ -456,15 +459,10 @@ mod tests {
         let user_address = Addr::from_str("0xb66227cf4ea800b6b19aed198395fd0a2d80ee1d").unwrap();
         let user_username = Username::from_str("javier").unwrap();
         let user_keyhash =
-            Hash256::from_str("622FE2E6EDABB23602D87CC65E4FE2749A232B32035651C99591A098AAD8629B")
+            Hash256::from_str("7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165")
                 .unwrap();
-        let user_key = Key::Secp256k1(
-            [
-                3, 115, 37, 57, 128, 37, 222, 189, 9, 42, 142, 196, 85, 27, 226, 112, 136, 195,
-                174, 6, 40, 39, 221, 182, 179, 146, 169, 207, 108, 218, 67, 27, 71,
-            ]
-            .into(),
-        );
+        let user_key =
+            Key::Ethereum(Addr::from_str("0x4c9d879264227583f49af3c99eb396fe4735a935").unwrap());
 
         let querier = MockQuerier::new()
             .with_app_config(AppConfig {
@@ -492,10 +490,10 @@ mod tests {
         let tx = r#"{
           "credential": {
             "standard": {
-              "key_hash": "622FE2E6EDABB23602D87CC65E4FE2749A232B32035651C99591A098AAD8629B",
+              "key_hash": "7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165",
               "signature": {
                 "eip712": {
-                  "sig": "qhvraAO/AnyJO621ig38y8Rc4k12UtuKurqTjMOCHogR5UpyptvZ2lTl0gH0wjFiUTNp3uFe+WAh760HWq2Mnw==",
+                  "sig": "qhvraAO/AnyJO621ig38y8Rc4k12UtuKurqTjMOCHogR5UpyptvZ2lTl0gH0wjFiUTNp3uFe+WAh760HWq2Mnxs=",
                   "typed_data": "eyJ0eXBlcyI6eyJFSVA3MTJEb21haW4iOlt7Im5hbWUiOiJuYW1lIiwidHlwZSI6InN0cmluZyJ9LHsibmFtZSI6InZlcmlmeWluZ0NvbnRyYWN0IiwidHlwZSI6ImFkZHJlc3MifV0sIk1lc3NhZ2UiOlt7Im5hbWUiOiJtZXRhZGF0YSIsInR5cGUiOiJNZXRhZGF0YSJ9LHsibmFtZSI6Imdhc19saW1pdCIsInR5cGUiOiJ1aW50MzIifSx7Im5hbWUiOiJtZXNzYWdlcyIsInR5cGUiOiJUeE1lc3NhZ2VbXSJ9XSwiTWV0YWRhdGEiOlt7Im5hbWUiOiJ1c2VybmFtZSIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJjaGFpbl9pZCIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJub25jZSIsInR5cGUiOiJ1aW50MzIifV0sIlR4TWVzc2FnZSI6W3sibmFtZSI6InRyYW5zZmVyIiwidHlwZSI6IlRyYW5zZmVyIn1dLCJUcmFuc2ZlciI6W3sibmFtZSI6IjB4MzMzNjFkZTQyNTcxZDZhYTIwYzM3ZGFhNmRhNGI1YWI2N2JmYWFkOSIsInR5cGUiOiJDb2luMCJ9XSwiQ29pbjAiOlt7Im5hbWUiOiJoeXAvZXRoL3VzZGMiLCJ0eXBlIjoic3RyaW5nIn1dfSwicHJpbWFyeVR5cGUiOiJNZXNzYWdlIiwiZG9tYWluIjp7Im5hbWUiOiJkYW5nbyIsInZlcmlmeWluZ0NvbnRyYWN0IjoiMHhiNjYyMjdjZjRlYTgwMGI2YjE5YWVkMTk4Mzk1ZmQwYTJkODBlZTFkIn0sIm1lc3NhZ2UiOnsibWV0YWRhdGEiOnsiY2hhaW5faWQiOiJkZXYtNiIsInVzZXJuYW1lIjoiamF2aWVyIiwibm9uY2UiOjB9LCJnYXNfbGltaXQiOjI0NDgxMzksIm1lc3NhZ2VzIjpbeyJ0cmFuc2ZlciI6eyIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiOnsiaHlwL2V0aC91c2RjIjoiMTAwMDAwMCJ9fX1dfX0="
                 }
               }
@@ -603,16 +601,16 @@ mod tests {
     }
 
     #[test]
-    fn session_key_authentication() {
-        let user_address = Addr::from_str("0xb66227cf4ea800b6b19aed198395fd0a2d80ee1d").unwrap();
-        let user_username = Username::from_str("javier").unwrap();
+    fn session_key_with_passkey_authentication() {
+        let user_address = Addr::from_str("0x5614a130eb9322e549e0d86d24a7bb1a7f683b28").unwrap();
+        let user_username = Username::from_str("pass_local").unwrap();
         let user_keyhash =
-            Hash256::from_str("622FE2E6EDABB23602D87CC65E4FE2749A232B32035651C99591A098AAD8629B")
+            Hash256::from_str("010AB8AAF008DA93DB00F94D818931832F54192A334D933629768B59A2932817")
                 .unwrap();
-        let user_key = Key::Secp256k1(
+        let user_key = Key::Secp256r1(
             [
-                3, 115, 37, 57, 128, 37, 222, 189, 9, 42, 142, 196, 85, 27, 226, 112, 136, 195,
-                174, 6, 40, 39, 221, 182, 179, 146, 169, 207, 108, 218, 67, 27, 71,
+                3, 49, 131, 213, 54, 16, 255, 178, 137, 198, 32, 99, 238, 21, 5, 25, 52, 140, 150,
+                228, 146, 68, 250, 57, 250, 251, 135, 159, 84, 162, 229, 40, 155,
             ]
             .into(),
         );
@@ -645,19 +643,94 @@ mod tests {
           "credential": {
             "session": {
               "authorization": {
-                "key_hash": "622FE2E6EDABB23602D87CC65E4FE2749A232B32035651C99591A098AAD8629B",
+                "key_hash": "010AB8AAF008DA93DB00F94D818931832F54192A334D933629768B59A2932817",
                 "signature": {
-                  "eip712": {
-                    "sig": "t0QXAD4vGR9p5bvVG3CUvrM4dgPAUBJZkiJqvYxRfgckJlcaPf4NELBiXRfg3ZVvpkDraWh3OyG02FpAzec/PQ==",
-                    "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSJ9LCJtZXNzYWdlIjp7InNlc3Npb25fa2V5IjoiQXNnRkd4NmJDenh6UElMQUo5Vkx5VDNFb3V5VHlsekNqcFJ2c0dleVVXOHQiLCJleHBpcmVfYXQiOiIxNzQzMDE1MzI3MTg3In0sInByaW1hcnlUeXBlIjoiTWVzc2FnZSIsInR5cGVzIjp7IkVJUDcxMkRvbWFpbiI6W3sibmFtZSI6Im5hbWUiLCJ0eXBlIjoic3RyaW5nIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoic2Vzc2lvbl9rZXkiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiZXhwaXJlX2F0IiwidHlwZSI6InN0cmluZyJ9XX19"
+                  "passkey": {
+                    "authenticator_data": "SZYN5YgOjGh0NBcPZHZgW4/krrmihjLHmVzzuoMdl2MZAAAAAA==",
+                    "client_data": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiTlMwTFVJUUZpUC1SN01MSmE5V3RBbEttcUZhcWdfbTdqTzZaeExubE1SZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTA4MCIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9",
+                    "sig": "kutvF0E0eD+K0FCD575y1HuaToPrdBFB20VIlxiA4HeKHdXwvDjKfcMPSnV752jb9xEeBvO1Jym+Z7PJR3dfeg=="
                   }
                 }
               },
               "session_info": {
-                "expire_at": "1743015327187",
-                "session_key": "AsgFGx6bCzxzPILAJ9VLyT3EouyTylzCjpRvsGeyUW8t"
+                "expire_at": "1743109311084",
+                "session_key": "A9q7FcgFOItKcmXpqTZZyAgTLqszNCdG/LkHF+UZyBMs"
               },
-              "session_signature": "8nK6wFA2AkafMOiTt7cfQfV7yBCZa477sxguieK2sI0C1iCOdX4OfiMAZYIOadZjG/+4m6IkvXe/GgTNloP72A=="
+              "session_signature": "lBPASUUQyv+YaQg0b/1XGvqn7Iuk7R5uGsh9m1m/IdU62YQHl+VT2ZURQ4GsIIWer9oHevALgMGqjA1KraW21A=="
+            }
+          },
+          "data": {
+            "chain_id": "dev-6",
+            "nonce": 0,
+            "username": "pass_local"
+          },
+          "gas_limit": 2448139,
+          "msgs": [
+            {
+              "transfer": {
+                "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9": {
+                  "hyp/eth/usdc": "1000000"
+                }
+              }
+            }
+          ],
+          "sender": "0x5614a130eb9322e549e0d86d24a7bb1a7f683b28"
+        }"#;
+
+        authenticate_tx(ctx.as_auth(), tx.deserialize_json::<Tx>().unwrap(), None).should_succeed();
+    }
+
+    #[test]
+    fn session_key_with_eip712_authentication() {
+        let user_address = Addr::from_str("0xb66227cf4ea800b6b19aed198395fd0a2d80ee1d").unwrap();
+        let user_username = Username::from_str("javier").unwrap();
+        let user_keyhash =
+            Hash256::from_str("7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165")
+                .unwrap();
+        let user_key =
+            Key::Ethereum(Addr::from_str("0x4c9d879264227583f49af3c99eb396fe4735a935").unwrap());
+
+        let querier = MockQuerier::new()
+            .with_app_config(AppConfig {
+                addresses: AppAddresses {
+                    account_factory: ACCOUNT_FACTORY,
+                    ..Default::default()
+                },
+                collateral_powers: btree_map! {},
+                ..Default::default()
+            })
+            .unwrap()
+            .with_raw_contract_storage(ACCOUNT_FACTORY, |storage| {
+                ACCOUNTS_BY_USER
+                    .insert(storage, (&user_username, user_address))
+                    .unwrap();
+                KEYS.save(storage, (&user_username, user_keyhash), &user_key)
+                    .unwrap();
+            });
+
+        let mut ctx = MockContext::new()
+            .with_querier(querier)
+            .with_contract(user_address)
+            .with_chain_id("dev-6")
+            .with_mode(AuthMode::Finalize);
+
+        let tx = r#"{
+          "credential": {
+            "session": {
+              "authorization": {
+                "key_hash": "7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165",
+                "signature": {
+                  "eip712": {
+                    "sig": "2JSrtr1cB6bEVxio6xNCb4z3G7JZo3cF2FF3h6GRSTZVI3Qrqme4wyNUseKrG8J/Mo/DxwzYcj6IlcQnWENtNRs=",
+                    "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSJ9LCJtZXNzYWdlIjp7InNlc3Npb25fa2V5IjoiQThiWDVhbU4yNGlXMDV4b2c2SGVLWXJ3THA5NU9qWStZcW1iUlQ3U0twZVgiLCJleHBpcmVfYXQiOiIxNzQzMTA5NjkzNjM3In0sInByaW1hcnlUeXBlIjoiTWVzc2FnZSIsInR5cGVzIjp7IkVJUDcxMkRvbWFpbiI6W3sibmFtZSI6Im5hbWUiLCJ0eXBlIjoic3RyaW5nIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoic2Vzc2lvbl9rZXkiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiZXhwaXJlX2F0IiwidHlwZSI6InN0cmluZyJ9XX19"
+                  }
+                }
+              },
+              "session_info": {
+                "expire_at": "1743109693637",
+                "session_key": "A8bX5amN24iW05xog6HeKYrwLp95OjY+YqmbRT7SKpeX"
+              },
+              "session_signature": "510PITf+ZKexzi+g+5J5SS1JkvKBeMoUvBNh7h9viTcGCMvdkgNvdJsdOGpJcG19XYsgPIaMSKZyHEQkVUK2DQ=="
             }
           },
           "data": {

--- a/dango/types/src/account_factory/salts.rs
+++ b/dango/types/src/account_factory/salts.rs
@@ -36,6 +36,7 @@ impl NewUserSalt {
     /// `key_tag` is a single byte identifying the key's type:
     /// - `0` for Secp256r1
     /// - `1` for Secp256k1
+    /// - `2` for Ethereum address
     pub fn into_bytes(self) -> [u8; 70] {
         // Maximum possible length for the bytes:
         // - secret: 4
@@ -54,6 +55,11 @@ impl NewUserSalt {
             Key::Secp256k1(pk) => {
                 bytes[36] = 1;
                 bytes[37..70].copy_from_slice(&pk);
+            },
+            Key::Ethereum(addr) => {
+                bytes[36] = 2;
+                // Front-pad the address with zeros.
+                bytes[50..70].copy_from_slice(&addr);
             },
         }
         bytes

--- a/dango/types/src/auth.rs
+++ b/dango/types/src/auth.rs
@@ -19,6 +19,17 @@ pub enum Key {
     Secp256r1(ByteArray<33>),
     /// An Secp256k1 public key in compressed form.
     Secp256k1(ByteArray<33>),
+    /// An Ethereum address.
+    ///
+    /// Ethereum uses Secp256k1 public keys, so why don't just use that? This is
+    /// because Ethereum wallets typically don't expose an API that allows a
+    /// webapp to know the public key. However, they do allow webapps to know the
+    /// address.
+    ///
+    /// A webapp can technically still know the pubkey by prompting the user to
+    /// sign a message, and extracting the pubkey from the signature. This would
+    /// however be a bad UX, and deter the more security-minded users.
+    Ethereum(Addr),
 }
 
 /// Data that the account expects for the transaction's [`credential`](grug::Tx::credential)
@@ -125,10 +136,14 @@ pub struct PasskeySignature {
 /// An EIP712 signature signed with a compatible eth wallet.
 #[grug::derive(Serde)]
 pub struct Eip712Signature {
-    /// The EIP712 typed data object containing type information,
-    /// domain and the message object.
+    /// The EIP712 typed data object containing type information, domain, and
+    /// the message object.
     pub typed_data: Binary,
-    pub sig: ByteArray<64>,
+    /// Ethereum signature.
+    ///
+    /// The first 64 bytes are the typical Secp256k1 signature. The last byte
+    /// is the recovery id, which can take on the values: 0, 1, 27, 28.
+    pub sig: ByteArray<65>,
 }
 
 /// Passkey client data.

--- a/grug/crypto/src/secp256k1.rs
+++ b/grug/crypto/src/secp256k1.rs
@@ -41,9 +41,8 @@ pub fn secp256k1_verify(msg_hash: &[u8], sig: &[u8], pk: &[u8]) -> CryptoResult<
 /// - `s`: the last 32 bytes of the signature;
 /// - `v`: the recovery ID.
 ///
-/// `v` must be 0 or 1. The values 2 and 3 are unsupported by this implementation,
+/// `v` must be 0, 1, 27, or 28. The values 2 and 3 are unsupported by this implementation,
 /// which is the same restriction [as Ethereum has](https://github.com/ethereum/go-ethereum/blob/v1.9.25/internal/ethapi/api.go#L466-L469).
-/// All other values are invalid.
 ///
 /// Note: This function takes the hash of the message, not the prehash.
 pub fn secp256k1_pubkey_recover(
@@ -59,8 +58,8 @@ pub fn secp256k1_pubkey_recover(
     let mut sig = Signature::from_bytes(&sig.into())?;
 
     let mut id = match recovery_id {
-        0 => RecoveryId::new(false, false),
-        1 => RecoveryId::new(true, false),
+        0 | 27 => RecoveryId::new(false, false),
+        1 | 28 => RecoveryId::new(true, false),
         _ => return Err(CryptoError::InvalidRecoveryId { recovery_id }),
     };
 

--- a/grug/types/src/imports/api.rs
+++ b/grug/types/src/imports/api.rs
@@ -29,10 +29,7 @@ pub trait Api {
     /// Note: this function takes the hash of the message, not the prehash.
     fn secp256k1_verify(&self, msg_hash: &[u8], sig: &[u8], pk: &[u8]) -> StdResult<()>;
 
-    /// Recover the compressed byte of the `public key` from the `signature` and `message hash`.
-    /// - **r**: the first `32 bytes` of the signature;
-    /// - **s**: the last `32 bytes` of the signature;
-    /// - **v**: the `recovery id`.
+    /// Recover the Secp256k1 public key from the signature over a message.
     ///
     /// Note: this function takes the hash of the message, not the prehash.
     fn secp256k1_pubkey_recover(


### PR DESCRIPTION
Currently we use `Key::Secp256k1` for Ethereum wallet login. This is not ideal, because Ethereum wallets typically don't allow webapps to know the pubkey (however, they do allow webapps to know the address). We circumvent this by prompting the user to sign a signature, and extracting the pubkey from the signature. This is however a bad UX.

This PR adds a new key type `Key::Ethereum` which takes an Ethereum address. In dango-auth, we use `ctx.api.secp256k1_pubkey_recover` to verify the signature.

Now there are 3 variants for `Key` and 3 variants for `Credential`. We require they have the following correspondance:

| Key | Credential | Use Case |
| --- | --- | --- |
| `Key::Ethereum` | `Credential::Eip712` | Ethereum wallet login |
| `Key::Secp256r1` | `Credential::Passkey` | Passkey login |
| `Key::Secp256k1` | `Credential::Secp256k1` | Primarily to be used by bots |