### PR TITLE
refactor(dango): require user signature when onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,7 @@ name = "dango-account-factory"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "dango-auth",
  "dango-types",
  "grug",
 ]
@@ -3207,7 +3208,6 @@ dependencies = [
  "alloy",
  "anyhow",
  "base64 0.22.1",
- "dango-account-factory",
  "dango-types",
  "grug",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,7 @@ dependencies = [
  "dango-types",
  "grug",
  "hex",
+ "serde",
  "sha2 0.10.8",
 ]
 

--- a/dango/account/factory/Cargo.toml
+++ b/dango/account/factory/Cargo.toml
@@ -19,6 +19,7 @@ library = []
 
 [dependencies]
 anyhow      = { workspace = true }
+dango-auth  = { workspace = true }
 dango-types = { workspace = true }
 grug        = { workspace = true }
 

--- a/dango/account/factory/src/execute.rs
+++ b/dango/account/factory/src/execute.rs
@@ -1,6 +1,7 @@
 use {
     crate::{ACCOUNTS, ACCOUNTS_BY_USER, CODE_HASHES, KEYS, MINIMUM_DEPOSIT, NEXT_ACCOUNT_INDEX},
     anyhow::{bail, ensure},
+    dango_auth::{VerifyData, verify_signature},
     dango_types::{
         account::{self, single},
         account_factory::{
@@ -11,7 +12,7 @@ use {
     },
     grug::{
         Addr, AuthCtx, AuthMode, AuthResponse, Coins, Hash256, Inner, JsonDeExt, Message,
-        MsgExecute, MutableCtx, Op, Order, Response, StdResult, Storage, Tx,
+        MsgExecute, MutableCtx, Op, Order, Response, StdResult, Storage, Tx, json,
     },
 };
 
@@ -127,7 +128,14 @@ fn register_user(
     signature: Signature,
 ) -> anyhow::Result<Response> {
     // Verify the signature is valid.
-    // TODO!!!!
+    verify_signature(
+        ctx.api,
+        data.key,
+        signature,
+        &VerifyData::Arbitrary(&json!({
+            "username": data.username,
+        })),
+    )?;
 
     // The username must not already exist.
     // We ensure this by asserting there isn't any key already associated with

--- a/dango/account/factory/src/execute.rs
+++ b/dango/account/factory/src/execute.rs
@@ -12,7 +12,7 @@ use {
     },
     grug::{
         Addr, AuthCtx, AuthMode, AuthResponse, Coins, Hash256, Inner, JsonDeExt, Message,
-        MsgExecute, MutableCtx, Op, Order, Response, StdResult, Storage, Tx, json,
+        MsgExecute, MutableCtx, Op, Order, Response, StdResult, Storage, Tx,
     },
 };
 
@@ -132,9 +132,7 @@ fn register_user(
         ctx.api,
         data.key,
         signature,
-        &VerifyData::Arbitrary(&json!({
-            "username": data.username,
-        })),
+        VerifyData::Onboard(data.clone()),
     )?;
 
     // The username must not already exist.

--- a/dango/account/factory/src/state.rs
+++ b/dango/account/factory/src/state.rs
@@ -12,8 +12,8 @@ pub const CODE_HASHES: Map<AccountType, Hash256> = Map::new("hash");
 
 pub const NEXT_ACCOUNT_INDEX: Counter<AccountIndex> = Counter::new("index", 0, 1);
 
-pub const KEYS: Map<(&Username, Hash256), Key> = Map::new("key");
+pub const KEYS: Map<(&Username, Hash256), Key> = dango_auth::account_factory::KEYS;
 
 pub const ACCOUNTS: Map<Addr, Account> = Map::new("account");
 
-pub const ACCOUNTS_BY_USER: Set<(&Username, Addr)> = Set::new("account__user");
+pub const ACCOUNTS_BY_USER: Set<(&Username, Addr)> = dango_auth::account_factory::ACCOUNTS_BY_USER;

--- a/dango/auth/Cargo.toml
+++ b/dango/auth/Cargo.toml
@@ -16,6 +16,7 @@ base64      = { workspace = true }
 dango-types = { workspace = true }
 grug        = { workspace = true }
 hex         = { workspace = true }
+serde       = { workspace = true }
 sha2        = { workspace = true }
 
 [dev-dependencies]

--- a/dango/auth/Cargo.toml
+++ b/dango/auth/Cargo.toml
@@ -10,13 +10,12 @@ rust-version  = { workspace = true }
 version       = { workspace = true }
 
 [dependencies]
-alloy                 = { workspace = true, features = ["dyn-abi", "eip712"] }
-anyhow                = { workspace = true }
-base64                = { workspace = true }
-dango-account-factory = { workspace = true, features = ["library"] }
-dango-types           = { workspace = true }
-grug                  = { workspace = true }
-hex                   = { workspace = true }
-sha2                  = { workspace = true }
+alloy       = { workspace = true, features = ["dyn-abi", "eip712"] }
+anyhow      = { workspace = true }
+base64      = { workspace = true }
+dango-types = { workspace = true }
+grug        = { workspace = true }
+hex         = { workspace = true }
+sha2        = { workspace = true }
 
 [dev-dependencies]

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -7,7 +7,7 @@ use {
     base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD},
     dango_types::{
         DangoQuerier,
-        account_factory::NewUserSalt,
+        account_factory::RegisterUserData,
         auth::{
             ClientData, Credential, Key, Metadata, Nonce, SessionInfo, SignDoc, Signature,
             StandardCredential,
@@ -351,8 +351,8 @@ pub enum VerifyData {
     Session(SessionInfo),
     /// The signature is for onboarding a new user.
     ///
-    /// To do this, the user must sign a `NewUserSalt`.
-    Onboard(NewUserSalt),
+    /// To do this, the user must sign a `RegisterUserData`.
+    Onboard(RegisterUserData),
 }
 
 impl SignData for VerifyData {
@@ -363,7 +363,7 @@ impl SignData for VerifyData {
         match self {
             VerifyData::Transaction(sign_doc) => sign_doc.to_prehash_sign_data(),
             VerifyData::Session(session_info) => session_info.to_prehash_sign_data(),
-            VerifyData::Onboard(salt) => salt.to_prehash_sign_data(),
+            VerifyData::Onboard(data) => data.to_prehash_sign_data(),
         }
     }
 }

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -257,7 +257,7 @@ pub fn verify_signature(
                     sign_doc.to_json_value()?,
                 ),
                 VerifyData::Session(session_info) => (None, session_info.to_json_value()?),
-                VerifyData::Onboard(salt) => (None, salt.to_json_value()?),
+                VerifyData::Onboard(data) => (None, data.to_json_value()?),
             };
 
             // EIP-712 hash used in the signature.

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -498,8 +498,8 @@ mod tests {
               "key_hash": "7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165",
               "signature": {
                 "eip712": {
-                  "sig": "qhvraAO/AnyJO621ig38y8Rc4k12UtuKurqTjMOCHogR5UpyptvZ2lTl0gH0wjFiUTNp3uFe+WAh760HWq2Mnxs=",
-                  "typed_data": "eyJ0eXBlcyI6eyJFSVA3MTJEb21haW4iOlt7Im5hbWUiOiJuYW1lIiwidHlwZSI6InN0cmluZyJ9LHsibmFtZSI6InZlcmlmeWluZ0NvbnRyYWN0IiwidHlwZSI6ImFkZHJlc3MifV0sIk1lc3NhZ2UiOlt7Im5hbWUiOiJtZXRhZGF0YSIsInR5cGUiOiJNZXRhZGF0YSJ9LHsibmFtZSI6Imdhc19saW1pdCIsInR5cGUiOiJ1aW50MzIifSx7Im5hbWUiOiJtZXNzYWdlcyIsInR5cGUiOiJUeE1lc3NhZ2VbXSJ9XSwiTWV0YWRhdGEiOlt7Im5hbWUiOiJ1c2VybmFtZSIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJjaGFpbl9pZCIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJub25jZSIsInR5cGUiOiJ1aW50MzIifV0sIlR4TWVzc2FnZSI6W3sibmFtZSI6InRyYW5zZmVyIiwidHlwZSI6IlRyYW5zZmVyIn1dLCJUcmFuc2ZlciI6W3sibmFtZSI6IjB4MzMzNjFkZTQyNTcxZDZhYTIwYzM3ZGFhNmRhNGI1YWI2N2JmYWFkOSIsInR5cGUiOiJDb2luMCJ9XSwiQ29pbjAiOlt7Im5hbWUiOiJoeXAvZXRoL3VzZGMiLCJ0eXBlIjoic3RyaW5nIn1dfSwicHJpbWFyeVR5cGUiOiJNZXNzYWdlIiwiZG9tYWluIjp7Im5hbWUiOiJkYW5nbyIsInZlcmlmeWluZ0NvbnRyYWN0IjoiMHhiNjYyMjdjZjRlYTgwMGI2YjE5YWVkMTk4Mzk1ZmQwYTJkODBlZTFkIn0sIm1lc3NhZ2UiOnsibWV0YWRhdGEiOnsiY2hhaW5faWQiOiJkZXYtNiIsInVzZXJuYW1lIjoiamF2aWVyIiwibm9uY2UiOjB9LCJnYXNfbGltaXQiOjI0NDgxMzksIm1lc3NhZ2VzIjpbeyJ0cmFuc2ZlciI6eyIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiOnsiaHlwL2V0aC91c2RjIjoiMTAwMDAwMCJ9fX1dfX0="
+                  "sig": "4h1wRoW6SJ1ZbVEp8DIwnJ5OV24QUdyGDOrney+Qbc0/PoTTi5wXRvN/LjB+iuGliyK08DGwu1udd8W3m385NRw=",
+                  "typed_data": "eyJ0eXBlcyI6eyJFSVA3MTJEb21haW4iOlt7Im5hbWUiOiJuYW1lIiwidHlwZSI6InN0cmluZyJ9LHsibmFtZSI6InZlcmlmeWluZ0NvbnRyYWN0IiwidHlwZSI6ImFkZHJlc3MifV0sIk1lc3NhZ2UiOlt7Im5hbWUiOiJzZW5kZXIiLCJ0eXBlIjoiYWRkcmVzcyJ9LHsibmFtZSI6ImRhdGEiLCJ0eXBlIjoiTWV0YWRhdGEifSx7Im5hbWUiOiJnYXNfbGltaXQiLCJ0eXBlIjoidWludDMyIn0seyJuYW1lIjoibWVzc2FnZXMiLCJ0eXBlIjoiVHhNZXNzYWdlW10ifV0sIk1ldGFkYXRhIjpbeyJuYW1lIjoidXNlcm5hbWUiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiY2hhaW5faWQiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoibm9uY2UiLCJ0eXBlIjoidWludDMyIn1dLCJUeE1lc3NhZ2UiOlt7Im5hbWUiOiJ0cmFuc2ZlciIsInR5cGUiOiJUcmFuc2ZlciJ9XSwiVHJhbnNmZXIiOlt7Im5hbWUiOiIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiLCJ0eXBlIjoiQ29pbjAifV0sIkNvaW4wIjpbeyJuYW1lIjoiaHlwL2V0aC91c2RjIiwidHlwZSI6InN0cmluZyJ9XX0sInByaW1hcnlUeXBlIjoiTWVzc2FnZSIsImRvbWFpbiI6eyJuYW1lIjoiZGFuZ28iLCJ2ZXJpZnlpbmdDb250cmFjdCI6IjB4YjY2MjI3Y2Y0ZWE4MDBiNmIxOWFlZDE5ODM5NWZkMGEyZDgwZWUxZCJ9LCJtZXNzYWdlIjp7InNlbmRlciI6IjB4YjY2MjI3Y2Y0ZWE4MDBiNmIxOWFlZDE5ODM5NWZkMGEyZDgwZWUxZCIsImRhdGEiOnsiY2hhaW5faWQiOiJkZXYtNiIsInVzZXJuYW1lIjoiamF2aWVyIiwibm9uY2UiOjB9LCJnYXNfbGltaXQiOjI0NDgxMzksIm1lc3NhZ2VzIjpbeyJ0cmFuc2ZlciI6eyIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiOnsiaHlwL2V0aC91c2RjIjoiMTAwMDAwMCJ9fX1dfX0="
                 }
               }
             }
@@ -729,16 +729,16 @@ mod tests {
                 "key_hash": "7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165",
                 "signature": {
                   "eip712": {
-                    "sig": "2JSrtr1cB6bEVxio6xNCb4z3G7JZo3cF2FF3h6GRSTZVI3Qrqme4wyNUseKrG8J/Mo/DxwzYcj6IlcQnWENtNRs=",
-                    "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSJ9LCJtZXNzYWdlIjp7InNlc3Npb25fa2V5IjoiQThiWDVhbU4yNGlXMDV4b2c2SGVLWXJ3THA5NU9qWStZcW1iUlQ3U0twZVgiLCJleHBpcmVfYXQiOiIxNzQzMTA5NjkzNjM3In0sInByaW1hcnlUeXBlIjoiTWVzc2FnZSIsInR5cGVzIjp7IkVJUDcxMkRvbWFpbiI6W3sibmFtZSI6Im5hbWUiLCJ0eXBlIjoic3RyaW5nIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoic2Vzc2lvbl9rZXkiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiZXhwaXJlX2F0IiwidHlwZSI6InN0cmluZyJ9XX19"
+                    "sig": "kEVvbKJZnU1hqRX/WTVXcn3v8pxvximpJKBFMS9/ZnRyauGuCdzs4AJy5t44KJ5ShWitebYI/fGTyZBxr+1ZYBs=",
+                    "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSJ9LCJtZXNzYWdlIjp7InNlc3Npb25fa2V5IjoiQW9MYWdid29Ldlc1djMrWWF6YnZlbXFtMk1HRVVDSTI0SkprWFo5MWZrTVMiLCJleHBpcmVfYXQiOiIxNzQzMTk5OTAyOTk2In0sInByaW1hcnlUeXBlIjoiTWVzc2FnZSIsInR5cGVzIjp7IkVJUDcxMkRvbWFpbiI6W3sibmFtZSI6Im5hbWUiLCJ0eXBlIjoic3RyaW5nIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoic2Vzc2lvbl9rZXkiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiZXhwaXJlX2F0IiwidHlwZSI6InN0cmluZyJ9XX19"
                   }
                 }
               },
               "session_info": {
-                "expire_at": "1743109693637",
-                "session_key": "A8bX5amN24iW05xog6HeKYrwLp95OjY+YqmbRT7SKpeX"
+                "expire_at": "1743199902996",
+                "session_key": "AoLagbwoKvW5v3+Yazbvemqm2MGEUCI24JJkXZ91fkMS"
               },
-              "session_signature": "510PITf+ZKexzi+g+5J5SS1JkvKBeMoUvBNh7h9viTcGCMvdkgNvdJsdOGpJcG19XYsgPIaMSKZyHEQkVUK2DQ=="
+              "session_signature": "VWS5LFu4yKZaaMD4Svf8DdXdVKzgj785f7DsZUfoXqMI9wzerv+H1YswlXiF/Mf9rvmmbdfAZvdigUze5SXQRQ=="
             }
           },
           "data": {

--- a/dango/genesis/src/lib.rs
+++ b/dango/genesis/src/lib.rs
@@ -314,11 +314,12 @@ where
     // Derive the addresses of the genesis accounts that were just created.
     let addresses = genesis_users
         .iter()
-        .map(|(username, user)| {
+        .enumerate()
+        .map(|(seed, (username, user))| {
             let salt = NewUserSalt {
-                username: username.clone(),
                 key: user.key,
                 key_hash: user.key_hash,
+                seed: seed as u32,
             }
             .to_bytes();
             let address = Addr::derive(account_factory, account_spot_code_hash, &salt);

--- a/dango/genesis/src/lib.rs
+++ b/dango/genesis/src/lib.rs
@@ -314,14 +314,13 @@ where
     // Derive the addresses of the genesis accounts that were just created.
     let addresses = genesis_users
         .iter()
-        .enumerate()
-        .map(|(secret, (username, user))| {
+        .map(|(username, user)| {
             let salt = NewUserSalt {
-                secret: secret as u32,
+                username: username.clone(),
                 key: user.key,
                 key_hash: user.key_hash,
             }
-            .into_bytes();
+            .to_bytes();
             let address = Addr::derive(account_factory, account_spot_code_hash, &salt);
             Ok((username.clone(), address))
         })

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -37,6 +37,7 @@ pyth-types              = { workspace = true }
 sea-orm                 = { workspace = true }
 serde                   = { workspace = true }
 serde_json              = { workspace = true }
+sha2                    = { workspace = true }
 
 [dev-dependencies]
 anyhow                = { workspace = true }
@@ -54,7 +55,6 @@ proptest              = { workspace = true }
 rand                  = { workspace = true }
 reqwest               = { workspace = true, features = ["json"] }
 serde_json            = { workspace = true }
-sha2                  = { workspace = true }
 test-case             = { workspace = true }
 tokio                 = { workspace = true, features = ["full"] }
 tracing               = { workspace = true }

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -131,17 +131,16 @@ impl TestAccount<Undefined<Addr>, (SigningKey, Key)> {
     pub fn predict_address(
         self,
         factory: Addr,
-        secret: u32,
         spot_code_hash: Hash256,
         new_user_salt: bool,
     ) -> TestAccount {
         let salt = if new_user_salt {
             NewUserSalt {
-                secret,
+                username: self.username.clone(),
                 key: self.keys.1,
                 key_hash: self.sign_with,
             }
-            .into_bytes()
+            .to_bytes()
         } else {
             todo!("implement address prediction for not new users");
         };

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -8,7 +8,7 @@ use {
         },
         auth::{Credential, Key, Metadata, SignDoc, Signature, StandardCredential},
     },
-    digest::{consts::U32, generic_array::GenericArray},
+    digest::{Digest, consts::U32, generic_array::GenericArray},
     grug::{
         Addr, Addressable, Coins, Defined, Duration, Hash256, HashExt, Json, JsonSerExt,
         MaybeDefined, Message, NonEmpty, QuerierExt, ResultExt, SignData, Signer, StdResult, Tx,
@@ -16,6 +16,7 @@ use {
     },
     grug_app::{AppError, ProposalPreparer},
     k256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng},
+    sha2::Sha256,
     std::{array, collections::BTreeMap, str::FromStr},
 };
 
@@ -178,6 +179,13 @@ where
             expiry,
             nonce,
         }
+    }
+
+    pub fn sign_arbitrary(&self, data: Json) -> StdResult<Signature> {
+        let bytes = Sha256::digest(data.to_json_vec()?);
+        let standard_credential = self.create_standard_credential(bytes);
+
+        Ok(standard_credential.signature)
     }
 
     pub fn sign_transaction_with_nonce(

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -132,14 +132,15 @@ impl TestAccount<Undefined<Addr>, (SigningKey, Key)> {
     pub fn predict_address(
         self,
         factory: Addr,
+        seed: u32,
         spot_code_hash: Hash256,
         new_user_salt: bool,
     ) -> TestAccount {
         let salt = if new_user_salt {
             NewUserSalt {
-                username: self.username.clone(),
                 key: self.keys.1,
                 key_hash: self.sign_with,
+                seed,
             }
             .to_bytes()
         } else {

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -23,7 +23,6 @@ fn user_onboarding() {
     // Create a new key offchain; then, predict what its address would be.
     let user = TestAccount::new_random("user").predict_address(
         contracts.account_factory,
-        0,
         codes.account_spot.to_bytes().hash256(),
         true,
     );

--- a/dango/types/src/account_factory/events.rs
+++ b/dango/types/src/account_factory/events.rs
@@ -1,6 +1,8 @@
 use {
-    super::{AccountParams, Username},
-    crate::auth::Key,
+    crate::{
+        account_factory::{AccountParams, NewUserSalt, Username},
+        auth::Key,
+    },
     grug::{Addr, Op},
 };
 
@@ -8,9 +10,8 @@ use {
 #[grug::derive(Serde)]
 #[grug::event("user_registered")]
 pub struct UserRegistered {
-    pub username: Username,
     pub address: Addr,
-    pub key: Key,
+    pub data: NewUserSalt,
 }
 
 /// An event indicating a new address has been created.

--- a/dango/types/src/account_factory/events.rs
+++ b/dango/types/src/account_factory/events.rs
@@ -1,17 +1,18 @@
 use {
     crate::{
-        account_factory::{AccountParams, NewUserSalt, Username},
+        account_factory::{AccountParams, Username},
         auth::Key,
     },
-    grug::{Addr, Op},
+    grug::{Addr, Hash256, Op},
 };
 
 /// An event indicating a new user has registered.
 #[grug::derive(Serde)]
 #[grug::event("user_registered")]
 pub struct UserRegistered {
-    pub address: Addr,
-    pub data: NewUserSalt,
+    pub username: Username,
+    pub key: Key,
+    pub key_hash: Hash256,
 }
 
 /// An event indicating a new address has been created.

--- a/dango/types/src/account_factory/msg.rs
+++ b/dango/types/src/account_factory/msg.rs
@@ -1,9 +1,10 @@
 use {
     crate::{
         account_factory::{
-            Account, AccountIndex, AccountParamUpdates, AccountParams, AccountType, Username,
+            Account, AccountIndex, AccountParamUpdates, AccountParams, AccountType, NewUserSalt,
+            Username,
         },
-        auth::Key,
+        auth::{Key, Signature},
     },
     grug::{Addr, Coins, Hash256, Op},
     std::collections::BTreeMap,
@@ -36,10 +37,8 @@ pub enum ExecuteMsg {
     ///
     /// This is the second of the two-step user onboarding process.
     RegisterUser {
-        username: Username,
-        secret: u32,
-        key: Key,
-        key_hash: Hash256,
+        data: NewUserSalt,
+        signature: Signature,
     },
     /// Register a new account for an existing user.
     RegisterAccount { params: AccountParams },

--- a/dango/types/src/account_factory/msg.rs
+++ b/dango/types/src/account_factory/msg.rs
@@ -1,12 +1,12 @@
 use {
     crate::{
         account_factory::{
-            Account, AccountIndex, AccountParamUpdates, AccountParams, AccountType, NewUserSalt,
-            Username,
+            Account, AccountIndex, AccountParamUpdates, AccountParams, AccountType, Username,
         },
         auth::{Key, Signature},
     },
-    grug::{Addr, Coins, Hash256, Op},
+    grug::{Addr, Coins, Hash256, JsonSerExt, Op, SignData, StdError, StdResult},
+    sha2::Sha256,
     std::collections::BTreeMap,
 };
 
@@ -17,6 +17,22 @@ pub struct User {
     pub keys: BTreeMap<Hash256, Key>,
     /// Accounts associated with this user, indexes by addresses.
     pub accounts: BTreeMap<Addr, Account>,
+}
+
+/// Data the user must sign when onboarding.
+#[grug::derive(Serde)]
+pub struct RegisterUserData {
+    pub username: Username,
+    pub chain_id: String,
+}
+
+impl SignData for RegisterUserData {
+    type Error = StdError;
+    type Hasher = Sha256;
+
+    fn to_prehash_sign_data(&self) -> StdResult<Vec<u8>> {
+        self.to_json_value()?.to_json_vec()
+    }
 }
 
 #[grug::derive(Serde)]
@@ -37,7 +53,11 @@ pub enum ExecuteMsg {
     ///
     /// This is the second of the two-step user onboarding process.
     RegisterUser {
-        data: NewUserSalt,
+        username: Username,
+        key: Key,
+        key_hash: Hash256,
+        seed: u32,
+        /// A signature over the `RegisterUserData`.
         signature: Signature,
     },
     /// Register a new account for an existing user.

--- a/dango/types/src/account_factory/salts.rs
+++ b/dango/types/src/account_factory/salts.rs
@@ -1,65 +1,90 @@
 use {
-    crate::{account_factory::AccountIndex, auth::Key},
-    grug::{Binary, Hash256},
+    crate::{
+        account_factory::{AccountIndex, Username},
+        auth::Key,
+    },
+    grug::{Binary, Hash256, Inner, JsonSerExt, SignData, StdError, StdResult},
+    sha2::Sha256,
 };
 
 // ------------------------------- new user salt -------------------------------
 
-/// The salt that account factory uses to create a new user's first ever account,
-/// during the onboarding flow.
+/// Necessary data for registering a new username.
 ///
-/// For any subsequent account, the salt is simply the account ID; that is, a
-/// string in the format: `{username}/account/{index}`.
+/// During onboarding, the account factory uses this data as salt to derive the
+/// address of the user's first account. The user must make a deposit to this
+/// address, then submit this data along with a signature over it.
+///
+/// For any subsequent account, the salt is simply the account index (in 32-bit
+/// unsigned big-endian encoding).
 ///
 /// The first ever account of a user needs a special salt, because it must
 /// encode the user's username, key, and key hash, such that these cannot be
 /// tempered with via frontrunning by a malicious block builder. Check the docs
 /// on the user onboarding flow for more details.
-#[derive(Debug, Clone, Copy)]
+#[grug::derive(Serde)]
 pub struct NewUserSalt {
-    pub secret: u32,
+    pub username: Username,
     pub key: Key,
+    /// An arbitrary hash used to identify the key.
+    ///
+    /// This is chosen by the client, without restriction on which hash algorithm
+    /// to use.
     pub key_hash: Hash256,
+}
+
+impl SignData for NewUserSalt {
+    type Error = StdError;
+    type Hasher = Sha256;
+
+    fn to_prehash_sign_data(&self) -> StdResult<Vec<u8>> {
+        // Convert to JSON value first, to ensure the structure fields are
+        // sorted alphabetically.
+        self.to_json_value()?.to_json_vec()
+    }
 }
 
 impl NewUserSalt {
     /// Convert the salt to raw binary, as follows:
     ///
     /// ```plain
-    /// bytes := secret (in big endian) || key_hash || key_tag || key
+    /// bytes := len(username) || username || key_hash || key_tag || key
     /// ```
     ///
-    /// `secret` is provided externally.
+    /// The `username` has a maximum length of 15 characters. It is prefixed
+    /// with a single byte indicating its length.
     ///
     /// `key_hash` doesn't need a length prefix because it's of fixed length.
     ///
     /// `key_tag` is a single byte identifying the key's type:
-    /// - `0` for Secp256r1
-    /// - `1` for Secp256k1
-    /// - `2` for Ethereum address
-    pub fn into_bytes(self) -> [u8; 70] {
+    ///
+    /// - `0` for Secp256r1;
+    /// - `1` for Secp256k1;
+    /// - `2` for Ethereum address.
+    pub fn to_bytes(&self) -> Vec<u8> {
         // Maximum possible length for the bytes:
-        // - secret: 4
+        // - len(username): 1
+        // - username: 15
         // - key_hash: 32
         // - key_tag: 1
         // - key: 33
-        // Total: 70 bytes.
-        let mut bytes = [0; 70];
-        bytes[0..4].copy_from_slice(&self.secret.to_be_bytes());
-        bytes[4..36].copy_from_slice(&self.key_hash);
+        // Total: 82 bytes.
+        let mut bytes = Vec::with_capacity(82);
+        bytes.push(self.username.len() as u8);
+        bytes.extend(self.username.inner().as_bytes());
+        bytes.extend(self.key_hash.inner());
         match self.key {
             Key::Secp256r1(pk) => {
-                bytes[36] = 0;
-                bytes[37..70].copy_from_slice(&pk);
+                bytes.push(0);
+                bytes.extend(pk.inner());
             },
             Key::Secp256k1(pk) => {
-                bytes[36] = 1;
-                bytes[37..70].copy_from_slice(&pk);
+                bytes.push(1);
+                bytes.extend(pk.inner());
             },
             Key::Ethereum(addr) => {
-                bytes[36] = 2;
-                // Front-pad the address with zeros.
-                bytes[50..70].copy_from_slice(&addr);
+                bytes.push(2);
+                bytes.extend(addr.inner());
             },
         }
         bytes
@@ -70,7 +95,7 @@ impl NewUserSalt {
 // `Message::instantiate` method.
 impl From<NewUserSalt> for Binary {
     fn from(salt: NewUserSalt) -> Self {
-        salt.into_bytes().into()
+        salt.to_bytes().into()
     }
 }
 


### PR DESCRIPTION
- Replace the `secret` in `NewUserSalt` to the `username`.
- In `account_factory::ExecuteMsg::RegisterUser`, user must provide the `NewUserSalt` and a signature signed over the salt.
- Change the `UserRegistered` event (@Rhaki this impacts the Galxe bot)