### PR TITLE
fix(dango/auth): nonce jump check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,6 +3433,7 @@ dependencies = [
  "async-graphql",
  "criterion",
  "dango-account-factory",
+ "dango-auth",
  "dango-bank",
  "dango-genesis",
  "dango-httpd",

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -36,11 +36,12 @@ pub mod account_factory {
 /// Max number of tracked nonces.
 pub const MAX_SEEN_NONCES: usize = 20;
 
-/// The maximum difference between an incoming nonce and the maximum seen nonce.
+/// The maximum difference betwen the nonce of an incoming transaction, and the
+/// biggest seen nonce so far.
 ///
 /// This is to prevent a specific DoS attack. A rogue member of a multisig can
-/// submit a batch of transactions with the maximum possible nonce, such that
-/// the `SEEN_NONCES` set is fully filled with the numbers:
+/// submit a batch of transactions, such that the `SEEN_NONCES` set is fully
+/// filled with the following nonces:
 ///
 /// ```plain
 /// (u32::MAX - MAX_SEEN_NONCES + 1)..=u32::MAX
@@ -52,8 +53,6 @@ pub const MAX_SEEN_NONCES: usize = 20;
 ///
 /// We prevent this attack by requiring the nonce of a new tx must not be too
 /// much bigger than the biggest nonce seen so far.
-///
-/// TODO: link to Zellic audit report that discovered this issue.
 pub const MAX_NONCE_INCREASE: Nonce = 100;
 
 /// The most recent nonces that have been used to send transactions.

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -36,7 +36,7 @@ pub mod account_factory {
 /// Max number of tracked nonces.
 pub const MAX_SEEN_NONCES: usize = 20;
 
-/// The maximum difference betwen an incoming nonce and the maximum seen nonce.
+/// The maximum difference between an incoming nonce and the maximum seen nonce.
 ///
 /// This is to prevent a specific DoS attack. A rogue member of a multisig can
 /// submit a batch of transactions with the maximum possible nonce, such that

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -36,6 +36,26 @@ pub mod account_factory {
 /// Max number of tracked nonces.
 pub const MAX_SEEN_NONCES: usize = 20;
 
+/// The maximum difference betwen an incoming nonce and the maximum seen nonce.
+///
+/// This is to prevent a specific DoS attack. A rogue member of a multisig can
+/// submit a batch of transactions with the maximum possible nonce, such that
+/// the `SEEN_NONCES` set is fully filled with the numbers:
+///
+/// ```plain
+/// (u32::MAX - MAX_SEEN_NONCES + 1)..=u32::MAX
+/// ```
+///
+/// This prevents the multisig from being able to submit any more transactions,
+/// because a new tx must come with a nonce bigger than `u32::MAX`, which is
+/// impossible.
+///
+/// We prevent this attack by requiring the nonce of a new tx must not be too
+/// much bigger than the biggest nonce seen so far.
+///
+/// TODO: link to Zellic audit report that discovered this issue.
+pub const MAX_NONCE_INCREASE: Nonce = 100;
+
 /// The most recent nonces that have been used to send transactions.
 ///
 /// All three account types (spot, margin, multi) stores their nonces in this
@@ -166,6 +186,20 @@ pub fn verify_nonce_and_signature(
                         // Ensure the first nonce is zero.
                         ensure!(metadata.nonce == 0, "first nonce must be 0");
                     },
+                }
+
+                // The nonce must not be too much bigger than the biggest nonce
+                // seen so far.
+                //
+                // See the documentation for `MAX_NONCE_INCREASE` for the rationale.
+                if let Some(max) = nonces.last() {
+                    ensure!(
+                        metadata.nonce <= max + MAX_NONCE_INCREASE,
+                        "nonce is too far ahead: {} > {} + MAX_NONCE_INCREASE ({})",
+                        metadata.nonce,
+                        max,
+                        MAX_NONCE_INCREASE
+                    );
                 }
 
                 nonces.insert(metadata.nonce);

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -44,6 +44,7 @@ anyhow                = { workspace = true }
 assertor              = { workspace = true }
 criterion             = { workspace = true }
 dango-account-factory = { workspace = true, features = ["library"] }
+dango-auth            = { workspace = true }
 dango-bank            = { workspace = true, features = ["library"] }
 dango-httpd           = { workspace = true }
 dango-oracle          = { workspace = true, features = ["library"] }

--- a/dango/testing/tests/multi.rs
+++ b/dango/testing/tests/multi.rs
@@ -938,7 +938,8 @@ fn max_nonce_dos_attack() {
     }
 
     // Member 3 (bad guy) attempts to DoS attack. He attempts to vote with a
-    // very big nonce. Should fail.
+    // very big nonce. Should fail. Specifically, it should fail at the `CheckTx`
+    // stage, meaning the tx won't enter the mempool at all.
     {
         let msgs = NonEmpty::new_unchecked(vec![
             Message::execute(
@@ -974,7 +975,7 @@ fn max_nonce_dos_attack() {
             credential: credential.to_json_value().unwrap(),
         };
 
-        suite.send_transaction(tx).should_fail_with_error(format!(
+        suite.check_tx(tx).should_fail_with_error(format!(
             "nonce is too far ahead: {} > {} + MAX_NONCE_INCREASE ({})",
             123456, 5, MAX_NONCE_INCREASE
         ));


### PR DESCRIPTION
require the nonce of an incoming tx to not be too much bigger than the biggest seen nonce so far. this is to prevent a possible DoS attack in a multisig by a rogue member.