### PR TITLE
dango: allow uppercase letters in usernames

### DIFF
--- a/dango/account/factory/src/state.rs
+++ b/dango/account/factory/src/state.rs
@@ -12,6 +12,8 @@ pub const CODE_HASHES: Map<AccountType, Hash256> = Map::new("hash");
 
 pub const NEXT_ACCOUNT_INDEX: Counter<AccountIndex> = Counter::new("index", 0, 1);
 
+pub const LOWERCASE_USERNAMES: Set<String> = Set::new("lowercase_username");
+
 pub const KEYS: Map<(&Username, Hash256), Key> = dango_auth::account_factory::KEYS;
 
 pub const ACCOUNTS: Map<Addr, Account> = Map::new("account");

--- a/dango/types/src/account_factory/username.rs
+++ b/dango/types/src/account_factory/username.rs
@@ -7,8 +7,8 @@ use {
 
 /// A name that uniquely identifies a user.
 ///
-/// A valid username must contain only lowercase ASCII letters (a-z), numbers
-/// (0-9), or the underscore (_) and be between 1-15 characters.
+/// A valid username must contain only ASCII letters (`A-Z|a-z`), numbers (`0-9`),
+/// or the underscore (`_`) and be between 1-15 characters.
 #[grug::derive(Borsh)]
 #[derive(Serialize, PartialOrd, Ord)]
 pub struct Username(String);
@@ -100,13 +100,10 @@ impl FromStr for Username {
             ));
         }
 
-        if !s
-            .chars()
-            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
-        {
+        if !s.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '_') {
             return Err(StdError::deserialize::<Self, _>(
                 "str",
-                "username can only contain lowercase alphanumeric characters (a-z|0-9) or underscore",
+                "username can only contain alphanumeric characters (A-Z|a-z|0-9) or underscore",
             ));
         }
 
@@ -129,7 +126,7 @@ impl de::Visitor<'_> for Visitor {
     type Value = Username;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("A string containing between 1 to 15 lowercase alphanumeric characters (a-z|0-9) or underscore")
+        formatter.write_str("A string containing between 1 to 15 alphanumeric characters (A-Z|a-z|0-9) or underscore")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>


### PR DESCRIPTION
I would like to make it possible to use uppercase letters in usernames. However we want to prevent duplicate usernames such as `larryengineer` and `LarryEngineer`. This is the same as how twitter handles work (you can't register `LarryEngineer` if `larryengineer` already exists). In order do to this, I have to introduce a `LOWERCASE_USERNAMES` set.

This PR is state breaking, so let's not merge it before the current testnet ends (in 2 weeks).