### PR TITLE
feat(pyth): add reconnection flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7209,6 +7209,7 @@ dependencies = [
  "grug-app",
  "indexer-disk-saver",
  "pyth-types",
+ "rand 0.8.5",
  "reqwest 0.12.15",
  "reqwest-eventsource",
  "thiserror 2.0.12",

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -109,7 +109,7 @@ pub fn authenticate_tx(
     verify_nonce_and_signature(ctx, tx, Some(factory), Some(metadata))
 }
 
-/// Ensure the nonce is acceptible and the signature is authentic.
+/// Ensure the nonce is acceptable and the signature is authentic.
 ///
 /// Compared to [`authenticate_tx`](crate::authenticate_tx), this function skips
 /// the part of verifying the username.

--- a/pyth/client/Cargo.toml
+++ b/pyth/client/Cargo.toml
@@ -28,3 +28,4 @@ url                 = { workspace = true }
 axum        = { workspace = true }
 dango-types = { workspace = true }
 futures     = { workspace = true }
+rand        = { workspace = true }

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -84,7 +84,7 @@ impl PythClientTrait for PythClient {
         let keep_running = self.keep_running.clone();
 
         let stream = stream! {
-            let mut retry_attemps = 0;
+            let mut retry_attempts = 0;
 
             loop{
                 // Create an EventSource.
@@ -111,15 +111,15 @@ impl PythClientTrait for PythClient {
                             }
 
                             // Exponential backoff before try to reconnect.
-                            let delay = if retry_attemps > 6 {
+                            let delay = if retry_attempts > 6 {
                                 MAX_DELAY
                             } else {
                                 min(
                                     MAX_DELAY,
-                                    Duration::from_secs((u32::pow(2, retry_attemps)) as u64),
+                                    Duration::from_secs((u32::pow(2, retry_attempts)) as u64),
                                 )
                             };
-                            retry_attemps += 1;
+                            retry_attempts += 1;
 
                             warn!("No new data received. Reconnecting in {} seconds", delay.as_secs());
 
@@ -141,7 +141,7 @@ impl PythClientTrait for PythClient {
                                         info!("Pyth SSE connection open");
                                     },
                                     Ok(Event::Message(message)) => {
-                                        retry_attemps = 0;
+                                        retry_attempts = 0;
 
                                         match message.data.deserialize_json::<LatestVaaResponse>() {
                                             Ok(vaas) => {

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -84,6 +84,7 @@ impl PythClient {
                         "Failed to create EventSource. Reconnecting in {} seconds",
                         current_sleep.as_secs()
                     );
+
                     sleep(current_sleep).await;
 
                     current_sleep = fn_next_backoff_duration(current_sleep);
@@ -105,6 +106,7 @@ impl PythClient {
                 Some(event_result) => match event_result {
                     Ok(_) => {
                         info!("Pyth SSE connection open");
+
                         return es;
                     },
                     Err(err) => {
@@ -170,7 +172,8 @@ impl PythClientTrait for PythClient {
                 let mut es = Self::create_event_source(
                     &builder,
                     Duration::from_millis(500),
-                ).await;
+                )
+                .await;
 
                 loop {
                     tokio::select! {
@@ -184,13 +187,13 @@ impl PythClientTrait for PythClient {
                                 return;
                             }
 
-                            warn!("No new data received, start reconnecting");
+                            warn!("No new data received. Start reconnecting");
 
                             es = Self::create_event_source(
                                 &builder,
                                 Duration::from_millis(100),
-                            ).await;
-
+                            )
+                            .await;
                         },
 
                         data = es.next() => {
@@ -226,7 +229,7 @@ impl PythClientTrait for PythClient {
                                     },
                                 }
                             } else {
-                                error!("Pyth SSE connection close, start reconnecting");
+                                error!("Pyth SSE connection closed. Start reconnecting");
                                 es.close();
                                 break;
                             }

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -83,7 +83,7 @@ impl PythClientTrait for PythClient {
         self.keep_running = Arc::new(AtomicBool::new(true));
         let keep_running = self.keep_running.clone();
 
-        // EventSource::new() return an Error only if the builder is not Cloneable.
+        // `EventSource::new()` return an Error only if the builder is not `Clone`-able.
         // Instead of returning a result inside of the stream, clone the builder
         // here to ensure it's cloneable.
         let _ = builder.try_clone().ok_or(CannotCloneRequestError)?;
@@ -91,8 +91,8 @@ impl PythClientTrait for PythClient {
         let stream = stream! {
             let mut retry_attempts = 0;
 
-            loop{
-                // Create an EventSource.
+            loop {
+                // Create an `EventSource`.
                 let mut es = EventSource::new(builder.try_clone().unwrap()).unwrap();
 
                 // Set the exponential backoff for reconnect.
@@ -124,6 +124,7 @@ impl PythClientTrait for PythClient {
                                     Duration::from_secs((u32::pow(2, retry_attempts)) as u64),
                                 )
                             };
+
                             retry_attempts += 1;
 
                             warn!("No new data received. Reconnecting in {} seconds", delay.as_secs());
@@ -131,8 +132,7 @@ impl PythClientTrait for PythClient {
                             sleep(delay).await;
 
                             break;
-                        }
-
+                        },
                         data = es.next() => {
                             if !keep_running.load(Ordering::Acquire) {
                                 es.close();
@@ -172,7 +172,7 @@ impl PythClientTrait for PythClient {
                                 es.close();
                                 break;
                             }
-                        }
+                        },
                     }
                 }
             }

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -174,7 +174,7 @@ impl PythClientTrait for PythClient {
                 // Create the `EventSource`.
                 let mut es = Self::create_event_source(
                     &builder,
-                    Duration::from_millis(500),
+                    Duration::from_millis(100),
                 )
                 .await;
 
@@ -187,16 +187,12 @@ impl PythClientTrait for PythClient {
 
                             // Check if the streaming has to be closed.
                             if !keep_running.load(Ordering::Relaxed) {
+                                info!("Pyth SSE connection closed");
                                 return;
                             }
 
                             warn!("No new data received. Start reconnecting");
-
-                            es = Self::create_event_source(
-                                &builder,
-                                Duration::from_millis(100),
-                            )
-                            .await;
+                            break;
                         },
 
                         data = es.next() => {

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -4,8 +4,8 @@ use {
     async_trait::async_trait,
     grug::{Binary, Inner, JsonDeExt, Lengthy, NonEmpty},
     pyth_types::LatestVaaResponse,
-    reqwest::{Client, IntoUrl, RequestBuilder, Url},
-    reqwest_eventsource::{CannotCloneRequestError, Event, EventSource, retry::ExponentialBackoff},
+    reqwest::{Client, IntoUrl, Url},
+    reqwest_eventsource::{Event, EventSource, retry::ExponentialBackoff},
     std::{
         cmp::min,
         pin::Pin,
@@ -20,7 +20,7 @@ use {
     tracing::{error, info, warn},
 };
 
-const MAX_DELAY: Duration = Duration::from_secs(10);
+const MAX_DELAY: Duration = Duration::from_secs(5);
 
 /// PythClient is a client to interact with the Pyth network.
 #[derive(Debug, Clone)]
@@ -60,7 +60,8 @@ impl PythClient {
     }
 
     async fn create_event_source(
-        builder: &RequestBuilder,
+        url: &Url,
+        params: &Vec<(&str, String)>,
         backoff_start_duration: Duration,
     ) -> EventSource {
         // Function to calculate the exponential backoff before try to reconnect.
@@ -76,11 +77,11 @@ impl PythClient {
 
         // Create the `EventSource`.
         loop {
-            let mut es = match EventSource::new(
-                builder
-                    .try_clone()
-                    .expect("Failed to clone builder, Pyth connection cannot be established"),
-            ) {
+            // Create the request builder at new iterations to avoid the ‘try_clone()’ that
+            // could lead to error.
+            let builder = Client::new().get(url.clone()).query(params);
+
+            let mut es = match EventSource::new(builder) {
                 Ok(es) => es,
                 Err(err) => {
                     error!(
@@ -99,7 +100,7 @@ impl PythClient {
 
             // Set the exponential backoff for reconnect.
             es.set_retry_policy(Box::new(ExponentialBackoff::new(
-                Duration::from_millis(500),
+                Duration::from_millis(100),
                 1.5,
                 Some(MAX_DELAY),
                 None,
@@ -156,32 +157,21 @@ impl PythClientTrait for PythClient {
         // Close the previous connection.
         self.close();
 
-        let params = PythClient::create_request_params(ids);
-        let builder = Client::new()
-            .get(self.base_url.join("v2/updates/price/stream")?)
-            .query(&params);
-
         self.keep_running = Arc::new(AtomicBool::new(true));
         let keep_running = self.keep_running.clone();
 
-        // Ensure the builder can be cloned before entering the stream, otherwise
-        // will raise a panic later.
-        let _ = builder.try_clone().ok_or(CannotCloneRequestError)?;
+        let url = self.base_url.join("v2/updates/price/stream")?;
+        let params = PythClient::create_request_params(ids);
 
         let stream = stream! {
-
-            loop{
+            loop {
                 // Create the `EventSource`.
-                let mut es = Self::create_event_source(
-                    &builder,
-                    Duration::from_millis(100),
-                )
-                .await;
+                let mut es = Self::create_event_source(&url, &params, Duration::from_millis(100)).await;
 
                 loop {
                     tokio::select! {
-                        // The server is not sending any more data. Drop connection and
-                        // establish a new one.
+                        // The server is not sending any more data.
+                        // Drop connection and establish a new one.
                         _ = tokio::time::sleep(tokio::time::Duration::from_millis(1000)) => {
                             es.close();
 
@@ -195,42 +185,46 @@ impl PythClientTrait for PythClient {
                             break;
                         },
 
+                        // Read next data from stream.
                         data = es.next() => {
+
+                            // Check if the streaming has to be closed.
                             if !keep_running.load(Ordering::Acquire) {
                                 es.close();
+                                info!("Pyth SSE connection closed");
                                 return;
                             }
 
-                            if let Some(event) = data {
-                                match event {
-                                    Ok(Event::Open) => {
-                                        info!("Pyth SSE connection open");
-                                    },
-                                    Ok(Event::Message(message)) => {
-
-                                        match message.data.deserialize_json::<LatestVaaResponse>() {
-                                            Ok(vaas) => {
-                                                yield vaas.binary.data;
-                                            },
-                                            Err(err) => {
-                                                error!(
-                                                    err = err.to_string(),
-                                                    "Failed to deserialize Pyth event into `LatestVaaResponse`"
-                                                );
-                                            },
-                                        }
-                                    },
-                                    Err(err) => {
-                                        error!(
-                                            err = err.to_string(),
-                                            "Error while receiving the events from Pyth"
-                                        );
-                                    },
-                                }
-                            } else {
+                            // If connection is closed, try to reconnect.
+                            let Some(event) = data else {
                                 error!("Pyth SSE connection closed. Start reconnecting");
                                 es.close();
                                 break;
+                            };
+
+                            match event {
+                                Ok(Event::Open) => {
+                                    info!("Pyth SSE connection open");
+                                },
+                                Ok(Event::Message(message)) => {
+                                    match message.data.deserialize_json::<LatestVaaResponse>() {
+                                        Ok(vaas) => {
+                                            yield vaas.binary.data;
+                                        },
+                                        Err(err) => {
+                                            error!(
+                                                err = err.to_string(),
+                                                "Failed to deserialize Pyth event into `LatestVaaResponse`"
+                                            );
+                                        },
+                                    }
+                                },
+                                Err(err) => {
+                                    error!(
+                                        err = err.to_string(),
+                                        "Error while receiving the events from Pyth"
+                                    );
+                                },
                             }
                         },
                     }

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -76,7 +76,11 @@ impl PythClient {
 
         // Create the `EventSource`.
         loop {
-            let mut es = match EventSource::new(builder.try_clone().unwrap()) {
+            let mut es = match EventSource::new(
+                builder
+                    .try_clone()
+                    .expect("Failed to clone builder, Pyth connection cannot be established"),
+            ) {
                 Ok(es) => es,
                 Err(err) => {
                     error!(
@@ -160,9 +164,8 @@ impl PythClientTrait for PythClient {
         self.keep_running = Arc::new(AtomicBool::new(true));
         let keep_running = self.keep_running.clone();
 
-        // `EventSource::new()` return an Error only if the builder is not `Clone`-able.
-        // Instead of returning a result inside of the stream, clone the builder
-        // here to ensure it's cloneable.
+        // Ensure the builder can be cloned before entering the stream, otherwise
+        // will raise a panic later.
         let _ = builder.try_clone().ok_or(CannotCloneRequestError)?;
 
         let stream = stream! {

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -85,7 +85,7 @@ impl PythClientTrait for PythClient {
 
         // EventSource::new() return an Error only if the builder is not Cloneable.
         // Instead of returning a result inside of the stream, clone the builder
-        // here and return the error if it fails.
+        // here to ensure it's cloneable.
         let _ = builder.try_clone().ok_or(CannotCloneRequestError)?;
 
         let stream = stream! {

--- a/pyth/client/src/error.rs
+++ b/pyth/client/src/error.rs
@@ -6,8 +6,5 @@ pub enum Error {
     Reqwest(#[from] reqwest::Error),
 
     #[error(transparent)]
-    CannotClone(#[from] reqwest_eventsource::CannotCloneRequestError),
-
-    #[error(transparent)]
     ParseErrorUrl(#[from] ParseError),
 }

--- a/pyth/client/tests/client.rs
+++ b/pyth/client/tests/client.rs
@@ -53,7 +53,7 @@ async fn test_sse_stream() {
 #[tokio::test]
 async fn test_client_reconnection() {
     let mut client = PythClient::new("http://127.0.0.1:3030").unwrap();
-    setup_tracing_subscriber(tracing::Level::DEBUG);
+    setup_tracing_subscriber(tracing::Level::INFO);
     let mut stream = client
         .stream(NonEmpty::new_unchecked(vec![BTC_USD_ID]))
         .await

--- a/pyth/client/tests/client.rs
+++ b/pyth/client/tests/client.rs
@@ -79,7 +79,7 @@ async fn test_client_reconnection() {
     // Each time the client should be able to reconnect.
     for _ in 0..10 {
         tokio::select! {
-            _ = tokio::time::sleep(Duration::from_secs(10)) => {
+            _ = tokio::time::sleep(Duration::from_secs(5)) => {
                 panic!("The client has not received any data for 10 seconds")
             },
             _ = stream.next() => {},
@@ -146,7 +146,7 @@ async fn sse_handler(
             } else {
                 // Wait some times to trigger the reconnect from client.
                 if request_index == 0 {
-                    sleep(Duration::from_secs(1000)).await;
+                    sleep(Duration::from_secs(10)).await;
                 } else if request_index == 1 {
                     // Panic to simulate an unexpected disconnection.
                     warn!("Panic inside the server");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds reconnection flow with exponential backoff to Pyth client, including tests for robust SSE connection handling.
> 
>   - **Reconnection Flow**:
>     - Adds `create_event_source()` in `client.rs` to handle SSE connections with exponential backoff.
>     - Implements reconnection logic in `stream()` method in `client.rs` to handle disconnections and data absence.
>   - **Testing**:
>     - Adds `test_client_reconnection()` in `client.rs` tests to validate reconnection logic with scenarios like valid/invalid data, connection close, and server panic.
>     - Uses random port allocation for server in tests to avoid conflicts.
>   - **Dependencies**:
>     - Adds `rand` to `Cargo.toml` for random number generation in tests.
>   - **Misc**:
>     - Fixes typo in `lib.rs` ("acceptible" to "acceptable").
>     - Removes `CannotCloneRequestError` from `error.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for bb91d92dba7c664b535a8431e39f0cc46c6d682f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->