### PR TITLE
Add test for single sided provide liquidity

### DIFF
--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -162,13 +162,26 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     /// Simulate a swap with exact input.
-    #[returns(Coin)]
+    #[returns(SimulateSwapExactAmountInResponse)]
     SimulateSwapExactAmountIn { route: SwapRoute, input: Coin },
     /// Simulate a swap with exact output.
-    #[returns(Coin)]
+    #[returns(SimulateSwapExactAmountOutResponse)]
     SimulateSwapExactAmountOut {
         route: SwapRoute,
         output: NonZero<Coin>,
+    },
+    /// Simulate a liquidity provision.
+    #[returns(SimulateProvideLiquidityResponse)]
+    SimulateProvideLiquidity {
+        /// The base asset denomination.
+        base_denom: Denom,
+        /// The quote asset denomination.
+        quote_denom: Denom,
+        /// The coins to deposit into the pool.
+        deposit: CoinPair,
+        /// Optional pool reserves before the provision. If not provided, the
+        /// current pool reserves will be used.
+        reserve: Option<CoinPair>,
     },
 }
 
@@ -219,4 +232,22 @@ pub struct OrdersByUserResponse {
     pub price: Udec128,
     pub amount: Uint128,
     pub remaining: Uint128,
+}
+
+#[grug::derive(Serde)]
+pub struct SimulateSwapExactAmountInResponse {
+    pub output: Coin,
+    pub reserves_after: Vec<(PairId, CoinPair)>,
+}
+
+#[grug::derive(Serde)]
+pub struct SimulateSwapExactAmountOutResponse {
+    pub input: Coin,
+    pub reserves_after: Vec<(PairId, CoinPair)>,
+}
+
+#[grug::derive(Serde)]
+pub struct SimulateProvideLiquidityResponse {
+    pub lp_tokens_minted: Coin,
+    pub reserves_after: CoinPair,
 }

--- a/grug/types/src/coin_pair.rs
+++ b/grug/types/src/coin_pair.rs
@@ -217,7 +217,7 @@ impl CoinPair {
         Ok(self)
     }
 
-    /// Return the ratio of the two coins in the coin pair.
+    /// Return the ratio of the two coins in the coin pair. Note: Division by zero will result in an error.
     ///
     /// The ratio is calculated as amount of coin index 0 divided by amount of
     /// coin index 1.

--- a/grug/types/src/coin_pair.rs
+++ b/grug/types/src/coin_pair.rs
@@ -1,7 +1,7 @@
 use {
     crate::{Coin, CoinRef, CoinRefMut, Coins, Denom, StdError, StdResult},
     borsh::{BorshDeserialize, BorshSerialize},
-    grug_math::{IsZero, MultiplyRatio, Number, NumberConst, Uint128},
+    grug_math::{IsZero, MultiplyRatio, Number, NumberConst, Udec128, Uint128},
     serde::{Serialize, de},
     std::{cmp::Ordering, collections::BTreeMap, io},
 };
@@ -215,6 +215,17 @@ impl CoinPair {
         }
 
         Ok(self)
+    }
+
+    /// Return the ratio of the two coins in the coin pair.
+    ///
+    /// The ratio is calculated as amount of coin index 0 divided by amount of
+    /// coin index 1.
+    pub fn ratio(&self) -> StdResult<Udec128> {
+        let amount1 = self.0[0].amount;
+        let amount2 = self.0[1].amount;
+
+        Ok(Udec128::checked_from_ratio(amount1, amount2)?)
     }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add test and query support for single-sided liquidity provision in DEX module.
> 
>   - **Behavior**:
>     - Adds `SimulateProvideLiquidity` to `QueryMsg` in `msgs.rs` to simulate liquidity provision.
>     - Implements `query_simulate_provide_liquidity()` in `query.rs` to handle `SimulateProvideLiquidity` queries.
>     - Updates `query()` in `query.rs` to handle `SimulateProvideLiquidity`.
>   - **Tests**:
>     - Adds `provide_liquidity_unbalanced()` test in `dex.rs` to verify single-sided liquidity provision.
>   - **Data Structures**:
>     - Adds `SimulateProvideLiquidityResponse` struct in `msgs.rs` to represent the response of liquidity provision simulation.
>     - Adds `ratio()` method to `CoinPair` in `coin_pair.rs` to calculate the ratio of two coins.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ef83bf555b3a5bcbabb109da8a3e7f48215a1f96. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->