### PR TITLE
fix(dango/oracle): skip denoms of which price sources exist but prices don't

### DIFF
--- a/dango/oracle/src/query.rs
+++ b/dango/oracle/src/query.rs
@@ -48,7 +48,7 @@ fn query_prices(
     let start = start_after.as_ref().map(Bound::Exclusive);
     let limit = limit.unwrap_or(DEFAULT_PAGE_LIMIT) as usize;
 
-    PRICE_SOURCES
+    Ok(PRICE_SOURCES
         .range(ctx.storage, start, None, Order::Ascending)
         .take(limit)
         .filter_map(|res| {
@@ -60,9 +60,9 @@ fn query_prices(
                 .querier
                 .query_price(ctx.contract, &denom, Some(price_source))
                 .ok()?;
-            Some(Ok((denom, price)))
+            Some((denom, price))
         })
-        .collect()
+        .collect())
 }
 
 fn query_price_source(ctx: ImmutableCtx, denom: Denom) -> StdResult<PriceSource> {

--- a/dango/oracle/src/query.rs
+++ b/dango/oracle/src/query.rs
@@ -14,7 +14,7 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             Ok(res.to_json_value()?)
         },
         QueryMsg::Prices { start_after, limit } => {
-            let res = query_prices(ctx, start_after, limit)?;
+            let res = query_prices(ctx, start_after, limit);
             Ok(res.to_json_value()?)
         },
         QueryMsg::PriceSource { denom } => {
@@ -44,11 +44,11 @@ fn query_prices(
     ctx: ImmutableCtx,
     start_after: Option<Denom>,
     limit: Option<u32>,
-) -> anyhow::Result<BTreeMap<Denom, PrecisionedPrice>> {
+) -> BTreeMap<Denom, PrecisionedPrice> {
     let start = start_after.as_ref().map(Bound::Exclusive);
     let limit = limit.unwrap_or(DEFAULT_PAGE_LIMIT) as usize;
 
-    Ok(PRICE_SOURCES
+    PRICE_SOURCES
         .range(ctx.storage, start, None, Order::Ascending)
         .take(limit)
         .filter_map(|res| {
@@ -62,7 +62,7 @@ fn query_prices(
                 .ok()?;
             Some((denom, price))
         })
-        .collect())
+        .collect()
 }
 
 fn query_price_source(ctx: ImmutableCtx, denom: Denom) -> StdResult<PriceSource> {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `query_prices` in `query.rs` now skips denoms with price sources but no prices, and `query_price` uses `ctx.contract` directly.
> 
>   - **Behavior**:
>     - `query_prices` in `query.rs` now skips denoms with existing price sources but no prices, using `filter_map`.
>     - Changes `query_prices` return type to `BTreeMap<Denom, PrecisionedPrice>` by removing `anyhow::Result`.
>   - **Functions**:
>     - `query_price` in `query.rs` now uses `ctx.contract` instead of `ctx.contract.address()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 89c3acdeb027b08287450f17f02bcf20aa2246b1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->