### PR TITLE
fix(grug): `CheckTxEvents` from `tx_sync::Response.data`

### DIFF
--- a/grug/types/src/outcome.rs
+++ b/grug/types/src/outcome.rs
@@ -212,13 +212,18 @@ impl CheckTxEvents {
         }
     }
 
+    #[cfg(feature = "tendermint")]
     pub fn from_tm_data(raw_bytes: &[u8]) -> StdResult<Self> {
         let b64 = BASE64_NOPAD.encode(&raw_bytes);
         let hex = HEXUPPER.decode(b64.as_bytes())?;
 
         // remove all bytes after the last }
         let end = hex.iter().rposition(|&b| b == b'}').unwrap_or(hex.len());
-        let mut bytes = hex[..=end].to_vec();
+        let mut bytes = if end == hex.len() {
+            hex.to_vec()
+        } else {
+            hex[..=end].to_vec()
+        };
 
         let curly_open = bytes.iter().filter(|b| **b == b'{').count();
         let curly_close = bytes.iter().filter(|b| **b == b'}').count();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `from_tm_data` method to `CheckTxEvents` for deserializing `tx_sync::Response.data` with fallback handling for malformed data.
> 
>   - **Behavior**:
>     - Adds `from_tm_data` method to `CheckTxEvents` to handle deserialization of `tx_sync::Response.data` with fallback to mock values if deserialization fails.
>     - Handles cases where the data format is malformed by adjusting curly braces.
>   - **Files**:
>     - Modifies `outcome.rs` to include new deserialization logic and error handling for `CheckTxEvents`.
>   - **Misc**:
>     - Adds imports for `BASE64_NOPAD` and `HEXUPPER` in `outcome.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 78cd22f5089ca59f4a5b42b0376e0b7a618fabd5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->