### PR TITLE
fix(grug): broadcast tx response decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
  "rand 0.8.5",
  "sentry",
  "serde",
- "tendermint 0.40.3",
+ "tendermint",
  "tokio",
  "tower 0.5.2",
  "tower-abci",
@@ -4576,7 +4576,7 @@ dependencies = [
  "grug-types",
  "ics23",
  "prost",
- "tendermint 0.40.3",
+ "tendermint",
  "thiserror 2.0.12",
  "tower 0.5.2",
  "tower-abci",
@@ -4593,7 +4593,7 @@ dependencies = [
  "grug-math",
  "grug-types",
  "serde",
- "tendermint 0.40.3",
+ "tendermint",
  "tendermint-rpc",
 ]
 
@@ -4800,7 +4800,7 @@ dependencies = [
  "sha3",
  "strum 0.27.1",
  "strum_macros 0.27.1",
- "tendermint 0.40.3",
+ "tendermint",
  "tendermint-rpc",
  "test-case",
  "thiserror 2.0.12",
@@ -5622,7 +5622,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tendermint 0.40.3",
+ "tendermint",
  "tendermint-rpc",
  "thiserror 2.0.12",
  "tokio",
@@ -9384,34 +9384,6 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9703e34d940c2a293804752555107f8dbe2b84ec4c6dd5203831235868105d2"
-dependencies = [
- "bytes",
- "digest 0.10.7",
- "ed25519",
- "ed25519-consensus",
- "flex-error",
- "futures",
- "num-traits",
- "once_cell",
- "prost",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.10.8",
- "signature",
- "subtle",
- "subtle-encoding",
- "tendermint-proto 0.40.1",
- "time",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint"
 version = "0.40.3"
 source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
 dependencies = [
@@ -9432,7 +9404,7 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.40.3",
+ "tendermint-proto",
  "time",
  "zeroize",
 ]
@@ -9445,24 +9417,9 @@ dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint 0.40.3",
+ "tendermint",
  "toml 0.8.20",
  "url",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9e1705aa0fa5ecb2c6aa7fb78c2313c4a31158ea5f02048bf318f849352eb"
-dependencies = [
- "bytes",
- "flex-error",
- "prost",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "time",
 ]
 
 [[package]]
@@ -9499,9 +9456,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint 0.40.3",
+ "tendermint",
  "tendermint-config",
- "tendermint-proto 0.40.3",
+ "tendermint-proto",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -9891,15 +9848,14 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f20500d25342b86338bc9e053694dd199e9dafbc1044126a54ce378bfbbcfa5"
+source = "git+https://github.com/left-curve/tower-abci.git?rev=6ba8190#6ba81903150128456c7c2949ca484972621c4e00"
 dependencies = [
  "bytes",
  "futures",
  "pin-project 1.1.10",
  "prost",
- "tendermint 0.40.1",
- "tendermint-proto 0.40.1",
+ "tendermint",
+ "tendermint-proto",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
  "rand 0.8.5",
  "sentry",
  "serde",
- "tendermint",
+ "tendermint 0.40.3",
  "tokio",
  "tower 0.5.2",
  "tower-abci",
@@ -4576,7 +4576,7 @@ dependencies = [
  "grug-types",
  "ics23",
  "prost",
- "tendermint",
+ "tendermint 0.40.3",
  "thiserror 2.0.12",
  "tower 0.5.2",
  "tower-abci",
@@ -4593,7 +4593,7 @@ dependencies = [
  "grug-math",
  "grug-types",
  "serde",
- "tendermint",
+ "tendermint 0.40.3",
  "tendermint-rpc",
 ]
 
@@ -4800,7 +4800,7 @@ dependencies = [
  "sha3",
  "strum 0.27.1",
  "strum_macros 0.27.1",
- "tendermint",
+ "tendermint 0.40.3",
  "tendermint-rpc",
  "test-case",
  "thiserror 2.0.12",
@@ -5622,7 +5622,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tendermint",
+ "tendermint 0.40.3",
  "tendermint-rpc",
  "thiserror 2.0.12",
  "tokio",
@@ -9405,21 +9405,47 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.40.1",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.40.3"
+source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.8",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.40.3",
  "time",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-config"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc3ea9a39b7ee34eefcff771cc067ecaa0c988c1c5ac08defd878471a06f76"
+version = "0.40.3"
+source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.40.3",
  "toml 0.8.20",
  "url",
 ]
@@ -9440,10 +9466,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendermint-proto"
+version = "0.40.3"
+source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
 name = "tendermint-rpc"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a52aa504c63ec05519e31348d3f4ba2fe79493c588e2cad5323d5e81b161a"
+version = "0.40.3"
+source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9460,9 +9499,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.3",
  "tendermint-config",
- "tendermint-proto",
+ "tendermint-proto 0.40.3",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -9859,8 +9898,8 @@ dependencies = [
  "futures",
  "pin-project 1.1.10",
  "prost",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.40.1",
+ "tendermint-proto 0.40.1",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ tokio                   = { version = "1", features = ["full"] }
 tokio-stream            = { version = "0.1", features = ["sync"] }
 toml                    = "0.8"
 tower                   = "0.5"
-tower-abci              = "0.19"
+tower-abci              = { git = "https://github.com/left-curve/tower-abci.git", rev = "6ba8190" }
 tracing                 = "0.1"
 tracing-actix-web       = "0.7"
 tracing-subscriber      = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,8 @@ strum                   = "0.27"
 strum_macros            = "0.27"
 syn                     = "2"
 tempfile                = "3"
-tendermint              = "0.40"
-tendermint-rpc          = "0.40"
+tendermint              = { git = "https://github.com/left-curve/tendermint-rs.git", rev = "2e323c8" }
+tendermint-rpc          = { git = "https://github.com/left-curve/tendermint-rs.git", rev = "2e323c8" }
 tera                    = "1"
 test-case               = "3"
 thiserror               = "2"

--- a/grug/types/src/outcome.rs
+++ b/grug/types/src/outcome.rs
@@ -281,7 +281,7 @@ impl BroadcastTxOutcome {
                 gas_limit: 0,
                 gas_used: 0,
                 result: into_generic_result(response.code, response.log),
-                events: BASE64.decode(&response.data)?.deserialize_json()?,
+                events: response.data.deserialize_json()?,
             },
         })
     }


### PR DESCRIPTION
The `tendermint-rs` crate currently has a wrong decode where the CometBFT return the field data as `hex` an the create try to decode as `base64`, as described in this issue : https://github.com/informalsystems/tendermint-rs/issues/1500 .
In order to fix this, we forked `tendermint-rs` and `tower-abci` (since depends on `tendermint-rs`) and adjust the code.

This PR adjust the dependency of these 2 crate to use the forks inside left-curve