### PR TITLE
refractor(dango): `compute_health` params

### DIFF
--- a/dango/account/margin/src/core.rs
+++ b/dango/account/margin/src/core.rs
@@ -142,7 +142,7 @@ pub fn compute_health(
     collateral_powers: BTreeMap<Denom, CollateralPower>,
     collateral_balances: BTreeMap<Denom, Uint128>,
     limit_orders: BTreeMap<u64, OrdersByUserResponse>,
-    exend: bool,
+    extend: bool,
 ) -> anyhow::Result<HealthResponse> {
     // ------------------------------- 1. Debts --------------------------------
 
@@ -285,12 +285,12 @@ pub fn compute_health(
         collaterals,
         limit_order_collaterals,
         limit_order_outputs,
-        scaled_debts: if exend {
+        scaled_debts: if extend {
             Some(scaled_debts)
         } else {
             None
         },
-        limit_orders: if exend {
+        limit_orders: if extend {
             Some(limit_orders)
         } else {
             None

--- a/dango/account/margin/src/core.rs
+++ b/dango/account/margin/src/core.rs
@@ -38,7 +38,6 @@ pub fn query_health(
     account: Addr,
     current_time: Timestamp,
     discount_collateral: Option<Coins>,
-    extend: bool,
 ) -> anyhow::Result<HealthResponse> {
     // ------------------------ 1. Query necessary data ------------------------
 
@@ -106,7 +105,6 @@ pub fn query_health(
         collateral_powers,
         collateral_balances,
         limit_orders,
-        extend,
     )
 }
 
@@ -142,7 +140,6 @@ pub fn compute_health(
     collateral_powers: BTreeMap<Denom, CollateralPower>,
     collateral_balances: BTreeMap<Denom, Uint128>,
     limit_orders: BTreeMap<u64, OrdersByUserResponse>,
-    extend: bool,
 ) -> anyhow::Result<HealthResponse> {
     // ------------------------------- 1. Debts --------------------------------
 
@@ -285,15 +282,7 @@ pub fn compute_health(
         collaterals,
         limit_order_collaterals,
         limit_order_outputs,
-        scaled_debts: if extend {
-            Some(scaled_debts)
-        } else {
-            None
-        },
-        limit_orders: if extend {
-            Some(limit_orders)
-        } else {
-            None
-        },
+        scaled_debts,
+        limit_orders,
     })
 }

--- a/dango/account/margin/src/execute.rs
+++ b/dango/account/margin/src/execute.rs
@@ -46,7 +46,7 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<AuthResponse> {
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn backrun(ctx: AuthCtx, _tx: Tx) -> anyhow::Result<Response> {
-    let health = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None, false)?;
+    let health = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
 
     // After executing all messages in the transactions, the account must have
     // a utilization rate no greater than one. Otherwise, we throw an error to
@@ -85,7 +85,6 @@ pub fn liquidate(ctx: MutableCtx, collateral_denom: Denom) -> anyhow::Result<Res
         ctx.contract,
         ctx.block.timestamp,
         Some(ctx.funds.clone()),
-        false,
     )?;
 
     // Ensure account is undercollateralized

--- a/dango/account/margin/src/execute.rs
+++ b/dango/account/margin/src/execute.rs
@@ -1,5 +1,5 @@
 use {
-    crate::query_health,
+    crate::core,
     anyhow::{anyhow, ensure},
     dango_auth::authenticate_tx,
     dango_oracle::OracleQuerier,
@@ -46,7 +46,8 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<AuthResponse> {
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn backrun(ctx: AuthCtx, _tx: Tx) -> anyhow::Result<Response> {
-    let health = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
+    let health =
+        core::query_and_compute_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
 
     // After executing all messages in the transactions, the account must have
     // a utilization rate no greater than one. Otherwise, we throw an error to
@@ -80,7 +81,7 @@ pub fn liquidate(ctx: MutableCtx, collateral_denom: Denom) -> anyhow::Result<Res
         collaterals,
         limit_order_collaterals,
         ..
-    } = query_health(
+    } = core::query_and_compute_health(
         &ctx.querier,
         ctx.contract,
         ctx.block.timestamp,

--- a/dango/account/margin/src/execute.rs
+++ b/dango/account/margin/src/execute.rs
@@ -46,7 +46,7 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<AuthResponse> {
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn backrun(ctx: AuthCtx, _tx: Tx) -> anyhow::Result<Response> {
-    let health = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
+    let health = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None, false)?;
 
     // After executing all messages in the transactions, the account must have
     // a utilization rate no greater than one. Otherwise, we throw an error to
@@ -85,6 +85,7 @@ pub fn liquidate(ctx: MutableCtx, collateral_denom: Denom) -> anyhow::Result<Res
         ctx.contract,
         ctx.block.timestamp,
         Some(ctx.funds.clone()),
+        false,
     )?;
 
     // Ensure account is undercollateralized

--- a/dango/account/margin/src/query.rs
+++ b/dango/account/margin/src/query.rs
@@ -12,8 +12,14 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = query_seen_nonces(ctx.storage)?;
             res.to_json_value()
         },
-        QueryMsg::Health {} => {
-            let res = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
+        QueryMsg::Health { extend } => {
+            let res = query_health(
+                &ctx.querier,
+                ctx.contract,
+                ctx.block.timestamp,
+                None,
+                extend,
+            )?;
             res.to_json_value()
         },
     }

--- a/dango/account/margin/src/query.rs
+++ b/dango/account/margin/src/query.rs
@@ -1,5 +1,5 @@
 use {
-    crate::core::query_health,
+    crate::core,
     dango_auth::query_seen_nonces,
     dango_types::account::margin::QueryMsg,
     grug::{ImmutableCtx, Json, JsonSerExt},
@@ -12,8 +12,17 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = query_seen_nonces(ctx.storage)?;
             res.to_json_value()
         },
+        QueryMsg::HealthData {} => {
+            let res = core::query_health(&ctx.querier, ctx.contract, ctx.block.timestamp)?;
+            res.to_json_value()
+        },
         QueryMsg::Health {} => {
-            let res = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
+            let res = core::query_and_compute_health(
+                &ctx.querier,
+                ctx.contract,
+                ctx.block.timestamp,
+                None,
+            )?;
             res.to_json_value()
         },
     }

--- a/dango/account/margin/src/query.rs
+++ b/dango/account/margin/src/query.rs
@@ -12,14 +12,8 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = query_seen_nonces(ctx.storage)?;
             res.to_json_value()
         },
-        QueryMsg::Health { extend } => {
-            let res = query_health(
-                &ctx.querier,
-                ctx.contract,
-                ctx.block.timestamp,
-                None,
-                extend,
-            )?;
+        QueryMsg::Health {} => {
+            let res = query_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
             res.to_json_value()
         },
     }

--- a/dango/testing/tests/margin.rs
+++ b/dango/testing/tests/margin.rs
@@ -482,9 +482,7 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
-            extend: false,
-        })
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
         .should_succeed_and(|health| health.utilization_rate < Udec128::ONE);
 
     // Update the oracle price of BTC to go from $71k to $96k, making the account undercollateralised
@@ -492,9 +490,7 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
-            extend: false,
-        })
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
         .unwrap();
     assert!(health.utilization_rate > Udec128::ONE);
     let debts_before = health.debts;
@@ -580,9 +576,7 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
-            extend: false,
-        })
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
         .unwrap();
     let app_config: AppConfig = suite.query_app_config().unwrap();
 
@@ -750,9 +744,7 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health and ensure the limit order is counted as collateral
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
-            extend: false,
-        })
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
         .unwrap();
     assert_eq!(
         health.total_adjusted_collateral_value,
@@ -785,9 +777,7 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health to ensure it is undercollateralised
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
-            extend: false,
-        })
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
         .unwrap();
     assert!(health.utilization_rate > Udec128::ONE);
 
@@ -837,9 +827,7 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health to ensure it has been liquidated
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
-            extend: false,
-        })
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
         .unwrap();
     assert!(health.limit_order_collaterals.is_empty());
     assert!(health.limit_order_outputs.is_empty());
@@ -1265,7 +1253,7 @@ proptest! {
 
         // Check margin accounts health
         let margin_account_health = suite
-            .query_wasm_smart(margin_account.address(), QueryHealthRequest { extend: false,})
+            .query_wasm_smart(margin_account.address(), QueryHealthRequest { })
             .unwrap();
 
         // Get liquidators total account value before liquidation

--- a/dango/testing/tests/margin.rs
+++ b/dango/testing/tests/margin.rs
@@ -482,7 +482,9 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            extend: false,
+        })
         .should_succeed_and(|health| health.utilization_rate < Udec128::ONE);
 
     // Update the oracle price of BTC to go from $71k to $96k, making the account undercollateralised
@@ -490,7 +492,9 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            extend: false,
+        })
         .unwrap();
     assert!(health.utilization_rate > Udec128::ONE);
     let debts_before = health.debts;
@@ -576,7 +580,9 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            extend: false,
+        })
         .unwrap();
     let app_config: AppConfig = suite.query_app_config().unwrap();
 
@@ -744,7 +750,9 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health and ensure the limit order is counted as collateral
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            extend: false,
+        })
         .unwrap();
     assert_eq!(
         health.total_adjusted_collateral_value,
@@ -777,7 +785,9 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health to ensure it is undercollateralised
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            extend: false,
+        })
         .unwrap();
     assert!(health.utilization_rate > Udec128::ONE);
 
@@ -827,7 +837,9 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health to ensure it has been liquidated
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            extend: false,
+        })
         .unwrap();
     assert!(health.limit_order_collaterals.is_empty());
     assert!(health.limit_order_outputs.is_empty());
@@ -1253,7 +1265,7 @@ proptest! {
 
         // Check margin accounts health
         let margin_account_health = suite
-            .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+            .query_wasm_smart(margin_account.address(), QueryHealthRequest { extend: false,})
             .unwrap();
 
         // Get liquidators total account value before liquidation

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -22,7 +22,7 @@ pub struct HealthResponse {
     /// All of the accounts debts.
     pub debts: Coins,
     /// All of the accounts scaled debts.
-    pub scaled_debts: Option<BTreeMap<Denom, Udec256>>,
+    pub scaled_debts: BTreeMap<Denom, Udec256>,
     /// All of the account's collateral balances.
     pub collaterals: Coins,
     /// All of the account's collateral balances that are inside of limit orders.
@@ -30,7 +30,7 @@ pub struct HealthResponse {
     /// The coins that would be returned if the account's limit orders were to be filled.
     pub limit_order_outputs: Coins,
     /// All of the account's limit orders.
-    pub limit_orders: Option<BTreeMap<u64, OrdersByUserResponse>>,
+    pub limit_orders: BTreeMap<u64, OrdersByUserResponse>,
 }
 
 #[grug::derive(Serde)]
@@ -50,7 +50,7 @@ pub enum QueryMsg {
     SeenNonces {},
     /// Queries the health of the margin account.
     #[returns(HealthResponse)]
-    Health { extend: bool },
+    Health {},
 }
 
 #[grug::derive(Serde)]

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{auth::Nonce, dex::OrdersByUserResponse},
+    crate::{auth::Nonce, dex::OrdersByUserResponse, lending::Market, oracle::PrecisionedPrice},
     grug::{Bounded, Coins, Denom, Udec128, Udec256, Uint128, ZeroExclusiveOneInclusive},
     std::collections::{BTreeMap, BTreeSet},
 };
@@ -7,7 +7,18 @@ use {
 /// A decimal bounded by the bounds: 0 < CollateralPower <= 1.
 pub type CollateralPower = Bounded<Udec128, ZeroExclusiveOneInclusive>;
 
-/// The response type for a margin account's `Health` query.
+/// Necessary input data for computing a margin account's health.
+#[grug::derive(Serde)]
+pub struct HealthData {
+    pub scaled_debts: BTreeMap<Denom, Udec256>,
+    pub markets: BTreeMap<Denom, Market>,
+    pub prices: BTreeMap<Denom, PrecisionedPrice>,
+    pub collateral_powers: BTreeMap<Denom, CollateralPower>,
+    pub collateral_balances: BTreeMap<Denom, Uint128>,
+    pub limit_orders: BTreeMap<u64, OrdersByUserResponse>,
+}
+
+/// Output for computing a margin account's health.
 #[grug::derive(Serde)]
 pub struct HealthResponse {
     /// The margin account's utilization rate.
@@ -21,16 +32,12 @@ pub struct HealthResponse {
     pub total_adjusted_collateral_value: Udec128,
     /// All of the accounts debts.
     pub debts: Coins,
-    /// All of the accounts scaled debts.
-    pub scaled_debts: BTreeMap<Denom, Udec256>,
     /// All of the account's collateral balances.
     pub collaterals: Coins,
     /// All of the account's collateral balances that are inside of limit orders.
     pub limit_order_collaterals: Coins,
     /// The coins that would be returned if the account's limit orders were to be filled.
     pub limit_order_outputs: Coins,
-    /// All of the account's limit orders.
-    pub limit_orders: BTreeMap<u64, OrdersByUserResponse>,
 }
 
 #[grug::derive(Serde)]
@@ -48,7 +55,11 @@ pub enum QueryMsg {
     /// Query the most recent transaction nonces that have been recorded.
     #[returns(BTreeSet<Nonce>)]
     SeenNonces {},
-    /// Queries the health of the margin account.
+    /// Query the data necessary for computing the account's health, but don't
+    /// compute it yet.
+    #[returns(HealthData)]
+    HealthData {},
+    /// Compute the health of the margin account.
     #[returns(HealthResponse)]
     Health {},
 }

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -1,7 +1,7 @@
 use {
-    crate::auth::Nonce,
-    grug::{Bounded, Coins, Denom, Udec128, Uint128, ZeroExclusiveOneInclusive},
-    std::collections::BTreeSet,
+    crate::{auth::Nonce, dex::OrdersByUserResponse},
+    grug::{Bounded, Coins, Denom, Udec128, Udec256, Uint128, ZeroExclusiveOneInclusive},
+    std::collections::{BTreeMap, BTreeSet},
 };
 
 /// A decimal bounded by the bounds: 0 < CollateralPower <= 1.
@@ -21,12 +21,16 @@ pub struct HealthResponse {
     pub total_adjusted_collateral_value: Udec128,
     /// All of the accounts debts.
     pub debts: Coins,
+    /// All of the accounts scaled debts.
+    pub scaled_debts: Option<BTreeMap<Denom, Udec256>>,
     /// All of the account's collateral balances.
     pub collaterals: Coins,
     /// All of the account's collateral balances that are inside of limit orders.
     pub limit_order_collaterals: Coins,
     /// The coins that would be returned if the account's limit orders were to be filled.
     pub limit_order_outputs: Coins,
+    /// All of the account's limit orders.
+    pub limit_orders: Option<BTreeMap<u64, OrdersByUserResponse>>,
 }
 
 #[grug::derive(Serde)]
@@ -46,7 +50,7 @@ pub enum QueryMsg {
     SeenNonces {},
     /// Queries the health of the margin account.
     #[returns(HealthResponse)]
-    Health {},
+    Health { extend: bool },
 }
 
 #[grug::derive(Serde)]

--- a/grug/types/src/builder.rs
+++ b/grug/types/src/builder.rs
@@ -10,7 +10,19 @@ use {
 };
 
 /// Represents a builder parameter that has not yet been provided.
-#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, Copy)]
+#[derive(
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+)]
 pub struct Undefined<T = ()>(PhantomData<T>);
 
 impl<T> Undefined<T> {
@@ -26,7 +38,19 @@ impl<T> Default for Undefined<T> {
 }
 
 /// Represents a builder parameter that has already been provided.
-#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, Copy)]
+#[derive(
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+)]
 pub struct Defined<T>(T);
 
 impl<T> Defined<T> {

--- a/grug/types/src/coins.rs
+++ b/grug/types/src/coins.rs
@@ -333,6 +333,18 @@ impl Coins {
     // instead.
 }
 
+impl Inner for Coins {
+    type U = BTreeMap<Denom, Uint128>;
+
+    fn inner(&self) -> &Self::U {
+        &self.0
+    }
+
+    fn into_inner(self) -> Self::U {
+        self.0
+    }
+}
+
 // cast a string of the following format to Coins:
 // denom1:amount1,denom2:amount2,...,denomN:amountN
 // allow the denoms to be out of order, but disallow duplicates and zero amounts.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `compute_health` into `query_health` and `compute_health`, update related functions and tests for improved clarity and organization.
> 
>   - **Refactor `compute_health`**:
>     - Split `compute_health` into `query_health` and `compute_health` in `core.rs`.
>     - `query_health` retrieves necessary data, `compute_health` performs calculations.
>   - **Function Updates**:
>     - Update `query_and_compute_health` to use `query_health` and `compute_health` in `core.rs`.
>     - Modify `backrun` and `liquidate` functions in `execute.rs` to use `query_and_compute_health`.
>     - Update `query` function in `query.rs` to handle `HealthData` and `Health` queries.
>   - **Model Changes**:
>     - Add `HealthData` struct in `margin.rs` for input data.
>     - Update `HealthResponse` struct in `margin.rs` to reflect new output structure.
>   - **Testing**:
>     - Adjust tests in `margin.rs` to align with refactored functions.
>   - **Miscellaneous**:
>     - Add `PartialEq`, `Eq`, `PartialOrd`, `Ord` derives to `Undefined` and `Defined` structs in `builder.rs`.
>     - Implement `Inner` trait for `Coins` in `coins.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 30dd9f82412b7fe6d636fbb3200293c9123cfadc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->