### PR TITLE
fix(grug): RPC search_tx decode failed 

### DIFF
--- a/grug/types/src/outcome.rs
+++ b/grug/types/src/outcome.rs
@@ -31,7 +31,7 @@ pub struct CheckTxOutcome {
 }
 
 /// The success case of [`TxOutcome`](crate::TxOutcome).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CheckTxSuccess {
     pub gas_limit: u64,
     pub gas_used: u64,
@@ -248,7 +248,7 @@ pub struct BlockOutcome {
     pub tx_outcomes: Vec<TxOutcome>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub struct BroadcastTxOutcome {
     pub tx_hash: Hash256,
     pub check_tx: CheckTxOutcome,
@@ -292,12 +292,13 @@ pub struct BroadcastTxError {
     pub check_tx: CheckTxError,
 }
 
+#[derive(Debug, Clone)]
 pub struct BroadcastTxSuccess {
     pub tx_hash: Hash256,
     pub check_tx: CheckTxSuccess,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Debug, Clone)]
 pub struct SearchTxOutcome {
     pub hash: Hash256,
     pub height: u64,
@@ -315,7 +316,7 @@ impl SearchTxOutcome {
             hash: Hash256::from_inner(response.hash.as_bytes().try_into()?),
             height: response.height.into(),
             index: response.index,
-            tx: BASE64.decode(&response.tx)?.deserialize_json()?,
+            tx: response.tx.deserialize_json()?,
             outcome: TxOutcome::from_tm_tx_result(response.tx_result)?,
         })
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Clone` and `Debug` traits to several structs in `outcome.rs` and fix decoding issue in `SearchTxOutcome`.
> 
>   - **Traits**:
>     - Add `Clone` trait to `CheckTxSuccess` and `BroadcastTxSuccess` structs.
>     - Add `Debug` and `Clone` traits to `BroadcastTxOutcome` and `SearchTxOutcome` structs.
>   - **Decoding Fix**:
>     - Fix decoding issue in `SearchTxOutcome::from_tm_query_tx_response()` by removing `BASE64.decode()` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 12da70b13afeb077c483e1729e77a39e9eedf19b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->