### PR TITLE
refactor(grug): delete the `Querier::Error` associated type

### DIFF
--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -6,8 +6,7 @@ use {
         lending::{NAMESPACE, SUBNAMESPACE},
         oracle::{PrecisionedPrice, PrecisionlessPrice, PriceSource},
     },
-    grug::{Addr, Denom, Number, Querier, QuerierExt, StdError, StorageQuerier},
-    std::fmt::Debug,
+    grug::{Addr, Denom, Number, Querier, QuerierExt, StorageQuerier},
 };
 
 /// A trait for querying prices from the oracle.
@@ -23,9 +22,7 @@ pub trait OracleQuerier: Querier {
 
 impl<Q> OracleQuerier for Q
 where
-    Q: QuerierExt,
-    Q::Error: From<StdError> + Debug,
-    anyhow::Error: From<Q::Error>,
+    Q: Querier,
 {
     fn query_price(
         &self,

--- a/dango/testing/tests/pyth_handler.rs
+++ b/dango/testing/tests/pyth_handler.rs
@@ -2,26 +2,11 @@ use {
     dango_proposal_preparer::PythHandler,
     dango_testing::setup_test,
     dango_types::oracle::{InstantiateMsg, PriceSource, QueryPriceSourcesRequest},
-    grug::{
-        Coins, HashExt, NonEmpty, Querier, QuerierExt, QuerierWrapper, ResultExt, StdError,
-        StdResult, btree_map,
-    },
+    grug::{Coins, HashExt, NonEmpty, QuerierExt, QuerierWrapper, ResultExt, btree_map},
     pyth_client::{PythClientCache, PythClientTrait},
     pyth_types::PYTH_URL,
     std::{thread::sleep, time::Duration},
 };
-
-struct QueryWrapperTest<'a> {
-    querier: QuerierWrapper<'a>,
-}
-
-impl Querier for QueryWrapperTest<'_> {
-    fn query_chain(&self, req: grug::Query) -> StdResult<grug::QueryResponse> {
-        self.querier
-            .query_chain(req)
-            .map_err(|_| StdError::host("query_chain failed".to_string()))
-    }
-}
 
 #[test]
 fn handler() {
@@ -74,11 +59,7 @@ fn handler() {
         .should_succeed()
         .address;
 
-    let wrapper_test: QueryWrapperTest<'_> = QueryWrapperTest {
-        querier: QuerierWrapper::new(&suite),
-    };
-    let querier = QuerierWrapper::new(&wrapper_test);
-
+    let querier = QuerierWrapper::new(&suite);
     let mut handler = PythHandler::<PythClientCache>::new_with_cache(PYTH_URL);
 
     // Start the handler with oracle.

--- a/dango/testing/tests/pyth_handler.rs
+++ b/dango/testing/tests/pyth_handler.rs
@@ -4,22 +4,19 @@ use {
     dango_types::oracle::{InstantiateMsg, PriceSource, QueryPriceSourcesRequest},
     grug::{
         Coins, HashExt, NonEmpty, Querier, QuerierExt, QuerierWrapper, ResultExt, StdError,
-        btree_map,
+        StdResult, btree_map,
     },
-    grug_app::AppError,
     pyth_client::{PythClientCache, PythClientTrait},
     pyth_types::PYTH_URL,
     std::{thread::sleep, time::Duration},
 };
 
 struct QueryWrapperTest<'a> {
-    querier: QuerierWrapper<'a, AppError>,
+    querier: QuerierWrapper<'a>,
 }
 
 impl Querier for QueryWrapperTest<'_> {
-    type Error = StdError;
-
-    fn query_chain(&self, req: grug::Query) -> Result<grug::QueryResponse, Self::Error> {
+    fn query_chain(&self, req: grug::Query) -> StdResult<grug::QueryResponse> {
         self.querier
             .query_chain(req)
             .map_err(|_| StdError::host("query_chain failed".to_string()))

--- a/dango/types/src/lending/market.rs
+++ b/dango/types/src/lending/market.rs
@@ -2,10 +2,9 @@ use {
     crate::lending::{InterestRateModel, NAMESPACE, SUBNAMESPACE},
     grug::{
         Bounded, Decimal, Denom, IsZero, MathResult, MultiplyFraction, NextNumber, Number,
-        NumberConst, PrevNumber, Querier, QuerierExt, StdError, StdResult, Timestamp, Udec128,
-        Udec256, Uint128, ZeroInclusiveOneInclusive,
+        NumberConst, PrevNumber, Querier, QuerierExt, StdResult, Timestamp, Udec128, Udec256,
+        Uint128, ZeroInclusiveOneInclusive,
     },
-    std::fmt::Debug,
 };
 
 /// Seconds in a year, assuming 365 days.
@@ -57,8 +56,6 @@ impl Market {
     ) -> anyhow::Result<Bounded<Udec128, ZeroInclusiveOneInclusive>>
     where
         Q: Querier,
-        Q::Error: From<StdError> + Debug,
-        anyhow::Error: From<Q::Error>,
     {
         let total_borrowed = self.total_borrowed()?;
         let total_supplied = self.total_supplied(querier)?;
@@ -84,8 +81,6 @@ impl Market {
     pub fn update_indices<Q>(self, querier: &Q, current_time: Timestamp) -> anyhow::Result<Self>
     where
         Q: Querier,
-        Q::Error: From<StdError> + Debug,
-        anyhow::Error: From<Q::Error>,
     {
         debug_assert!(
             current_time >= self.last_update_time,
@@ -221,8 +216,6 @@ impl Market {
     pub fn total_supplied<Q>(&self, querier: &Q) -> anyhow::Result<Uint128>
     where
         Q: Querier,
-        Q::Error: From<StdError> + Debug,
-        anyhow::Error: From<Q::Error>,
     {
         Ok(querier
             .query_supply(self.supply_lp_denom.clone())?

--- a/grug/app/src/proposal_preparer.rs
+++ b/grug/app/src/proposal_preparer.rs
@@ -2,7 +2,7 @@
 use tracing::info;
 use {
     crate::{AppError, ProposalPreparer},
-    grug_types::{Querier, QuerierWrapper, Query, QueryResponse, StdError, StdResult},
+    grug_types::{Querier, QuerierWrapper, Query, QueryResponse, StdResult},
     prost::bytes::Bytes,
     std::{
         convert::Infallible,
@@ -70,8 +70,6 @@ impl From<NaiveError> for AppError {
 pub struct NaiveQuerier;
 
 impl Querier for NaiveQuerier {
-    type Error = StdError;
-
     fn query_chain(&self, _req: Query) -> StdResult<QueryResponse> {
         unreachable!("attempting to query a no-op querier");
     }

--- a/grug/app/src/providers/querier.rs
+++ b/grug/app/src/providers/querier.rs
@@ -24,8 +24,6 @@ pub trait QuerierProvider {
 }
 
 impl Querier for Box<dyn QuerierProvider> {
-    type Error = StdError;
-
     fn query_chain(&self, req: Query) -> StdResult<QueryResponse> {
         // TODO: ignoring query depth for now
         self.do_query_chain(req, 0).map_err(StdError::host)

--- a/grug/ffi/src/imports.rs
+++ b/grug/ffi/src/imports.rs
@@ -444,8 +444,6 @@ impl Api for ExternalApi {
 pub struct ExternalQuerier;
 
 impl Querier for ExternalQuerier {
-    type Error = StdError;
-
     fn query_chain(&self, req: Query) -> StdResult<QueryResponse> {
         let req_bytes = req.to_borsh_vec()?;
         let req_region = Region::build(&req_bytes);

--- a/grug/storage/src/querier.rs
+++ b/grug/storage/src/querier.rs
@@ -1,7 +1,6 @@
 use {
     crate::{Codec, Path},
-    grug_types::{Addr, Querier, QuerierExt, StdError},
-    std::fmt::Debug,
+    grug_types::{Addr, Querier, QuerierExt, StdError, StdResult},
 };
 
 pub trait StorageQuerier: Querier {
@@ -12,32 +11,27 @@ pub trait StorageQuerier: Querier {
         &self,
         contract: Addr,
         path: Path<'_, T, C>,
-    ) -> Result<Option<T>, Self::Error>
+    ) -> StdResult<Option<T>>
     where
         C: Codec<T>;
 
     /// Query and deserialize the data corresponding to a given storage path in
     /// the given contract.
     /// Error if the data is not found.
-    fn query_wasm_path<T, C>(
-        &self,
-        contract: Addr,
-        path: &Path<'_, T, C>,
-    ) -> Result<T, Self::Error>
+    fn query_wasm_path<T, C>(&self, contract: Addr, path: &Path<'_, T, C>) -> StdResult<T>
     where
         C: Codec<T>;
 }
 
 impl<Q> StorageQuerier for Q
 where
-    Q: QuerierExt,
-    Q::Error: From<StdError> + Debug,
+    Q: Querier,
 {
     fn may_query_wasm_path<T, C>(
         &self,
         contract: Addr,
         path: Path<'_, T, C>,
-    ) -> Result<Option<T>, Self::Error>
+    ) -> StdResult<Option<T>>
     where
         C: Codec<T>,
     {
@@ -46,7 +40,7 @@ where
             .transpose()
     }
 
-    fn query_wasm_path<T, C>(&self, contract: Addr, path: &Path<'_, T, C>) -> Result<T, Self::Error>
+    fn query_wasm_path<T, C>(&self, contract: Addr, path: &Path<'_, T, C>) -> StdResult<T>
     where
         C: Codec<T>,
     {

--- a/grug/storage/src/querier.rs
+++ b/grug/storage/src/querier.rs
@@ -36,7 +36,7 @@ where
         C: Codec<T>,
     {
         self.query_wasm_raw(contract, path.storage_key())?
-            .map(|data| C::decode(&data).map_err(Into::into))
+            .map(|data| C::decode(&data))
             .transpose()
     }
 
@@ -47,6 +47,5 @@ where
         self.query_wasm_raw(contract, path.storage_key())?
             .ok_or_else(|| StdError::data_not_found::<T>(path.storage_key()))
             .and_then(|data| C::decode(&data))
-            .map_err(Into::into)
     }
 }

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -4,8 +4,7 @@ use {
         UploadOutcome,
     },
     grug_app::{
-        App, AppError, AppResult, Db, Indexer, NaiveProposalPreparer, NullIndexer,
-        ProposalPreparer, Vm,
+        App, AppError, Db, Indexer, NaiveProposalPreparer, NullIndexer, ProposalPreparer, Vm,
     },
     grug_crypto::sha2_256,
     grug_db_memory::MemDb,
@@ -13,11 +12,12 @@ use {
     grug_types::{
         Addr, Addressable, Binary, Block, BlockInfo, CheckTxOutcome, Coins, Config, Denom,
         Duration, GenesisState, Hash256, HashExt, JsonDeExt, JsonSerExt, Message, NonEmpty,
-        Querier, Query, QueryResponse, Signer, StdError, StdResult, Tx, TxOutcome, UnsignedTx,
+        Querier, QuerierExt, Query, QueryResponse, Signer, StdError, StdResult, Tx, TxOutcome,
+        UnsignedTx,
     },
     grug_vm_rust::RustVm,
     serde::ser::Serialize,
-    std::{collections::BTreeMap, fmt::Debug},
+    std::collections::BTreeMap,
 };
 
 pub struct TestSuite<DB = MemDb, VM = RustVm, PP = NaiveProposalPreparer, ID = NullIndexer>
@@ -648,21 +648,16 @@ where
     pub fn query_balance<D>(&self, address: &dyn Addressable, denom: D) -> StdResult<Uint128>
     where
         D: TryInto<Denom>,
-        <D as TryInto<Denom>>::Error: Debug,
+        StdError: From<D::Error>,
     {
-        let denom = denom.try_into().unwrap();
-        self.query_chain(Query::balance(address.address(), denom))
-            .map(|res| res.as_balance().amount)
+        let address = address.address();
+        let denom = denom.try_into()?;
+        <Self as QuerierExt>::query_balance(self, address, denom)
     }
 
-    pub fn query_balances(&self, account: &dyn Addressable) -> AppResult<Coins> {
-        self.app
-            .do_query_app(
-                Query::balances(account.address(), None, Some(u32::MAX)),
-                0, // zero means to use the latest height
-                false,
-            )
-            .map(|res| res.as_balances())
+    pub fn query_balances(&self, account: &dyn Addressable) -> StdResult<Coins> {
+        let address = account.address();
+        <Self as QuerierExt>::query_balances(self, address, None, Some(u32::MAX))
     }
 
     pub fn balances(&mut self) -> BalanceTracker<DB, VM, PP, ID> {

--- a/grug/types/src/imports/querier.rs
+++ b/grug/types/src/imports/querier.rs
@@ -43,7 +43,7 @@ pub trait QuerierExt: Querier {
         T: DeserializeOwned,
     {
         self.query_chain(Query::app_config())
-            .and_then(|res| res.as_app_config().deserialize_json().map_err(Into::into))
+            .and_then(|res| res.as_app_config().deserialize_json())
     }
 
     fn query_balance(&self, address: Addr, denom: Denom) -> StdResult<Uint128> {
@@ -120,7 +120,7 @@ pub trait QuerierExt: Querier {
         let msg = R::Message::from(req);
 
         self.query_chain(Query::wasm_smart(contract, &msg)?)
-            .and_then(|res| res.as_wasm_smart().deserialize_json().map_err(Into::into))
+            .and_then(|res| res.as_wasm_smart().deserialize_json())
     }
 
     fn query_multi<const N: usize>(
@@ -147,7 +147,6 @@ pub trait QuerierExt: Querier {
                 iter.next()
                     .unwrap() // unwrap is safe because we've checked the length.
                     .map_err(StdError::host)
-                    .map_err(Into::into)
             })
         })
     }

--- a/grug/types/src/imports/querier.rs
+++ b/grug/types/src/imports/querier.rs
@@ -1,19 +1,17 @@
 use {
     crate::{
         Addr, Binary, Code, Coins, Config, ContractInfo, Denom, Hash256, JsonDeExt, Query,
-        QueryRequest, QueryResponse, StdError,
+        QueryRequest, QueryResponse, StdError, StdResult,
     },
     grug_math::Uint128,
     serde::{de::DeserializeOwned, ser::Serialize},
-    std::{collections::BTreeMap, fmt::Debug},
+    std::collections::BTreeMap,
 };
 
 pub trait Querier {
-    type Error;
-
     /// Make a query. This is the only method that the context needs to manually
     /// implement. The other methods will be implemented automatically.
-    fn query_chain(&self, req: Query) -> Result<QueryResponse, Self::Error>;
+    fn query_chain(&self, req: Query) -> StdResult<QueryResponse>;
 }
 
 /// Core querying functionality that builds on top of the base `Querier` trait.
@@ -23,27 +21,24 @@ pub trait Querier {
 /// non-object-safe. By keeping these methods in a separate trait, we can still
 /// use `dyn Querier`. This trait is automatically implemented for any type that
 /// implements `Querier`.
-pub trait QuerierExt: Querier
-where
-    Self::Error: From<StdError> + Debug,
-{
-    fn query_config(&self) -> Result<Config, Self::Error> {
+pub trait QuerierExt: Querier {
+    fn query_config(&self) -> StdResult<Config> {
         self.query_chain(Query::config()).map(|res| res.as_config())
     }
 
-    fn query_owner(&self) -> Result<Addr, Self::Error> {
+    fn query_owner(&self) -> StdResult<Addr> {
         self.query_config().map(|res| res.owner)
     }
 
-    fn query_bank(&self) -> Result<Addr, Self::Error> {
+    fn query_bank(&self) -> StdResult<Addr> {
         self.query_config().map(|res| res.bank)
     }
 
-    fn query_taxman(&self) -> Result<Addr, Self::Error> {
+    fn query_taxman(&self) -> StdResult<Addr> {
         self.query_config().map(|res| res.taxman)
     }
 
-    fn query_app_config<T>(&self) -> Result<T, Self::Error>
+    fn query_app_config<T>(&self) -> StdResult<T>
     where
         T: DeserializeOwned,
     {
@@ -51,7 +46,7 @@ where
             .and_then(|res| res.as_app_config().deserialize_json().map_err(Into::into))
     }
 
-    fn query_balance(&self, address: Addr, denom: Denom) -> Result<Uint128, Self::Error> {
+    fn query_balance(&self, address: Addr, denom: Denom) -> StdResult<Uint128> {
         self.query_chain(Query::balance(address, denom))
             .map(|res| res.as_balance().amount)
     }
@@ -61,26 +56,22 @@ where
         address: Addr,
         start_after: Option<Denom>,
         limit: Option<u32>,
-    ) -> Result<Coins, Self::Error> {
+    ) -> StdResult<Coins> {
         self.query_chain(Query::balances(address, start_after, limit))
             .map(|res| res.as_balances())
     }
 
-    fn query_supply(&self, denom: Denom) -> Result<Uint128, Self::Error> {
+    fn query_supply(&self, denom: Denom) -> StdResult<Uint128> {
         self.query_chain(Query::supply(denom))
             .map(|res| res.as_supply().amount)
     }
 
-    fn query_supplies(
-        &self,
-        start_after: Option<Denom>,
-        limit: Option<u32>,
-    ) -> Result<Coins, Self::Error> {
+    fn query_supplies(&self, start_after: Option<Denom>, limit: Option<u32>) -> StdResult<Coins> {
         self.query_chain(Query::supplies(start_after, limit))
             .map(|res| res.as_supplies())
     }
 
-    fn query_code(&self, hash: Hash256) -> Result<Code, Self::Error> {
+    fn query_code(&self, hash: Hash256) -> StdResult<Code> {
         self.query_chain(Query::code(hash)).map(|res| res.as_code())
     }
 
@@ -88,12 +79,12 @@ where
         &self,
         start_after: Option<Hash256>,
         limit: Option<u32>,
-    ) -> Result<BTreeMap<Hash256, Code>, Self::Error> {
+    ) -> StdResult<BTreeMap<Hash256, Code>> {
         self.query_chain(Query::codes(start_after, limit))
             .map(|res| res.as_codes())
     }
 
-    fn query_contract(&self, address: Addr) -> Result<ContractInfo, Self::Error> {
+    fn query_contract(&self, address: Addr) -> StdResult<ContractInfo> {
         self.query_chain(Query::contract(address))
             .map(|res| res.as_contract())
     }
@@ -102,7 +93,7 @@ where
         &self,
         start_after: Option<Addr>,
         limit: Option<u32>,
-    ) -> Result<BTreeMap<Addr, ContractInfo>, Self::Error> {
+    ) -> StdResult<BTreeMap<Addr, ContractInfo>> {
         self.query_chain(Query::contracts(start_after, limit))
             .map(|res| res.as_contracts())
     }
@@ -112,7 +103,7 @@ where
     ///
     /// The only case where `query_wasm_raw` is preferred is if you just want to
     /// know whether a data exists or not, without needing to deserialize it.
-    fn query_wasm_raw<B>(&self, contract: Addr, key: B) -> Result<Option<Binary>, Self::Error>
+    fn query_wasm_raw<B>(&self, contract: Addr, key: B) -> StdResult<Option<Binary>>
     where
         B: Into<Binary>,
     {
@@ -120,7 +111,7 @@ where
             .map(|res| res.as_wasm_raw())
     }
 
-    fn query_wasm_smart<R>(&self, contract: Addr, req: R) -> Result<R::Response, Self::Error>
+    fn query_wasm_smart<R>(&self, contract: Addr, req: R) -> StdResult<R::Response>
     where
         R: QueryRequest,
         R::Message: Serialize,
@@ -135,7 +126,7 @@ where
     fn query_multi<const N: usize>(
         &self,
         requests: [Query; N],
-    ) -> Result<[Result<QueryResponse, Self::Error>; N], Self::Error> {
+    ) -> StdResult<[StdResult<QueryResponse>; N]> {
         self.query_chain(Query::Multi(requests.into())).map(|res| {
             // We trust that the host has properly implemented the multi
             // query method, meaning the number of responses should always
@@ -162,31 +153,24 @@ where
     }
 }
 
-impl<Q> QuerierExt for Q
-where
-    Q: Querier,
-    Q::Error: From<StdError> + Debug,
-{
-}
+impl<Q> QuerierExt for Q where Q: Querier {}
 
 /// Wraps around a `Querier` to provide some convenience methods.
 ///
 /// We have to do this because `&dyn Querier` itself doesn't implement `Querier`,
 /// so given a `&dyn Querier` you aren't able to access the `QuerierExt` methods.
-pub struct QuerierWrapper<'a, E = StdError> {
-    inner: &'a dyn Querier<Error = E>,
+pub struct QuerierWrapper<'a> {
+    inner: &'a dyn Querier,
 }
 
-impl<E> Querier for QuerierWrapper<'_, E> {
-    type Error = E;
-
-    fn query_chain(&self, req: Query) -> Result<QueryResponse, Self::Error> {
+impl Querier for QuerierWrapper<'_> {
+    fn query_chain(&self, req: Query) -> StdResult<QueryResponse> {
         self.inner.query_chain(req)
     }
 }
 
-impl<'a, E> QuerierWrapper<'a, E> {
-    pub fn new(inner: &'a dyn Querier<Error = E>) -> Self {
+impl<'a> QuerierWrapper<'a> {
+    pub fn new(inner: &'a dyn Querier) -> Self {
         Self { inner }
     }
 }

--- a/grug/types/src/testing/context.rs
+++ b/grug/types/src/testing/context.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
 use crate::{
-    Addr, Api, AuthCtx, AuthMode, BlockInfo, Coins, Defined, Hash256, ImmutableCtx, MockApi, MockQuerier, MockStorage, MutableCtx, Querier, QuerierWrapper, StdError, Storage, SudoCtx, Timestamp, Undefined
+    Addr, Api, AuthCtx, AuthMode, BlockInfo, Coins, Defined, Hash256, ImmutableCtx, MockApi,
+    MockQuerier, MockStorage, MutableCtx, Querier, QuerierWrapper, Storage, SudoCtx, Timestamp,
+    Undefined,
 };
 
 /// Default mock chain ID used in mock context.
@@ -216,7 +218,7 @@ impl<S, A, Q> MockContext<S, A, Q, Undefined<Addr>, Undefined<Coins>, Undefined<
 where
     S: Storage,
     A: Api,
-    Q: Querier<Error = StdError>,
+    Q: Querier,
 {
     pub fn as_immutable(&self) -> ImmutableCtx {
         ImmutableCtx {
@@ -245,7 +247,7 @@ impl<S, A, Q> MockContext<S, A, Q, Defined<Addr>, Defined<Coins>, Undefined<Auth
 where
     S: Storage,
     A: Api,
-    Q: Querier<Error = StdError>,
+    Q: Querier,
 {
     pub fn as_mutable(&mut self) -> MutableCtx {
         MutableCtx {
@@ -265,7 +267,7 @@ impl<S, A, Q> MockContext<S, A, Q, Undefined<Addr>, Undefined<Coins>, Defined<Au
 where
     S: Storage,
     A: Api,
-    Q: Querier<Error = StdError>,
+    Q: Querier,
 {
     pub fn as_auth(&mut self) -> AuthCtx {
         AuthCtx {

--- a/grug/types/src/testing/querier.rs
+++ b/grug/types/src/testing/querier.rs
@@ -110,8 +110,6 @@ impl MockQuerier {
 }
 
 impl Querier for MockQuerier {
-    type Error = StdError;
-
     fn query_chain(&self, req: Query) -> StdResult<QueryResponse> {
         match req {
             Query::Config(_req) => {

--- a/grug/vm/rust/src/contract.rs
+++ b/grug/vm/rust/src/contract.rs
@@ -480,7 +480,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Response>> {
         let mutable_ctx = make_mutable_ctx!(ctx, storage, api, querier);
@@ -495,7 +495,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Response>> {
         let Some(execute_fn) = &self.execute_fn else {
@@ -514,7 +514,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Response>> {
         let Some(migrate_fn) = &self.migrate_fn else {
@@ -533,7 +533,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
     ) -> VmResult<GenericResult<Response>> {
         let Some(receive_fn) = &self.receive_fn else {
             return Err(VmError::function_not_found("receive"));
@@ -550,7 +550,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
         result: SubMsgResult,
     ) -> VmResult<GenericResult<Response>> {
@@ -570,7 +570,7 @@ where
         ctx: Context,
         storage: &dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Json>> {
         let Some(query_fn) = &self.query_fn else {
@@ -589,7 +589,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
     ) -> VmResult<GenericResult<AuthResponse>> {
         let Some(authenticate_fn) = &self.authenticate_fn else {
@@ -607,7 +607,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
     ) -> VmResult<GenericResult<Response>> {
         let Some(backrun_fn) = &self.backrun_fn else {
@@ -625,7 +625,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: BankMsg,
     ) -> VmResult<GenericResult<Response>> {
         let Some(bank_execute_fn) = &self.bank_execute_fn else {
@@ -643,7 +643,7 @@ where
         ctx: Context,
         storage: &dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: BankQuery,
     ) -> VmResult<GenericResult<BankQueryResponse>> {
         let Some(bank_query_fn) = &self.bank_query_fn else {
@@ -661,7 +661,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
     ) -> VmResult<GenericResult<Response>> {
         let Some(withhold_fee_fn) = &self.withhold_fee_fn else {
@@ -679,7 +679,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
         outcome: TxOutcome,
     ) -> VmResult<GenericResult<Response>> {
@@ -698,7 +698,7 @@ where
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
     ) -> VmResult<GenericResult<Response>> {
         let Some(cron_execute_fn) = &self.cron_execute_fn else {
             return Err(VmError::function_not_found("cron_execute"));

--- a/grug/vm/rust/src/traits.rs
+++ b/grug/vm/rust/src/traits.rs
@@ -5,7 +5,9 @@
 use {
     crate::VmResult,
     grug_types::{
-        Api, AuthCtx, AuthResponse, BankMsg, BankQuery, BankQueryResponse, Context, GenericResult, ImmutableCtx, Json, MutableCtx, Querier, Response, StdError, Storage, SubMsgResult, SudoCtx, Tx, TxOutcome
+        Api, AuthCtx, AuthResponse, BankMsg, BankQuery, BankQueryResponse, Context, GenericResult,
+        ImmutableCtx, Json, MutableCtx, Querier, Response, Storage, SubMsgResult, SudoCtx, Tx,
+        TxOutcome,
     },
 };
 
@@ -15,7 +17,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Response>>;
 
@@ -24,7 +26,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Response>>;
 
@@ -33,7 +35,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Response>>;
 
@@ -42,7 +44,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
     ) -> VmResult<GenericResult<Response>>;
 
     fn reply(
@@ -50,7 +52,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
         result: SubMsgResult,
     ) -> VmResult<GenericResult<Response>>;
@@ -60,7 +62,7 @@ pub trait Contract {
         ctx: Context,
         storage: &dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: &[u8],
     ) -> VmResult<GenericResult<Json>>;
 
@@ -69,7 +71,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
     ) -> VmResult<GenericResult<AuthResponse>>;
 
@@ -78,7 +80,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
     ) -> VmResult<GenericResult<Response>>;
 
@@ -87,7 +89,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: BankMsg,
     ) -> VmResult<GenericResult<Response>>;
 
@@ -96,7 +98,7 @@ pub trait Contract {
         ctx: Context,
         storage: &dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         msg: BankQuery,
     ) -> VmResult<GenericResult<BankQueryResponse>>;
 
@@ -105,7 +107,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
     ) -> VmResult<GenericResult<Response>>;
 
@@ -114,7 +116,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
         tx: Tx,
         outcome: TxOutcome,
     ) -> VmResult<GenericResult<Response>>;
@@ -124,7 +126,7 @@ pub trait Contract {
         ctx: Context,
         storage: &mut dyn Storage,
         api: &dyn Api,
-        querier: &dyn Querier<Error = StdError>,
+        querier: &dyn Querier,
     ) -> VmResult<GenericResult<Response>>;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `Error` associated type from `Querier` trait, refactoring error handling to use `StdResult` across the codebase.
> 
>   - **Behavior**:
>     - Remove `Error` associated type from `Querier` trait in `grug/types/src/imports/querier.rs`.
>     - Update all implementations of `Querier` to use `StdResult` for error handling.
>   - **Refactoring**:
>     - Remove `type Error` from `Querier` implementations in `oracle_querier.rs`, `pyth_handler.rs`, `market.rs`, `proposal_preparer.rs`, `querier.rs`, `imports.rs`, `suite.rs`, `context.rs`, `querier.rs`, `contract.rs`, and `traits.rs`.
>     - Replace `Result` with `StdResult` in `query_chain` and related methods across affected files.
>   - **Misc**:
>     - Update `QuerierExt` trait to remove constraints on `Error` type.
>     - Adjust test cases in `pyth_handler.rs` to align with new error handling approach.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 668bc5c6647d21ae6cc61df8caadc2d5177ddcb5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->