### PR TITLE
refractor(dango): small `HealthData`

### DIFF
--- a/dango/account/margin/src/query.rs
+++ b/dango/account/margin/src/query.rs
@@ -1,7 +1,7 @@
 use {
     crate::core,
     dango_auth::query_seen_nonces,
-    dango_types::account::margin::QueryMsg,
+    dango_types::{DangoQuerier, account::margin::QueryMsg},
     grug::{ImmutableCtx, Json, JsonSerExt},
 };
 
@@ -13,7 +13,8 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             res.to_json_value()
         },
         QueryMsg::HealthData {} => {
-            let res = core::query_health(&ctx.querier, ctx.contract, ctx.block.timestamp)?;
+            let app_cfg = ctx.querier.query_dango_config()?;
+            let res = core::query_health(&ctx.querier, ctx.contract, &app_cfg)?;
             res.to_json_value()
         },
         QueryMsg::Health {} => {

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{auth::Nonce, dex::OrdersByUserResponse, lending::Market, oracle::PrecisionedPrice},
+    crate::{auth::Nonce, dex::OrdersByUserResponse},
     grug::{Bounded, Coins, Denom, Udec128, Udec256, Uint128, ZeroExclusiveOneInclusive},
     std::collections::{BTreeMap, BTreeSet},
 };
@@ -11,9 +11,6 @@ pub type CollateralPower = Bounded<Udec128, ZeroExclusiveOneInclusive>;
 #[grug::derive(Serde)]
 pub struct HealthData {
     pub scaled_debts: BTreeMap<Denom, Udec256>,
-    pub markets: BTreeMap<Denom, Market>,
-    pub prices: BTreeMap<Denom, PrecisionedPrice>,
-    pub collateral_powers: BTreeMap<Denom, CollateralPower>,
     pub collateral_balances: BTreeMap<Denom, Uint128>,
     pub limit_orders: BTreeMap<u64, OrdersByUserResponse>,
 }


### PR DESCRIPTION
Is not needed for the liquidation bot to get all the data we currently return in `QueryMsg::HealhData`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `HealthData` to exclude unnecessary fields, updating related functions in `core.rs` and `query.rs`.
> 
>   - **Behavior**:
>     - `query_and_compute_health` in `core.rs` now queries `markets` and `prices` separately instead of using `HealthData`.
>     - `query_health` in `core.rs` no longer includes `markets`, `prices`, and `collateral_powers` in `HealthData`.
>     - `compute_health` in `core.rs` now takes `markets`, `prices`, and `collateral_powers` as separate arguments.
>   - **Data Structures**:
>     - `HealthData` in `margin.rs` no longer includes `markets`, `prices`, and `collateral_powers` fields.
>   - **Query Handling**:
>     - `query` in `query.rs` updated to pass `AppConfig` to `query_health`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for bef8aa3f62b9ebee9b1f3db7ab07d0003b10f12a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->