### PR TITLE
feat(lending): update indices in QueryMsg::Market and QueryMsg::Markets

### DIFF
--- a/dango/testing/tests/lending.rs
+++ b/dango/testing/tests/lending.rs
@@ -212,9 +212,6 @@ fn indexes_are_updated_when_interest_rate_model_is_updated() {
         )
         .should_succeed();
 
-    // Increase time to accrue interest
-    suite.increase_time(Duration::from_seconds(60 * 60 * 24)); // 1 day
-
     // Query the current market for USDC
     let market = suite
         .query_wasm_smart(contracts.lending, QueryMarketRequest {
@@ -224,6 +221,9 @@ fn indexes_are_updated_when_interest_rate_model_is_updated() {
 
     let old_borrow_index = market.borrow_index;
     let old_supply_index = market.supply_index;
+
+    // Increase time to accrue interest
+    suite.increase_time(Duration::from_seconds(60 * 60 * 24)); // 1 day
 
     // Update the interest rate model
     suite


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `query_market` and `query_markets` to refresh indices before returning data, and adjust related test for correct flow.
> 
>   - **Behavior**:
>     - Update `query_market` and `query_markets` in `query.rs` to call `update_indices` before returning market data.
>     - Ensure indices are updated with the latest timestamp and querier data.
>   - **Testing**:
>     - Adjust test `indexes_are_updated_when_interest_rate_model_is_updated` in `lending.rs` to move time increase operation after querying market data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 6948ac8de0e173deb00d1331737d493d2ea891c7. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->