### PR TITLE
test: volume tracking with multiple orders from same user in same block

### DIFF
--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -265,6 +265,7 @@ where
                 balances: coins! {
                     DANGO_DENOM.clone() => 100_000_000_000_000,
                     USDC_DENOM.clone()  => 100_000_000_000_000,
+                    BTC_DENOM.clone()   => 100_000_000_000_000,
                 },
             },
             user3.username.clone() => GenesisUser {

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -12,11 +12,14 @@ use {
         oracle::{self, PriceSource},
     },
     grug::{
-        Addr, Addressable, BalanceChange, Bounded, Coin, CoinPair, Coins, Denom, Inner, IsZero,
-        MaxLength, Message, MultiplyFraction, NonEmpty, NonZero, NumberConst, QuerierExt,
+        Addr, Addressable, BalanceChange, Bounded, Coin, CoinPair, Coins, Denom, Fraction, Inner,
+        IsZero, MaxLength, Message, MultiplyFraction, NonEmpty, NonZero, NumberConst, QuerierExt,
         ResultExt, Signer, StdResult, Udec128, Uint128, UniqueVec, btree_map, coins,
     },
-    std::collections::{BTreeMap, BTreeSet},
+    std::{
+        collections::{BTreeMap, BTreeSet},
+        str::FromStr,
+    },
     test_case::test_case,
 };
 
@@ -1997,7 +2000,6 @@ fn volume_tracking_works() {
         )
         .should_succeed();
 
-    // let user1 = &accounts.user1.username;
     let mut user1_addr_1 = accounts.user1;
     let mut user1_addr_2 = user1_addr_1
         .register_new_account(
@@ -2277,4 +2279,313 @@ fn volume_tracking_works() {
             since: Some(timestamp_after_first_trade),
         })
         .should_succeed_and_equal(Uint128::new(100));
+}
+
+#[test]
+fn volume_tracking_works_with_multiple_orders_from_same_user() {
+    let (mut suite, mut accounts, _, contracts) = setup_test_naive();
+
+    // Register oracle price source for USDC
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.oracle,
+            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
+                USDC_DENOM.clone() => PriceSource::Fixed {
+                    humanized_price: Udec128::ONE,
+                    precision: 6,
+                    timestamp: 1730802926,
+                },
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Register oracle price source for DANGO
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.oracle,
+            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
+                DANGO_DENOM.clone() => PriceSource::Fixed {
+                    humanized_price: Udec128::ONE,
+                    precision: 6,
+                    timestamp: 1730802926,
+                },
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Register oracle price source for BTC
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.oracle,
+            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
+                BTC_DENOM.clone() => PriceSource::Fixed {
+                    humanized_price: Udec128::from_str("85248.71").unwrap(),
+                    precision: 8,
+                    timestamp: 1730802926,
+                },
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Submit two orders for DANGO/USDC and one for BTC/USDC with user1
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.dex,
+            &dex::ExecuteMsg::BatchUpdateOrders {
+                creates: vec![
+                    CreateLimitOrderRequest {
+                        base_denom: DANGO_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: Uint128::new(100_000_000),
+                        price: Udec128::new(1),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: DANGO_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: Uint128::new(100_000_000),
+                        price: Udec128::from_str("1.01").unwrap(),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: BTC_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: Uint128::new(117304),
+                        price: Udec128::from_str("852.485845").unwrap(),
+                    },
+                ],
+                cancels: None,
+            },
+            Coins::one(USDC_DENOM.clone(), 301_000_000).unwrap(),
+        )
+        .should_succeed();
+
+    // Submit matching orders with user2
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.dex,
+            &dex::ExecuteMsg::BatchUpdateOrders {
+                creates: vec![
+                    CreateLimitOrderRequest {
+                        base_denom: DANGO_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Ask,
+                        amount: Uint128::new(200_000_000),
+                        price: Udec128::new(1),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: BTC_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Ask,
+                        amount: Uint128::new(117304),
+                        price: Udec128::from_str("852.485845").unwrap(),
+                    },
+                ],
+                cancels: None,
+            },
+            coins! {
+                DANGO_DENOM.clone() => 200_000_000,
+                BTC_DENOM.clone() => 117304,
+            },
+        )
+        .should_succeed();
+
+    // Get timestamp after trade
+    let timestamp_after_first_trade = suite.block.timestamp;
+
+    // Query the volume for username user1, should be 300
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user1.username.clone(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(300));
+
+    // Query the volume for username user2, should be 300
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user2.username.clone(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(300));
+
+    // Query the volume for user1 address, should be 300
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
+            user: accounts.user1.address(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(300));
+
+    // Query the volume for user2 address, should be 300
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
+            user: accounts.user2.address(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(300));
+
+    // Query the volume for both usernames since timestamp after first trade, should be zero
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user1.username.clone(),
+            since: Some(timestamp_after_first_trade),
+        })
+        .should_succeed_and_equal(Uint128::ZERO);
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user2.username.clone(),
+            since: Some(timestamp_after_first_trade),
+        })
+        .should_succeed_and_equal(Uint128::ZERO);
+
+    // Submit new orders with user1
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.dex,
+            &dex::ExecuteMsg::BatchUpdateOrders {
+                creates: vec![
+                    CreateLimitOrderRequest {
+                        base_denom: DANGO_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: Uint128::new(100_000_000),
+                        price: Udec128::new(1),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: DANGO_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: Uint128::new(100_000_000),
+                        price: Udec128::from_str("1.01").unwrap(),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: BTC_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: Uint128::new(117304),
+                        price: Udec128::from_str("852.485845").unwrap(),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: BTC_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: Uint128::new(117304),
+                        price: Udec128::from_str("937.7344336").unwrap(),
+                    },
+                ],
+                cancels: None,
+            },
+            coins! {
+                USDC_DENOM.clone() => 411_000_000,
+            },
+        )
+        .should_succeed();
+
+    // Submit matching orders with user2
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.dex,
+            &dex::ExecuteMsg::BatchUpdateOrders {
+                creates: vec![
+                    CreateLimitOrderRequest {
+                        base_denom: DANGO_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Ask,
+                        amount: Uint128::new(300_000_000),
+                        price: Udec128::new(1),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: BTC_DENOM.clone(),
+                        quote_denom: USDC_DENOM.clone(),
+                        direction: Direction::Ask,
+                        amount: Uint128::new(117304 * 2),
+                        price: Udec128::from_str("85248.71")
+                            .unwrap()
+                            .checked_inv()
+                            .unwrap(),
+                    },
+                ],
+                cancels: None,
+            },
+            coins! {
+                DANGO_DENOM.clone() => 300_000_000,
+                BTC_DENOM.clone() => 117304 * 2,
+            },
+        )
+        .should_succeed();
+
+    // Get timestamp after second trade
+    let timestamp_after_second_trade = suite.block.timestamp;
+
+    // Query the volume for username user1, should be 700
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user1.username.clone(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(700));
+
+    // Query the volume for username user2, should be 700
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user2.username.clone(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(700));
+
+    // Query the volume for user1 address, should be 700
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
+            user: accounts.user1.address(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(700));
+
+    // Query the volume for user2 address, should be 700
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
+            user: accounts.user2.address(),
+            since: None,
+        })
+        .should_succeed_and_equal(Uint128::new(700));
+
+    // Query the volume for both usernames since timestamp after second trade, should be zero
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user1.username.clone(),
+            since: Some(timestamp_after_second_trade),
+        })
+        .should_succeed_and_equal(Uint128::ZERO);
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
+            user: accounts.user2.username.clone(),
+            since: Some(timestamp_after_second_trade),
+        })
+        .should_succeed_and_equal(Uint128::ZERO);
+
+    // Query the volume for both addresses since timestamp after the first trade, should be 400
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
+            user: accounts.user1.address(),
+            since: Some(timestamp_after_first_trade),
+        })
+        .should_succeed_and_equal(Uint128::new(400));
+    suite
+        .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
+            user: accounts.user2.address(),
+            since: Some(timestamp_after_first_trade),
+        })
+        .should_succeed_and_equal(Uint128::new(400));
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add test for volume tracking with multiple orders from the same user in the same block in `dex.rs`.
> 
>   - **Test Addition**:
>     - Adds `volume_tracking_works_with_multiple_orders_from_same_user()` in `dex.rs` to test volume tracking with multiple orders from the same user in the same block.
>   - **Setup Changes**:
>     - Adds `BTC_DENOM` to user balances in `setup.rs` for `user3`.
>   - **Test Logic**:
>     - Registers price sources for `USDC`, `DANGO`, and `BTC`.
>     - Submits multiple orders for `DANGO/USDC` and `BTC/USDC` pairs.
>     - Verifies volume tracking for both usernames and addresses before and after trades.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 3fe3b55de715c2dddd3b5f472b449dba67b32a06. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->