### PR TITLE
grug: make `QuerierWrapper` copy-able

### DIFF
--- a/dango/account/margin/src/core.rs
+++ b/dango/account/margin/src/core.rs
@@ -31,7 +31,7 @@ use {
 ///   funds to the account that should not be included in the total collateral
 ///   value.
 pub fn query_and_compute_health(
-    querier: &QuerierWrapper,
+    querier: QuerierWrapper,
     account: Addr,
     current_time: Timestamp,
     discount_collateral: Option<Coins>,
@@ -46,7 +46,7 @@ pub fn query_and_compute_health(
         .map(|denom| {
             let market = querier
                 .query_wasm_path(app_cfg.addresses.lending, &MARKETS.path(denom))?
-                .update_indices(querier, current_time)?;
+                .update_indices(&querier, current_time)?;
 
             Ok((denom.clone(), market))
         })
@@ -84,7 +84,7 @@ pub fn query_and_compute_health(
 
 /// Query relevant data necessary for computing the health of a margin account.
 pub fn query_health(
-    querier: &QuerierWrapper,
+    querier: QuerierWrapper,
     account: Addr,
     app_cfg: &AppConfig,
 ) -> anyhow::Result<HealthData> {

--- a/dango/account/margin/src/core.rs
+++ b/dango/account/margin/src/core.rs
@@ -46,7 +46,7 @@ pub fn query_and_compute_health(
         .map(|denom| {
             let market = querier
                 .query_wasm_path(app_cfg.addresses.lending, &MARKETS.path(denom))?
-                .update_indices(&querier, current_time)?;
+                .update_indices(querier, current_time)?;
 
             Ok((denom.clone(), market))
         })

--- a/dango/account/margin/src/execute.rs
+++ b/dango/account/margin/src/execute.rs
@@ -47,7 +47,7 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<AuthResponse> {
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn backrun(ctx: AuthCtx, _tx: Tx) -> anyhow::Result<Response> {
     let health =
-        core::query_and_compute_health(&ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
+        core::query_and_compute_health(ctx.querier, ctx.contract, ctx.block.timestamp, None)?;
 
     // After executing all messages in the transactions, the account must have
     // a utilization rate no greater than one. Otherwise, we throw an error to
@@ -82,7 +82,7 @@ pub fn liquidate(ctx: MutableCtx, collateral_denom: Denom) -> anyhow::Result<Res
         limit_order_collaterals,
         ..
     } = core::query_and_compute_health(
-        &ctx.querier,
+        ctx.querier,
         ctx.contract,
         ctx.block.timestamp,
         Some(ctx.funds.clone()),

--- a/dango/account/margin/src/query.rs
+++ b/dango/account/margin/src/query.rs
@@ -14,12 +14,12 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
         },
         QueryMsg::HealthData {} => {
             let app_cfg = ctx.querier.query_dango_config()?;
-            let res = core::query_health(&ctx.querier, ctx.contract, &app_cfg)?;
+            let res = core::query_health(ctx.querier, ctx.contract, &app_cfg)?;
             res.to_json_value()
         },
         QueryMsg::Health {} => {
             let res = core::query_and_compute_health(
-                &ctx.querier,
+                ctx.querier,
                 ctx.contract,
                 ctx.block.timestamp,
                 None,

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -459,7 +459,7 @@ pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
     for (base_denom, quote_denom) in pairs {
         clear_orders_of_pair(
             ctx.storage,
-            &ctx.querier,
+            ctx.querier,
             app_cfg.addresses.oracle,
             app_cfg.addresses.account_factory,
             base_denom,
@@ -494,7 +494,7 @@ pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
 #[inline]
 fn clear_orders_of_pair(
     storage: &mut dyn Storage,
-    querier: &QuerierWrapper,
+    querier: QuerierWrapper,
     oracle: Addr,          // TODO: replace this with an `OracleQuerier` with caching
     account_factory: Addr, // TODO: replace this with an `AccountQuerier` with caching
     base_denom: Denom,

--- a/dango/lending/src/core/borrow.rs
+++ b/dango/lending/src/core/borrow.rs
@@ -7,7 +7,7 @@ use {
 
 pub fn borrow(
     storage: &dyn Storage,
-    querier: &QuerierWrapper,
+    querier: QuerierWrapper,
     current_time: Timestamp,
     sender: Addr,
     coins: &Coins,
@@ -19,7 +19,7 @@ pub fn borrow(
         // Update the market state
         let market = MARKETS
             .load(storage, coin.denom)?
-            .update_indices(querier, current_time)?;
+            .update_indices(&querier, current_time)?;
 
         // Update the sender's liabilities
         let prev_scaled_debt = scaled_debts.get(coin.denom).cloned().unwrap_or_default();

--- a/dango/lending/src/core/borrow.rs
+++ b/dango/lending/src/core/borrow.rs
@@ -19,7 +19,7 @@ pub fn borrow(
         // Update the market state
         let market = MARKETS
             .load(storage, coin.denom)?
-            .update_indices(&querier, current_time)?;
+            .update_indices(querier, current_time)?;
 
         // Update the sender's liabilities
         let prev_scaled_debt = scaled_debts.get(coin.denom).cloned().unwrap_or_default();

--- a/dango/lending/src/core/deposit.rs
+++ b/dango/lending/src/core/deposit.rs
@@ -9,7 +9,7 @@ use {
 /// Returns the amount of LP tokens and the updated markets.
 pub fn deposit(
     storage: &dyn Storage,
-    querier: &QuerierWrapper,
+    querier: QuerierWrapper,
     current_time: Timestamp,
     coins: Coins,
 ) -> anyhow::Result<(Coins, BTreeMap<Denom, Market>)> {
@@ -20,7 +20,7 @@ pub fn deposit(
         // Get market and update the market indices
         let market = MARKETS
             .load(storage, &coin.denom)?
-            .update_indices(querier, current_time)?;
+            .update_indices(&querier, current_time)?;
 
         // Compute the amount of LP tokens to mint
         let supply_index = market.supply_index;

--- a/dango/lending/src/core/deposit.rs
+++ b/dango/lending/src/core/deposit.rs
@@ -20,7 +20,7 @@ pub fn deposit(
         // Get market and update the market indices
         let market = MARKETS
             .load(storage, &coin.denom)?
-            .update_indices(&querier, current_time)?;
+            .update_indices(querier, current_time)?;
 
         // Compute the amount of LP tokens to mint
         let supply_index = market.supply_index;

--- a/dango/lending/src/core/repay.rs
+++ b/dango/lending/src/core/repay.rs
@@ -14,7 +14,7 @@ use {
 /// - Excess funds to be returned to the user.
 pub fn repay(
     storage: &dyn Storage,
-    querier: &QuerierWrapper,
+    querier: QuerierWrapper,
     current_time: Timestamp,
     sender: Addr,
     coins: &Coins,
@@ -27,7 +27,7 @@ pub fn repay(
         // Update the market indices
         let market = MARKETS
             .load(storage, coin.denom)?
-            .update_indices(querier, current_time)?;
+            .update_indices(&querier, current_time)?;
 
         // Calculated the users real debt
         let scaled_debt = scaled_debts.get(coin.denom).cloned().unwrap_or_default();

--- a/dango/lending/src/core/repay.rs
+++ b/dango/lending/src/core/repay.rs
@@ -27,7 +27,7 @@ pub fn repay(
         // Update the market indices
         let market = MARKETS
             .load(storage, coin.denom)?
-            .update_indices(&querier, current_time)?;
+            .update_indices(querier, current_time)?;
 
         // Calculated the users real debt
         let scaled_debt = scaled_debts.get(coin.denom).cloned().unwrap_or_default();

--- a/dango/lending/src/core/withdraw.rs
+++ b/dango/lending/src/core/withdraw.rs
@@ -25,7 +25,7 @@ pub fn withdraw(
         // Update the market indices
         let market = MARKETS
             .load(storage, &underlying_denom)?
-            .update_indices(&querier, current_time)?;
+            .update_indices(querier, current_time)?;
 
         // Compute the amount of underlying coins to withdraw
         let underlying_amount = coin.amount.checked_mul_dec_floor(market.supply_index)?;

--- a/dango/lending/src/core/withdraw.rs
+++ b/dango/lending/src/core/withdraw.rs
@@ -10,7 +10,7 @@ use {
 /// Returns the amount of underlying coins and the updated markets.
 pub fn withdraw(
     storage: &dyn Storage,
-    querier: &QuerierWrapper,
+    querier: QuerierWrapper,
     current_time: Timestamp,
     coins: Coins,
 ) -> anyhow::Result<(Coins, BTreeMap<Denom, Market>)> {
@@ -25,7 +25,7 @@ pub fn withdraw(
         // Update the market indices
         let market = MARKETS
             .load(storage, &underlying_denom)?
-            .update_indices(querier, current_time)?;
+            .update_indices(&querier, current_time)?;
 
         // Compute the amount of underlying coins to withdraw
         let underlying_amount = coin.amount.checked_mul_dec_floor(market.supply_index)?;

--- a/dango/lending/src/execute.rs
+++ b/dango/lending/src/execute.rs
@@ -67,7 +67,7 @@ fn update_markets(
 fn deposit(ctx: MutableCtx) -> anyhow::Result<Response> {
     // Immutably update markets and compute the amount of LP tokens to mint.
     let (lp_tokens, markets) =
-        core::deposit(ctx.storage, &ctx.querier, ctx.block.timestamp, ctx.funds)?;
+        core::deposit(ctx.storage, ctx.querier, ctx.block.timestamp, ctx.funds)?;
 
     // Save the updated markets.
     for (denom, market) in markets {
@@ -98,7 +98,7 @@ fn withdraw(ctx: MutableCtx) -> anyhow::Result<Response> {
     // Immutably update markets and compute the amount of underlying coins to withdraw
     let (withdrawn, markets) = core::withdraw(
         ctx.storage,
-        &ctx.querier,
+        ctx.querier,
         ctx.block.timestamp,
         ctx.funds.clone(),
     )?;
@@ -146,7 +146,7 @@ fn borrow(ctx: MutableCtx, coins: NonEmpty<Coins>) -> anyhow::Result<Response> {
 
     let (debts, markets) = core::borrow(
         ctx.storage,
-        &ctx.querier,
+        ctx.querier,
         ctx.block.timestamp,
         ctx.sender,
         coins.inner(),
@@ -172,7 +172,7 @@ fn borrow(ctx: MutableCtx, coins: NonEmpty<Coins>) -> anyhow::Result<Response> {
 fn repay(ctx: MutableCtx) -> anyhow::Result<Response> {
     let (scaled_debts, markets, refunds) = core::repay(
         ctx.storage,
-        &ctx.querier,
+        ctx.querier,
         ctx.block.timestamp,
         ctx.sender,
         &ctx.funds,

--- a/dango/lending/src/execute.rs
+++ b/dango/lending/src/execute.rs
@@ -53,7 +53,7 @@ fn update_markets(
             if let Some(market) = maybe_market {
                 // Update indexes first, so that interests accumulated up to this
                 // point are accounted for. Then, set the new interest rate model.
-                let market = market.update_indices(&ctx.querier, ctx.block.timestamp)?;
+                let market = market.update_indices(ctx.querier, ctx.block.timestamp)?;
                 Ok(market.set_interest_rate_model(new_interest_rate_model))
             } else {
                 Ok(Market::new(&denom, new_interest_rate_model)?)
@@ -212,7 +212,7 @@ fn claim_pending_protocol_fees(ctx: MutableCtx) -> anyhow::Result<Response> {
         .range(ctx.storage, None, None, Order::Ascending)
         .map(|res| -> anyhow::Result<_> {
             let (denom, market) = res?;
-            let market = market.update_indices(&ctx.querier, ctx.block.timestamp)?;
+            let market = market.update_indices(ctx.querier, ctx.block.timestamp)?;
             Ok((
                 Message::execute(
                     bank,

--- a/dango/lending/src/query.rs
+++ b/dango/lending/src/query.rs
@@ -66,7 +66,7 @@ fn query_debt(ctx: ImmutableCtx, account: Addr) -> anyhow::Result<Coins> {
         .map(|(denom, scaled_debt)| {
             let market = MARKETS
                 .load(ctx.storage, &denom)?
-                .update_indices(&ctx.querier, ctx.block.timestamp)?;
+                .update_indices(ctx.querier, ctx.block.timestamp)?;
             let debt = market.calculate_debt(scaled_debt)?;
 
             Ok((denom, debt))
@@ -94,7 +94,7 @@ fn query_debts(
                 .map(|(denom, scaled_debt)| {
                     let market = MARKETS
                         .load(ctx.storage, &denom)?
-                        .update_indices(&ctx.querier, ctx.block.timestamp)?;
+                        .update_indices(ctx.querier, ctx.block.timestamp)?;
                     let debt = market.calculate_debt(scaled_debt)?;
 
                     Ok((denom, debt))

--- a/dango/lending/src/query.rs
+++ b/dango/lending/src/query.rs
@@ -29,12 +29,12 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
         },
         QueryMsg::SimulateDeposit { underlying } => {
             let (lp_tokens, _) =
-                core::deposit(ctx.storage, &ctx.querier, ctx.block.timestamp, underlying)?;
+                core::deposit(ctx.storage, ctx.querier, ctx.block.timestamp, underlying)?;
             lp_tokens.to_json_value()
         },
         QueryMsg::SimulateWithdraw { lp_tokens } => {
             let (coins, _) =
-                core::withdraw(ctx.storage, &ctx.querier, ctx.block.timestamp, lp_tokens)?;
+                core::withdraw(ctx.storage, ctx.querier, ctx.block.timestamp, lp_tokens)?;
             coins.to_json_value()
         },
     }

--- a/dango/proposal-preparer/src/proposal_preparer.rs
+++ b/dango/proposal-preparer/src/proposal_preparer.rs
@@ -68,7 +68,7 @@ where
         let mut pyth_handler = self.pyth_handler.as_ref().unwrap().lock().unwrap();
 
         // Update the Pyth stream if the PythIds in the oracle have changed.
-        if let Err(err) = pyth_handler.update_stream(&querier, cfg.addresses.oracle) {
+        if let Err(err) = pyth_handler.update_stream(querier, cfg.addresses.oracle) {
             error!("Failed to update Pyth stream: {:?}", err);
         }
 

--- a/dango/proposal-preparer/src/pyth_handler.rs
+++ b/dango/proposal-preparer/src/pyth_handler.rs
@@ -77,7 +77,7 @@ where
 
     //  TODO: optimize this by using the raw WasmScan query.
     /// Retrieve the Pyth ids from the Oracle contract.
-    pub fn pyth_ids(querier: &QuerierWrapper, oracle: Addr) -> StdResult<Vec<PythId>> {
+    pub fn pyth_ids(querier: QuerierWrapper, oracle: Addr) -> StdResult<Vec<PythId>> {
         let new_ids = querier
             .query_wasm_smart(oracle, QueryPriceSourcesRequest {
                 start_after: None,
@@ -160,7 +160,7 @@ where
         ));
     }
 
-    pub fn update_stream(&mut self, querier: &QuerierWrapper, oracle: Addr) -> StdResult<()> {
+    pub fn update_stream(&mut self, querier: QuerierWrapper, oracle: Addr) -> StdResult<()> {
         // Retrieve the Pyth ids from the Oracle contract.
         let pyth_ids = Self::pyth_ids(querier, oracle)?;
 

--- a/dango/testing/tests/lending.rs
+++ b/dango/testing/tests/lending.rs
@@ -824,7 +824,7 @@ fn interest_rate_model_works(
     // Compute interest rates
     let (_, deposit_rate) = market
         .interest_rate_model
-        .calculate_rates(market.utilization_rate(suite).unwrap());
+        .calculate_rates(market.utilization_rate(suite.querier()).unwrap());
 
     // Assert that the supply interest rate is zero (since no one has borrowed yet)
     assert_eq!(deposit_rate, Udec128::ZERO);
@@ -903,7 +903,7 @@ fn interest_rate_model_works(
     // Compute interest rates
     let (borrow_rate, deposit_rate) = market
         .interest_rate_model
-        .calculate_rates(market.utilization_rate(suite).unwrap());
+        .calculate_rates(market.utilization_rate(suite.querier()).unwrap());
 
     // Assert that the all interest rates are non-zero
     assert!(borrow_rate.is_positive());
@@ -964,9 +964,9 @@ fn interest_rate_model_works(
             denom: USDC_DENOM.clone(),
         })
         .should_succeed()
-        .update_indices(suite, time)
+        .update_indices(suite.querier(), time)
         .unwrap();
-    let total_supply = market.total_supplied(suite).unwrap();
+    let total_supply = market.total_supplied(suite.querier()).unwrap();
     let total_borrowed = market.total_borrowed().unwrap();
 
     let supply_increase = total_supply - Uint128::from(deposit_amount);
@@ -1117,6 +1117,9 @@ fn interest_rate_model_works(
         .should_succeed();
 
     // Ensure that total supply is equal to the protocol revenueand total borrowed are zero
-    assert_eq!(market.total_supplied(suite).unwrap(), Uint128::ZERO);
+    assert_eq!(
+        market.total_supplied(suite.querier()).unwrap(),
+        Uint128::ZERO
+    );
     assert_eq!(market.total_borrowed_scaled, Udec256::ZERO);
 }

--- a/dango/testing/tests/pyth_handler.rs
+++ b/dango/testing/tests/pyth_handler.rs
@@ -63,7 +63,7 @@ fn handler() {
     let mut handler = PythHandler::<PythClientCache>::new_with_cache(PYTH_URL);
 
     // Start the handler with oracle.
-    handler.update_stream(&querier, oracle).unwrap();
+    handler.update_stream(querier, oracle).unwrap();
 
     // Give some times to get the data ready.
     sleep(Duration::from_millis(500));
@@ -75,7 +75,7 @@ fn handler() {
     }
 
     // Update the handler with the empty oracle.
-    handler.update_stream(&querier, empty_oracle).unwrap();
+    handler.update_stream(querier, empty_oracle).unwrap();
 
     // Remove possible data.
     handler.fetch_latest_vaas();
@@ -87,7 +87,7 @@ fn handler() {
     }
 
     // Update the handler with oracle.
-    handler.update_stream(&querier, oracle).unwrap();
+    handler.update_stream(querier, oracle).unwrap();
 
     // Give some times to get the data ready.
     sleep(Duration::from_millis(500));

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -12,8 +12,8 @@ use {
     grug_types::{
         Addr, Addressable, Binary, Block, BlockInfo, CheckTxOutcome, Coins, Config, Denom,
         Duration, GenesisState, Hash256, HashExt, JsonDeExt, JsonSerExt, Message, NonEmpty,
-        Querier, QuerierExt, Query, QueryResponse, Signer, StdError, StdResult, Tx, TxOutcome,
-        UnsignedTx,
+        Querier, QuerierExt, QuerierWrapper, Query, QueryResponse, Signer, StdError, StdResult, Tx,
+        TxOutcome, UnsignedTx,
     },
     grug_vm_rust::RustVm,
     serde::ser::Serialize,
@@ -618,6 +618,11 @@ where
             gas_limit,
             Message::migrate(contract, new_code_hash, msg).unwrap(),
         )
+    }
+
+    /// Return a `QuerierWrapper` object.
+    pub fn querier(&self) -> QuerierWrapper {
+        QuerierWrapper::new(self)
     }
 }
 

--- a/grug/types/src/imports/querier.rs
+++ b/grug/types/src/imports/querier.rs
@@ -158,6 +158,7 @@ impl<Q> QuerierExt for Q where Q: Querier {}
 ///
 /// We have to do this because `&dyn Querier` itself doesn't implement `Querier`,
 /// so given a `&dyn Querier` you aren't able to access the `QuerierExt` methods.
+#[derive(Clone, Copy)]
 pub struct QuerierWrapper<'a> {
     inner: &'a dyn Querier,
 }


### PR DESCRIPTION
`QuerierWrapper` is just a wrapper over an immutable reference (`&dyn Querier`) so there's no reason it can't be `Copy`-able.

I've changed various functions that take `&QuerierWrapper` by reference to taking `QuerierWrapper` by value instead.

~The only one I can't change is `Market::update_indices` because in tests we give it a `&TestSuite` which has to be reference.~ For `Market::update_indices`, I introduced a new `TestSuite::querier` method which returns a `QuerierWrapper`, which can be used as input to this function.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `QuerierWrapper` copyable and update function signatures to accept it by value across the codebase.
> 
>   - **Behavior**:
>     - `QuerierWrapper` is now `Copy`-able, allowing it to be passed by value.
>     - Functions in `core.rs`, `execute.rs`, and `query.rs` now take `QuerierWrapper` by value instead of by reference.
>     - `Market::update_indices` still requires `&QuerierWrapper` due to test constraints.
>   - **Code Changes**:
>     - Updated function signatures in `core.rs`, `execute.rs`, `query.rs`, `borrow.rs`, `deposit.rs`, `repay.rs`, `withdraw.rs`, `proposal_preparer.rs`, `pyth_handler.rs`, and `tests/pyth_handler.rs` to accept `QuerierWrapper` by value.
>     - Added `#[derive(Clone, Copy)]` to `QuerierWrapper` in `querier.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 0541dbfd268084895059c06eb0541610d953ce18. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->