### PR TITLE
feat(grug): add a few more in-place math methods

### DIFF
--- a/grug/math/src/integer.rs
+++ b/grug/math/src/integer.rs
@@ -33,6 +33,26 @@ pub trait Integer: Sized + Copy {
     fn wrapping_mul(self, other: Self) -> Self;
 
     fn wrapping_pow(self, exp: u32) -> Self;
+
+    #[inline]
+    fn wrapping_add_assign(&mut self, other: Self) {
+        *self = self.wrapping_add(other);
+    }
+
+    #[inline]
+    fn wrapping_sub_assign(&mut self, other: Self) {
+        *self = self.wrapping_sub(other);
+    }
+
+    #[inline]
+    fn wrapping_mul_assign(&mut self, other: Self) {
+        *self = self.wrapping_mul(other);
+    }
+
+    #[inline]
+    fn wrapping_pow_assign(&mut self, exp: u32) {
+        *self = self.wrapping_pow(exp);
+    }
 }
 
 // ------------------------------------ int ------------------------------------

--- a/grug/math/src/number.rs
+++ b/grug/math/src/number.rs
@@ -72,6 +72,26 @@ pub trait Number: Sized + Copy {
     fn saturating_mul(self, other: Self) -> Self;
 
     fn saturating_pow(self, exp: u32) -> Self;
+
+    #[inline]
+    fn saturating_add_assign(&mut self, other: Self) {
+        *self = self.saturating_add(other);
+    }
+
+    #[inline]
+    fn saturating_sub_assign(&mut self, other: Self) {
+        *self = self.saturating_sub(other);
+    }
+
+    #[inline]
+    fn saturating_mul_assign(&mut self, other: Self) {
+        *self = self.saturating_mul(other);
+    }
+
+    #[inline]
+    fn saturating_pow_assign(&mut self, exp: u32) {
+        *self = self.saturating_pow(exp);
+    }
 }
 
 // ------------------------------------ int ------------------------------------


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add in-place wrapping and saturating math methods to `Integer` and `Number` traits in `grug/math`.
> 
>   - **Integer Trait**:
>     - Adds `wrapping_add_assign`, `wrapping_sub_assign`, `wrapping_mul_assign`, `wrapping_pow_assign` methods in `integer.rs`.
>   - **Number Trait**:
>     - Adds `saturating_add_assign`, `saturating_sub_assign`, `saturating_mul_assign`, `saturating_pow_assign` methods in `number.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 52c6d9d0c5a405b41f1fda9c5c9fb2cf14134932. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->