### PR TITLE
dango(refactor): lending revamp

### DIFF
--- a/dango/lending/src/core.rs
+++ b/dango/lending/src/core.rs
@@ -3,6 +3,7 @@ mod deposit;
 mod interest_rate;
 mod market;
 mod repay;
+mod scaling;
 mod withdraw;
 
-pub use {borrow::*, deposit::*, interest_rate::*, market::*, repay::*, withdraw::*};
+pub use {borrow::*, deposit::*, interest_rate::*, market::*, repay::*, scaling::*, withdraw::*};

--- a/dango/lending/src/core/borrow.rs
+++ b/dango/lending/src/core/borrow.rs
@@ -1,36 +1,49 @@
 use {
     crate::{DEBTS, MARKETS, core},
     dango_types::lending::Market,
-    grug::{Addr, Coins, Denom, Number, QuerierWrapper, Storage, Timestamp, Udec256},
+    grug::{Addr, Coins, Denom, Number, Storage, Timestamp, Uint128},
     std::collections::BTreeMap,
 };
 
 pub fn borrow(
     storage: &dyn Storage,
-    querier: QuerierWrapper,
     current_time: Timestamp,
     sender: Addr,
     coins: &Coins,
-) -> anyhow::Result<(BTreeMap<Denom, Udec256>, Vec<(Denom, Market)>)> {
+) -> anyhow::Result<(BTreeMap<Denom, Uint128>, Vec<(Denom, Market)>)> {
     let mut markets = Vec::with_capacity(coins.len());
     let mut scaled_debts = DEBTS.may_load(storage, sender)?.unwrap_or_default();
 
     for coin in coins {
-        // Update the market state
+        // Load and update the market state.
         let market = MARKETS.load(storage, coin.denom)?;
-        let market = core::update_indices(market, querier, current_time)?;
+        let mut market = core::update_indices(market, current_time)?;
 
-        // Update the sender's liabilities
-        let prev_scaled_debt = scaled_debts.get(coin.denom).cloned().unwrap_or_default();
-        let new_scaled_debt = core::into_scaled_debt(*coin.amount, &market)?;
-        let added_scaled_debt = prev_scaled_debt.checked_add(new_scaled_debt)?;
-        scaled_debts.insert(coin.denom.clone(), added_scaled_debt);
+        // Update the user's debt.
+        let diff = {
+            // Find the user's current scaled debt.
+            let scaled_before = scaled_debts.get(coin.denom).copied().unwrap_or_default();
 
-        // Update the market's borrowed amount.
-        let market = market.add_borrowed(added_scaled_debt)?;
+            // Convert the user's current scaled debt from scaled to underlying.
+            let underlying_before = core::scaled_debt_to_underlying(scaled_before, &market)?;
 
-        // Save the updated market state.
-        markets.push((coin.denom.clone(), market));
+            // Increase the user's underlying debt amount.
+            let underlying_after = underlying_before.checked_add(*coin.amount)?;
+
+            // Convert the user's updated debt from underlying to scaled.
+            let scaled_after = core::underlying_debt_to_scaled(underlying_after, &market)?;
+
+            scaled_debts.insert(coin.denom.clone(), scaled_after);
+
+            scaled_after - scaled_before
+        };
+
+        // Update the market's total debt.
+        {
+            market.total_borrowed_scaled.checked_add_assign(diff)?;
+
+            markets.push((coin.denom.clone(), market));
+        }
     }
 
     Ok((scaled_debts, markets))

--- a/dango/lending/src/core/deposit.rs
+++ b/dango/lending/src/core/deposit.rs
@@ -1,33 +1,50 @@
 use {
-    crate::{MARKETS, core},
+    crate::{ASSETS, MARKETS, core},
     dango_types::lending::Market,
-    grug::{Coin, Coins, Denom, QuerierWrapper, Storage, Timestamp},
+    grug::{Addr, Coins, Denom, Number, Storage, Timestamp, Uint128},
     std::collections::BTreeMap,
 };
 
-/// Calculates the amount of LP tokens to mint for a deposit.
-/// Returns the amount of LP tokens and the updated markets.
 pub fn deposit(
     storage: &dyn Storage,
-    querier: QuerierWrapper,
     current_time: Timestamp,
-    coins: Coins,
-) -> anyhow::Result<(Coins, BTreeMap<Denom, Market>)> {
-    let mut lp_tokens = Coins::new();
-    let mut markets = BTreeMap::new();
+    sender: Addr,
+    coins: &Coins,
+) -> anyhow::Result<(BTreeMap<Denom, Uint128>, Vec<(Denom, Market)>)> {
+    let mut markets = Vec::with_capacity(coins.len());
+    let mut scaled_assets = ASSETS.may_load(storage, sender)?.unwrap_or_default();
 
     for coin in coins {
         // Get market and update the market indices
-        let market = MARKETS.load(storage, &coin.denom)?;
-        let market = core::update_indices(market, querier, current_time)?;
+        let market = MARKETS.load(storage, coin.denom)?;
+        let mut market = core::update_indices(market, current_time)?;
 
-        // Compute the amount of LP tokens to mint
-        let amount_scaled = core::into_scaled_collateral(coin.amount, &market)?;
-        lp_tokens.insert(Coin::new(market.supply_lp_denom.clone(), amount_scaled)?)?;
+        // Update the user's asset.
+        let diff = {
+            // Find the user's current scaled asset.
+            let scaled_before = scaled_assets.get(coin.denom).copied().unwrap_or_default();
 
-        // Save the updated market state.
-        markets.insert(coin.denom, market);
+            // Convert the user's current scaled asset from scaled to underlying.
+            let underlying_before = core::scaled_asset_to_underlying(scaled_before, &market)?;
+
+            // Increase the user's underlying asset amount.
+            let underlying_after = underlying_before.checked_add(*coin.amount)?;
+
+            // Convert the user's updated asset from underlying to scaled.
+            let scaled_after = core::underlying_asset_to_scaled(underlying_after, &market)?;
+
+            scaled_assets.insert(coin.denom.clone(), scaled_after);
+
+            scaled_after - scaled_before
+        };
+
+        // Update the market's total asset.
+        {
+            market.total_supplied_scaled.checked_add_assign(diff)?;
+
+            markets.push((coin.denom.clone(), market));
+        }
     }
 
-    Ok((lp_tokens, markets))
+    Ok((scaled_assets, markets))
 }

--- a/dango/lending/src/core/scaling.rs
+++ b/dango/lending/src/core/scaling.rs
@@ -1,0 +1,66 @@
+//! Logics for the conversion between _underlying_ and _scaled_ asset amounts.
+//!
+//! In the Dango lending protocol, we use a decimal variable termed _index_ to
+//! account for the continuous accrual of interest over time.
+//!
+//! For example, inside the contract we stored a _scaled depsoit amount_ of 100.
+//! If the `supply_index` is 1.2, this means there is `100 * 1.2 = 120` units of
+//! tokens supplied.
+//!
+//! Over time, as interest accrues, the index increases, but the _scaled_ amount
+//! remains the same. As such, the _underlying_ amount increases.
+//!
+//! ## On rounding errors
+//!
+//! Sometimes the underlying amount may not be a full integer number. For example,
+//! if the index is 1.234, the underlying amount would be `100 * 1.234 = 123.4`.
+//! Do we round this up to 124, or down to 123?
+//!
+//! Incorrect rounding is one of the most exploited vulnerabilities in lending
+//! markets. See:
+//!
+//! - <https://www.dlnews.com/articles/defi/hackers-continue-to-profit-from-defi-developers-math-problem/>
+//! - <https://osec.io/blog/2024-01-18-rounding-bugs>
+//!
+//! In Dango, we follow this principle: **always round to the advantage to the
+//! protocol, and to the disadvantage of the user**.
+//!
+//! This means always round _down_ the amount that the protocol owes the user,
+//! and _up_ the amount the user owes the protocol.
+//!
+//! In this file, we provide four functions for the conversion between scaled
+//! and underlying amounts. They should be considered the _source of truth for
+//! such conversions_. All other codes that perform such conversions should call
+//! these functions.
+use {
+    dango_types::lending::Market,
+    grug::{MathResult, MultiplyFraction, Uint128},
+};
+
+/// Convert an underlying (unscaled) amount of deposit to a scaled amount.
+///
+/// NOTE: round down.
+pub fn underlying_asset_to_scaled(underlying: Uint128, market: &Market) -> MathResult<Uint128> {
+    underlying.checked_div_dec_floor(market.supply_index)
+}
+
+/// Convert a scaled amount of deposit to an underlying (unscaled) amount.
+///
+/// NOTE: round down.
+pub fn scaled_asset_to_underlying(scaled: Uint128, market: &Market) -> MathResult<Uint128> {
+    scaled.checked_mul_dec_floor(market.supply_index)
+}
+
+/// Convert an underlying (unscaled) amount of debt to a scaled amount.
+///
+/// NOTE: round up.
+pub fn underlying_debt_to_scaled(underlying: Uint128, market: &Market) -> MathResult<Uint128> {
+    underlying.checked_div_dec_ceil(market.borrow_index)
+}
+
+/// Convert a scaled amount of debt to an underlying (unscaled) amount.
+///
+/// NOTE: round up.
+pub fn scaled_debt_to_underlying(scaled: Uint128, market: &Market) -> MathResult<Uint128> {
+    scaled.checked_mul_dec_ceil(market.borrow_index)
+}

--- a/dango/lending/src/core/withdraw.rs
+++ b/dango/lending/src/core/withdraw.rs
@@ -1,38 +1,72 @@
 use {
-    crate::{MARKETS, core},
+    crate::{ASSETS, MARKETS, core},
     anyhow::bail,
-    dango_types::lending::{Market, NAMESPACE, SUBNAMESPACE},
-    grug::{Coin, Coins, Denom, QuerierWrapper, Storage, Timestamp},
-    std::collections::BTreeMap,
+    dango_types::lending::Market,
+    grug::{Addr, Coins, Denom, Number, Storage, Timestamp, Uint128},
+    std::{cmp::Ordering, collections::BTreeMap},
 };
 
-/// Calculates the amount of underlying coins to withdraw for a given amount of LP tokens.
-/// Returns the amount of underlying coins and the updated markets.
 pub fn withdraw(
     storage: &dyn Storage,
-    querier: QuerierWrapper,
     current_time: Timestamp,
-    coins: Coins,
-) -> anyhow::Result<(Coins, BTreeMap<Denom, Market>)> {
-    let mut withdrawn = Coins::new();
-    let mut markets = BTreeMap::new();
+    sender: Addr,
+    coins: &Coins,
+) -> anyhow::Result<(BTreeMap<Denom, Uint128>, Vec<(Denom, Market)>)> {
+    let mut markets = Vec::with_capacity(coins.len());
+    let mut scaled_assets = ASSETS.may_load(storage, sender)?.unwrap_or_default();
 
     for coin in coins {
-        let Some(underlying_denom) = coin.denom.strip(&[&NAMESPACE, &SUBNAMESPACE]) else {
-            bail!("not a lending pool token: {}", coin.denom)
+        // Load and update the market state.
+        let market = MARKETS.load(storage, coin.denom)?;
+        let mut market = core::update_indices(market, current_time)?;
+
+        // Update the user's asset.
+        let diff = {
+            // Find the user's current scaled asset.
+            let scaled_before = scaled_assets.get(coin.denom).copied().unwrap_or_default();
+
+            // Convert the user's current scaled asset from scaled to underlying.
+            let underlying_before = core::scaled_asset_to_underlying(scaled_before, &market)?;
+
+            // Decrease the user's underlying asset amount.
+            match underlying_before.cmp(coin.amount) {
+                // User withdraws exactly the full amount.
+                Ordering::Equal => {
+                    // Clear the asset.
+                    scaled_assets.remove(coin.denom);
+
+                    scaled_before
+                },
+                // User attempts to withdraw more than the full amount. Reject.
+                Ordering::Less => {
+                    bail!(
+                        "can't withdraw more than the available deposited balance! available: {}, requested: {}",
+                        underlying_before,
+                        coin.amount
+                    );
+                },
+                // User withdraws less than the full amount.
+                Ordering::Greater => {
+                    // Decrease the user's underlying asset amount.
+                    let underlying_after = underlying_before.checked_sub(*coin.amount)?;
+
+                    // Convert the user's updated asset from underlying to scaled.
+                    let scaled_after = core::underlying_asset_to_scaled(underlying_after, &market)?;
+
+                    scaled_assets.insert(coin.denom.clone(), scaled_after);
+
+                    scaled_after - scaled_before
+                },
+            }
         };
 
-        // Update the market indices
-        let market = MARKETS.load(storage, &underlying_denom)?;
-        let market = core::update_indices(market, querier, current_time)?;
+        // Update the market's total asset.
+        {
+            market.total_supplied_scaled.checked_sub_assign(diff)?;
 
-        // Compute the amount of underlying coins to withdraw
-        let underlying_amount = core::into_underlying_collateral(coin.amount, &market)?;
-        withdrawn.insert(Coin::new(underlying_denom.clone(), underlying_amount)?)?;
-
-        // Save the updated market state
-        markets.insert(underlying_denom, market);
+            markets.push((coin.denom.clone(), market));
+        }
     }
 
-    Ok((withdrawn, markets))
+    Ok((scaled_assets, markets))
 }

--- a/dango/lending/src/execute.rs
+++ b/dango/lending/src/execute.rs
@@ -1,13 +1,13 @@
 use {
-    crate::{DEBTS, MARKETS, core},
+    crate::{ASSETS, DEBTS, MARKETS, core},
     anyhow::ensure,
     dango_account_factory::ACCOUNTS,
     dango_types::{
-        DangoQuerier, bank,
+        DangoQuerier,
         lending::{Borrowed, ExecuteMsg, InstantiateMsg, InterestRateModel, Market, Repaid},
     },
     grug::{
-        Coins, Denom, Inner, Message, MutableCtx, NonEmpty, Order, QuerierExt, Response, StdResult,
+        Coins, Denom, Inner, Message, MutableCtx, Number, Order, QuerierExt, Response, StdResult,
         StorageQuerier,
     },
     std::collections::BTreeMap,
@@ -16,11 +16,7 @@ use {
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     for (denom, interest_rate_model) in msg.markets {
-        MARKETS.save(
-            ctx.storage,
-            &denom,
-            &Market::new(&denom, interest_rate_model)?,
-        )?;
+        MARKETS.save(ctx.storage, &denom, &Market::new(interest_rate_model)?)?;
     }
 
     Ok(Response::new())
@@ -31,8 +27,8 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::UpdateMarkets(updates) => update_markets(ctx, updates),
         ExecuteMsg::Deposit {} => deposit(ctx),
-        ExecuteMsg::Withdraw {} => withdraw(ctx),
-        ExecuteMsg::Borrow(coins) => borrow(ctx, coins),
+        ExecuteMsg::Withdraw(coins) => withdraw(ctx, coins.into_inner()),
+        ExecuteMsg::Borrow(coins) => borrow(ctx, coins.into_inner()),
         ExecuteMsg::Repay {} => repay(ctx),
         ExecuteMsg::ClaimPendingProtocolFees {} => claim_pending_protocol_fees(ctx),
     }
@@ -53,10 +49,10 @@ fn update_markets(
             if let Some(market) = maybe_market {
                 // Update indexes first, so that interests accumulated up to this
                 // point are accounted for. Then, set the new interest rate model.
-                let market = core::update_indices(market, ctx.querier, ctx.block.timestamp)?;
+                let market = core::update_indices(market, ctx.block.timestamp)?;
                 Ok(market.set_interest_rate_model(new_interest_rate_model))
             } else {
-                Ok(Market::new(&denom, new_interest_rate_model)?)
+                Ok(Market::new(new_interest_rate_model)?)
             }
         })?;
     }
@@ -65,73 +61,41 @@ fn update_markets(
 }
 
 fn deposit(ctx: MutableCtx) -> anyhow::Result<Response> {
-    // Immutably update markets and compute the amount of LP tokens to mint.
-    let (lp_tokens, markets) =
-        core::deposit(ctx.storage, ctx.querier, ctx.block.timestamp, ctx.funds)?;
+    let (assets, markets) =
+        core::deposit(ctx.storage, ctx.block.timestamp, ctx.sender, &ctx.funds)?;
 
     // Save the updated markets.
     for (denom, market) in markets {
         MARKETS.save(ctx.storage, &denom, &market)?;
     }
 
-    // Mint the LP tokens to the sender.
-    let bank = ctx.querier.query_bank()?;
-    let msgs = lp_tokens
-        .into_iter()
-        .map(|coin| {
-            Message::execute(
-                bank,
-                &bank::ExecuteMsg::Mint {
-                    to: ctx.sender,
-                    denom: coin.denom,
-                    amount: coin.amount,
-                },
-                Coins::new(),
-            )
-        })
-        .collect::<StdResult<Vec<_>>>()?;
+    // Save the user's updated assets.
+    ASSETS.save(ctx.storage, ctx.sender, &assets)?;
 
-    Ok(Response::new().add_messages(msgs))
+    Ok(Response::new())
+    // TODO: add `Deposited` event
 }
 
-fn withdraw(ctx: MutableCtx) -> anyhow::Result<Response> {
-    // Immutably update markets and compute the amount of underlying coins to withdraw
-    let (withdrawn, markets) = core::withdraw(
-        ctx.storage,
-        ctx.querier,
-        ctx.block.timestamp,
-        ctx.funds.clone(),
-    )?;
+fn withdraw(ctx: MutableCtx, coins: Coins) -> anyhow::Result<Response> {
+    let (assets, markets) = core::withdraw(ctx.storage, ctx.block.timestamp, ctx.sender, &coins)?;
 
-    // Save the updated markets
+    // Save the updated markets.
     for (denom, market) in markets {
         MARKETS.save(ctx.storage, &denom, &market)?;
     }
 
-    // Burn the LP tokens.
-    let bank = ctx.querier.query_bank()?;
-    let msgs = ctx
-        .funds
-        .into_iter()
-        .map(|coin| {
-            Message::execute(
-                bank,
-                &bank::ExecuteMsg::Burn {
-                    from: ctx.contract,
-                    denom: coin.denom,
-                    amount: coin.amount,
-                },
-                Coins::new(),
-            )
-        })
-        .collect::<StdResult<Vec<_>>>()?;
+    // Save the user's updated assets.
+    if assets.is_empty() {
+        ASSETS.remove(ctx.storage, ctx.sender);
+    } else {
+        ASSETS.save(ctx.storage, ctx.sender, &assets)?;
+    };
 
-    Ok(Response::new()
-        .add_messages(msgs)
-        .add_message(Message::transfer(ctx.sender, withdrawn)?))
+    Ok(Response::new().add_message(Message::transfer(ctx.sender, coins)?))
+    // TODO: add `Withdrawn` event
 }
 
-fn borrow(ctx: MutableCtx, coins: NonEmpty<Coins>) -> anyhow::Result<Response> {
+fn borrow(ctx: MutableCtx, coins: Coins) -> anyhow::Result<Response> {
     let account_factory = ctx.querier.query_account_factory()?;
 
     // Ensure sender is a margin account.
@@ -144,39 +108,28 @@ fn borrow(ctx: MutableCtx, coins: NonEmpty<Coins>) -> anyhow::Result<Response> {
         "only margin accounts can borrow and repay"
     );
 
-    let (debts, markets) = core::borrow(
-        ctx.storage,
-        ctx.querier,
-        ctx.block.timestamp,
-        ctx.sender,
-        coins.inner(),
-    )?;
+    let (debts, markets) = core::borrow(ctx.storage, ctx.block.timestamp, ctx.sender, &coins)?;
 
     // Save the updated markets.
     for (denom, market) in markets {
         MARKETS.save(ctx.storage, &denom, &market)?;
     }
 
-    // Save the updated debts
+    // Save the user's updated debts.
     DEBTS.save(ctx.storage, ctx.sender, &debts)?;
 
     // Transfer the coins to the caller
     Ok(Response::new()
-        .add_message(Message::transfer(ctx.sender, coins.inner().clone())?)
+        .add_message(Message::transfer(ctx.sender, coins.clone())?)
         .add_event(Borrowed {
             user: ctx.sender,
-            borrowed: coins.into_inner(),
+            borrowed: coins,
         })?)
 }
 
 fn repay(ctx: MutableCtx) -> anyhow::Result<Response> {
-    let (scaled_debts, markets, refunds) = core::repay(
-        ctx.storage,
-        ctx.querier,
-        ctx.block.timestamp,
-        ctx.sender,
-        &ctx.funds,
-    )?;
+    let (debts, markets, refunds) =
+        core::repay(ctx.storage, ctx.block.timestamp, ctx.sender, &ctx.funds)?;
 
     // Save the updated markets.
     for (denom, market) in markets {
@@ -184,10 +137,10 @@ fn repay(ctx: MutableCtx) -> anyhow::Result<Response> {
     }
 
     // Save the updated debts.
-    if scaled_debts.is_empty() {
+    if debts.is_empty() {
         DEBTS.remove(ctx.storage, ctx.sender);
     } else {
-        DEBTS.save(ctx.storage, ctx.sender, &scaled_debts)?;
+        DEBTS.save(ctx.storage, ctx.sender, &debts)?;
     };
 
     Ok(Response::new()
@@ -200,39 +153,40 @@ fn repay(ctx: MutableCtx) -> anyhow::Result<Response> {
             user: ctx.sender,
             repaid: ctx.funds,
             refunds,
-            remaining_scaled_debts: scaled_debts,
+            remaining_scaled_debts: debts,
         })?)
 }
 
 fn claim_pending_protocol_fees(ctx: MutableCtx) -> anyhow::Result<Response> {
-    let bank = ctx.querier.query_bank()?;
     let owner = ctx.querier.query_owner()?;
 
-    let (msgs, markets) = MARKETS
+    let (new_assets, markets) = MARKETS
         .range(ctx.storage, None, None, Order::Ascending)
         .map(|res| -> anyhow::Result<_> {
             let (denom, market) = res?;
-            let market = core::update_indices(market, ctx.querier, ctx.block.timestamp)?;
+            let market = core::update_indices(market, ctx.block.timestamp)?;
             Ok((
-                Message::execute(
-                    bank,
-                    &bank::ExecuteMsg::Mint {
-                        to: owner,
-                        denom: market.supply_lp_denom.clone(),
-                        amount: market.pending_protocol_fee_scaled,
-                    },
-                    Coins::new(),
-                )?,
-                (denom, market),
+                (denom.clone(), market.pending_protocol_fee_scaled),
+                (denom, market.reset_pending_protocol_fee()),
             ))
         })
         .collect::<Result<(Vec<_>, Vec<_>), _>>()?;
 
+    // Save the updated markets.
     for (denom, market) in markets {
-        let market = market.reset_pending_protocol_fee();
-
         MARKETS.save(ctx.storage, &denom, &market)?;
     }
 
-    Ok(Response::new().add_messages(msgs))
+    // Assign the pending protocol fees to the chain owner as assets.
+    ASSETS.may_update(ctx.storage, owner, |maybe_assets| -> StdResult<_> {
+        let mut assets = maybe_assets.unwrap_or_default();
+        for (denom, new_asset) in new_assets {
+            let asset = assets.entry(denom).or_default();
+            asset.checked_add_assign(new_asset)?;
+        }
+
+        Ok(assets)
+    })?;
+
+    Ok(Response::new())
 }

--- a/dango/lending/src/state.rs
+++ b/dango/lending/src/state.rs
@@ -1,14 +1,26 @@
 use {
     dango_types::lending::Market,
-    grug::{Addr, Denom, Map, Udec256},
+    grug::{Addr, Denom, Map, Uint128},
     std::collections::BTreeMap,
 };
 
-/// The markets that are available to borrow from. The key is the denom of the
-/// borrowable asset.
+/// The markets that are available to borrow from.
+///
+/// ```raw
+/// denom => market
+/// ```
 pub const MARKETS: Map<&Denom, Market> = Map::new("market");
 
-/// The debts of all margin accounts. The key is a the address of the
-/// margin account. The value is a BTreeMap of the denom of the debt and the
-/// amount of debt scaled by the borrow index.
-pub const DEBTS: Map<Addr, BTreeMap<Denom, Udec256>> = Map::new("debt");
+/// The deposits of all lenders.
+///
+/// ```raw
+/// lender_addr => (denom => amount_scaled)
+/// ```
+pub const ASSETS: Map<Addr, BTreeMap<Denom, Uint128>> = Map::new("asset");
+
+/// The debts of all borrowers.
+///
+/// ```raw
+/// borrower_addr => (denom => amount_scaled)
+/// ```
+pub const DEBTS: Map<Addr, BTreeMap<Denom, Uint128>> = Map::new("debt");

--- a/dango/types/src/lending/events.rs
+++ b/dango/types/src/lending/events.rs
@@ -1,5 +1,5 @@
 use {
-    grug::{Addr, Coins, Denom, Udec256},
+    grug::{Addr, Coins, Denom, Uint128},
     std::collections::BTreeMap,
 };
 
@@ -18,5 +18,5 @@ pub struct Repaid {
     pub user: Addr,
     pub repaid: Coins,
     pub refunds: Coins,
-    pub remaining_scaled_debts: BTreeMap<Denom, Udec256>,
+    pub remaining_scaled_debts: BTreeMap<Denom, Uint128>,
 }

--- a/dango/types/src/lending/market.rs
+++ b/dango/types/src/lending/market.rs
@@ -1,8 +1,6 @@
 use {
-    crate::lending::{InterestRateModel, NAMESPACE, SUBNAMESPACE},
-    grug::{
-        Denom, MathResult, Number, NumberConst, StdResult, Timestamp, Udec128, Udec256, Uint128,
-    },
+    crate::lending::InterestRateModel,
+    grug::{MathResult, Number, NumberConst, StdResult, Timestamp, Udec128, Uint128},
 };
 
 /// Seconds in a year, assuming 365 days.
@@ -11,17 +9,17 @@ pub const SECONDS_PER_YEAR: u128 = 31536000;
 /// Configurations and state of a market.
 #[grug::derive(Serde, Borsh)]
 pub struct Market {
-    /// The LP token denom that is minted when coins are deposited on the supply
-    /// side.
-    pub supply_lp_denom: Denom,
     /// The current interest rate model of this market.
     pub interest_rate_model: InterestRateModel,
-    /// The total amount of coins borrowed from this market scaled by the
+    /// The total amount of coins borrowed from this market, scaled by the
     /// borrow index.
-    pub total_borrowed_scaled: Udec256,
+    pub total_borrowed_scaled: Uint128,
     /// The current borrow index of this market. This is used to calculate the
     /// interest accrued on borrows.
     pub borrow_index: Udec128,
+    /// The total amount of coins supplied to this market, scaled by the supply
+    /// index.
+    pub total_supplied_scaled: Uint128,
     /// The current supply index of this market. This is used to calculate the
     /// interest accrued on deposits.
     pub supply_index: Udec128,
@@ -32,36 +30,15 @@ pub struct Market {
 }
 
 impl Market {
-    pub fn new(
-        underlying_denom: &Denom,
-        interest_rate_model: InterestRateModel,
-    ) -> StdResult<Self> {
+    pub fn new(interest_rate_model: InterestRateModel) -> StdResult<Self> {
         Ok(Self {
-            supply_lp_denom: underlying_denom.prepend(&[&NAMESPACE, &SUBNAMESPACE])?,
             interest_rate_model,
-            total_borrowed_scaled: Udec256::ZERO,
+            total_borrowed_scaled: Uint128::ZERO,
             borrow_index: Udec128::ONE,
+            total_supplied_scaled: Uint128::ZERO,
             supply_index: Udec128::ONE,
             last_update_time: Timestamp::ZERO,
             pending_protocol_fee_scaled: Uint128::ZERO,
-        })
-    }
-
-    /// Immutably adds the given amount to the scaled total borrowed and returns
-    /// the new market state.
-    pub fn add_borrowed(self, amount_scaled: Udec256) -> MathResult<Self> {
-        Ok(Self {
-            total_borrowed_scaled: self.total_borrowed_scaled.checked_add(amount_scaled)?,
-            ..self
-        })
-    }
-
-    /// Immutably deducts the given amount from the scaled total borrowed and
-    /// returns the new market state.
-    pub fn deduct_borrowed(self, amount_scaled: Udec256) -> MathResult<Self> {
-        Ok(Self {
-            total_borrowed_scaled: self.total_borrowed_scaled.checked_sub(amount_scaled)?,
-            ..self
         })
     }
 

--- a/dango/types/src/lending/msg.rs
+++ b/dango/types/src/lending/msg.rs
@@ -1,15 +1,8 @@
 use {
     crate::lending::{InterestRateModel, Market},
-    grug::{Addr, Coins, Denom, NonEmpty, Part},
-    std::{collections::BTreeMap, sync::LazyLock},
+    grug::{Addr, Coins, Denom, NonEmpty},
+    std::collections::BTreeMap,
 };
-
-/// The namespace that tokens associated with lending will be minted under.
-/// The lending contract must be granted admin power over this namespace.
-pub static NAMESPACE: LazyLock<Part> = LazyLock::new(|| Part::new_unchecked("lending"));
-
-/// Sub-namespace that liquidity share tokens will be minted under.
-pub static SUBNAMESPACE: LazyLock<Part> = LazyLock::new(|| Part::new_unchecked("pool"));
 
 #[grug::derive(Serde)]
 pub struct InstantiateMsg {
@@ -23,9 +16,8 @@ pub enum ExecuteMsg {
     /// Deposit tokens into the lending pool.
     /// Sender must attach one or more supported tokens and nothing else.
     Deposit {},
-    /// Withdraw tokens from the lending pool by redeeming LP tokens.
-    /// Sender must attach one or more LP tokens and nothing else.
-    Withdraw {},
+    /// Withdraw tokens from the lending pool.
+    Withdraw(NonEmpty<Coins>),
     /// Borrow coins from the lending pool.
     /// Sender must be a margin account.
     Borrow(NonEmpty<Coins>),
@@ -47,19 +39,22 @@ pub enum QueryMsg {
         start_after: Option<Denom>,
         limit: Option<u32>,
     },
-    /// Query the debt of a single margin account.
+    /// Query the deposit of a single lender.
+    #[returns(Coins)]
+    Asset { account: Addr },
+    /// Enumerate deposits of all lenders.
+    #[returns(BTreeMap<Addr, Coins>)]
+    Assets {
+        start_after: Option<Addr>,
+        limit: Option<u32>,
+    },
+    /// Query the debt of a single borrower.
     #[returns(Coins)]
     Debt { account: Addr },
-    /// Enumerate debts of all margin accounts.
+    /// Enumerate debts of all borrowers.
     #[returns(BTreeMap<Addr, Coins>)]
     Debts {
         start_after: Option<Addr>,
         limit: Option<u32>,
     },
-    /// Converts the supplied amount of underlying tokens to LP tokens.
-    #[returns(Coins)]
-    SimulateDeposit { underlying: Coins },
-    /// Converts the supplied amount of LP tokens to the underlying tokens.
-    #[returns(Coins)]
-    SimulateWithdraw { lp_tokens: Coins },
 }


### PR DESCRIPTION
1. Use `Uint128` instead of `Udec256` for scaled debt amount.

2. Do not tokenize LP tokens; store scaled deposit amounts in the contract instead, same as debts.

   Reason 1 is related to the `ExecuteMsg::Withdraw` API. Currently we withdraw by sending LP tokens to the contract. This means we can't withdraw an exact amount of underlying tokens. Let's say I want to withdraw 100 USDC. The frontend computes 100 USDC equals 99.9 LP tokens. When the tx confirms, 99.9 LP tokens may no longer equal 100 USDC, so I get a different amount. This is bad UX.

   Reason 2 is, by putting scaled deposit amounts in the contract, we can have highly symmetrical logics between deposit<>borrow, and withdraw<>repay, which is good.

3. In deposit/withdraw/borrow/repay, we first convert the scaled amount to underlying amount, perform the addition/subtraction on the underlying amount, then convert back to scaled amount.

   This allows us to use the same rounding logic when converting between scaled and underlying amounts. For deposits we always round down; for debts we always round up. I introduced a `core::scaling` submodule that handles this.

Apparently, with these changes, the `compute_health` logic in margin account needs to be changed, as well as the LP token price source on the oracle contract. Tests need to be updated as well.