### PR TITLE
feat(dango): ethereum chain_id for authentication compatibility

### DIFF
--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -1,7 +1,7 @@
 use {
     alloy::{
         dyn_abi::{Eip712Domain, TypedData},
-        primitives::{U160, address},
+        primitives::{U160, U256, address},
     },
     anyhow::{bail, ensure},
     base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD},
@@ -310,6 +310,10 @@ pub fn verify_signature(
                 resolver,
                 domain: Eip712Domain {
                     name: domain.name,
+                    // The EIP-712 standard requires the `chainId` field
+                    // in the domain. Some wallets enforce this requirement.
+                    // We use ethereum chainId (1) EIP-155 for compatibility.
+                    chain_id: Some(U256::from(1)),
                     verifying_contract,
                     ..Default::default()
                 },
@@ -505,7 +509,7 @@ mod tests {
 
     #[test]
     fn eip712_authentication() {
-        let user_address = Addr::from_str("0xb66227cf4ea800b6b19aed198395fd0a2d80ee1d").unwrap();
+        let user_address = Addr::from_str("0x385a97faeabe4adc6c5bcac2ff3627e60ba23b50").unwrap();
         let user_username = Username::from_str("javier").unwrap();
         let user_keyhash =
             Hash256::from_str("7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165")
@@ -543,28 +547,18 @@ mod tests {
               "key_hash": "7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165",
               "signature": {
                 "eip712": {
-                  "sig": "4h1wRoW6SJ1ZbVEp8DIwnJ5OV24QUdyGDOrney+Qbc0/PoTTi5wXRvN/LjB+iuGliyK08DGwu1udd8W3m385NRw=",
-                  "typed_data": "eyJ0eXBlcyI6eyJFSVA3MTJEb21haW4iOlt7Im5hbWUiOiJuYW1lIiwidHlwZSI6InN0cmluZyJ9LHsibmFtZSI6InZlcmlmeWluZ0NvbnRyYWN0IiwidHlwZSI6ImFkZHJlc3MifV0sIk1lc3NhZ2UiOlt7Im5hbWUiOiJzZW5kZXIiLCJ0eXBlIjoiYWRkcmVzcyJ9LHsibmFtZSI6ImRhdGEiLCJ0eXBlIjoiTWV0YWRhdGEifSx7Im5hbWUiOiJnYXNfbGltaXQiLCJ0eXBlIjoidWludDMyIn0seyJuYW1lIjoibWVzc2FnZXMiLCJ0eXBlIjoiVHhNZXNzYWdlW10ifV0sIk1ldGFkYXRhIjpbeyJuYW1lIjoidXNlcm5hbWUiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiY2hhaW5faWQiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoibm9uY2UiLCJ0eXBlIjoidWludDMyIn1dLCJUeE1lc3NhZ2UiOlt7Im5hbWUiOiJ0cmFuc2ZlciIsInR5cGUiOiJUcmFuc2ZlciJ9XSwiVHJhbnNmZXIiOlt7Im5hbWUiOiIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiLCJ0eXBlIjoiQ29pbjAifV0sIkNvaW4wIjpbeyJuYW1lIjoiaHlwL2V0aC91c2RjIiwidHlwZSI6InN0cmluZyJ9XX0sInByaW1hcnlUeXBlIjoiTWVzc2FnZSIsImRvbWFpbiI6eyJuYW1lIjoiZGFuZ28iLCJ2ZXJpZnlpbmdDb250cmFjdCI6IjB4YjY2MjI3Y2Y0ZWE4MDBiNmIxOWFlZDE5ODM5NWZkMGEyZDgwZWUxZCJ9LCJtZXNzYWdlIjp7InNlbmRlciI6IjB4YjY2MjI3Y2Y0ZWE4MDBiNmIxOWFlZDE5ODM5NWZkMGEyZDgwZWUxZCIsImRhdGEiOnsiY2hhaW5faWQiOiJkZXYtNiIsInVzZXJuYW1lIjoiamF2aWVyIiwibm9uY2UiOjB9LCJnYXNfbGltaXQiOjI0NDgxMzksIm1lc3NhZ2VzIjpbeyJ0cmFuc2ZlciI6eyIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiOnsiaHlwL2V0aC91c2RjIjoiMTAwMDAwMCJ9fX1dfX0="
+                  "sig": "cpcxIOxKLlBx2QongOl+8LbntUx7YR6mQIcmsT9fvngwfGesFvEaHYPOh4namgfXKlipm7OSoJWdUaw7fdFGJBw=",
+                  "typed_data": "eyJ0eXBlcyI6eyJFSVA3MTJEb21haW4iOlt7Im5hbWUiOiJuYW1lIiwidHlwZSI6InN0cmluZyJ9LHsibmFtZSI6ImNoYWluSWQiLCJ0eXBlIjoidWludDI1NiJ9LHsibmFtZSI6InZlcmlmeWluZ0NvbnRyYWN0IiwidHlwZSI6ImFkZHJlc3MifV0sIk1lc3NhZ2UiOlt7Im5hbWUiOiJzZW5kZXIiLCJ0eXBlIjoiYWRkcmVzcyJ9LHsibmFtZSI6ImRhdGEiLCJ0eXBlIjoiTWV0YWRhdGEifSx7Im5hbWUiOiJnYXNfbGltaXQiLCJ0eXBlIjoidWludDMyIn0seyJuYW1lIjoibWVzc2FnZXMiLCJ0eXBlIjoiVHhNZXNzYWdlW10ifV0sIk1ldGFkYXRhIjpbeyJuYW1lIjoidXNlcm5hbWUiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiY2hhaW5faWQiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoibm9uY2UiLCJ0eXBlIjoidWludDMyIn1dLCJUeE1lc3NhZ2UiOlt7Im5hbWUiOiJ0cmFuc2ZlciIsInR5cGUiOiJUcmFuc2ZlciJ9XSwiVHJhbnNmZXIiOlt7Im5hbWUiOiIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiLCJ0eXBlIjoiQ29pbjAifV0sIkNvaW4wIjpbeyJuYW1lIjoiaHlwL2V0aC91c2RjIiwidHlwZSI6InN0cmluZyJ9XX0sInByaW1hcnlUeXBlIjoiTWVzc2FnZSIsImRvbWFpbiI6eyJuYW1lIjoiZGFuZ28iLCJjaGFpbklkIjoxLCJ2ZXJpZnlpbmdDb250cmFjdCI6IjB4Mzg1YTk3ZmFlYWJlNGFkYzZjNWJjYWMyZmYzNjI3ZTYwYmEyM2I1MCJ9LCJtZXNzYWdlIjp7InNlbmRlciI6IjB4Mzg1YTk3ZmFlYWJlNGFkYzZjNWJjYWMyZmYzNjI3ZTYwYmEyM2I1MCIsImRhdGEiOnsiY2hhaW5faWQiOiJkZXYtNiIsInVzZXJuYW1lIjoiamF2aWVyIiwibm9uY2UiOjB9LCJnYXNfbGltaXQiOjI0NDgxMzksIm1lc3NhZ2VzIjpbeyJ0cmFuc2ZlciI6eyIweDMzMzYxZGU0MjU3MWQ2YWEyMGMzN2RhYTZkYTRiNWFiNjdiZmFhZDkiOnsiaHlwL2V0aC91c2RjIjoiMTAwMDAwMCJ9fX1dfX0="
                 }
               }
             }
           },
-          "data": {
-            "chain_id": "dev-6",
-            "nonce": 0,
-            "username": "javier"
-          },
+          "data": { "chain_id": "dev-6", "nonce": 0, "username": "javier" },
           "gas_limit": 2448139,
           "msgs": [
-            {
-              "transfer": {
-                "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9": {
-                  "hyp/eth/usdc": "1000000"
-                }
-              }
-            }
+            { "transfer": { "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9": { "hyp/eth/usdc": "1000000" } } }
           ],
-          "sender": "0xb66227cf4ea800b6b19aed198395fd0a2d80ee1d"
+          "sender": "0x385a97faeabe4adc6c5bcac2ff3627e60ba23b50"
         }"#;
 
         authenticate_tx(ctx.as_auth(), tx.deserialize_json::<Tx>().unwrap(), None).should_succeed();
@@ -734,7 +728,7 @@ mod tests {
 
     #[test]
     fn session_key_with_eip712_authentication() {
-        let user_address = Addr::from_str("0x632b2917552dc07fca89d285d6108ae1d1229771").unwrap();
+        let user_address = Addr::from_str("0x385a97faeabe4adc6c5bcac2ff3627e60ba23b50").unwrap();
         let user_username = Username::from_str("javier").unwrap();
         let user_keyhash =
             Hash256::from_str("7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165")
@@ -774,16 +768,16 @@ mod tests {
                 "key_hash": "7D8FB7895BEAE0DF16E3E5F6FA7EB10CDE735E5B7C9A79DFCD8DD32A6BDD2165",
                 "signature": {
                   "eip712": {
-                    "sig": "6P23dAiy3wW/c3c89cuNX7W86M0o33HKo/XE/2R03Okr/+dZmClCh6COg4Jt+lGRo0dJyN48LgSpobP9O9vm6xs=",
-                    "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSIsInZlcmlmeWluZ0NvbnRyYWN0IjoiMHgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm1lc3NhZ2UiOnsic2Vzc2lvbl9rZXkiOiJBMW51SWtwOXB6R0RaQXFBL1Z4S1U2a2tyNXpvWmNrZzRVL2FtVW9EUGVsaCIsImV4cGlyZV9hdCI6IjE3NDM3OTc5NjU1MjMifSwicHJpbWFyeVR5cGUiOiJNZXNzYWdlIiwidHlwZXMiOnsiRUlQNzEyRG9tYWluIjpbeyJuYW1lIjoibmFtZSIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJ2ZXJpZnlpbmdDb250cmFjdCIsInR5cGUiOiJhZGRyZXNzIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoic2Vzc2lvbl9rZXkiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiZXhwaXJlX2F0IiwidHlwZSI6InN0cmluZyJ9XX19"
+                    "sig": "SQvtngWCBODJSQuLloFTFK/QFRV0qGq0UTYs/4u/j8xhItf7R5Y2Is74XxlCwC+lCvHk1B0e6Sfdt8TQc8SNWRw=",
+                    "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSIsImNoYWluSWQiOjEsInZlcmlmeWluZ0NvbnRyYWN0IjoiMHgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm1lc3NhZ2UiOnsic2Vzc2lvbl9rZXkiOiJBN0V5TThVMXVmOHlna3pwNHMrdVZ1djQ0ZStUdFVqdE9qQVczSHphNk96dCIsImV4cGlyZV9hdCI6IjE3NDU1OTY3MTYzODMifSwicHJpbWFyeVR5cGUiOiJNZXNzYWdlIiwidHlwZXMiOnsiRUlQNzEyRG9tYWluIjpbeyJuYW1lIjoibmFtZSIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJjaGFpbklkIiwidHlwZSI6InVpbnQyNTYifSx7Im5hbWUiOiJ2ZXJpZnlpbmdDb250cmFjdCIsInR5cGUiOiJhZGRyZXNzIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoic2Vzc2lvbl9rZXkiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiZXhwaXJlX2F0IiwidHlwZSI6InN0cmluZyJ9XX19"
                   }
                 }
               },
               "session_info": {
-                "expire_at": "1743797965523",
-                "session_key": "A1nuIkp9pzGDZAqA/VxKU6kkr5zoZckg4U/amUoDPelh"
+                "expire_at": "1745596716383",
+                "session_key": "A7EyM8U1uf8ygkzp4s+uVuv44e+TtUjtOjAW3Hza6Ozt"
               },
-              "session_signature": "s8ogzBV5zMy+zR742gYfykg8x1IfAavliQE3DlnOgRoIzSNhyItHXcL2TDzOV+v9YnLMHYnDlHVMyruNEDjT3g=="
+              "session_signature": "l/NvC8O4fXo32avZppBL8ICO39QEdQijYu9AVKLQLGB0iXSxfp/vb8JWWvMNnKlivDNoTlGHpgVFQysl6IJc4g=="
             }
           },
           "data": {
@@ -801,7 +795,7 @@ mod tests {
               }
             }
           ],
-          "sender": "0x632b2917552dc07fca89d285d6108ae1d1229771"
+          "sender": "0x385a97faeabe4adc6c5bcac2ff3627e60ba23b50"
         }"#;
 
         authenticate_tx(ctx.as_auth(), tx.deserialize_json::<Tx>().unwrap(), None).should_succeed();
@@ -818,8 +812,8 @@ mod tests {
 
         let signature = r#"{
           "eip712": {
-            "sig": "S+o4kpODT5h+ZDIf9w52j0UzaWASEdel7loxoWR5iWUM7SIAXAJXKEQAjZHeoerKESImMkhgYD4AIvlf4H/5pRw=",
-            "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSIsInZlcmlmeWluZ0NvbnRyYWN0IjoiMHgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm1lc3NhZ2UiOnsidXNlcm5hbWUiOiJqYXZpZXJfdGVzdCIsImNoYWluX2lkIjoiZGV2LTYifSwicHJpbWFyeVR5cGUiOiJNZXNzYWdlIiwidHlwZXMiOnsiRUlQNzEyRG9tYWluIjpbeyJuYW1lIjoibmFtZSIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJ2ZXJpZnlpbmdDb250cmFjdCIsInR5cGUiOiJhZGRyZXNzIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoidXNlcm5hbWUiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiY2hhaW5faWQiLCJ0eXBlIjoic3RyaW5nIn1dfX0="
+            "sig": "ZmeW546igJejAskWXr/2o0WhOgpDbNlTiBnScGeNHLdDlS5qSpTtkTkffnMxLYTCfQ900RtNs+oV8zmfNtveDxs=",
+            "typed_data": "eyJkb21haW4iOnsibmFtZSI6IkRhbmdvQXJiaXRyYXJ5TWVzc2FnZSIsImNoYWluSWQiOjEsInZlcmlmeWluZ0NvbnRyYWN0IjoiMHgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIn0sIm1lc3NhZ2UiOnsidXNlcm5hbWUiOiJqYXZpZXJfdGVzdCIsImNoYWluX2lkIjoiZGV2LTYifSwicHJpbWFyeVR5cGUiOiJNZXNzYWdlIiwidHlwZXMiOnsiRUlQNzEyRG9tYWluIjpbeyJuYW1lIjoibmFtZSIsInR5cGUiOiJzdHJpbmcifSx7Im5hbWUiOiJjaGFpbklkIiwidHlwZSI6InVpbnQyNTYifSx7Im5hbWUiOiJ2ZXJpZnlpbmdDb250cmFjdCIsInR5cGUiOiJhZGRyZXNzIn1dLCJNZXNzYWdlIjpbeyJuYW1lIjoidXNlcm5hbWUiLCJ0eXBlIjoic3RyaW5nIn0seyJuYW1lIjoiY2hhaW5faWQiLCJ0eXBlIjoic3RyaW5nIn1dfX0="
           }
         }"#.deserialize_json::<Signature>().unwrap();
 

--- a/dango/auth/src/lib.rs
+++ b/dango/auth/src/lib.rs
@@ -578,8 +578,7 @@ mod tests {
             }
           ],
           "sender": "0x385a97faeabe4adc6c5bcac2ff3627e60ba23b50"
-        }
-        "#;
+        }"#;
 
         authenticate_tx(ctx.as_auth(), tx.deserialize_json::<Tx>().unwrap(), None).should_succeed();
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces Ethereum's EIP-155 chain ID for EIP-712 compatibility in Dango's authentication, updating relevant tests.
> 
>   - **Behavior**:
>     - Introduces `EIP155_CHAIN_ID` constant in `dango/auth/src/lib.rs` for Ethereum mainnet compatibility.
>     - Updates `verify_signature()` to use Ethereum's EIP-155 chain ID (0x1) for EIP-712 domain compatibility.
>   - **Tests**:
>     - Updates `eip712_authentication()` and `session_key_with_eip712_authentication()` tests to reflect new chain ID usage.
>     - Modifies test data in `eip712_authentication()` and `session_key_with_eip712_authentication()` to use updated signatures and addresses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b6b7ec3af94ec7de3a922fd63618ce4fd640a2e9. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->