### PR TITLE
feat(ui): eip-712 ethereum chain_id

### DIFF
--- a/sdk/dango/src/actions/app/mutations/signAndBroadcastTx.ts
+++ b/sdk/dango/src/actions/app/mutations/signAndBroadcastTx.ts
@@ -56,6 +56,7 @@ export async function signAndBroadcastTx<transport extends Transport>(
 
   const domain = {
     name: "dango",
+    chainId: 1,
     verifyingContract: sender,
   };
 

--- a/sdk/dango/src/types/typedData.ts
+++ b/sdk/dango/src/types/typedData.ts
@@ -35,6 +35,7 @@ export type SolidityTypes =
 
 export type DomainType = [
   { name: "name"; type: "string" },
+  { name: "chainId"; type: "uint256" },
   { name: "verifyingContract"; type: "address" },
 ];
 
@@ -81,6 +82,7 @@ export type EIP712Message = {
 
 export type EIP712Domain = {
   name: string;
+  chainId: number;
   verifyingContract: Address;
 };
 

--- a/sdk/dango/src/utils/typedData.ts
+++ b/sdk/dango/src/utils/typedData.ts
@@ -41,6 +41,7 @@ export function composeArbitraryTypedData(parameters: ArbitraryTypedData) {
   return {
     domain: {
       name: "DangoArbitraryMessage",
+      chainId: 1,
       verifyingContract: "0x0000000000000000000000000000000000000000",
     },
     message: recursiveTransform(message, camelToSnake) as Record<string, unknown>,
@@ -48,6 +49,7 @@ export function composeArbitraryTypedData(parameters: ArbitraryTypedData) {
     types: {
       EIP712Domain: [
         { name: "name", type: "string" },
+        { name: "chainId", type: "uint256" },
         { name: "verifyingContract", type: "address" },
       ],
       ...types,
@@ -75,6 +77,7 @@ export function composeTxTypedData(
     types: {
       EIP712Domain: [
         { name: "name", type: "string" },
+        { name: "chainId", type: "uint256" },
         { name: "verifyingContract", type: "address" },
       ],
       Message: [

--- a/ui/portal/web/src/components/auth/Signup.tsx
+++ b/ui/portal/web/src/components/auth/Signup.tsx
@@ -293,11 +293,11 @@ const Username: React.FC = () => {
         });
         if (!("standard" in credential)) throw new Error("error: signed with wrong credential");
 
-        /*  const response = await fetch(
+        const response = await fetch(
           `${import.meta.env.PUBLIC_FAUCET_URI || "https://devnet.dango.exchange/faucet"}/mint/${address}`,
         );
         if (!response.ok) throw new Error(m["signup.errors.failedSendingFunds"]());
- */
+
         await registerUser(client, {
           key,
           keyHash,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add EIP-712 `chainId` support to transaction signing and typed data, and enable fund minting in signup.
> 
>   - **EIP-712 Support**:
>     - Add `chainId` to `domain` in `signAndBroadcastTx()` in `signAndBroadcastTx.ts`.
>     - Add `chainId` to `DomainType` and `EIP712Domain` in `typedData.ts`.
>     - Add `chainId` to `domain` in `composeArbitraryTypedData()` and `composeTxTypedData()` in `typedData.ts`.
>   - **UI Changes**:
>     - Uncomment `fetch` call in `Signup.tsx` to enable fund minting during signup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 6fb333f78057f77001f6f61f580366945d2a6898. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->