### PR TITLE
feat: add variants to tabs component

### DIFF
--- a/ui/applets/kit/src/components/Tabs.stories.tsx
+++ b/ui/applets/kit/src/components/Tabs.stories.tsx
@@ -29,6 +29,8 @@ const meta: Meta<typeof Tabs> = {
   args: {
     keys: ["Token", "Pools", "Earn"],
     defaultKey: "Pools",
+    color: "green",
+    fullWidth: false,
   },
   parameters: {
     layout: "centered",

--- a/ui/applets/kit/src/components/Tabs.stories.tsx
+++ b/ui/applets/kit/src/components/Tabs.stories.tsx
@@ -5,6 +5,11 @@ const meta: Meta<typeof Tabs> = {
   title: "Design System/Foundation/Tabs",
   component: Tabs,
   argTypes: {
+    color: {
+      options: ["green", "light-green", "line-red"],
+      control: { type: "select" },
+      description: "The colors of the tabs.",
+    },
     keys: {
       control: { type: "object" },
       description: "The keys of the Tabs.",
@@ -12,6 +17,9 @@ const meta: Meta<typeof Tabs> = {
     defaultKey: {
       control: { type: "text" },
       description: "The default key of the Tabs.",
+    },
+    fullWidth: {
+      control: { type: "boolean" },
     },
     onTabChange: {
       action: "onTabChange",

--- a/ui/applets/kit/src/components/Tabs.tsx
+++ b/ui/applets/kit/src/components/Tabs.tsx
@@ -2,16 +2,17 @@ import { motion } from "framer-motion";
 import { Children, cloneElement } from "react";
 import { useControlledState } from "#hooks/useControlledState.js";
 import { twMerge } from "#utils/twMerge.js";
+import { tv } from "tailwind-variants";
 
 import type React from "react";
 import type { PropsWithChildren } from "react";
+import type { VariantProps } from "tailwind-variants";
 
-export interface TabsProps {
+export interface TabsProps extends VariantProps<typeof tabsVariants> {
   onTabChange?: (tab: string) => void;
   defaultKey?: string;
   keys?: string[];
   selectedTab?: string;
-  fullWidth?: boolean;
   layoutId: string;
 }
 
@@ -23,6 +24,7 @@ export const Tabs: React.FC<PropsWithChildren<TabsProps>> = ({
   defaultKey,
   fullWidth,
   layoutId,
+  color,
 }) => {
   const tabs = keys ? keys : Children.toArray(children);
   const [activeTab, setActiveTab] = useControlledState(selectedTab, onTabChange, () => {
@@ -34,14 +36,13 @@ export const Tabs: React.FC<PropsWithChildren<TabsProps>> = ({
     return "";
   });
 
+  const styles = tabsVariants({
+    fullWidth,
+    color,
+  });
+
   return (
-    <motion.div
-      layoutId={layoutId}
-      className={twMerge(
-        "flex text-base relative items-center w-fit bg-green-bean-200 p-1 rounded-md",
-        { "w-full": fullWidth },
-      )}
-    >
+    <motion.div layoutId={layoutId} className={twMerge(styles.base())}>
       {tabs.map((e, i) => {
         const isKey = typeof e === "string";
         const elemKey = isKey ? e : (e as React.ReactElement).props.title;
@@ -49,23 +50,23 @@ export const Tabs: React.FC<PropsWithChildren<TabsProps>> = ({
 
         return (
           <motion.button
-            className={twMerge(
-              "relative capitalize transition-all flex items-center justify-center py-2 px-4 cursor-pointer",
-              { "flex-1": fullWidth },
-            )}
+            className={twMerge(styles.button(), { "flex-1": fullWidth })}
             key={`navLink-${e}`}
             onClick={() => setActiveTab(elemKey)}
           >
             {isKey ? (
-              <Tab key={elemKey} title={elemKey} isActive={isActive} />
+              <Tab
+                key={elemKey}
+                title={elemKey}
+                isActive={isActive}
+                color={color}
+                fullWidth={fullWidth}
+              />
             ) : (
               cloneElement(e as React.ReactElement, { isActive })
             )}
             {isActive ? (
-              <motion.div
-                className="w-full h-full rounded-[10px] bg-green-bean-50 absolute bottom-0 left-0 [box-shadow:0px_4px_6px_2px_#1919191F]"
-                layoutId="active"
-              />
+              <motion.div className={twMerge(styles["animated-element"]())} layoutId="active" />
             ) : null}
           </motion.button>
         );
@@ -74,20 +75,114 @@ export const Tabs: React.FC<PropsWithChildren<TabsProps>> = ({
   );
 };
 
-export interface TabProps {
+const tabsVariants = tv({
+  slots: {
+    base: "flex text-base relative items-center w-fit  p-1 rounded-md",
+    button:
+      "relative capitalize transition-all flex items-center justify-center py-2 px-4 cursor-pointer",
+    "animated-element": "absolute bottom-0 left-0",
+  },
+  variants: {
+    color: {
+      green: {
+        base: "bg-green-bean-200",
+        "animated-element":
+          "bg-green-bean-50 [box-shadow:0px_4px_6px_2px_#1919191F] w-full h-full rounded-[10px]",
+      },
+      "light-green": {
+        base: "bg-green-bean-100",
+        "animated-element":
+          "bg-green-bean-400 [box-shadow:0px_4px_6px_2px_#1919191F] w-full h-full rounded-[10px]",
+      },
+      "line-red": {
+        base: "",
+        button: "border-b-[1px] border-gray-100",
+        "animated-element": "bg-red-bean-400 w-full h-[2px] bottom-[-1px]",
+      },
+    },
+    fullWidth: {
+      true: "w-full",
+      false: "",
+    },
+  },
+
+  defaultVariants: {
+    fullWidth: false,
+    color: "green",
+  },
+});
+
+export interface TabProps extends VariantProps<typeof tabVariants> {
   title: string;
-  isActive?: boolean;
 }
 
-export const Tab: React.FC<PropsWithChildren<TabProps>> = ({ isActive, title, children }) => {
-  return (
-    <p
-      className={twMerge(
-        "italic font-medium font-exposure transition-all relative z-10",
-        isActive ? "text-black" : "text-gray-300",
-      )}
-    >
-      {children ? children : title}
-    </p>
-  );
+export const Tab: React.FC<PropsWithChildren<TabProps>> = ({
+  isActive,
+  color,
+  fullWidth,
+  title,
+  children,
+}) => {
+  const styles = tabVariants({
+    color,
+    isActive,
+    fullWidth,
+  });
+  return <p className={twMerge(styles)}>{children ? children : title}</p>;
 };
+
+const tabVariants = tv({
+  base: "italic font-medium font-exposure transition-all relative z-10",
+  variants: {
+    color: {
+      green: "",
+      "light-green": "",
+      "line-red": "",
+    },
+    fullWidth: {
+      true: "flex-1",
+      false: "",
+    },
+    isActive: {
+      true: "",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    fullWidth: false,
+    color: "green",
+    isActive: false,
+  },
+  compoundVariants: [
+    {
+      isActive: true,
+      color: "green",
+      class: "text-black",
+    },
+    {
+      isActive: false,
+      color: "green",
+      class: "text-gray-300",
+    },
+    {
+      isActive: true,
+      color: "light-green",
+      class: "text-white-100",
+    },
+    {
+      isActive: false,
+      color: "light-green",
+      class: "text-gray-300",
+    },
+    {
+      isActive: true,
+      color: "line-red",
+      class: "text-red-bean-400",
+    },
+    {
+      isActive: false,
+      color: "line-red",
+      class: "text-gray-300",
+    },
+  ],
+});


### PR DESCRIPTION
Added color variants to the Tabs component
Three color variants have been added to the Tabs component to match the styles defined in Figma:
- "green"
- "light-green" 
- "line-red"

These variants apply specific styles to the tab container and animated indicator, making the component more visually adaptable.

<img width="313" alt="image" src="https://github.com/user-attachments/assets/b6cda647-e341-479a-8829-e81bdc15e477" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds color variants "green", "light-green", and "line-red" to the `Tabs` component, updating styles and stories accordingly.
> 
>   - **Behavior**:
>     - Adds color variants "green", "light-green", and "line-red" to `Tabs` component in `Tabs.tsx`.
>     - Updates `Tabs` to apply styles based on `color` and `fullWidth` props using `tabsVariants`.
>     - Default color set to "green".
>   - **Stories**:
>     - Updates `Tabs.stories.tsx` to include `color` prop with options "green", "light-green", "line-red".
>     - Sets default `color` to "green" in story args.
>   - **Styles**:
>     - Defines `tabsVariants` and `tabVariants` in `Tabs.tsx` for styling based on `color` and `fullWidth`.
>     - Adds compound variants for active/inactive states and color combinations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e437b1505f04eed005332a52070b8c1efc90e511. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->