### PR TITLE
refactor(dango): make bank `mint,burn,force_transfer` methods batched

### DIFF
--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -20,7 +20,7 @@ use {
         Addr, Coin, CoinPair, Coins, Denom, EventBuilder, GENESIS_SENDER, Inner, IsZero, Message,
         MultiplyFraction, MutableCtx, NonZero, Number, NumberConst, Order as IterationOrder,
         QuerierExt, QuerierWrapper, Response, StdResult, Storage, StorageQuerier, SudoCtx, Udec128,
-        Uint128, UniqueVec,
+        Uint128, UniqueVec, coins,
     },
     std::collections::{BTreeMap, BTreeSet, HashMap, hash_map::Entry},
 };
@@ -301,8 +301,7 @@ fn provide_liquidity(
             bank,
             &bank::ExecuteMsg::Mint {
                 to: ctx.sender,
-                denom: pair.lp_denom,
-                amount: lp_mint_amount,
+                coins: coins! { pair.lp_denom => lp_mint_amount },
             },
             Coins::new(), // No funds needed for minting
         )?
@@ -351,8 +350,7 @@ fn withdraw_liquidity(
                 bank,
                 &bank::ExecuteMsg::Burn {
                     from: ctx.contract,
-                    denom: pair.lp_denom,
-                    amount: lp_burn_amount,
+                    coins: coins! { pair.lp_denom => lp_burn_amount },
                 },
                 Coins::new(), // No funds needed for burning
             )?

--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -8,6 +8,7 @@ use {
     grug::{
         Addr, AuthCtx, AuthMode, Coins, ContractEvent, IsZero, Message, MultiplyFraction,
         MutableCtx, Number, NumberConst, QuerierExt, Response, StdResult, Tx, TxOutcome, Uint128,
+        coins,
     },
     std::collections::BTreeMap,
 };
@@ -113,8 +114,7 @@ pub fn withhold_fee(ctx: AuthCtx, tx: Tx) -> StdResult<Response> {
             &bank::ExecuteMsg::ForceTransfer {
                 from: tx.sender,
                 to: ctx.contract,
-                denom: fee_cfg.fee_denom.clone(),
-                amount: withhold_amount,
+                coins: coins! { fee_cfg.fee_denom.clone() => withhold_amount },
             },
             Coins::new(),
         )?)
@@ -159,8 +159,7 @@ pub fn finalize_fee(ctx: AuthCtx, tx: Tx, outcome: TxOutcome) -> StdResult<Respo
             &bank::ExecuteMsg::ForceTransfer {
                 from: ctx.contract,
                 to: tx.sender,
-                denom: fee_cfg.fee_denom,
-                amount: refund_amount,
+                coins: coins! { fee_cfg.fee_denom.clone() => refund_amount },
             },
             Coins::new(),
         )?)

--- a/dango/testing/tests/margin.rs
+++ b/dango/testing/tests/margin.rs
@@ -172,20 +172,14 @@ fn mint_coins(
     address: Addr,
     coins: Coins,
 ) {
-    for coin in coins {
-        suite
-            .execute(
-                &mut accounts.owner,
-                contracts.bank,
-                &dango_types::bank::ExecuteMsg::Mint {
-                    to: address,
-                    amount: coin.amount,
-                    denom: coin.denom,
-                },
-                Coins::new(),
-            )
-            .should_succeed();
-    }
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.bank,
+            &dango_types::bank::ExecuteMsg::Mint { to: address, coins },
+            Coins::new(),
+        )
+        .should_succeed();
 }
 
 /// Helper function to register a fixed price for a collateral

--- a/dango/types/src/bank/msgs.rs
+++ b/dango/types/src/bank/msgs.rs
@@ -1,6 +1,6 @@
 use {
     crate::bank::Metadata,
-    grug::{Addr, Coins, Denom, Part, Uint128},
+    grug::{Addr, Coins, Denom, Part},
     std::collections::BTreeMap,
 };
 
@@ -35,29 +35,16 @@ pub enum ExecuteMsg {
     SetMetadata { denom: Denom, metadata: Metadata },
     /// Mint tokens of the specified amount to a recipient.
     /// Can only be called by the namespace owner.
-    Mint {
-        to: Addr,
-        denom: Denom,
-        amount: Uint128,
-    },
+    Mint { to: Addr, coins: Coins },
     /// Burn tokens of the specified amount from an account.
     /// Can only be called by the namespace owner.
-    Burn {
-        from: Addr,
-        denom: Denom,
-        amount: Uint128,
-    },
-    /// Forcily transfer a coin from an account to a receiver.
+    Burn { from: Addr, coins: Coins },
+    /// Forcily transfer coins from an account to a receiver.
     /// Can only be called by the chain's taxman contract.
     /// Used by taxman to withhold pending transaction fees.
     ///
     /// Note: The `receive` method isn't invoked when calling this.
-    ForceTransfer {
-        from: Addr,
-        to: Addr,
-        denom: Denom,
-        amount: Uint128,
-    },
+    ForceTransfer { from: Addr, to: Addr, coins: Coins },
     /// Retrieve funds sent to a non-existing recipient.
     RecoverTransfer { sender: Addr, recipient: Addr },
 }

--- a/dango/warp/src/execute.rs
+++ b/dango/warp/src/execute.rs
@@ -140,8 +140,7 @@ fn transfer_remote(
             cfg.bank,
             &bank::ExecuteMsg::Burn {
                 from: ctx.contract,
-                denom: token.denom.clone(),
-                amount: token.amount,
+                coins: coins! { token.denom.clone() => token.amount },
             },
             Coins::new(),
         )?;
@@ -189,8 +188,7 @@ fn transfer_remote(
                 cfg.bank,
                 &bank::ExecuteMsg::Burn {
                     from: ctx.contract,
-                    denom: token.denom.clone(),
-                    amount: token.amount,
+                    coins: coins! { token.denom.clone() => token.amount },
                 },
                 Coins::new(),
             )?)
@@ -263,8 +261,7 @@ fn handle(
                 bank,
                 &bank::ExecuteMsg::Mint {
                     to: ctx.contract,
-                    denom,
-                    amount: body.amount,
+                    coins: coins! { denom => body.amount },
                 },
                 Coins::new(),
             )?;
@@ -288,8 +285,7 @@ fn handle(
                 bank,
                 &bank::ExecuteMsg::Mint {
                     to: body.recipient.try_into()?,
-                    denom: denom.clone(),
-                    amount: body.amount,
+                    coins: coins! { denom.clone() => body.amount },
                 },
                 Coins::new(),
             )?


### PR DESCRIPTION
Instead of minting/burning/transferring one token at a time, you can now do them in a batch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `mint`, `burn`, and `force_transfer` methods to support batch operations across multiple modules, improving efficiency for token operations.
> 
>   - **Behavior**:
>     - Refactor `mint`, `burn`, and `force_transfer` methods in `dango/bank/src/execute.rs` to support batch operations using `Coins`.
>     - Update `ExecuteMsg` in `dango/types/src/bank/msgs.rs` to use `Coins` for `Mint`, `Burn`, and `ForceTransfer`.
>   - **Dex Module**:
>     - Update `provide_liquidity` and `withdraw_liquidity` in `dango/dex/src/execute.rs` to use batch `Mint` and `Burn` operations.
>   - **Lending Module**:
>     - Modify `deposit`, `withdraw`, and `claim_pending_protocol_fees` in `dango/lending/src/execute.rs` to use batch `Mint` and `Burn` operations.
>   - **Taxman Module**:
>     - Update `withhold_fee` and `finalize_fee` in `dango/taxman/src/execute.rs` to use batch `ForceTransfer` operations.
>   - **Warp Module**:
>     - Adjust `transfer_remote` and `handle` in `dango/warp/src/execute.rs` to use batch `Mint` and `Burn` operations.
>   - **Testing**:
>     - Update `mint_coins` helper function in `dango/testing/tests/margin.rs` to use batch `Mint` operation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 2eeaf08effe9c6885fda6f595078ba1bd81a7da5. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->