### PR TITLE
chore: bump tendermint-rs to 0.40.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9386,8 +9386,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.40.3"
-source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc997743ecfd4864bbca8170d68d9b2bee24653b034210752c2d883ef4b838b1"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -9413,8 +9414,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.40.3"
-source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069d1791f9b02a596abcd26eb72003b2e9906c6169a60fa82ffc080dd3a43fda"
 dependencies = [
  "flex-error",
  "serde",
@@ -9426,8 +9428,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.40.3"
-source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c40e13d39ca19082d8a7ed22de7595979350319833698f8b1080f29620a094"
 dependencies = [
  "bytes",
  "flex-error",
@@ -9440,8 +9443,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.40.3"
-source = "git+https://github.com/left-curve/tendermint-rs.git?rev=2e323c8#2e323c89088394593b4450f4a20f914434ac0ec4"
+version = "0.40.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e0569a4b4cc42ff00df5a665be2858a39ff79df4790b176f1cd0e169bc0fc2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9850,7 +9854,8 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.19.1"
-source = "git+https://github.com/left-curve/tower-abci.git?rev=6ba8190#6ba81903150128456c7c2949ca484972621c4e00"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f20500d25342b86338bc9e053694dd199e9dafbc1044126a54ce378bfbbcfa5"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,8 @@ strum                   = "0.27"
 strum_macros            = "0.27"
 syn                     = "2"
 tempfile                = "3"
-tendermint              = { git = "https://github.com/left-curve/tendermint-rs.git", rev = "2e323c8" } # TODO: https://github.com/informalsystems/tendermint-rs/issues/1500
-tendermint-rpc          = { git = "https://github.com/left-curve/tendermint-rs.git", rev = "2e323c8" } # TODO: https://github.com/informalsystems/tendermint-rs/issues/1500
+tendermint              = "0.40.4"
+tendermint-rpc          = "0.40.4"
 tera                    = "1"
 test-case               = "3"
 thiserror               = "2"
@@ -145,7 +145,7 @@ tokio                   = { version = "1", features = ["full"] }
 tokio-stream            = { version = "0.1", features = ["sync"] }
 toml                    = "0.8"
 tower                   = "0.5"
-tower-abci              = { git = "https://github.com/left-curve/tower-abci.git", rev = "6ba8190" } # TODO: https://github.com/informalsystems/tendermint-rs/issues/1500
+tower-abci              = "0.19"
 tracing                 = "0.1"
 tracing-actix-web       = "0.7"
 tracing-subscriber      = { version = "0.3", features = ["env-filter", "fmt"] }


### PR DESCRIPTION
The bug we found related to deserializing the `ResultBroadcastTx` has been fixed, so no longer necessary to use a fork.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `tendermint`, `tendermint-rpc`, and `tower-abci` dependencies to specific versions from crates.io, removing git commit references.
> 
>   - **Dependencies**:
>     - Update `tendermint` and `tendermint-rpc` from git commit to version `0.40.4` in `Cargo.toml` and `Cargo.lock`.
>     - Update `tower-abci` from git commit to version `0.19` in `Cargo.toml` and `Cargo.lock`.
>   - **Misc**:
>     - Remove references to specific git commits for `tendermint`, `tendermint-rpc`, and `tower-abci` in `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c9e19e0aa173a16fbb7ded0eb1627b1745c51505. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->