### PR TITLE
fix(ui): account menu padding and bg color

### DIFF
--- a/ui/portal/web/src/components/foundation/AccountMenu.tsx
+++ b/ui/portal/web/src/components/foundation/AccountMenu.tsx
@@ -76,7 +76,7 @@ const Menu: React.FC<AccountMenuProps> = ({ backAllowed }) => {
           ) : null}
           <AnimatePresence mode="wait">
             <motion.div
-              className="flex flex-col items-center h-full w-full"
+              className="flex flex-col items-center h-full w-full px-4"
               key={account.address}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
@@ -126,7 +126,7 @@ export const Desktop: React.FC = () => {
     <div
       ref={menuRef}
       className={twMerge(
-        "transition-all lg:absolute fixed top-0 flex h-[92vh] justify-end z-50 duration-300 w-full lg:max-w-[360px] bg-[linear-gradient(90deg,_rgba(0,_0,_0,_0)_3.2%,_rgba(46,_37,_33,_0.1)_19.64%,_rgba(255,_255,_255,_0.1)_93.91%)]",
+        "transition-all lg:absolute fixed top-0 flex h-[92vh] justify-end z-50 duration-300 w-full lg:max-w-[376px] bg-[linear-gradient(90deg,_rgba(0,_0,_0,_0)_3.2%,_rgba(46,_37,_33,_0.1)_19.64%,_rgba(255,_255,_255,_0.1)_93.91%)]",
         isSidebarVisible ? "right-0" : "right-[-50vw]",
         isQuestBannerVisible ? "h-[92vh]" : "h-[100svh]",
       )}

--- a/ui/portal/web/src/components/foundation/SearchMenu.tsx
+++ b/ui/portal/web/src/components/foundation/SearchMenu.tsx
@@ -73,7 +73,7 @@ const SearchMenu: React.FC = () => {
           className={twMerge(
             "flex-col bg-rice-25 rounded-md h-[44px] lg:h-auto w-full flex items-center lg:absolute relative lg:-top-5 flex-1 lg:[box-shadow:0px_2px_6px_0px_#C7C2B666] transition-all duration-300",
             !isLg && isSearchBarVisible
-              ? "h-svh w-screen -left-4 -bottom-4 absolute z-[100] bg-white p-4 gap-4"
+              ? "h-svh w-screen -left-4 -bottom-4 absolute z-[100] bg-white-100 p-4 gap-4"
               : "",
           )}
         >
@@ -163,7 +163,7 @@ const Body: React.FC<SearchMenuBodyProps> = ({ isVisible, hideMenu, searchResult
           className="menu w-full overflow-hidden"
         >
           <motion.div
-            className="p-1 w-full flex items-center flex-col gap-1"
+            className="lg:p-1 w-full flex items-center flex-col gap-1"
             variants={{
               hidden: {},
               visible: {


### PR DESCRIPTION
Fixes included in this PR:

- Increased top padding on the Account sidebar to better balance with left/right padding LEF-76
- Adjusted right padding for the mobile Search bar
- Updated mobile Search bar background to white-100
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI style adjustments in `AccountMenu.tsx` and `SearchMenu.tsx` for improved padding and background consistency.
> 
>   - **AccountMenu.tsx**:
>     - Increased top padding on the Account sidebar for better balance with left/right padding.
>     - Adjusted `lg:max-w` from `360px` to `376px` for the Account sidebar.
>   - **SearchMenu.tsx**:
>     - Adjusted right padding for the mobile Search bar.
>     - Updated mobile Search bar background to `bg-white-100`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 9374f91c5d9eb1d6b318e4c62041b93d6500df28. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->