### PR TITLE
feat(dango): subscription httpd mock

### DIFF
--- a/dango/mocks/httpd/src/bin/mock.rs
+++ b/dango/mocks/httpd/src/bin/mock.rs
@@ -8,6 +8,7 @@ async fn main() -> Result<(), Error> {
         None,
         TestOption::default(),
         true,
+        None,
     )
     .await
 }

--- a/dango/mocks/httpd/src/lib.rs
+++ b/dango/mocks/httpd/src/lib.rs
@@ -28,6 +28,7 @@ pub async fn run(
     let indexer = indexer_sql::non_blocking_indexer::IndexerBuilder::default()
         .with_keep_blocks(keep_blocks)
         .with_memory_database()
+        .with_sqlx_pubsub()
         .with_tmpdir()
         .with_hooks(dango_indexer_sql::hooks::Hooks)
         .build()?;

--- a/dango/mocks/httpd/src/lib.rs
+++ b/dango/mocks/httpd/src/lib.rs
@@ -20,14 +20,22 @@ pub async fn run(
     cors_allowed_origin: Option<String>,
     test_opt: TestOption,
     keep_blocks: bool,
+    database_url: Option<String>,
 ) -> Result<(), Error> {
     setup_tracing_subscriber(Level::INFO);
 
     let codes = build_rust_codes();
 
-    let indexer = indexer_sql::non_blocking_indexer::IndexerBuilder::default()
+    let indexer = indexer_sql::non_blocking_indexer::IndexerBuilder::default();
+
+    let indexer = if let Some(url) = database_url {
+        indexer.with_database_url(url)
+    } else {
+        indexer.with_memory_database()
+    };
+
+    let indexer = indexer
         .with_keep_blocks(keep_blocks)
-        .with_memory_database()
         .with_sqlx_pubsub()
         .with_tmpdir()
         .with_hooks(dango_indexer_sql::hooks::Hooks)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `database_url` parameter to `run` function for database configuration in `lib.rs`, updating `main` in `mock.rs`.
> 
>   - **Behavior**:
>     - Adds `database_url` parameter to `run` function in `lib.rs` to allow database URL configuration.
>     - Defaults to in-memory database if `database_url` is `None`.
>   - **Main Function**:
>     - Updates `main` function in `mock.rs` to include `None` for `database_url` parameter.
>   - **IndexerBuilder**:
>     - Modifies `IndexerBuilder` in `lib.rs` to use `with_database_url` if `database_url` is provided, otherwise uses `with_memory_database`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 7c31cad771e578b3d729c061a8de13643a4d4a80. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->