### PR TITLE
fix(ui): graphql uri subscription

### DIFF
--- a/ui/portal/web/src/app.provider.tsx
+++ b/ui/portal/web/src/app.provider.tsx
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/react";
 import { type Client as GraphqlSubscriptionClient, createClient } from "graphql-ws";
 import { type PropsWithChildren, createContext, useCallback, useEffect, useState } from "react";
 
+import { GRAPHQL_URI } from "../store.config";
 import { router } from "./app.router";
 
 import type { AnyCoin } from "@left-curve/store/types";
@@ -134,7 +135,7 @@ export const AppProvider: React.FC<PropsWithChildren> = ({ children }) => {
     if (!username) return;
     let client: GraphqlSubscriptionClient | undefined;
     (async () => {
-      client = createClient({ url: chain.urls.indexer });
+      client = createClient({ url: GRAPHQL_URI });
       const subscription = client.iterate({
         query: `subscription($address: String) {
           sentTransfers: transfers(fromAddress: $address) {

--- a/ui/portal/web/store.config.ts
+++ b/ui/portal/web/store.config.ts
@@ -4,7 +4,7 @@ import type { Config } from "@left-curve/store/types";
 
 const dango = devnet;
 
-const GRAPHQL_URI =
+export const GRAPHQL_URI =
   import.meta.env.PUBLIC_ENVIRONMENT === "local"
     ? import.meta.env.PUBLIC_GRAPHQL_URI
     : dango.urls.indexer;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change GraphQL subscription client URL to use `GRAPHQL_URI` for consistent environment-based configuration.
> 
>   - **Behavior**:
>     - Change GraphQL subscription client URL in `AppProvider` in `app.provider.tsx` to use `GRAPHQL_URI` instead of `chain.urls.indexer`.
>   - **Configuration**:
>     - Export `GRAPHQL_URI` in `store.config.ts` to determine the GraphQL endpoint based on environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 064152c3c82f1f5dc1bb45b62e9ce211b17a3eed. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->