### PR TITLE
feat(ui): switch to ethereum when connect and signing

### DIFF
--- a/ui/store/src/connectors/eip1193.ts
+++ b/ui/store/src/connectors/eip1193.ts
@@ -11,7 +11,7 @@ import type { Address } from "@left-curve/dango/types";
 import type { ConnectorId } from "../types/connector.js";
 import type { EIP1193Provider } from "../types/eip1193.js";
 
-const ETHEREM_HEX_CHAIN_ID = "0x1";
+const ETHEREUM_HEX_CHAIN_ID = "0x1";
 
 type EIP1193ConnectorParameters = {
   id: ConnectorId;
@@ -43,7 +43,7 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
         });
 
         const provider = await this.getProvider();
-        await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
+        await this.switchChain?.({ chainId: ETHEREUM_HEX_CHAIN_ID });
         const accountsInfo = await getAccountsByUsername(client, { username });
         const accounts = Object.entries(accountsInfo).map(([address, accountInfo]) =>
           toAccount({ username, address: address as Address, info: accountInfo }),
@@ -120,7 +120,7 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
       },
       async isAuthorized() {
         const provider = await this.getProvider();
-        await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
+        await this.switchChain?.({ chainId: ETHEREUM_HEX_CHAIN_ID });
         const [controllerAddress] = await provider.request({ method: "eth_accounts" });
         return !!controllerAddress;
       },
@@ -128,7 +128,7 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
         const { types, primaryType, message } = payload;
 
         const provider = await this.getProvider();
-        await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
+        await this.switchChain?.({ chainId: ETHEREUM_HEX_CHAIN_ID });
         const [controllerAddress] = await provider.request({ method: "eth_requestAccounts" });
 
         const typedData = composeArbitraryTypedData({ message, types, primaryType });
@@ -154,7 +154,7 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
       async signTx(signDoc) {
         try {
           const provider = await this.getProvider();
-          await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
+          await this.switchChain?.({ chainId: ETHEREUM_HEX_CHAIN_ID });
           const [controllerAddress] = await provider.request({ method: "eth_requestAccounts" });
 
           const signData = JSON.stringify(signDoc);

--- a/ui/store/src/connectors/eip1193.ts
+++ b/ui/store/src/connectors/eip1193.ts
@@ -11,6 +11,8 @@ import type { Address } from "@left-curve/dango/types";
 import type { ConnectorId } from "../types/connector.js";
 import type { EIP1193Provider } from "../types/eip1193.js";
 
+const ETHEREM_HEX_CHAIN_ID = "0x1";
+
 type EIP1193ConnectorParameters = {
   id: ConnectorId;
   name?: string;
@@ -41,6 +43,7 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
         });
 
         const provider = await this.getProvider();
+        await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
         const accountsInfo = await getAccountsByUsername(client, { username });
         const accounts = Object.entries(accountsInfo).map(([address, accountInfo]) =>
           toAccount({ username, address: address as Address, info: accountInfo }),
@@ -107,8 +110,17 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
           toAccount({ username, address: address as Address, info: accountInfo }),
         );
       },
+      async switchChain({ chainId }) {
+        const provider = await this.getProvider();
+
+        await provider.request({
+          method: "wallet_switchEthereumChain",
+          params: [{ chainId }],
+        });
+      },
       async isAuthorized() {
         const provider = await this.getProvider();
+        await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
         const [controllerAddress] = await provider.request({ method: "eth_accounts" });
         return !!controllerAddress;
       },
@@ -116,6 +128,7 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
         const { types, primaryType, message } = payload;
 
         const provider = await this.getProvider();
+        await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
         const [controllerAddress] = await provider.request({ method: "eth_requestAccounts" });
 
         const typedData = composeArbitraryTypedData({ message, types, primaryType });
@@ -141,6 +154,7 @@ export function eip1193(parameters: EIP1193ConnectorParameters) {
       async signTx(signDoc) {
         try {
           const provider = await this.getProvider();
+          await this.switchChain?.({ chainId: ETHEREM_HEX_CHAIN_ID });
           const [controllerAddress] = await provider.request({ method: "eth_requestAccounts" });
 
           const signData = JSON.stringify(signDoc);

--- a/ui/store/src/types/connector.ts
+++ b/ui/store/src/types/connector.ts
@@ -112,7 +112,7 @@ export type CreateConnectorFn<
       getAccounts(): Promise<readonly Account[]>;
       getClient(): Promise<SignerClient<transport>>;
       isAuthorized(): Promise<boolean>;
-      switchChain?(parameters: { chainId: string }): Promise<Chain>;
+      switchChain?(parameters: { chainId: string }): Promise<void>;
       onAccountsChanged?(accounts: string[]): void;
       onChainChanged?(chainId: string): void;
       onConnect?(connectInfo: { chainId: string }): void;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switch to Ethereum chain when connecting and signing in `eip1193.ts`, updating `switchChain` function and its return type.
> 
>   - **Behavior**:
>     - Switch to Ethereum chain (ID `0x1`) when connecting and signing in `eip1193()` in `eip1193.ts`.
>     - Functions `connect`, `isAuthorized`, `signArbitrary`, and `signTx` now switch to Ethereum chain.
>   - **Functions**:
>     - Add `switchChain` function in `eip1193()` to switch Ethereum chain using `wallet_switchEthereumChain` method.
>   - **Types**:
>     - Update `switchChain` return type to `Promise<void>` in `connector.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 70d71b03dc4f9c1934af8e400325f99b6963f5bb. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

ISSUE: LEF-78