### PR TITLE
feat: renew session modal

### DIFF
--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -207,6 +207,11 @@
       "accountName": "Account Name",
       "accountBalance": "Account Balance",
       "getStarted": "Get Started!"
+    },
+    "renewSession": {
+      "title": "Session expired",
+      "description": "For your security, each login session expires after 24 hours. Please sign in again.",
+      "stayLogout": "Stay logged out"
     }
   },
   "signin": {

--- a/ui/portal/web/constants.config.ts
+++ b/ui/portal/web/constants.config.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SESSION_EXPIRATION = 24 * 60 * 60 * 1000; // 24 hours

--- a/ui/portal/web/rsbuild.config.ts
+++ b/ui/portal/web/rsbuild.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     alias: {
       "~": "./src",
       "~/paraglide": path.resolve(__dirname, "./.paraglide"),
+      "~/constants": path.resolve(__dirname, "./constants.config.ts"),
     },
     define: publicVars,
   },

--- a/ui/portal/web/src/app.provider.tsx
+++ b/ui/portal/web/src/app.provider.tsx
@@ -159,7 +159,7 @@ export const AppProvider: React.FC<PropsWithChildren> = ({ children }) => {
     return () => {
       clearInterval(intervalId);
     };
-  }, [session, modal]);
+  }, [session, modal, settings.useSessionKey, connector]);
 
   // Track notifications
   useEffect(() => {

--- a/ui/portal/web/src/app.provider.tsx
+++ b/ui/portal/web/src/app.provider.tsx
@@ -9,7 +9,7 @@ import { router } from "./app.router";
 
 import type { AnyCoin } from "@left-curve/store/types";
 
-export type EventBusMap = {
+export type NotificationsMap = {
   submit_tx:
     | { isSubmitting: true; txResult?: never }
     | { isSubmitting: false; txResult: { hasSucceeded: boolean; message: string } };
@@ -22,10 +22,10 @@ export type EventBusMap = {
   };
 };
 
-export type Notifications<key extends keyof EventBusMap = keyof EventBusMap> = {
+export type Notifications<key extends keyof NotificationsMap = keyof NotificationsMap> = {
   createdAt: number;
   type: string;
-  data: EventBusMap[key];
+  data: NotificationsMap[key];
 };
 
 export type Subscription = {
@@ -38,12 +38,12 @@ export type Subscription = {
   };
 };
 
-export const eventBus = createEventBus<EventBusMap>();
+export const notifier = createEventBus<NotificationsMap>();
 
 type AppState = {
   router: typeof router;
   config: ReturnType<typeof useAppConfig>;
-  eventBus: typeof eventBus;
+  notifier: typeof notifier;
   notifications: { type: string; data: any; createdAt: number }[];
   isSidebarVisible: boolean;
   setSidebarVisibility: (visibility: boolean) => void;
@@ -68,7 +68,7 @@ type AppState = {
 export const AppContext = createContext<AppState | null>(null);
 
 export const AppProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const { chain, coins } = useConfig();
+  const { coins } = useConfig();
   // Global component state
   const [isSidebarVisible, setSidebarVisibility] = useState(false);
   const [isNotificationMenuVisible, setNotificationMenuVisibility] = useState(false);
@@ -172,9 +172,9 @@ export const AppProvider: React.FC<PropsWithChildren> = ({ children }) => {
             ...transfer,
             type: isSent ? "sent" : "received",
             coin,
-          } as EventBusMap["transfer"];
+          } as NotificationsMap["transfer"];
 
-          eventBus.publish("transfer", notification);
+          notifier.publish("transfer", notification);
           pushNotification({
             type: "transfer",
             data: notification,
@@ -193,7 +193,7 @@ export const AppProvider: React.FC<PropsWithChildren> = ({ children }) => {
       value={{
         router,
         config,
-        eventBus,
+        notifier,
         notifications,
         isSidebarVisible,
         setSidebarVisibility,

--- a/ui/portal/web/src/components/auth/Signin.tsx
+++ b/ui/portal/web/src/components/auth/Signin.tsx
@@ -28,6 +28,7 @@ import { Modals } from "../modals/RootModal";
 import { AuthCarousel } from "./AuthCarousel";
 import { AuthOptions } from "./AuthOptions";
 
+import { DEFAULT_SESSION_EXPIRATION } from "~/constants";
 import { m } from "~/paraglide/messages";
 
 import type React from "react";
@@ -206,7 +207,7 @@ const CredentialStep: React.FC = () => {
 
   const { mutateAsync: connectWithConnector, isPending } = useSignin({
     username,
-    sessionKey,
+    sessionKey: sessionKey && { expireAt: DEFAULT_SESSION_EXPIRATION },
     mutation: {
       onSuccess: () => {
         navigate({ to: "/" });

--- a/ui/portal/web/src/components/auth/Signin.tsx
+++ b/ui/portal/web/src/components/auth/Signin.tsx
@@ -109,6 +109,16 @@ const UsernameStep: React.FC = () => {
           <Button onClick={() => setUseAnotherAccount(true)} fullWidth variant="primary">
             {m["signin.useAnotherAccount"]()}
           </Button>
+          <ExpandOptions showOptionText={m["signin.advancedOptions"]()}>
+            <div className="flex items-center gap-2 flex-col">
+              <Checkbox
+                size="md"
+                label={m["common.signinWithSession"]()}
+                checked={useSessionKey}
+                onChange={(v) => changeSettings({ useSessionKey: v })}
+              />
+            </div>
+          </ExpandOptions>
         </>
       ) : (
         <form className="flex flex-col gap-6 w-full" onSubmit={signInWithUsername}>

--- a/ui/portal/web/src/components/auth/Signup.tsx
+++ b/ui/portal/web/src/components/auth/Signup.tsx
@@ -43,14 +43,14 @@ import { AuthOptions } from "./AuthOptions";
 
 import { m } from "~/paraglide/messages";
 
-import type { Address, AppConfig, Hex, Key } from "@left-curve/dango/types";
+import type { Address, Hex, Key } from "@left-curve/dango/types";
 import type { EIP1193Provider } from "@left-curve/store/types";
 import type React from "react";
 import { useApp } from "~/hooks/useApp";
 import { AuthCarousel } from "./AuthCarousel";
 
 import { captureException } from "@sentry/react";
-import { add } from "date-fns";
+import { DEFAULT_SESSION_EXPIRATION } from "~/constants";
 
 const Container: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { activeStep, previousStep, data } = useWizard<{ username: string }>();
@@ -381,7 +381,7 @@ const Signin: React.FC = () => {
 
   const { mutateAsync: connectWithConnector, isPending } = useSignin({
     username,
-    sessionKey: useSessionKey,
+    sessionKey: useSessionKey && { expireAt: Date.now() + DEFAULT_SESSION_EXPIRATION },
     mutation: {
       onSuccess: () => {
         navigate({ to: "/" });

--- a/ui/portal/web/src/components/create-account/CreateAccountDepositStep.tsx
+++ b/ui/portal/web/src/components/create-account/CreateAccountDepositStep.tsx
@@ -20,9 +20,9 @@ export const CreateAccountDepositStep: React.FC = () => {
 
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { showModal, eventBus } = useApp();
-  const { coins, state } = useConfig();
-  const { account, refreshAccounts, changeAccount } = useAccount();
+  const { showModal, notifier } = useApp();
+  const { coins } = useConfig();
+  const { account, refreshAccounts } = useAccount();
   const { settings } = useApp();
   const { formatNumberOptions } = settings;
   const { data: signingClient } = useSigningClient();
@@ -38,7 +38,7 @@ export const CreateAccountDepositStep: React.FC = () => {
   const { mutateAsync: send, isPending } = useMutation({
     mutationFn: async () => {
       if (!signingClient) throw new Error("error: no signing client");
-      eventBus.publish("submit_tx", { isSubmitting: true });
+      notifier.publish("submit_tx", { isSubmitting: true });
       try {
         const parsedAmount = parseUnits(fundsAmount || "0", coinInfo.decimals).toString();
 
@@ -53,7 +53,7 @@ export const CreateAccountDepositStep: React.FC = () => {
           }),
         ]);
 
-        eventBus.publish("submit_tx", {
+        notifier.publish("submit_tx", {
           isSubmitting: false,
           txResult: { hasSucceeded: true, message: m["accountCreation.accountCreated"]() },
         });
@@ -71,7 +71,7 @@ export const CreateAccountDepositStep: React.FC = () => {
       } catch (e) {
         console.error(e);
         const error = ensureErrorMessage(e);
-        eventBus.publish("submit_tx", {
+        notifier.publish("submit_tx", {
           isSubmitting: false,
           txResult: { hasSucceeded: false, message: m["signup.errors.couldntCompleteRequest"]() },
         });

--- a/ui/portal/web/src/components/dex/SimpleSwap.tsx
+++ b/ui/portal/web/src/components/dex/SimpleSwap.tsx
@@ -45,7 +45,7 @@ const SimpleSwapContainer: React.FC<PropsWithChildren<UseSimpleSwapParameters>> 
 }) => {
   const simpleSwapState = state(parameters);
   const controllers = useInputs();
-  const { eventBus, settings, showModal } = useApp();
+  const { notifier, settings, showModal } = useApp();
   const { account } = useAccount();
   const { data: signingClient } = useSigningClient();
   const { reset } = controllers;
@@ -58,7 +58,7 @@ const SimpleSwapContainer: React.FC<PropsWithChildren<UseSimpleSwapParameters>> 
       if (!signingClient) throw new Error("error: no signing client");
       if (!pair) throw new Error("error: no pair");
       if (!simulation.input || !simulation.data) throw new Error("error: no simulation");
-      eventBus.publish("submit_tx", { isSubmitting: true });
+      notifier.publish("submit_tx", { isSubmitting: true });
 
       try {
         const { promise, resolve: confirmSwap, reject: rejectSwap } = withResolvers();
@@ -79,7 +79,7 @@ const SimpleSwapContainer: React.FC<PropsWithChildren<UseSimpleSwapParameters>> 
         const response = await promise
           .then(() => true)
           .catch(() => {
-            eventBus.publish("submit_tx", {
+            notifier.publish("submit_tx", {
               isSubmitting: false,
               txResult: { hasSucceeded: false, message: m["dex.simpleSwap.errors.failure"]() },
             });
@@ -95,14 +95,14 @@ const SimpleSwapContainer: React.FC<PropsWithChildren<UseSimpleSwapParameters>> 
 
         reset();
         toast.success({ title: m["dex.simpleSwap.swapSuccessfully"]() });
-        eventBus.publish("submit_tx", {
+        notifier.publish("submit_tx", {
           isSubmitting: false,
           txResult: { hasSucceeded: true, message: m["dex.simpleSwap.swapSuccessfully"]() },
         });
         refreshBalances();
       } catch (e) {
         console.error(e);
-        eventBus.publish("submit_tx", {
+        notifier.publish("submit_tx", {
           isSubmitting: false,
           txResult: { hasSucceeded: false, message: m["dex.simpleSwap.errors.failure"]() },
         });

--- a/ui/portal/web/src/components/foundation/TxIndicator.tsx
+++ b/ui/portal/web/src/components/foundation/TxIndicator.tsx
@@ -22,7 +22,7 @@ export const TxIndicator = <C extends React.ElementType = React.ElementType>({
   children,
   ...props
 }: IndicatorProps<C>) => {
-  const { eventBus } = useApp();
+  const { notifier } = useApp();
   const [isSubmittingTx, setIsSubmittingTx] = useState(false);
   const [indicator, setIndicator] = useState<keyof typeof Indicators>("spinner");
 
@@ -30,7 +30,7 @@ export const TxIndicator = <C extends React.ElementType = React.ElementType>({
   const WrapperComponent = as ?? "button";
 
   useEffect(() => {
-    const unsubscribe = eventBus.subscribe("submit_tx", ({ isSubmitting, txResult }) => {
+    const unsubscribe = notifier.subscribe("submit_tx", ({ isSubmitting, txResult }) => {
       if (isSubmitting) {
         setIndicator("spinner");
         setIsSubmittingTx(isSubmitting);

--- a/ui/portal/web/src/components/modals/RenewSession.tsx
+++ b/ui/portal/web/src/components/modals/RenewSession.tsx
@@ -1,0 +1,41 @@
+import { forwardRef } from "react";
+import { useApp } from "~/hooks/useApp";
+
+import { m } from "~/paraglide/messages";
+
+import { Button, IconButton, IconClose, IconKey, IconTrash } from "@left-curve/applets-kit";
+
+export const RenewSession = forwardRef<undefined>(() => {
+  const { hideModal } = useApp();
+
+  return (
+    <div className="flex flex-col bg-white-100 rounded-xl relative max-w-[400px]">
+      <IconButton
+        className="hidden lg:block absolute right-2 top-2"
+        variant="link"
+        onClick={hideModal}
+      >
+        <IconClose />
+      </IconButton>
+      <div className="p-4 flex flex-col gap-4">
+        <div className="w-12 h-12 rounded-full bg-green-bean-100 flex items-center justify-center text-green-bean-600">
+          <IconKey />
+        </div>
+        <p className="text-gray-700 h4-bold">Renew Your Session Key</p>
+        <p className="text-gray-500 diatype-m-medium">
+          Your session key is not active or has expired. Would you like to start a new session to
+          use the app?
+        </p>
+      </div>
+      <span className="w-full h-[1px] bg-gray-100 my-2 lg:block hidden" />
+      <div className="p-4 flex gap-4 flex-col-reverse lg:flex-row">
+        <Button fullWidth variant="primary" onClick={() => hideModal()}>
+          Activate session key
+        </Button>
+        <Button fullWidth variant="secondary" onClick={() => hideModal()}>
+          Do it later
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/ui/portal/web/src/components/modals/RenewSession.tsx
+++ b/ui/portal/web/src/components/modals/RenewSession.tsx
@@ -3,10 +3,15 @@ import { useApp } from "~/hooks/useApp";
 
 import { m } from "~/paraglide/messages";
 
-import { Button, IconButton, IconClose, IconKey, IconTrash } from "@left-curve/applets-kit";
+import { Button, IconButton, IconClose, IconKey } from "@left-curve/applets-kit";
+import { useAccount, useSessionKey } from "@left-curve/store";
+
+const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
 export const RenewSession = forwardRef<undefined>(() => {
+  const { connector } = useAccount();
   const { hideModal } = useApp();
+  const { createSessionKey } = useSessionKey();
 
   return (
     <div className="flex flex-col bg-white-100 rounded-xl relative max-w-[400px]">
@@ -21,19 +26,27 @@ export const RenewSession = forwardRef<undefined>(() => {
         <div className="w-12 h-12 rounded-full bg-green-bean-100 flex items-center justify-center text-green-bean-600">
           <IconKey />
         </div>
-        <p className="text-gray-700 h4-bold">Renew Your Session Key</p>
-        <p className="text-gray-500 diatype-m-medium">
-          Your session key is not active or has expired. Would you like to start a new session to
-          use the app?
-        </p>
+        <p className="text-gray-700 h4-bold">{m["modals.renewSession.title"]()}</p>
+        <p className="text-gray-500 diatype-m-medium">{m["modals.renewSession.description"]()}</p>
       </div>
       <span className="w-full h-[1px] bg-gray-100 my-2 lg:block hidden" />
       <div className="p-4 flex gap-4 flex-col-reverse lg:flex-row">
-        <Button fullWidth variant="primary" onClick={() => hideModal()}>
-          Activate session key
+        <Button
+          fullWidth
+          variant="primary"
+          onClick={() => [
+            createSessionKey({ expireAt: Date.now() + TWENTY_FOUR_HOURS }),
+            hideModal(),
+          ]}
+        >
+          {m["common.signin"]()}
         </Button>
-        <Button fullWidth variant="secondary" onClick={() => hideModal()}>
-          Do it later
+        <Button
+          fullWidth
+          variant="secondary"
+          onClick={() => [connector?.disconnect(), hideModal()]}
+        >
+          {m["modals.renewSession.stayLogout"]()}
         </Button>
       </div>
     </div>

--- a/ui/portal/web/src/components/modals/RenewSession.tsx
+++ b/ui/portal/web/src/components/modals/RenewSession.tsx
@@ -1,26 +1,25 @@
-import { forwardRef } from "react";
+import { forwardRef, useEffect } from "react";
 import { useApp } from "~/hooks/useApp";
 
 import { DEFAULT_SESSION_EXPIRATION } from "~/constants";
 import { m } from "~/paraglide/messages";
 
-import { Button, IconButton, IconClose, IconKey } from "@left-curve/applets-kit";
+import { Button, IconKey } from "@left-curve/applets-kit";
 import { useAccount, useSessionKey } from "@left-curve/store";
 
 export const RenewSession = forwardRef<undefined>(() => {
   const { connector } = useAccount();
   const { hideModal } = useApp();
-  const { createSessionKey } = useSessionKey();
+  const { createSessionKey, session } = useSessionKey();
+
+  useEffect(() => {
+    if (session && Date.now() < Number(session.sessionInfo.expireAt)) {
+      hideModal();
+    }
+  }, [session]);
 
   return (
     <div className="flex flex-col bg-white-100 rounded-xl relative max-w-[400px]">
-      <IconButton
-        className="hidden lg:block absolute right-2 top-2"
-        variant="link"
-        onClick={hideModal}
-      >
-        <IconClose />
-      </IconButton>
       <div className="p-4 flex flex-col gap-4">
         <div className="w-12 h-12 rounded-full bg-green-bean-100 flex items-center justify-center text-green-bean-600">
           <IconKey />
@@ -33,10 +32,7 @@ export const RenewSession = forwardRef<undefined>(() => {
         <Button
           fullWidth
           variant="primary"
-          onClick={() => [
-            createSessionKey({ expireAt: Date.now() + DEFAULT_SESSION_EXPIRATION }),
-            hideModal(),
-          ]}
+          onClick={() => createSessionKey({ expireAt: Date.now() + DEFAULT_SESSION_EXPIRATION })}
         >
           {m["common.signin"]()}
         </Button>

--- a/ui/portal/web/src/components/modals/RenewSession.tsx
+++ b/ui/portal/web/src/components/modals/RenewSession.tsx
@@ -1,12 +1,11 @@
 import { forwardRef } from "react";
 import { useApp } from "~/hooks/useApp";
 
+import { DEFAULT_SESSION_EXPIRATION } from "~/constants";
 import { m } from "~/paraglide/messages";
 
 import { Button, IconButton, IconClose, IconKey } from "@left-curve/applets-kit";
 import { useAccount, useSessionKey } from "@left-curve/store";
-
-const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
 export const RenewSession = forwardRef<undefined>(() => {
   const { connector } = useAccount();
@@ -35,7 +34,7 @@ export const RenewSession = forwardRef<undefined>(() => {
           fullWidth
           variant="primary"
           onClick={() => [
-            createSessionKey({ expireAt: Date.now() + TWENTY_FOUR_HOURS }),
+            createSessionKey({ expireAt: Date.now() + DEFAULT_SESSION_EXPIRATION }),
             hideModal(),
           ]}
         >

--- a/ui/portal/web/src/components/modals/RootModal.tsx
+++ b/ui/portal/web/src/components/modals/RootModal.tsx
@@ -17,6 +17,7 @@ export const Modals = {
   ConfirmAccount: "confirm-account",
   SignWithDesktop: "sign-with-desktop",
   ConfirmSwap: "confirm-swap",
+  RenewSession: "renew-session",
 };
 
 export type ModalRef = {
@@ -58,6 +59,13 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
     component: lazy(() =>
       import("./ConfirmSwap").then(({ ConfirmSwap }) => ({
         default: ConfirmSwap,
+      })),
+    ),
+  },
+  [Modals.RenewSession]: {
+    component: lazy(() =>
+      import("./RenewSession").then(({ RenewSession }) => ({
+        default: RenewSession,
       })),
     ),
   },

--- a/ui/portal/web/src/components/modals/RootModal.tsx
+++ b/ui/portal/web/src/components/modals/RootModal.tsx
@@ -27,29 +27,17 @@ export type ModalRef = {
 const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
   [Modals.AddKey]: {
     component: lazy(() => import("./AddKey").then(({ AddKeyModal }) => ({ default: AddKeyModal }))),
-    options: {
-      allowClosing: true,
-    },
   },
   [Modals.RemoveKey]: {
     component: lazy(() => import("./RemoveKey").then(({ RemoveKey }) => ({ default: RemoveKey }))),
-    options: {
-      allowClosing: true,
-    },
   },
   [Modals.QRConnect]: {
     component: lazy(() => import("./QRConnect").then(({ QRConnect }) => ({ default: QRConnect }))),
-    options: {
-      allowClosing: true,
-    },
   },
   [Modals.ConfirmSend]: {
     component: lazy(() =>
       import("./ConfirmSend").then(({ ConfirmSend }) => ({ default: ConfirmSend })),
     ),
-    options: {
-      allowClosing: true,
-    },
   },
   [Modals.ConfirmAccount]: {
     component: lazy(() =>
@@ -57,9 +45,6 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
         default: ConfirmAccount,
       })),
     ),
-    options: {
-      allowClosing: true,
-    },
   },
   [Modals.SignWithDesktop]: {
     component: lazy(() =>
@@ -69,7 +54,6 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
     ),
     options: {
       header: m["common.signin"](),
-      allowClosing: true,
     },
   },
   [Modals.ConfirmSwap]: {
@@ -80,7 +64,6 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
     ),
     options: {
       header: m["dex.swap"](),
-      allowClosing: true,
     },
   },
   [Modals.RenewSession]: {
@@ -90,16 +73,16 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
       })),
     ),
     options: {
-      allowClosing: false,
+      disableClosing: true,
     },
   },
 };
 
 type ModalDefinition = {
   component: React.LazyExoticComponent<React.ForwardRefExoticComponent<any>>;
-  options: {
+  options?: {
     header?: string;
-    allowClosing?: boolean;
+    disableClosing?: boolean;
   };
 };
 
@@ -113,7 +96,7 @@ export const RootModal: React.FC = () => {
 
   const { modal: activeModal, props: modalProps } = modal;
 
-  const { component: Modal, options } =
+  const { component: Modal, options = {} } =
     useMemo(() => modals[activeModal as keyof typeof modals], [activeModal, sheetRef]) || {};
 
   const closeModal = () => {
@@ -127,7 +110,7 @@ export const RootModal: React.FC = () => {
   if (!isMd) {
     return (
       <Sheet
-        disableDrag={!options.allowClosing}
+        disableDrag={options.disableClosing}
         ref={sheetRef}
         isOpen={!!activeModal}
         onClose={closeModal}
@@ -152,7 +135,7 @@ export const RootModal: React.FC = () => {
             </Suspense>
           </Sheet.Content>
         </Sheet.Container>
-        <Sheet.Backdrop onTap={() => options.allowClosing && closeModal()} />
+        <Sheet.Backdrop onTap={() => !options.disableClosing && closeModal()} />
       </Sheet>
     );
   }
@@ -162,7 +145,7 @@ export const RootModal: React.FC = () => {
       <motion.div
         ref={overlayRef}
         onClick={(e) => {
-          if (e.target === overlayRef.current && options.allowClosing) closeModal();
+          if (e.target === overlayRef.current && !options.disableClosing) closeModal();
         }}
         className="backdrop-blur-[10px] bg-gray-900/10 w-screen h-screen fixed top-0 z-[60] flex items-center justify-center p-4"
         initial={{ opacity: 0 }}

--- a/ui/portal/web/src/components/modals/RootModal.tsx
+++ b/ui/portal/web/src/components/modals/RootModal.tsx
@@ -27,17 +27,29 @@ export type ModalRef = {
 const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
   [Modals.AddKey]: {
     component: lazy(() => import("./AddKey").then(({ AddKeyModal }) => ({ default: AddKeyModal }))),
+    options: {
+      allowClosing: true,
+    },
   },
   [Modals.RemoveKey]: {
     component: lazy(() => import("./RemoveKey").then(({ RemoveKey }) => ({ default: RemoveKey }))),
+    options: {
+      allowClosing: true,
+    },
   },
   [Modals.QRConnect]: {
     component: lazy(() => import("./QRConnect").then(({ QRConnect }) => ({ default: QRConnect }))),
+    options: {
+      allowClosing: true,
+    },
   },
   [Modals.ConfirmSend]: {
     component: lazy(() =>
       import("./ConfirmSend").then(({ ConfirmSend }) => ({ default: ConfirmSend })),
     ),
+    options: {
+      allowClosing: true,
+    },
   },
   [Modals.ConfirmAccount]: {
     component: lazy(() =>
@@ -45,22 +57,31 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
         default: ConfirmAccount,
       })),
     ),
+    options: {
+      allowClosing: true,
+    },
   },
   [Modals.SignWithDesktop]: {
-    header: m["common.signin"](),
     component: lazy(() =>
       import("./SignWithDesktop").then(({ SignWithDesktop }) => ({
         default: SignWithDesktop,
       })),
     ),
+    options: {
+      header: m["common.signin"](),
+      allowClosing: true,
+    },
   },
   [Modals.ConfirmSwap]: {
-    header: m["dex.swap"](),
     component: lazy(() =>
       import("./ConfirmSwap").then(({ ConfirmSwap }) => ({
         default: ConfirmSwap,
       })),
     ),
+    options: {
+      header: m["dex.swap"](),
+      allowClosing: true,
+    },
   },
   [Modals.RenewSession]: {
     component: lazy(() =>
@@ -68,12 +89,18 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
         default: RenewSession,
       })),
     ),
+    options: {
+      allowClosing: false,
+    },
   },
 };
 
 type ModalDefinition = {
-  header?: string;
   component: React.LazyExoticComponent<React.ForwardRefExoticComponent<any>>;
+  options: {
+    header?: string;
+    allowClosing?: boolean;
+  };
 };
 
 export const RootModal: React.FC = () => {
@@ -86,7 +113,7 @@ export const RootModal: React.FC = () => {
 
   const { modal: activeModal, props: modalProps } = modal;
 
-  const { component: Modal, header } =
+  const { component: Modal, options } =
     useMemo(() => modals[activeModal as keyof typeof modals], [activeModal, sheetRef]) || {};
 
   const closeModal = () => {
@@ -100,6 +127,7 @@ export const RootModal: React.FC = () => {
   if (!isMd) {
     return (
       <Sheet
+        disableDrag={!options.allowClosing}
         ref={sheetRef}
         isOpen={!!activeModal}
         onClose={closeModal}
@@ -108,12 +136,12 @@ export const RootModal: React.FC = () => {
       >
         <Sheet.Container className="!bg-white-100 !rounded-t-2xl !shadow-none">
           <Sheet.Header>
-            {header ? (
+            {options.header ? (
               <div className="flex items-center justify-between w-full">
                 <Button variant="link" onClick={hideModal}>
                   {m["common.cancel"]()}
                 </Button>
-                <p className="mt-1 text-gray-500 font-semibold">{header}</p>
+                <p className="mt-1 text-gray-500 font-semibold">{options.header}</p>
                 <div className="w-[66px]" />
               </div>
             ) : null}
@@ -124,7 +152,7 @@ export const RootModal: React.FC = () => {
             </Suspense>
           </Sheet.Content>
         </Sheet.Container>
-        <Sheet.Backdrop onTap={closeModal} />
+        <Sheet.Backdrop onTap={() => options.allowClosing && closeModal()} />
       </Sheet>
     );
   }
@@ -134,7 +162,7 @@ export const RootModal: React.FC = () => {
       <motion.div
         ref={overlayRef}
         onClick={(e) => {
-          if (e.target === overlayRef.current) closeModal();
+          if (e.target === overlayRef.current && options.allowClosing) closeModal();
         }}
         className="backdrop-blur-[10px] bg-gray-900/10 w-screen h-screen fixed top-0 z-[60] flex items-center justify-center p-4"
         initial={{ opacity: 0 }}

--- a/ui/portal/web/src/pages/(app)/_app.transfer.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.transfer.lazy.tsx
@@ -5,14 +5,7 @@ import {
   parseUnits,
   withResolvers,
 } from "@left-curve/dango/utils";
-import {
-  useAccount,
-  useBalances,
-  useChainId,
-  useConfig,
-  usePrices,
-  useSigningClient,
-} from "@left-curve/store";
+import { useAccount, useBalances, useConfig, usePrices, useSigningClient } from "@left-curve/store";
 import { createLazyFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useState } from "react";
 import { useApp } from "~/hooks/useApp";
@@ -48,7 +41,7 @@ export const Route = createLazyFileRoute("/(app)/_app/transfer")({
 function TransferApplet() {
   const { action } = useSearch({ strict: false });
   const navigate = useNavigate({ from: "/transfer" });
-  const { settings, showModal, eventBus } = useApp();
+  const { settings, showModal, notifier } = useApp();
   const { formatNumberOptions } = settings;
 
   const queryClient = useQueryClient();
@@ -88,7 +81,7 @@ function TransferApplet() {
   >({
     mutationFn: async ({ address, amount }) => {
       if (!signingClient) throw new Error("error: no signing client");
-      eventBus.publish("submit_tx", { isSubmitting: true });
+      notifier.publish("submit_tx", { isSubmitting: true });
       try {
         const parsedAmount = parseUnits(amount, selectedCoin.decimals).toString();
 
@@ -105,7 +98,7 @@ function TransferApplet() {
         const response = await promise
           .then(() => true)
           .catch(() => {
-            eventBus.publish("submit_tx", {
+            notifier.publish("submit_tx", {
               isSubmitting: false,
               txResult: { hasSucceeded: false, message: m["transfer.error.description"]() },
             });
@@ -125,7 +118,7 @@ function TransferApplet() {
 
         reset();
         toast.success({ title: m["sendAndReceive.sendSuccessfully"]() });
-        eventBus.publish("submit_tx", {
+        notifier.publish("submit_tx", {
           isSubmitting: false,
           txResult: { hasSucceeded: true, message: m["sendAndReceive.sendSuccessfully"]() },
         });
@@ -133,7 +126,7 @@ function TransferApplet() {
         queryClient.invalidateQueries({ queryKey: ["quests", account] });
       } catch (e) {
         console.error(e);
-        eventBus.publish("submit_tx", {
+        notifier.publish("submit_tx", {
           isSubmitting: false,
           txResult: { hasSucceeded: false, message: m["transfer.error.description"]() },
         });

--- a/ui/portal/web/tsconfig.json
+++ b/ui/portal/web/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "paths": {
       "~/*": ["./src/*"],
-      "~/paraglide/*": ["./.paraglide/*"]
+      "~/paraglide/*": ["./.paraglide/*"],
+      "~/constants": ["./constants.config.ts"]
     },
     "noEmit": true
   },

--- a/ui/store/src/hooks/useSignin.ts
+++ b/ui/store/src/hooks/useSignin.ts
@@ -8,7 +8,11 @@ import { useSessionKey } from "./useSessionKey.js";
 export type UseSigninParameters = {
   username: string;
   connectors?: UseConnectorsReturnType;
-  sessionKey?: boolean;
+  sessionKey?:
+    | {
+        expireAt: number;
+      }
+    | false;
   mutation?: UseMutationParameters<void, Error, { connectorId: string }>;
 };
 
@@ -36,11 +40,9 @@ export function useSignin(parameters: UseSigninParameters) {
       const keyPair = Secp256k1.makeKeyPair();
       const publicKey = keyPair.getPublicKey();
 
-      const expireAt = Date.now() + 1000 * 60 * 60 * 24;
-
       const sessionInfo = {
         sessionKey: encodeBase64(publicKey),
-        expireAt: expireAt.toString(),
+        expireAt: sessionKey.expireAt.toString(),
       };
 
       const { credential } = await connector.signArbitrary({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces session renewal feature with a new modal for expired sessions, refactors event handling, and updates sign-in logic for session management.
> 
>   - **Session Renewal**:
>     - Adds `RenewSession` modal in `RenewSession.tsx` to prompt users to sign in again when session expires.
>     - Tracks session expiration in `app.provider.tsx` and shows `RenewSession` modal if expired.
>     - Adds `DEFAULT_SESSION_EXPIRATION` constant in `constants.config.ts` for session duration.
>   - **Refactoring**:
>     - Renames `eventBus` to `notifier` in `app.provider.tsx`, `CreateAccountDepositStep.tsx`, `SimpleSwap.tsx`, `TxIndicator.tsx`, and `_app.transfer.lazy.tsx`.
>     - Changes `EventBusMap` to `NotificationsMap` in `app.provider.tsx`.
>   - **Modals**:
>     - Updates `RootModal.tsx` to include `RenewSession` modal with `disableClosing` option.
>   - **Sign-in/Sign-up**:
>     - Updates `Signin.tsx` and `Signup.tsx` to use `DEFAULT_SESSION_EXPIRATION` for session key expiration.
>   - **Localization**:
>     - Adds session renewal messages to `en.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 4d067d46bf96917a4d3920b0c53a707b1d4ae35c. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->