### PR TITLE
feat(dango): Account Factory query users by key hash

### DIFF
--- a/dango/account/factory/src/execute.rs
+++ b/dango/account/factory/src/execute.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         ACCOUNTS, ACCOUNTS_BY_USER, CODE_HASHES, KEYS, MINIMUM_DEPOSIT, NEXT_ACCOUNT_INDEX,
-        REVERSE_KEYS,
+        USERNAMES_BY_KEY,
     },
     anyhow::{bail, ensure},
     dango_auth::{VerifyData, verify_signature},
@@ -37,7 +37,7 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> 
         .enumerate()
         .map(|(seed, (username, (key_hash, key)))| {
             KEYS.save(ctx.storage, (&username, key_hash), &key)?;
-            REVERSE_KEYS.insert(ctx.storage, (key_hash, &username))?;
+            USERNAMES_BY_KEY.insert(ctx.storage, (key_hash, &username))?;
 
             let (msg, user_registered, account_registered) = onboard_new_user(
                 ctx.storage,
@@ -169,7 +169,7 @@ fn register_user(
 
     // Save the key.
     KEYS.save(ctx.storage, (&username, key_hash), &key)?;
-    REVERSE_KEYS.insert(ctx.storage, (key_hash, &username))?;
+    USERNAMES_BY_KEY.insert(ctx.storage, (key_hash, &username))?;
 
     let minimum_deposit = MINIMUM_DEPOSIT.load(ctx.storage)?;
 
@@ -331,11 +331,11 @@ fn update_key(ctx: MutableCtx, key_hash: Hash256, key: Op<Key>) -> anyhow::Resul
     match key {
         Op::Insert(key) => {
             KEYS.save(ctx.storage, (&username, key_hash), &key)?;
-            REVERSE_KEYS.insert(ctx.storage, (key_hash, &username))?;
+            USERNAMES_BY_KEY.insert(ctx.storage, (key_hash, &username))?;
         },
         Op::Delete => {
             KEYS.remove(ctx.storage, (&username, key_hash));
-            REVERSE_KEYS.remove(ctx.storage, (key_hash, &username));
+            USERNAMES_BY_KEY.remove(ctx.storage, (key_hash, &username));
 
             // Ensure the user hasn't removed every single key associated with
             // their username. There must be at least one remaining.

--- a/dango/account/factory/src/execute.rs
+++ b/dango/account/factory/src/execute.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{ACCOUNTS, ACCOUNTS_BY_USER, CODE_HASHES, KEYS, MINIMUM_DEPOSIT, NEXT_ACCOUNT_INDEX},
+    crate::{
+        ACCOUNTS, ACCOUNTS_BY_USER, CODE_HASHES, KEYS, MINIMUM_DEPOSIT, NEXT_ACCOUNT_INDEX,
+        REVERSE_KEYS,
+    },
     anyhow::{bail, ensure},
     dango_auth::{VerifyData, verify_signature},
     dango_types::{
@@ -34,6 +37,7 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> 
         .enumerate()
         .map(|(seed, (username, (key_hash, key)))| {
             KEYS.save(ctx.storage, (&username, key_hash), &key)?;
+            REVERSE_KEYS.insert(ctx.storage, (key_hash, &username))?;
 
             let (msg, user_registered, account_registered) = onboard_new_user(
                 ctx.storage,
@@ -165,6 +169,7 @@ fn register_user(
 
     // Save the key.
     KEYS.save(ctx.storage, (&username, key_hash), &key)?;
+    REVERSE_KEYS.insert(ctx.storage, (key_hash, &username))?;
 
     let minimum_deposit = MINIMUM_DEPOSIT.load(ctx.storage)?;
 
@@ -326,9 +331,11 @@ fn update_key(ctx: MutableCtx, key_hash: Hash256, key: Op<Key>) -> anyhow::Resul
     match key {
         Op::Insert(key) => {
             KEYS.save(ctx.storage, (&username, key_hash), &key)?;
+            REVERSE_KEYS.insert(ctx.storage, (key_hash, &username))?;
         },
         Op::Delete => {
             KEYS.remove(ctx.storage, (&username, key_hash));
+            REVERSE_KEYS.remove(ctx.storage, (key_hash, &username));
 
             // Ensure the user hasn't removed every single key associated with
             // their username. There must be at least one remaining.

--- a/dango/account/factory/src/query.rs
+++ b/dango/account/factory/src/query.rs
@@ -64,12 +64,12 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = query_user(ctx.storage, username)?;
             res.to_json_value()
         },
-        QueryMsg::UsersByKey {
+        QueryMsg::ForgotUsername {
             key_hash,
             start_after,
             limit,
         } => {
-            let res = query_users_by_key(ctx.storage, key_hash, start_after, limit)?;
+            let res = forgot_username(ctx.storage, key_hash, start_after, limit)?;
             res.to_json_value()
         },
     }
@@ -178,7 +178,7 @@ fn query_user(storage: &dyn Storage, username: Username) -> StdResult<User> {
     Ok(User { keys, accounts })
 }
 
-fn query_users_by_key(
+fn forgot_username(
     storage: &dyn Storage,
     key_hash: Hash256,
     start_after: Option<Username>,

--- a/dango/account/factory/src/query.rs
+++ b/dango/account/factory/src/query.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         ACCOUNTS, ACCOUNTS_BY_USER, CODE_HASHES, KEYS, MINIMUM_DEPOSIT, NEXT_ACCOUNT_INDEX,
-        REVERSE_KEYS,
+        USERNAMES_BY_KEY,
     },
     dango_types::{
         account_factory::{
@@ -187,7 +187,7 @@ fn forgot_username(
     let start = start_after.as_ref().map(Bound::Exclusive);
     let limit = limit.unwrap_or(DEFAULT_PAGE_LIMIT) as usize;
 
-    REVERSE_KEYS
+    USERNAMES_BY_KEY
         .prefix(key_hash)
         .keys(storage, start, None, Order::Ascending)
         .take(limit)

--- a/dango/account/factory/src/state.rs
+++ b/dango/account/factory/src/state.rs
@@ -14,6 +14,8 @@ pub const NEXT_ACCOUNT_INDEX: Counter<AccountIndex> = Counter::new("index", 0, 1
 
 pub const KEYS: Map<(&Username, Hash256), Key> = dango_auth::account_factory::KEYS;
 
+pub const REVERSE_KEYS: Set<(Hash256, &Username)> = Set::new("reverse_key");
+
 pub const ACCOUNTS: Map<Addr, Account> = Map::new("account");
 
 pub const ACCOUNTS_BY_USER: Set<(&Username, Addr)> = dango_auth::account_factory::ACCOUNTS_BY_USER;

--- a/dango/account/factory/src/state.rs
+++ b/dango/account/factory/src/state.rs
@@ -14,7 +14,7 @@ pub const NEXT_ACCOUNT_INDEX: Counter<AccountIndex> = Counter::new("index", 0, 1
 
 pub const KEYS: Map<(&Username, Hash256), Key> = dango_auth::account_factory::KEYS;
 
-pub const REVERSE_KEYS: Set<(Hash256, &Username)> = Set::new("reverse_key");
+pub const USERNAMES_BY_KEY: Set<(Hash256, &Username)> = Set::new("username__key");
 
 pub const ACCOUNTS: Map<Addr, Account> = Map::new("account");
 

--- a/dango/types/src/account_factory/msg.rs
+++ b/dango/types/src/account_factory/msg.rs
@@ -113,8 +113,10 @@ pub enum QueryMsg {
     /// Query a single user by username.
     #[returns(User)]
     User { username: Username },
+    /// Query usernames associated with a given key hash.
+    /// Useful if user forgot their username but still have access to the key.
     #[returns(BTreeSet<Username>)]
-    UsersByKey {
+    ForgotUsername {
         key_hash: Hash256,
         start_after: Option<Username>,
         limit: Option<u32>,

--- a/dango/types/src/account_factory/msg.rs
+++ b/dango/types/src/account_factory/msg.rs
@@ -7,7 +7,7 @@ use {
     },
     grug::{Addr, Coins, Hash256, JsonSerExt, Op, SignData, StdError, StdResult},
     sha2::Sha256,
-    std::collections::BTreeMap,
+    std::collections::{BTreeMap, BTreeSet},
 };
 
 /// Information about a user. Used in query response.
@@ -113,6 +113,12 @@ pub enum QueryMsg {
     /// Query a single user by username.
     #[returns(User)]
     User { username: Username },
+    #[returns(BTreeSet<Username>)]
+    UsersByKey {
+        key_hash: Hash256,
+        start_after: Option<Username>,
+        limit: Option<u32>,
+    },
 }
 
 #[grug::derive(Serde)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ForgotUsername` query to retrieve usernames by key hash, updating relevant functions and state management.
> 
>   - **Behavior**:
>     - Adds `ForgotUsername` query to `QueryMsg` in `msg.rs` to retrieve usernames by key hash.
>     - Implements `forgot_username()` in `query.rs` to handle the new query.
>     - Updates `instantiate()`, `register_user()`, and `update_key()` in `execute.rs` to manage `USERNAMES_BY_KEY`.
>   - **State**:
>     - Introduces `USERNAMES_BY_KEY` in `state.rs` to map key hashes to usernames.
>   - **Misc**:
>     - Updates imports in `execute.rs`, `query.rs`, and `msg.rs` to include `USERNAMES_BY_KEY` and `BTreeSet`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for f03722e15fc53a78193581df361c728b97b6537d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->