### PR TITLE
feat(ui): show rate when swapping

### DIFF
--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -500,8 +500,7 @@
       "swapSuccessfully": "Swap Successfully",
       "youGet": "You get",
       "youSwap": "You swap",
-      "priceImpact": "Price Impact",
-      "slippage": "Max Slippage",
+      "rate": "Rate",
       "errors": {
         "failure": "Swap failed"
       }

--- a/ui/portal/web/src/components/auth/Signin.tsx
+++ b/ui/portal/web/src/components/auth/Signin.tsx
@@ -210,7 +210,7 @@ const CredentialStep: React.FC = () => {
 
   const { mutateAsync: connectWithConnector, isPending } = useSignin({
     username,
-    sessionKey: sessionKey && { expireAt: DEFAULT_SESSION_EXPIRATION },
+    sessionKey: sessionKey && { expireAt: Date.now() + DEFAULT_SESSION_EXPIRATION },
     mutation: {
       onSuccess: () => {
         navigate({ to: "/" });

--- a/ui/portal/web/src/components/auth/Signin.tsx
+++ b/ui/portal/web/src/components/auth/Signin.tsx
@@ -110,6 +110,9 @@ const UsernameStep: React.FC = () => {
           <Button onClick={() => setUseAnotherAccount(true)} fullWidth variant="primary">
             {m["signin.useAnotherAccount"]()}
           </Button>
+          <Button as={Link} fullWidth variant="secondary" to="/">
+            {m["signin.continueWithoutSignin"]()}
+          </Button>
           <ExpandOptions showOptionText={m["signin.advancedOptions"]()}>
             <div className="flex items-center gap-2 flex-col">
               <Checkbox

--- a/ui/portal/web/src/components/dex/SimpleSwap.tsx
+++ b/ui/portal/web/src/components/dex/SimpleSwap.tsx
@@ -8,14 +8,7 @@ import {
   useSigningClient,
 } from "@left-curve/store";
 
-import {
-  Badge,
-  Button,
-  CoinSelector,
-  IconArrowDown,
-  IconGear,
-  Input,
-} from "@left-curve/applets-kit";
+import { Badge, Button, CoinSelector, IconArrowDown, Input } from "@left-curve/applets-kit";
 import { toast } from "../foundation/Toast";
 
 import { m } from "~/paraglide/messages";
@@ -220,7 +213,6 @@ export const SimpleSwapForm: React.FC = () => {
         submission.mutate();
       }}
     >
-      <IconGear className="w-[18px] h-[18px] absolute right-0 top-0" />
       <Input
         isDisabled={isPending}
         placeholder="0"
@@ -260,7 +252,10 @@ export const SimpleSwapForm: React.FC = () => {
                 variant="secondary"
                 size="xs"
                 className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
-                onClick={() => setValue("base", baseBalance)}
+                onClick={() => {
+                  setActiveInput("base");
+                  setValue("base", baseBalance);
+                }}
               >
                 {m["common.max"]()}
               </Button>
@@ -322,7 +317,10 @@ export const SimpleSwapForm: React.FC = () => {
                 variant="secondary"
                 size="xs"
                 className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
-                onClick={() => setValue("quote", quoteBalance)}
+                onClick={() => {
+                  setActiveInput("quote");
+                  setValue("quote", quoteBalance);
+                }}
               >
                 {m["common.max"]()}
               </Button>
@@ -342,10 +340,17 @@ export const SimpleSwapForm: React.FC = () => {
 };
 
 const SimpleSwapDetails: React.FC = () => {
+  const { account } = useAccount();
   const { settings } = useApp();
-  const { state } = useSimpleSwap();
-  const { pair, priceImpact, fee, slippage } = state;
+  const { state, controllers } = useSimpleSwap();
+  const { pair, simulation, fee, coins } = state;
   const { formatNumberOptions } = settings;
+  const { input, data } = simulation;
+
+  if (!input || !data || !account || input.amount === "0") return <div />;
+
+  const inputCoin = coins[input.denom];
+  const outputCoin = coins[data.denom];
 
   return (
     <div className="flex flex-col gap-1 w-full">
@@ -358,12 +363,18 @@ const SimpleSwapDetails: React.FC = () => {
         </p>
       </div>
       <div className="flex w-full gap-2 items-center justify-between">
-        <p className="text-gray-500 diatype-sm-regular">{m["dex.simpleSwap.priceImpact"]()}</p>
-        <p className="text-gray-700 diatype-sm-medium">{priceImpact.toFixed(5)}%</p>
-      </div>
-      <div className="flex w-full gap-2 items-center justify-between">
-        <p className="text-gray-500 diatype-sm-regular">{m["dex.simpleSwap.slippage"]()}</p>
-        <p className="text-gray-700 diatype-sm-medium">{Number(slippage) * 100}%</p>
+        <p className="text-gray-500 diatype-sm-regular">{m["dex.simpleSwap.rate"]()}</p>
+        <p className="text-gray-700 diatype-sm-medium">
+          1 {inputCoin.symbol} ≈{" "}
+          {formatNumber(
+            formatUnits(
+              Math.round(Number(data.amount) / Number(controllers.inputs.quote.value || 0)),
+              outputCoin.decimals,
+            ) || 0,
+            formatNumberOptions,
+          )}{" "}
+          {outputCoin.symbol}
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance UI to display swap rate, refine sign-in process, and update session handling logic.
> 
>   - **UI Enhancements**:
>     - Display rate in `SimpleSwapDetails` in `SimpleSwap.tsx`.
>     - Add 'Continue without sign-in' button in `Signin.tsx`.
>   - **Logic Changes**:
>     - Update session expiration logic in `CredentialStep` in `Signin.tsx`.
>     - Handle connected state in `SimpleSwapForm` and `SimpleSwapTrigger` in `SimpleSwap.tsx`.
>   - **Localization**:
>     - Rename `priceImpact` and `slippage` to `rate` in `en.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 25039b25f95d4067f9a24c480eca4674fe60df7e. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->