### PR TITLE
feat(dango): events indicating owning/disowning an account or a key

### DIFF
--- a/dango/types/src/account_factory/events.rs
+++ b/dango/types/src/account_factory/events.rs
@@ -3,7 +3,7 @@ use {
         account_factory::{AccountIndex, AccountParams, Username},
         auth::Key,
     },
-    grug::{Addr, Hash256, Op},
+    grug::{Addr, Hash256},
 };
 
 /// An event indicating a new user has registered.
@@ -40,10 +40,19 @@ pub struct AccountDisowned {
     pub address: Addr,
 }
 
-/// An event indicating a key has been updated.
+/// An event indicating a username begin to own a key.
 #[grug::derive(Serde)]
-#[grug::event("key_updated")]
-pub struct KeyUpdated {
+#[grug::event("key_owned")]
+pub struct KeyOwned {
     pub username: Username,
-    pub key: Op<Key>,
+    pub key_hash: Hash256,
+    pub key: Key,
+}
+
+/// An event indicating a username cease to own a key.
+#[grug::derive(Serde)]
+#[grug::event("key_disowned")]
+pub struct KeyDisowned {
+    pub username: Username,
+    pub key_hash: Hash256,
 }

--- a/dango/types/src/account_factory/events.rs
+++ b/dango/types/src/account_factory/events.rs
@@ -24,6 +24,22 @@ pub struct AccountRegistered {
     pub index: AccountIndex,
 }
 
+/// An event indicating a username begin to own an account.
+#[grug::derive(Serde)]
+#[grug::event("account_owned")]
+pub struct AccountOwned {
+    pub username: Username,
+    pub address: Addr,
+}
+
+/// An event indicating a username cease to own an account.
+#[grug::derive(Serde)]
+#[grug::event("account_disowned")]
+pub struct AccountDisowned {
+    pub username: Username,
+    pub address: Addr,
+}
+
 /// An event indicating a key has been updated.
 #[grug::derive(Serde)]
 #[grug::event("key_updated")]

--- a/dango/types/src/account_factory/events.rs
+++ b/dango/types/src/account_factory/events.rs
@@ -24,7 +24,7 @@ pub struct AccountRegistered {
     pub index: AccountIndex,
 }
 
-/// An event indicating a username begin to own an account.
+/// An event indicating a username begins to own an account.
 #[grug::derive(Serde)]
 #[grug::event("account_owned")]
 pub struct AccountOwned {
@@ -32,7 +32,7 @@ pub struct AccountOwned {
     pub address: Addr,
 }
 
-/// An event indicating a username cease to own an account.
+/// An event indicating a username ceases to own an account.
 #[grug::derive(Serde)]
 #[grug::event("account_disowned")]
 pub struct AccountDisowned {
@@ -40,7 +40,7 @@ pub struct AccountDisowned {
     pub address: Addr,
 }
 
-/// An event indicating a username begin to own a key.
+/// An event indicating a username begins to own a key.
 #[grug::derive(Serde)]
 #[grug::event("key_owned")]
 pub struct KeyOwned {
@@ -49,7 +49,7 @@ pub struct KeyOwned {
     pub key: Key,
 }
 
-/// An event indicating a username cease to own a key.
+/// An event indicating a username ceases to own a key.
 #[grug::derive(Serde)]
 #[grug::event("key_disowned")]
 pub struct KeyDisowned {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add events for account and key ownership changes, updating relevant functions to emit these events in `execute.rs` and `events.rs`.
> 
>   - **Events**:
>     - Add `AccountOwned`, `AccountDisowned`, `KeyOwned`, and `KeyDisowned` events in `events.rs`.
>     - Emit `AccountOwned` and `AccountDisowned` in `register_account()` and `update_account()` in `execute.rs`.
>     - Emit `KeyOwned` and `KeyDisowned` in `update_key()` in `execute.rs`.
>   - **Functions**:
>     - Update `register_account()` to emit `AccountOwned` events for new account ownership.
>     - Update `update_account()` to emit `AccountOwned` and `AccountDisowned` for membership changes.
>     - Update `update_key()` to emit `KeyOwned` and `KeyDisowned` for key changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for be635ff950251bc5ff6b7749ad226d27bd5aa7e2. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->