### PR TITLE
Add a way to reset deploys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -314,6 +314,11 @@ jobs:
         run: |
           cd deploy
           pipx ensurepath
+          # TODO: Make sure we only deploy on devnet
+          ansible-playbook reset-cometbft.yml
+          ansible-playbook reset-dango.yml
+          ansible-playbook cometbft.yml
+          ansible-playbook dango.yml --tags setup
           ansible-playbook dango.yml \
             --skip-tags setup \
             -e dango_image_tag=${{ env.GIT_COMMIT }} \

--- a/deploy/cometbft.yml
+++ b/deploy/cometbft.yml
@@ -2,7 +2,6 @@
   become: true
   become_user: "{{ deploy_user }}"
   vars:
-    cometbft_target_dir: "{{ ansible_env.HOME }}/cometbft"
     COMETBFT_NODE_KEY: "{{ lookup('env','COMETBFT_NODE_KEY') }}"
     COMETBFT_VALIDATOR_ADDRESS: "{{ lookup('env','COMETBFT_VALIDATOR_ADDRESS') }}"
     COMETBFT_VALIDATOR_PUB_KEY: "{{ lookup('env','COMETBFT_VALIDATOR_PUB_KEY') }}"

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -26,14 +26,12 @@ cold-deploy-dango:
   ansible-playbook dango.yml
 
 deploy-dango:
+  ansible-playbook dango.yml --tags setup
   ansible-playbook dango.yml --skip-tags setup
 
 reset-deploy:
   ansible-playbook reset-cometbft.yml
   ansible-playbook reset-dango.yml
-  ansible-playbook cometbft.yml
-  ansible-playbook dango.yml --tags setup
-  ansible-playbook dango.yml --skip-tags setup
 
 setup-deploy-dango:
   ansible-playbook dango.yml --tags setup

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -28,6 +28,13 @@ cold-deploy-dango:
 deploy-dango:
   ansible-playbook dango.yml --skip-tags setup
 
+reset-deploy:
+  ansible-playbook reset-cometbft.yml
+  ansible-playbook reset-dango.yml
+  ansible-playbook cometbft.yml
+  ansible-playbook dango.yml --tags setup
+  ansible-playbook dango.yml --skip-tags setup
+
 setup-deploy-dango:
   ansible-playbook dango.yml --tags setup
 

--- a/deploy/reset-cometbft.yml
+++ b/deploy/reset-cometbft.yml
@@ -1,0 +1,17 @@
+- hosts: cometbft
+  become: true
+  become_user: "{{ deploy_user }}"
+  collections:
+    - community.docker
+  vars_files:
+    - roles/cometbft/defaults/main.yml
+  tasks:
+    - name: Stop and remove cometbft container
+      docker_container:
+        name: cometbft
+        state: absent
+        keep_volumes: false
+    - name: Remove directory
+      file:
+        path: "{{ cometbft_target_dir }}"
+        state: absent

--- a/deploy/reset-dango.yml
+++ b/deploy/reset-dango.yml
@@ -1,0 +1,26 @@
+- hosts: dango
+  become: true
+  become_user: "{{ deploy_user }}"
+  vars_files:
+    - roles/dango/defaults/main.yml
+  collections:
+    - community.docker
+  tasks:
+    - name: Stop and remove dango container
+      docker_container:
+        name: dango
+        state: absent
+        keep_volumes: false
+    - name: Remove directory
+      file:
+        path: "{{ dango_target_dir }}"
+        state: absent
+    - name: Drop Dango production database
+      tags: cleanup
+      community.postgresql.postgresql_db:
+        name: "{{ dango_db_name }}"
+        login_user: "{{ db_user }}"
+        login_password: "{{ db_pass }}"
+        login_host: "{{ db_host }}"
+        login_port: "{{ db_port }}"
+        state: absent

--- a/deploy/roles/cometbft/defaults/main.yml
+++ b/deploy/roles/cometbft/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
+cometbft_target_dir: "{{ ansible_env.HOME }}/cometbft"
 host_port: 26657


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Ansible playbooks and workflow steps to reset `cometbft` and `dango` deployments.
> 
>   - **Deployment Reset**:
>     - Adds `reset-cometbft.yml` and `reset-dango.yml` playbooks to stop and remove containers, delete directories, and drop databases.
>     - Updates `justfile` with `reset-deploy` command to execute reset playbooks.
>   - **Workflow Changes**:
>     - Modifies `.github/workflows/rust.yml` to include reset steps before deploying `cometbft` and `dango`.
>   - **Configuration**:
>     - Moves `cometbft_target_dir` definition to `roles/cometbft/defaults/main.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 067ac6ae691062293e4ab7815eb4ac4072935831. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->