### PR TITLE
fix: session settings styles & text

### DIFF
--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -443,7 +443,7 @@
     "language": "Language",
     "session": {
       "title": "Session",
-      "description": "For security reasons, each login session lasts 24 hours. You will need to log in again once your session expires.",
+      "description": "For security reasons, each session is limited to 24 hours. Please log in again if your current session expires.",
       "remaining": "Remaining time",
       "time": { "hours": "h", "minutes": "m", "seconds": "s" }
     },

--- a/ui/portal/web/src/components/auth/ForgotUsername.tsx
+++ b/ui/portal/web/src/components/auth/ForgotUsername.tsx
@@ -62,7 +62,7 @@ const Credential: React.FC = () => {
   });
 
   return (
-    <div className="flex flex-col gap-6 w-full items-center">
+    <div className="flex flex-col gap-6 w-full items-center text-center">
       <div className="flex flex-col gap-7 items-center justify-center">
         <img
           src="./favicon.svg"
@@ -115,7 +115,7 @@ const AvailableUsernames: React.FC = () => {
   const existUsernames = usernames.length;
 
   return (
-    <div className="flex flex-col gap-6 w-full">
+    <div className="flex flex-col gap-6 w-full items-center text-center">
       <div className="flex flex-col gap-7 items-center justify-center">
         <img
           src="./favicon.svg"

--- a/ui/portal/web/src/components/settings/SessionCountdown.tsx
+++ b/ui/portal/web/src/components/settings/SessionCountdown.tsx
@@ -17,7 +17,7 @@ export const SessionCountdown: React.FC = () => {
   });
 
   return (
-    <div className="flex gap-1 text-gray-700">
+    <div className="flex gap-1 text-gray-700 px-4 py-3 shadow-card-shadow rounded-md min-w-[9rem] h-[46px] items-center justify-center">
       {[
         { value: hours, label: hoursLabel },
         { value: minutes, label: minutesLabel },
@@ -29,7 +29,7 @@ export const SessionCountdown: React.FC = () => {
         if (value === "00" && label === hoursLabel) return null;
 
         return (
-          <div className="flex min-w-[30px] gap-[1px] items-center justify-center" key={label}>
+          <div className="flex min-w-[30px] gap-[1px] items-center justify-center " key={label}>
             <div className="relative h-4 w-full overflow-hidden flex items-center justify-center">
               <AnimatePresence mode="popLayout">
                 <motion.div

--- a/ui/portal/web/src/pages/(app)/_app.settings.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.settings.lazy.tsx
@@ -16,7 +16,7 @@ import { KeyManagement } from "~/components/settings/KeyManagement";
 import { useApp } from "~/hooks/useApp";
 import { m } from "~/paraglide/messages";
 import { getLocale, locales, setLocale } from "~/paraglide/runtime";
-import { useState } from "react";
+
 import { SessionCountdown } from "~/components/settings/SessionCountdown";
 
 export const Route = createLazyFileRoute("/(app)/_app/settings")({
@@ -32,7 +32,7 @@ function SettingsComponent() {
   const { session } = useSessionKey();
 
   return (
-    <div className="w-full md:max-w-[50rem] mx-auto flex flex-col gap-4 p-4 pt-6 mb-16">
+    <div className="w-full md:max-w-[50rem] mx-auto flex flex-col gap-5 p-4 pt-6 mb-16">
       <h2 className="flex gap-2 items-center">
         {isMd ? null : (
           <IconButton variant="link" onClick={() => history.go(-1)}>
@@ -44,18 +44,20 @@ function SettingsComponent() {
       {session ? (
         <div className="rounded-xl bg-rice-25 shadow-card-shadow flex flex-col w-full px-2 py-4">
           <h3 className="h4-bold text-gray-900 px-2 pb-4">{m["settings.session.title"]()}</h3>
-          <div className="flex items-center justify-between pt-2 rounded-md">
-            <p className="flex items-center justify-center gap-2 px-2">
-              <IconInfo className="text-gray-500" />
-              <span className="diatype-m-bold text-gray-700">
-                {m["settings.session.remaining"]()}
-              </span>
-            </p>
+          <div className="flex items-start justify-between py-2 rounded-md gap-8">
+            <div className="flex flex-col">
+              <p className="flex items-start gap-2 px-2">
+                <IconInfo className="text-gray-500" />
+                <span className="diatype-m-bold text-gray-700">
+                  {m["settings.session.remaining"]()}
+                </span>
+              </p>
+              <p className="text-gray-500 diatype-sm-regular pl-10 pb-2">
+                {m["settings.session.description"]()}
+              </p>
+            </div>
             <SessionCountdown />
           </div>
-          <p className="text-gray-500 diatype-sm-regular pl-10 max-w-96 pb-2">
-            {m["settings.session.description"]()}
-          </p>
         </div>
       ) : null}
       <div className="rounded-xl bg-rice-25 shadow-card-shadow flex flex-col w-full px-2 py-4">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves session settings UI and text for better user experience and clarity.
> 
>   - **Text Changes**:
>     - Update session description in `en.json` to "For security reasons, each session is limited to 24 hours. Please log in again if your current session expires."
>   - **Style Changes**:
>     - Add `text-center` to `div` elements in `ForgotUsername.tsx` for better alignment.
>     - Update `SessionCountdown.tsx` to include padding, shadow, and rounded corners for improved UI.
>     - Adjust layout and spacing in `_app.settings.lazy.tsx` for session settings display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ca8a606ad9b6e0c1aee5de89e39afed69a5c94c6. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->