### PR TITLE
feat(ui): not found applet on unhandle error

### DIFF
--- a/ui/portal/web/src/app.provider.tsx
+++ b/ui/portal/web/src/app.provider.tsx
@@ -229,7 +229,7 @@ export const AppProvider: React.FC<PropsWithChildren> = ({ children }) => {
         setNotificationMenuVisibility,
         isSearchBarVisible,
         setSearchBarVisibility,
-        isQuestBannerVisible,
+        isQuestBannerVisible: false,
         setQuestBannerVisibility,
         showModal,
         hideModal,

--- a/ui/portal/web/src/pages/(app)/_app.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.tsx
@@ -2,6 +2,7 @@ import { twMerge } from "@left-curve/applets-kit";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { Header } from "~/components/foundation/Header";
+import { NotFound } from "~/components/foundation/NotFound";
 import { QuestBanner } from "~/components/foundation/QuestBanner";
 import { WelcomeModal } from "~/components/modals/WelcomeModal";
 
@@ -18,13 +19,7 @@ export const Route = createFileRoute("/(app)/_app")({
           )}
         />
         <Header isScrolled={false} />
-        <div className="flex items-center justify-start w-full z-30 h-full relative flex-col">
-          <div className="w-full flex flex-1 justify-center items-center p-4">
-            <h3 className="text-center max-w-4xl diatype text-[40px] md:text-[80px] font-extrabold text-gray-500">
-              Sorry, we couldn't find the page you were looking for.
-            </h3>
-          </div>
-        </div>
+        <NotFound />
       </main>
     );
   },

--- a/ui/portal/web/src/pages/__root.tsx
+++ b/ui/portal/web/src/pages/__root.tsx
@@ -1,4 +1,10 @@
 import { createRootRouteWithContext } from "@tanstack/react-router";
+
+import { Header } from "~/components/foundation/Header";
+import { NotFound } from "~/components/foundation/NotFound";
+
+import { twMerge } from "@left-curve/applets-kit";
+
 import type { RouterContext } from "~/app.router";
 
 export const Route = createRootRouteWithContext<RouterContext>()({
@@ -13,5 +19,17 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       });
     }
   },
-  errorComponent: () => <div>Something went wrong</div>,
+  errorComponent: () => (
+    <main className="flex flex-col h-screen w-screen relative items-center justify-start overflow-y-auto overflow-x-hidden scrollbar-none bg-white-100">
+      <img
+        src="/images/union.png"
+        alt="bg-image"
+        className={twMerge(
+          "drag-none select-none h-[15vh] lg:h-[20vh] w-full fixed lg:absolute bottom-0 lg:top-0 left-0 z-40 lg:z-0 rotate-180 lg:rotate-0",
+        )}
+      />
+      <Header isScrolled={false} />
+      <NotFound />
+    </main>
+  ),
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `NotFound` component for unhandled errors and sets `isQuestBannerVisible` to false in `AppProvider`.
> 
>   - **Error Handling**:
>     - Replaces inline error message with `NotFound` component in `_app.tsx` and `__root.tsx`.
>     - `NotFound` component imported from `~/components/foundation/NotFound`.
>   - **State Management**:
>     - Sets `isQuestBannerVisible` to `false` in `AppProvider` in `app.provider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 83c524264c6392070a7f4b73afd276a6db72988d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->