### PR TITLE
Add SSL root certificates

### DIFF
--- a/docker/dango/Dockerfile
+++ b/docker/dango/Dockerfile
@@ -12,7 +12,7 @@ ENV GIT_COMMIT=$GIT_COMMIT
 # ENV USERNAME=${USERNAME}
 
 RUN apt-get update && \
-    apt-get install -y libssl-dev pkg-config libsqlite3-0 && \
+    apt-get install -y libssl-dev pkg-config libsqlite3-0 ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # RUN useradd --create-home --shell /bin/bash $USERNAME


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `ca-certificates` to `docker/dango/Dockerfile` to include SSL root certificates.
> 
>   - **Dockerfile Update**:
>     - Add `ca-certificates` to `apt-get install` in `docker/dango/Dockerfile` to include SSL root certificates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 8a4d23ebb32fe82a8360cacb3d30e7987a68be43. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->