### PR TITLE
feat(grug): cache abstraction

### DIFF
--- a/dango/account/factory/src/account_querier.rs
+++ b/dango/account/factory/src/account_querier.rs
@@ -12,7 +12,7 @@ impl<'a> AccountQuerier<'a> {
     pub fn new(factory: Addr, querier: QuerierWrapper<'a>) -> Self {
         Self {
             cache: Cache::new(move |address, ()| {
-                querier.query_wasm_path(factory, &ACCOUNTS.path(address))
+                querier.query_wasm_path(factory, &ACCOUNTS.path(*address))
             }),
         }
     }

--- a/dango/account/factory/src/account_querier.rs
+++ b/dango/account/factory/src/account_querier.rs
@@ -11,13 +11,13 @@ pub struct AccountQuerier<'a> {
 impl<'a> AccountQuerier<'a> {
     pub fn new(factory: Addr, querier: QuerierWrapper<'a>) -> Self {
         Self {
-            cache: Cache::new(move |address, ()| {
+            cache: Cache::new(move |address, _| {
                 querier.query_wasm_path(factory, &ACCOUNTS.path(*address))
             }),
         }
     }
 
     pub fn query_account(&mut self, address: Addr) -> StdResult<&Account> {
-        self.cache.get_or_fetch(&address, ())
+        self.cache.get_or_fetch(&address, None)
     }
 }

--- a/dango/account/factory/src/account_querier.rs
+++ b/dango/account/factory/src/account_querier.rs
@@ -1,36 +1,23 @@
 use {
     crate::ACCOUNTS,
     dango_types::account_factory::Account,
-    grug::{Addr, QuerierWrapper, StorageQuerier},
-    std::collections::HashMap,
+    grug::{Addr, Cache, QuerierWrapper, StdResult, StorageQuerier},
 };
 
 pub struct AccountQuerier<'a> {
-    querier: QuerierWrapper<'a>,
-    address: Addr,
-    cache: HashMap<Addr, Account>,
+    cache: Cache<'a, Addr, Account>,
 }
 
 impl<'a> AccountQuerier<'a> {
-    pub fn new(address: Addr, querier: QuerierWrapper<'a>) -> Self {
+    pub fn new(factory: Addr, querier: QuerierWrapper<'a>) -> Self {
         Self {
-            address,
-            querier,
-            cache: HashMap::new(),
+            cache: Cache::new(move |address, ()| {
+                querier.query_wasm_path(factory, &ACCOUNTS.path(address))
+            }),
         }
     }
 
-    pub fn query_account(&mut self, address: Addr) -> anyhow::Result<Account> {
-        if let Some(account) = self.cache.get(&address) {
-            return Ok(account.clone());
-        }
-
-        let account = self
-            .querier
-            .query_wasm_path(self.address, &ACCOUNTS.path(address))?;
-
-        self.cache.insert(address, account.clone());
-
-        Ok(account)
+    pub fn query_account(&mut self, address: Addr) -> StdResult<&Account> {
+        self.cache.get_or_fetch(&address, ())
     }
 }

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -712,7 +712,7 @@ fn clear_orders_of_pair(
                 },
                 Entry::Vacant(v) => {
                     let volume = VOLUMES_BY_USER
-                        .prefix(&username)
+                        .prefix(username)
                         .values(storage, None, None, IterationOrder::Descending)
                         .next()
                         .transpose()?

--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -14,7 +14,7 @@ use {
 };
 
 pub struct OracleQuerier<'a> {
-    cache: Cache<'a, Denom, PrecisionedPrice, anyhow::Error, Option<PriceSource>>,
+    cache: Cache<'a, Denom, PrecisionedPrice, anyhow::Error, PriceSource>,
 }
 
 impl<'a> OracleQuerier<'a> {

--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -25,7 +25,7 @@ impl<'a> OracleQuerier<'a> {
 
         Self {
             cache: Cache::new(move |denom, price_source| {
-                no_cache_querier.query_price(&denom, price_source)
+                no_cache_querier.query_price(denom, price_source)
             }),
         }
     }

--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -39,7 +39,7 @@ impl<'a> OracleQuerier<'a> {
     }
 }
 
-pub struct OracleQuerierNoCache<'a> {
+pub(crate) struct OracleQuerierNoCache<'a> {
     ctx: OracleContext<'a>,
     lending: RemoteLending<'a>,
 }

--- a/dango/oracle/src/query.rs
+++ b/dango/oracle/src/query.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{GUARDIAN_SETS, OracleQuerier, PRICE_SOURCES},
+    crate::{GUARDIAN_SETS, OracleQuerierNoCache, PRICE_SOURCES},
     dango_types::oracle::{PrecisionedPrice, PriceSource, QueryMsg},
     grug::{Bound, DEFAULT_PAGE_LIMIT, Denom, ImmutableCtx, Json, JsonSerExt, Order, StdResult},
     pyth_types::{GuardianSet, GuardianSetIndex},
@@ -37,7 +37,7 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
 }
 
 fn query_price(ctx: ImmutableCtx, denom: Denom) -> anyhow::Result<PrecisionedPrice> {
-    let mut oracle_querier = OracleQuerier::new_local(ctx.storage, ctx.querier);
+    let oracle_querier = OracleQuerierNoCache::new_local(ctx.storage, ctx.querier);
     oracle_querier.query_price(&denom, None)
 }
 
@@ -46,7 +46,7 @@ fn query_prices(
     start_after: Option<Denom>,
     limit: Option<u32>,
 ) -> anyhow::Result<BTreeMap<Denom, PrecisionedPrice>> {
-    let mut oracle_querier = OracleQuerier::new_local(ctx.storage, ctx.querier);
+    let oracle_querier = OracleQuerierNoCache::new_local(ctx.storage, ctx.querier);
 
     let start = start_after.as_ref().map(Bound::Exclusive);
     let limit = limit.unwrap_or(DEFAULT_PAGE_LIMIT) as usize;

--- a/dango/types/src/account_factory/account.rs
+++ b/dango/types/src/account_factory/account.rs
@@ -126,9 +126,9 @@ impl AccountParams {
     /// Returns the owner (username) of the account.
     ///
     /// Returns `None` for multisig accounts.
-    pub fn owner(self) -> Option<Username> {
+    pub fn owner(&self) -> Option<&Username> {
         match self {
-            AccountParams::Spot(params) | AccountParams::Margin(params) => Some(params.owner),
+            AccountParams::Spot(params) | AccountParams::Margin(params) => Some(&params.owner),
             AccountParams::Multi(_) => None,
         }
     }

--- a/grug/types/src/cache.rs
+++ b/grug/types/src/cache.rs
@@ -8,7 +8,7 @@ where
     K: Eq + Hash + Clone,
 {
     data: HashMap<K, V>,
-    fetcher: Box<dyn Fn(&K, Aux) -> Result<V, Err> + 'a>,
+    fetcher: Box<dyn Fn(&K, Option<Aux>) -> Result<V, Err> + 'a>,
 }
 
 impl<'a, K, V, Err, Aux> Cache<'a, K, V, Err, Aux>
@@ -17,7 +17,7 @@ where
 {
     pub fn new<F>(fetcher: F) -> Self
     where
-        F: Fn(&K, Aux) -> Result<V, Err> + 'a,
+        F: Fn(&K, Option<Aux>) -> Result<V, Err> + 'a,
     {
         Self {
             data: HashMap::new(),
@@ -25,7 +25,7 @@ where
         }
     }
 
-    pub fn get_or_fetch(&mut self, k: &K, aux: Aux) -> Result<&V, Err> {
+    pub fn get_or_fetch(&mut self, k: &K, aux: Option<Aux>) -> Result<&V, Err> {
         if !self.data.contains_key(k) {
             let v = (self.fetcher)(k, aux)?;
             self.data.insert(k.clone(), v);

--- a/grug/types/src/cache.rs
+++ b/grug/types/src/cache.rs
@@ -1,0 +1,36 @@
+use {
+    crate::StdError,
+    std::{collections::HashMap, hash::Hash},
+};
+
+pub struct Cache<'a, K, V, Err = StdError, Aux = ()>
+where
+    K: Eq + Hash + Clone,
+{
+    data: HashMap<K, V>,
+    fetcher: Box<dyn Fn(K, Aux) -> Result<V, Err> + 'a>,
+}
+
+impl<'a, K, V, Err, Aux> Cache<'a, K, V, Err, Aux>
+where
+    K: Eq + Hash + Clone,
+{
+    pub fn new<F>(fetcher: F) -> Self
+    where
+        F: Fn(K, Aux) -> Result<V, Err> + 'a,
+    {
+        Self {
+            data: HashMap::new(),
+            fetcher: Box::new(fetcher),
+        }
+    }
+
+    pub fn get_or_fetch(&mut self, k: &K, aux: Aux) -> Result<&V, Err> {
+        if !self.data.contains_key(k) {
+            let v = (self.fetcher)(k.clone(), aux)?;
+            self.data.insert(k.clone(), v);
+        }
+
+        Ok(self.data.get(k).unwrap())
+    }
+}

--- a/grug/types/src/cache.rs
+++ b/grug/types/src/cache.rs
@@ -8,7 +8,7 @@ where
     K: Eq + Hash + Clone,
 {
     data: HashMap<K, V>,
-    fetcher: Box<dyn Fn(K, Aux) -> Result<V, Err> + 'a>,
+    fetcher: Box<dyn Fn(&K, Aux) -> Result<V, Err> + 'a>,
 }
 
 impl<'a, K, V, Err, Aux> Cache<'a, K, V, Err, Aux>
@@ -17,7 +17,7 @@ where
 {
     pub fn new<F>(fetcher: F) -> Self
     where
-        F: Fn(K, Aux) -> Result<V, Err> + 'a,
+        F: Fn(&K, Aux) -> Result<V, Err> + 'a,
     {
         Self {
             data: HashMap::new(),
@@ -27,7 +27,7 @@ where
 
     pub fn get_or_fetch(&mut self, k: &K, aux: Aux) -> Result<&V, Err> {
         if !self.data.contains_key(k) {
-            let v = (self.fetcher)(k.clone(), aux)?;
+            let v = (self.fetcher)(k, aux)?;
             self.data.insert(k.clone(), v);
         }
 

--- a/grug/types/src/lib.rs
+++ b/grug/types/src/lib.rs
@@ -6,6 +6,7 @@ mod bound;
 mod buffer;
 mod builder;
 mod bytes;
+mod cache;
 mod changeset;
 mod code;
 mod coin;
@@ -43,7 +44,7 @@ mod unique_vec;
 mod utils;
 
 pub use {
-    address::*, app::*, bank::*, binary::*, bound::*, buffer::*, builder::*, bytes::*,
+    address::*, app::*, bank::*, binary::*, bound::*, buffer::*, builder::*, bytes::*, cache::*,
     changeset::*, code::*, coin::*, coin_pair::*, coins::*, context::*, db::*, denom::*, empty::*,
     encoded_bytes::*, encoders::*, error::*, events::*, ffi::*, hash::*, hashers::*, imports::*,
     jellyfish_merkle::*, json::*, length_bounded::*, lengthy::*, non_zero::*, outcome::*, query::*,


### PR DESCRIPTION
We already have two querier types that implement caching:

- `dango_account_factory::AccountQuerier`
- `dango_oracle::OracleQuerier`

Now, in #709 we're introducing another cache for file reads.

I think it's better if we extract the common caching logic between these to a struct, `grug::Cache`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce `Cache` abstraction to unify caching logic in `AccountQuerier` and `OracleQuerier`.
> 
>   - **Cache Abstraction**:
>     - Introduces `Cache` struct in `grug/types/src/cache.rs` to unify caching logic.
>     - `AccountQuerier` in `account_querier.rs` now uses `Cache` for caching accounts.
>     - `OracleQuerier` in `oracle_querier.rs` now uses `Cache` for caching prices.
>   - **Refactoring**:
>     - `OracleQuerierNoCache` introduced for non-caching operations in `oracle_querier.rs`.
>     - `owner()` method in `account.rs` now takes `&self` instead of `self`.
>   - **Miscellaneous**:
>     - Fixes minor typo in `execute.rs` (`prefix(&username)` to `prefix(username)`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 4a995e53196407a86dd70eda68c6961cc94c02a3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->