### PR TITLE
refactor(dango): account querier to return `Option<&Account>`

### DIFF
--- a/dango/account/factory/src/account_querier.rs
+++ b/dango/account/factory/src/account_querier.rs
@@ -5,19 +5,19 @@ use {
 };
 
 pub struct AccountQuerier<'a> {
-    cache: Cache<'a, Addr, Account>,
+    cache: Cache<'a, Addr, Option<Account>>,
 }
 
 impl<'a> AccountQuerier<'a> {
     pub fn new(factory: Addr, querier: QuerierWrapper<'a>) -> Self {
         Self {
             cache: Cache::new(move |address, _| {
-                querier.query_wasm_path(factory, &ACCOUNTS.path(*address))
+                querier.may_query_wasm_path(factory, &ACCOUNTS.path(*address))
             }),
         }
     }
 
-    pub fn query_account(&mut self, address: Addr) -> StdResult<&Account> {
-        self.cache.get_or_fetch(&address, None)
+    pub fn query_account(&mut self, address: Addr) -> StdResult<Option<&Account>> {
+        self.cache.get_or_fetch(&address, None).map(|a| a.as_ref()) // Convert `&Option<T>` to `Option<&T>`
     }
 }

--- a/dango/account/margin/src/core.rs
+++ b/dango/account/margin/src/core.rs
@@ -89,7 +89,7 @@ pub fn query_health(
 ) -> anyhow::Result<HealthData> {
     // Query all debts for the account.
     let scaled_debts = querier
-        .may_query_wasm_path(app_cfg.addresses.lending, DEBTS.path(account))?
+        .may_query_wasm_path(app_cfg.addresses.lending, &DEBTS.path(account))?
         .unwrap_or_default();
 
     // Query collateral balances.

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -705,7 +705,10 @@ fn clear_orders_of_pair(
 
         // Record trading volume for the user's username, if the trader is a
         // single-signature account (skip for multisig accounts).
-        if let Some(username) = account_querier.query_account(order.user)?.params.owner() {
+        if let Some(username) = account_querier
+            .query_account(order.user)?
+            .and_then(|account| account.params.owner())
+        {
             match volumes_by_username.entry(username.clone()) {
                 Entry::Occupied(mut v) => {
                     v.get_mut().checked_add_assign(new_volume)?;

--- a/grug/storage/src/querier.rs
+++ b/grug/storage/src/querier.rs
@@ -10,7 +10,7 @@ pub trait StorageQuerier: Querier {
     fn may_query_wasm_path<T, C>(
         &self,
         contract: Addr,
-        path: Path<'_, T, C>,
+        path: &Path<'_, T, C>,
     ) -> StdResult<Option<T>>
     where
         C: Codec<T>;
@@ -30,7 +30,7 @@ where
     fn may_query_wasm_path<T, C>(
         &self,
         contract: Addr,
-        path: Path<'_, T, C>,
+        path: &Path<'_, T, C>,
     ) -> StdResult<Option<T>>
     where
         C: Codec<T>,


### PR DESCRIPTION
A contract isn't necessarily an account registered at the account factory. So it makes sense to return a `None` in case it's not.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `AccountQuerier` to return `Option<&Account>` and update related functions to handle unregistered accounts.
> 
>   - **Behavior**:
>     - `AccountQuerier` in `account_querier.rs` now returns `Option<&Account>` in `query_account()` to handle unregistered accounts.
>     - `may_query_wasm_path` in `querier.rs` now takes `&Path` instead of `Path`.
>   - **Usage**:
>     - Updated `clear_orders_of_pair()` in `execute.rs` to handle `Option<&Account>` when recording trading volume.
>     - Updated `query_health()` in `core.rs` to use `&Path` in `may_query_wasm_path()`.
>   - **Misc**:
>     - Minor refactor in `account_querier.rs` to convert `&Option<T>` to `Option<&T>`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e941dea93a5364bee62d44d739d7868dd232241a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->