### PR TITLE
Enable cometbft indexing

### DIFF
--- a/deploy/roles/cometbft/files/config/config.toml
+++ b/deploy/roles/cometbft/files/config/config.toml
@@ -564,7 +564,7 @@ initial_block_results_retain_height = 0
 # 		- When "kv" is chosen "tx.height" and "tx.hash" will always be indexed.
 #   3) "psql" - the indexer services backed by PostgreSQL.
 # When "kv" or "psql" is chosen "tx.height" and "tx.hash" will always be indexed.
-indexer = "null"
+indexer = "kv"
 
 # The PostgreSQL connection configuration, the connection format:
 #   postgresql://<user>:<password>@<host>:<port>/<db>?<opts>

--- a/networks/localdango/configs/cometbft/config/config.toml
+++ b/networks/localdango/configs/cometbft/config/config.toml
@@ -564,7 +564,7 @@ initial_block_results_retain_height = 0
 # 		- When "kv" is chosen "tx.height" and "tx.hash" will always be indexed.
 #   3) "psql" - the indexer services backed by PostgreSQL.
 # When "kv" or "psql" is chosen "tx.height" and "tx.hash" will always be indexed.
-indexer = "null"
+indexer = "kv"
 
 # The PostgreSQL connection configuration, the connection format:
 #   postgresql://<user>:<password>@<host>:<port>/<db>?<opts>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable key-value based transaction indexing in CometBFT by changing `indexer` from `null` to `kv` in two `config.toml` files.
> 
>   - **Configuration Changes**:
>     - In `deploy/roles/cometbft/files/config/config.toml` and `networks/localdango/configs/cometbft/config.toml`, change `indexer` from `null` to `kv`.
>     - Enables key-value based transaction indexing, ensuring `tx.height` and `tx.hash` are always indexed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 5a8b64594a0741f7df27f7e1fa6429bcd3887e17. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->