### PR TITLE
Add dozzle to view docker logs

### DIFF
--- a/deploy/dozzle.yml
+++ b/deploy/dozzle.yml
@@ -1,0 +1,7 @@
+- hosts: dozzle
+  become: true
+  become_user: "{{ deploy_user }}"
+  collections:
+    - community.docker
+  roles:
+    - dozzle

--- a/deploy/dozzle.yml
+++ b/deploy/dozzle.yml
@@ -1,6 +1,9 @@
 - hosts: dozzle
   become: true
   become_user: "{{ deploy_user }}"
+  vars:
+    tailscale_iface: tailscale0
+    tailscale_ip: "{{ hostvars[inventory_hostname]['ansible_' + tailscale_iface].ipv4.address }}"
   collections:
     - community.docker
   roles:

--- a/deploy/inventory
+++ b/deploy/inventory
@@ -4,6 +4,9 @@ ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 [github_runners]
 100.96.253.40 hostname=ovh1 ansible_user=debian
 
+[dozzle]
+100.96.253.40 ansible_user=debian
+
 [db]
 100.96.253.40 ansible_user=debian
 

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -25,6 +25,9 @@ install-runners:
 deploy-bots:
   ansible-playbook bots.yml
 
+deploy-dozzle:
+  ansible-playbook dozzle.yml
+
 cold-deploy-dango:
   ansible-playbook dango.yml
 

--- a/deploy/roles/dozzle/defaults/main.yml
+++ b/deploy/roles/dozzle/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+dozzle_dir: "{{ ansible_env.HOME }}/dozzle"

--- a/deploy/roles/dozzle/files/docker-compose.yml
+++ b/deploy/roles/dozzle/files/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 9090:8080
+    environment:
+      # Uncomment to enable container actions (stop, start, restart). See https://dozzle.dev/guide/actions
+      - DOZZLE_ENABLE_ACTIONS=false
+
+      # Uncomment to allow access to container shells. See https://dozzle.dev/guide/shell
+      - DOZZLE_ENABLE_SHELL=false
+      #
+      # Uncomment to enable authentication. See https://dozzle.dev/guide/authentication
+      # - DOZZLE_AUTH_PROVIDER=simple

--- a/deploy/roles/dozzle/tasks/main.yml
+++ b/deploy/roles/dozzle/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Ensure dir exists
+  file:
+    path: "{{ dozzle_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Copy files
+  copy:
+    src: "{{ playbook_dir }}/roles/dozzle/files/"
+    dest: "{{ dozzle_dir }}"
+    mode: '0644'
+
+- name: Launch Dozzle stack
+  community.docker.docker_compose_v2:
+    project_src: "{{ dozzle_dir }}"
+    pull: missing
+    state: present

--- a/deploy/roles/dozzle/tasks/main.yml
+++ b/deploy/roles/dozzle/tasks/main.yml
@@ -4,11 +4,10 @@
     state: directory
     mode: '0755'
 
-- name: Copy files
-  copy:
-    src: "{{ playbook_dir }}/roles/dozzle/files/"
-    dest: "{{ dozzle_dir }}"
-    mode: '0644'
+- name: Copy docker-compose
+  template:
+    src: "{{ playbook_dir }}/roles/dozzle/templates/docker-compose.yml"
+    dest: "{{ dozzle_dir }}/docker-compose.yml"
 
 - name: Launch Dozzle stack
   community.docker.docker_compose_v2:

--- a/deploy/roles/dozzle/templates/docker-compose.yml
+++ b/deploy/roles/dozzle/templates/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
-      - 9090:8080
+      - "{{ tailscale_ip }}:9090:8080"
     environment:
       # Uncomment to enable container actions (stop, start, restart). See https://dozzle.dev/guide/actions
       - DOZZLE_ENABLE_ACTIONS=false


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Ansible role and playbook to deploy Dozzle for viewing Docker logs.
> 
>   - **Deployment**:
>     - Adds `dozzle.yml` playbook to deploy Dozzle using Ansible.
>     - Updates `inventory` to include a new `dozzle` group.
>     - Adds `deploy-dozzle` command to `justfile`.
>   - **Roles**:
>     - Creates `roles/dozzle` with `defaults/main.yml` to set `dozzle_dir`.
>     - Adds `tasks/main.yml` to ensure directory, copy `docker-compose.yml`, and launch Dozzle stack.
>     - Includes `templates/docker-compose.yml` for Dozzle service configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b41541740c4fbf6faa3f2b323783984ee40feb2d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->