### PR TITLE
feat(dango): define token decimals as constants

### DIFF
--- a/dango/testing/src/genesis.rs
+++ b/dango/testing/src/genesis.rs
@@ -13,7 +13,9 @@ use {
     dango_types::{
         auth::Key,
         bank::Metadata,
-        constants::{PYTH_PRICE_SOURCES, btc, dango, eth, sol, usdc},
+        constants::{
+            PYTH_PRICE_SOURCES, atom, bch, bnb, btc, dango, doge, eth, ltc, sol, usdc, xrp,
+        },
         dex::{CurveInvariant, PairParams, PairUpdate},
         gateway::{Remote, WithdrawalFee},
         lending::InterestRateModel,
@@ -260,9 +262,69 @@ impl Preset for BankOption {
                 dango::DENOM.clone() => Metadata {
                     name: LengthBounded::new_unchecked("Dango".to_string()),
                     symbol: LengthBounded::new_unchecked("DGX".to_string()),
-                    decimals: 6,
-                    description: Some(LengthBounded::new_unchecked("Native token of Dango".to_string()))
-                }
+                    decimals: dango::DECIMAL,
+                    description: Some(LengthBounded::new_unchecked("Native token of Dango".to_string())),
+                },
+                atom::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Atom".to_string()),
+                    symbol: LengthBounded::new_unchecked("ATOM".to_string()),
+                    decimals: atom::DECIMAL,
+                    description: None,
+                },
+                bch::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Bitcoin Cash".to_string()),
+                    symbol: LengthBounded::new_unchecked("BCH".to_string()),
+                    decimals: bch::DECIMAL,
+                    description: None,
+                },
+                bnb::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Binance Coin".to_string()),
+                    symbol: LengthBounded::new_unchecked("BNB".to_string()),
+                    decimals: bnb::DECIMAL,
+                    description: None,
+                },
+                btc::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Bitcoin".to_string()),
+                    symbol: LengthBounded::new_unchecked("BTC".to_string()),
+                    decimals: btc::DECIMAL,
+                    description: None,
+                },
+                doge::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Dogecoin".to_string()),
+                    symbol: LengthBounded::new_unchecked("DOGE".to_string()),
+                    decimals: doge::DECIMAL,
+                    description: None,
+                },
+                eth::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Ether".to_string()),
+                    symbol: LengthBounded::new_unchecked("ETH".to_string()),
+                    decimals: eth::DECIMAL,
+                    description: None,
+                },
+                ltc::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Litecoin".to_string()),
+                    symbol: LengthBounded::new_unchecked("LTC".to_string()),
+                    decimals: ltc::DECIMAL,
+                    description: None,
+                },
+                sol::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("Solana".to_string()),
+                    symbol: LengthBounded::new_unchecked("SOL".to_string()),
+                    decimals: sol::DECIMAL,
+                    description: None,
+                },
+                usdc::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("USD Coin".to_string()),
+                    symbol: LengthBounded::new_unchecked("USDC".to_string()),
+                    decimals: usdc::DECIMAL,
+                    description: None,
+                },
+                xrp::DENOM.clone() => Metadata {
+                    name: LengthBounded::new_unchecked("XRP".to_string()),
+                    symbol: LengthBounded::new_unchecked("XRP".to_string()),
+                    decimals: xrp::DECIMAL,
+                    description: None,
+                },
             },
         }
     }

--- a/dango/types/src/constants/tokens.rs
+++ b/dango/types/src/constants/tokens.rs
@@ -7,10 +7,12 @@ pub mod dango {
     use super::*;
 
     pub static DENOM: LazyLock<Denom> = LazyLock::new(|| Denom::new_unchecked(["dango"]));
+
+    pub const DECIMAL: u8 = 6;
 }
 
 macro_rules! define_denom {
-    ($name:ident) => {
+    ($name:ident => $decimal:literal) => {
         pub mod $name {
             use super::*;
 
@@ -19,13 +21,26 @@ macro_rules! define_denom {
             pub static DENOM: LazyLock<Denom> = LazyLock::new(|| {
                 Denom::from_parts([crate::gateway::NAMESPACE.clone(), SUBDENOM.clone()]).unwrap()
             });
+
+            pub const DECIMAL: u8 = $decimal;
         }
     };
-    ($($name:ident),*) => {
+    ($($name:ident => $decimal:literal),*) => {
         $(
-            define_denom!($name);
+            define_denom!($name => $decimal);
         )*
     };
 }
 
-define_denom!(atom, bch, bnb, btc, doge, eth, ltc, sol, usdc, xrp);
+define_denom! {
+    atom => 6,
+    bch  => 8,
+    bnb  => 18,
+    btc  => 8,
+    doge => 8,
+    eth  => 18,
+    ltc  => 8,
+    sol  => 9,
+    usdc => 6,
+    xrp  => 6
+}


### PR DESCRIPTION
we should also update the `genesis.json`s, but it doesn't matter too much at this point
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Define token decimals as constants and update `genesis.rs` to use them, adding new tokens.
> 
>   - **Constants**:
>     - Define token decimals as constants in `dango/types/src/constants/tokens.rs` for `atom`, `bch`, `bnb`, `btc`, `doge`, `eth`, `ltc`, `sol`, `usdc`, and `xrp`.
>   - **Genesis Updates**:
>     - Update `dango/testing/src/genesis.rs` to use the new decimal constants for token metadata.
>   - **Misc**:
>     - Add new tokens `atom`, `bch`, `bnb`, `doge`, `ltc`, and `xrp` to `dango/testing/src/genesis.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for bd48a627daebcb1b5f24a19cce0f98037eca2daa. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->