### PR TITLE
feat(ui): signing one signature

### DIFF
--- a/ui/portal/web/src/components/auth/Signup.tsx
+++ b/ui/portal/web/src/components/auth/Signup.tsx
@@ -370,7 +370,6 @@ const Username: React.FC = () => {
 
 const Signin: React.FC = () => {
   const navigate = useNavigate();
-  const { addUsername } = useUsernames();
   const { done, data } = useWizard<{ username: string; connectorId: string }>();
   const { settings, changeSettings } = useApp();
   const { useSessionKey } = settings;
@@ -378,11 +377,10 @@ const Signin: React.FC = () => {
   const { username, connectorId } = data;
 
   const { mutateAsync: connectWithConnector, isPending } = useSignin({
-    sessionKey: useSessionKey && { expireAt: Date.now() + DEFAULT_SESSION_EXPIRATION },
+    session: useSessionKey && { expireAt: Date.now() + DEFAULT_SESSION_EXPIRATION },
     mutation: {
       onSuccess: () => {
         navigate({ to: "/" });
-        addUsername(username);
         done();
       },
       onError: (err) => {

--- a/ui/store/src/hooks/useSessionKey.ts
+++ b/ui/store/src/hooks/useSessionKey.ts
@@ -5,13 +5,23 @@ import { createStorage } from "../storages/createStorage.js";
 import { useQuery } from "@tanstack/react-query";
 import { useAccount } from "./useAccount.js";
 import { useConfig } from "./useConfig.js";
-import { useConnectorClient } from "./useConnectorClient.js";
 import useStorage from "./useStorage.js";
 
-import type { SigningSession } from "@left-curve/dango/types";
+import { encodeBase64 } from "@left-curve/dango/encoding";
+import type { SigningSession, SigningSessionInfo } from "@left-curve/dango/types";
+import type { Connector } from "../types/connector.js";
 
 export type UseSessionKeyParameters = {
   session?: SigningSession;
+};
+
+type CreateSessionKeyParameters = {
+  connector?: Connector;
+  expireAt: number;
+};
+
+type CreateSessionKeyOptions = {
+  setSession?: boolean;
 };
 
 export type UseSessionKeyReturnType = {
@@ -19,13 +29,15 @@ export type UseSessionKeyReturnType = {
   session: SigningSession | null;
   setSession: (session: SigningSession | null) => void;
   deleteSessionKey: () => void;
-  createSessionKey: (parameters: { expireAt: number }) => Promise<void>;
+  createSessionKey: (
+    parameters: CreateSessionKeyParameters,
+    options?: CreateSessionKeyOptions,
+  ) => Promise<SigningSession>;
 };
 
 export function useSessionKey(parameters: UseSessionKeyParameters = {}): UseSessionKeyReturnType {
   const config = useConfig();
-  const { username } = useAccount();
-  const { data: connectorClient } = useConnectorClient();
+  const { username, connector } = useAccount();
   const [session, setSession] = useStorage<SigningSession | null>("session_key", {
     initialValue: parameters.session,
     storage: createStorage({ storage: sessionStorage }),
@@ -46,26 +58,47 @@ export function useSessionKey(parameters: UseSessionKeyParameters = {}): UseSess
     },
   });
 
-  async function createSessionKey(parameters: {
-    expireAt: number;
-  }) {
-    if (!connectorClient) throw new Error("connector client not found");
-    const { expireAt } = parameters;
+  async function createSessionKey(
+    parameters: CreateSessionKeyParameters,
+    options: CreateSessionKeyOptions = {},
+  ) {
+    const c = parameters.connector || connector;
+    if (!c) throw new Error("connector not found");
+    const { expireAt = true } = parameters;
+    const { setSession: loadSession = true } = options;
+
     const keyPair = Secp256k1.makeKeyPair();
     const publicKey = keyPair.getPublicKey();
 
-    const { authorization, keyHash, sessionInfo } = await connectorClient.createSession({
-      expireAt,
-      pubKey: publicKey,
+    const sessionInfo: SigningSessionInfo = {
+      sessionKey: encodeBase64(publicKey),
+      expireAt: expireAt.toString(),
+    };
+
+    const { credential } = await c.signArbitrary({
+      primaryType: "Message" as const,
+      message: sessionInfo,
+      types: {
+        Message: [
+          { name: "session_key", type: "string" },
+          { name: "expire_at", type: "string" },
+        ],
+      },
     });
 
-    setSession({
-      keyHash,
+    if (!("standard" in credential)) throw new Error("unsupported credential type");
+
+    const session = {
+      keyHash: credential.standard.keyHash,
       sessionInfo,
       privateKey: keyPair.privateKey,
       publicKey,
-      authorization,
-    });
+      authorization: credential.standard,
+    };
+
+    if (loadSession) setSession(session);
+
+    return session;
   }
 
   function deleteSessionKey() {

--- a/ui/store/src/hooks/useSessionKey.ts
+++ b/ui/store/src/hooks/useSessionKey.ts
@@ -64,7 +64,7 @@ export function useSessionKey(parameters: UseSessionKeyParameters = {}): UseSess
   ) {
     const c = parameters.connector || connector;
     if (!c) throw new Error("connector not found");
-    const { expireAt = true } = parameters;
+    const { expireAt } = parameters;
     const { setSession: loadSession = true } = options;
 
     const keyPair = Secp256k1.makeKeyPair();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds session key management for authentication in `Signin.tsx` and `Signup.tsx`, updating sign-in and sign-up flows to support session-based authentication.
> 
>   - **Session Management**:
>     - Introduces session key management in `useSessionKey.ts` with `createSessionKey()` and `deleteSessionKey()` functions.
>     - Updates `useSignin.ts` to handle session-based authentication using `session` parameter.
>   - **UI Components**:
>     - Modifies `Signin.tsx` to use session keys for signing in, with conditional logic based on `useSessionKey` setting.
>     - Updates `Signup.tsx` to integrate session key creation in the sign-up process.
>   - **Behavior Changes**:
>     - `CredentialStep` and `UsernameStep` in `Signin.tsx` now handle session key creation and usage.
>     - `Signin` component in `Signup.tsx` uses session keys for authentication if enabled.
>   - **Miscellaneous**:
>     - Removes `addUsername` from `Signup.tsx` as it is no longer needed.
>     - Adjusts button states in `Signin.tsx` and `Signup.tsx` to reflect pending states during async operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 882ebee5bf57226575620bf03167fa94b80a2015. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->