### PR TITLE
Change swap fee to be `ZeroExclusiveOneExclusive`

### DIFF
--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -411,7 +411,6 @@ mod tests {
         super::*,
         dango_types::constants::{eth, usdc},
         grug::{Bounded, Coins, coins},
-        std::mem::take,
         test_case::test_case,
     };
 
@@ -419,7 +418,7 @@ mod tests {
         CurveInvariant::Xyk {
             order_spacing: Udec128::ONE,
         },
-        Udec128::ZERO,
+        Udec128::new_permille(5),
         coins! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 200 * 10000000,
@@ -449,7 +448,7 @@ mod tests {
             (Udec128::new_percent(21000), Uint128::from(45568)),
         ],
         1;
-        "xyk pool balance 1:200 tick size 1 no fee"
+        "xyk pool balance 1:200 tick size 1 0.5% fee"
     )]
     #[test_case(
         CurveInvariant::Xyk {
@@ -491,37 +490,37 @@ mod tests {
         CurveInvariant::Xyk {
             order_spacing: Udec128::new_percent(1),
         },
-        Udec128::ZERO,
+        Udec128::new_permille(5),
         coins! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
         },
         vec![
-            (Udec128::new_percent(99), Uint128::from(101010)),
-            (Udec128::new_percent(98), Uint128::from(103072)),
-            (Udec128::new_percent(97), Uint128::from(105197)),
-            (Udec128::new_percent(96), Uint128::from(107388)),
-            (Udec128::new_percent(95), Uint128::from(109649)),
-            (Udec128::new_percent(94), Uint128::from(111982)),
-            (Udec128::new_percent(93), Uint128::from(114390)),
-            (Udec128::new_percent(92), Uint128::from(116877)),
-            (Udec128::new_percent(91), Uint128::from(119446)),
-            (Udec128::new_percent(90), Uint128::from(122100)),
+            (Udec128::new_permille(995), Uint128::from(50251)),
+            (Udec128::new_permille(985), Uint128::from(102033)),
+            (Udec128::new_permille(975), Uint128::from(104126)),
+            (Udec128::new_permille(965), Uint128::from(106284)),
+            (Udec128::new_permille(955), Uint128::from(108510)),
+            (Udec128::new_permille(945), Uint128::from(110806)),
+            (Udec128::new_permille(935), Uint128::from(113177)),
+            (Udec128::new_permille(925), Uint128::from(115624)),
+            (Udec128::new_permille(915), Uint128::from(118151)),
+            (Udec128::new_permille(905), Uint128::from(120762)),
         ],
         vec![
-            (Udec128::new_percent(101), Uint128::from(99010)),
-            (Udec128::new_percent(102), Uint128::from(97069)),
-            (Udec128::new_percent(103), Uint128::from(95184)),
-            (Udec128::new_percent(104), Uint128::from(93353)),
-            (Udec128::new_percent(105), Uint128::from(91575)),
-            (Udec128::new_percent(106), Uint128::from(89847)),
-            (Udec128::new_percent(107), Uint128::from(88168)),
-            (Udec128::new_percent(108), Uint128::from(86535)),
-            (Udec128::new_percent(109), Uint128::from(84947)),
-            (Udec128::new_percent(110), Uint128::from(83403)),
+            (Udec128::new_permille(1005), Uint128::from(49751)),
+            (Udec128::new_permille(1015), Uint128::from(98032)),
+            (Udec128::new_permille(1025), Uint128::from(96119)),
+            (Udec128::new_permille(1035), Uint128::from(94262)),
+            (Udec128::new_permille(1045), Uint128::from(92458)),
+            (Udec128::new_permille(1055), Uint128::from(90705)),
+            (Udec128::new_permille(1065), Uint128::from(89002)),
+            (Udec128::new_permille(1075), Uint128::from(87346)),
+            (Udec128::new_permille(1085), Uint128::from(85736)),
+            (Udec128::new_permille(1095), Uint128::from(84170)),
         ],
         1;
-        "xyk pool balance 1:1 no fee"
+        "xyk pool balance 1:1 0.5% fee"
     )]
     #[test_case(
         CurveInvariant::Xyk {
@@ -569,7 +568,7 @@ mod tests {
     ) {
         let pair = PairParams {
             curve_invariant,
-            swap_fee_rate: Bounded::new_unchecked(swap_fee_rate),
+            swap_fee_rate: Bounded::new(swap_fee_rate).unwrap(),
             lp_denom: Denom::new_unchecked(vec!["lp".to_string()]),
         };
 

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -411,6 +411,7 @@ mod tests {
         super::*,
         dango_types::constants::{eth, usdc},
         grug::{Bounded, Coins, coins},
+        std::mem::take,
         test_case::test_case,
     };
 
@@ -577,14 +578,21 @@ mod tests {
             .reflect_curve(eth::DENOM.clone(), usdc::DENOM.clone(), &reserve)
             .unwrap();
 
-        for (bid, expected_bid) in bids.zip(expected_bids.iter()) {
+        // Assert that at least 10 orders are returned.
+        let bids = bids.take(10).collect::<Vec<_>>();
+        let asks = asks.take(10).collect::<Vec<_>>();
+        assert_eq!(bids.len(), 10);
+        assert_eq!(asks.len(), 10);
+
+        // Assert that the orders are correct.
+        for (bid, expected_bid) in bids.into_iter().zip(expected_bids.iter()) {
             assert_eq!(bid.0, expected_bid.0);
             assert!(
                 bid.1.into_inner().abs_diff(expected_bid.1.into_inner()) <= order_size_tolerance
             );
         }
 
-        for (ask, expected_ask) in asks.zip(expected_asks.iter()) {
+        for (ask, expected_ask) in asks.into_iter().zip(expected_asks.iter()) {
             assert_eq!(ask.0, expected_ask.0);
             assert!(
                 ask.1.into_inner().abs_diff(expected_ask.1.into_inner()) <= order_size_tolerance

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1111,7 +1111,7 @@ fn only_owner_can_create_passive_pool() {
                     curve_invariant: CurveInvariant::Xyk {
                         order_spacing: Udec128::new_bps(1),
                     },
-                    swap_fee_rate: Bounded::new_unchecked(Udec128::ZERO),
+                    swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
             }]),
             Coins::new(),
@@ -1131,7 +1131,7 @@ fn only_owner_can_create_passive_pool() {
                     curve_invariant: CurveInvariant::Xyk {
                         order_spacing: Udec128::new_bps(1),
                     },
-                    swap_fee_rate: Bounded::new_unchecked(Udec128::ZERO),
+                    swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
             }]),
             Coins::new(),
@@ -1144,8 +1144,8 @@ fn only_owner_can_create_passive_pool() {
         dango::DENOM.clone() => 100,
         usdc::DENOM.clone() => 100,
     },
-    Udec128::ZERO,
-    Uint128::new(100);
+    Udec128::new_permille(5),
+    Uint128::new(99);
     "provision at pool ratio"
 )]
 #[test_case(
@@ -1153,8 +1153,8 @@ fn only_owner_can_create_passive_pool() {
         dango::DENOM.clone() => 50,
         usdc::DENOM.clone() => 50,
     },
-    Udec128::ZERO,
-    Uint128::new(50);
+    Udec128::new_permille(5),
+    Uint128::new(49);
     "provision at half pool balance same ratio"
 )]
 #[test_case(
@@ -1162,8 +1162,8 @@ fn only_owner_can_create_passive_pool() {
         dango::DENOM.clone() => 100,
         usdc::DENOM.clone() => 50,
     },
-    Udec128::ZERO,
-    Uint128::new(73);
+    Udec128::new_permille(5),
+    Uint128::new(72);
     "provision at different ratio"
 )]
 fn provide_liquidity(provision: Coins, swap_fee: Udec128, expected_lp_balance: Uint128) {
@@ -1269,17 +1269,17 @@ fn provide_liquidity(provision: Coins, swap_fee: Udec128, expected_lp_balance: U
 }
 
 #[test_case(
-    Uint128::new(100),
-    Udec128::ZERO,
+    Uint128::new(99),
+    Udec128::new_permille(5),
     coins! {
-        dango::DENOM.clone() => 100,
-        usdc::DENOM.clone()  => 100,
+        dango::DENOM.clone() => 99,
+        usdc::DENOM.clone()  => 99,
     };
     "withdrawa all"
 )]
 #[test_case(
     Uint128::new(50),
-    Udec128::ZERO,
+    Udec128::new_permille(5),
     coins! {
         dango::DENOM.clone() => 50,
         usdc::DENOM.clone()  => 50,
@@ -1419,16 +1419,16 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
         dango::DENOM.clone() => 1000000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(5),
     },
     None,
     coins! {
-        usdc::DENOM.clone() => 500000,
+        usdc::DENOM.clone() => 497500,
     },
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 2000000,
-            usdc::DENOM.clone() => 500000,
+            dango::DENOM.clone() => 1000000 + 1000000,
+            usdc::DENOM.clone() => 1000000 - 497500,
         },
     };
     "1:1 pool no swap fee one step route input 100% of pool liquidity"
@@ -1448,16 +1448,16 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
         dango::DENOM.clone() => 500000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(5),
     },
     None,
     coins! {
-        usdc::DENOM.clone() => 333333,
+        usdc::DENOM.clone() => 331666,
     },
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 1500000,
-            usdc::DENOM.clone() => 666667,
+            dango::DENOM.clone() => 1000000 + 500000,
+            usdc::DENOM.clone() => 1000000 - 331666,
         },
     };
     "1:1 pool no swap fee one step route input 50% of pool liquidity"
@@ -1474,19 +1474,19 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
         quote_denom: usdc::DENOM.clone(),
     }],
     coins! {
-        dango::DENOM.clone() => 333333,
+        dango::DENOM.clone() => 331666,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(5),
     },
     None,
     coins! {
-        usdc::DENOM.clone() => 249999,
+        usdc::DENOM.clone() => 247814,
     },
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 1333333,
-            usdc::DENOM.clone() => 1000000 - 249999,
+            dango::DENOM.clone() => 1000000 + 331666,
+            usdc::DENOM.clone() => 1000000 - 247814,
         },
     };
     "1:1 pool no swap fee one step route input 33% of pool liquidity"
@@ -1516,24 +1516,24 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
         dango::DENOM.clone() => 500000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
-        (eth::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(5),
+        (eth::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(5),
     },
     None,
     coins! {
-        eth::DENOM.clone() => 249999,
+        eth::DENOM.clone() => 247814,
     },
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 1000000 + 500000,
-            usdc::DENOM.clone() => 1000000 - 333333,
+            usdc::DENOM.clone() => 1000000 - 331666,
         },
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            eth::DENOM.clone() => 1000000 - 249999,
-            usdc::DENOM.clone() => 1000000 + 333333,
+            eth::DENOM.clone() => 1000000 - 247814,
+            usdc::DENOM.clone() => 1000000 + 331666,
         },
     };
-    "1:1 pools no swap fee input 100% of pool liquidity two step route"
+    "1:1 pools 0.5% swap fee input 100% of pool liquidity two step route"
 )]
 #[test_case(
     btree_map! {
@@ -1550,7 +1550,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
         dango::DENOM.clone() => 1000000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(5),
     },
     Some(500000u128.into()),
     coins! {
@@ -1561,8 +1561,8 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
             dango::DENOM.clone() => 2000000,
             usdc::DENOM.clone() => 500000,
         },
-    };
-    "1:1 pool no swap fee one step route input 100% of pool liquidity output is not less than minimum output"
+    } => panics "output amount is below the minimum: 497500 < 500000" ;
+    "1:1 pool no swap fee one step route input 100% of pool liquidity output is less than minimum output"
 )]
 #[test_case(
     btree_map! {
@@ -1579,19 +1579,19 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
         dango::DENOM.clone() => 1000000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(5),
     },
-    Some(499999u128.into()),
+    Some(497500u128.into()),
     coins! {
-        usdc::DENOM.clone() => 500000,
+        usdc::DENOM.clone() => 497500,
     },
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 2000000,
-            usdc::DENOM.clone() => 500000,
+            usdc::DENOM.clone() => 1000000 - 497500,
         },
     };
-    "1:1 pool no swap fee one step route input 100% of pool liquidity output is less than minimum output"
+    "1:1 pool no swap fee one step route input 100% of pool liquidity output is not less than minimum output"
 )]
 #[test_case(
     btree_map! {
@@ -1732,19 +1732,19 @@ fn swap_exact_amount_in(
     }],
     Coin::new(usdc::DENOM.clone(), 500000).unwrap(),
     coins! {
-        dango::DENOM.clone() => 1000000,
+        dango::DENOM.clone() => 1002006,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
-    Coin::new(dango::DENOM.clone(), 1000000).unwrap(),
+    Coin::new(dango::DENOM.clone(), 1002006).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 2000000,
-            usdc::DENOM.clone() => 500000,
+            dango::DENOM.clone() => 1000000 + 1002006,
+            usdc::DENOM.clone() => 1000000 - 500000,
         },
     };
-    "1:1 pool no swap fee one step route output 50% of pool liquidity"
+    "1:1 pool 0.1% swap fee one step route output 50% of pool liquidity"
 )]
 #[test_case(
     btree_map! {
@@ -1759,19 +1759,19 @@ fn swap_exact_amount_in(
     }],
     Coin::new(usdc::DENOM.clone(), 333333).unwrap(),
     coins! {
-        dango::DENOM.clone() => 499999,
+        dango::DENOM.clone() => 500751,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
-    Coin::new(dango::DENOM.clone(), 499999).unwrap(),
+    Coin::new(dango::DENOM.clone(), 500751).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 1000000 + 499999,
+            dango::DENOM.clone() => 1000000 + 500751,
             usdc::DENOM.clone() => 1000000 - 333333,
         },
     };
-    "1:1 pool no swap fee one step route output 33% of pool liquidity"
+    "1:1 pool 0.1% swap fee one step route output 33% of pool liquidity"
 )]
 #[test_case(
     btree_map! {
@@ -1786,19 +1786,19 @@ fn swap_exact_amount_in(
     }],
     Coin::new(usdc::DENOM.clone(), 250000).unwrap(),
     coins! {
-        dango::DENOM.clone() => 333333,
+        dango::DENOM.clone() => 333779,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
-    Coin::new(dango::DENOM.clone(), 333333).unwrap(),
+    Coin::new(dango::DENOM.clone(), 333779).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 1000000 + 333333,
+            dango::DENOM.clone() => 1000000 + 333779,
             usdc::DENOM.clone() => 1000000 - 250000,
         },
     };
-    "1:1 pool no swap fee one step route output 25% of pool liquidity"
+    "1:1 pool 0.1% swap fee one step route output 25% of pool liquidity"
 )]
 #[test_case(
     btree_map! {
@@ -1816,7 +1816,7 @@ fn swap_exact_amount_in(
         dango::DENOM.clone() => 1000000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 1000000).unwrap(),
     btree_map! {
@@ -1844,7 +1844,7 @@ fn swap_exact_amount_in(
         dango::DENOM.clone() => 999999,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 1000000).unwrap(),
     btree_map! {
@@ -1872,16 +1872,16 @@ fn swap_exact_amount_in(
         dango::DENOM.clone() => 1100000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
-    Coin::new(dango::DENOM.clone(), 1000000).unwrap(),
+    Coin::new(dango::DENOM.clone(), 1002006).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 2000000,
-            usdc::DENOM.clone() => 500000,
+            dango::DENOM.clone() => 1000000 + 1002006,
+            usdc::DENOM.clone() => 1000000 - 500000,
         },
     };
-    "1:1 pool no swap fee one step route output 50% of pool liquidity excessive funds returned"
+    "1:1 pool 0.1% swap fee one step route output 50% of pool liquidity excessive funds returned"
 )]
 #[test_case(
     btree_map! {
@@ -1909,21 +1909,21 @@ fn swap_exact_amount_in(
         dango::DENOM.clone() => 1000000,
     },
     btree_map! {
-        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
-        (eth::DENOM.clone(), usdc::DENOM.clone()) => Udec128::ZERO,
+        (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
+        (eth::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
-    Coin::new(dango::DENOM.clone(), 499999).unwrap(),
+    Coin::new(dango::DENOM.clone(), 501758).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
-            dango::DENOM.clone() => 1000000 + 499999,
-            usdc::DENOM.clone() => 1000000 - 333333,
+            dango::DENOM.clone() => 1000000 + 501758,
+            usdc::DENOM.clone() => 1000000 - 333779,
         },
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             eth::DENOM.clone() => 1000000 - 250000,
-            usdc::DENOM.clone() => 1000000 + 333333,
+            usdc::DENOM.clone() => 1000000 + 333779,
         },
     };
-    "1:1 pool no swap fee two step route output 25% of pool liquidity"
+    "1:1 pool 0.1% swap fee two step route output 25% of pool liquidity"
 )]
 #[test_case(
     btree_map! {

--- a/dango/types/src/dex/types.rs
+++ b/dango/types/src/dex/types.rs
@@ -1,5 +1,8 @@
-use grug::{
-    Bounded, Denom, PrimaryKey, RawKey, StdError, StdResult, Udec128, ZeroInclusiveOneExclusive,
+use {
+    grug::{
+        Bounded, Denom, PrimaryKey, RawKey, StdError, StdResult, Udec128, ZeroExclusiveOneExclusive,
+    },
+    std::fmt::Display,
 };
 
 /// Numerical identifier of an order.
@@ -60,10 +63,9 @@ pub struct PairParams {
     /// Curve invariant for the passive liquidity pool.
     pub curve_invariant: CurveInvariant,
     /// Fee rate for instant swaps in the passive liquidity pool.
-    ///
     /// For the xyk pool, this also sets the spread of the orders when the
     /// passive liquidity is reflected onto the orderbook.
-    pub swap_fee_rate: Bounded<Udec128, ZeroInclusiveOneExclusive>,
+    pub swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
     // TODO: minimum order size
 }
 

--- a/dango/types/src/dex/types.rs
+++ b/dango/types/src/dex/types.rs
@@ -1,8 +1,5 @@
-use {
-    grug::{
-        Bounded, Denom, PrimaryKey, RawKey, StdError, StdResult, Udec128, ZeroExclusiveOneExclusive,
-    },
-    std::fmt::Display,
+use grug::{
+    Bounded, Denom, PrimaryKey, RawKey, StdError, StdResult, Udec128, ZeroExclusiveOneExclusive,
 };
 
 /// Numerical identifier of an order.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change swap fee rate type in `PairParams` to `ZeroExclusiveOneExclusive` and update related tests.
> 
>   - **Behavior**:
>     - Change swap fee rate type in `PairParams` from `ZeroInclusiveOneExclusive` to `ZeroExclusiveOneExclusive` in `types.rs`.
>     - Update swap fee rate initialization in `liquidity_pool.rs` and `dex.rs` to use `Bounded::new()` instead of `Bounded::new_unchecked()`.
>   - **Tests**:
>     - Update test cases in `liquidity_pool.rs` to reflect new swap fee rate type and expected outcomes.
>     - Modify test cases in `dex.rs` to ensure correct application of new swap fee rate type and adjust expected results.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 82a03297d11f3f90084fcf9227c721478653842a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->