### PR TITLE
fix(ui): self-start to mobile title

### DIFF
--- a/ui/portal/web/src/components/foundation/MobileTitle.tsx
+++ b/ui/portal/web/src/components/foundation/MobileTitle.tsx
@@ -12,7 +12,7 @@ type MobileTitleProps = {
 export const MobileTitle: React.FC<MobileTitleProps> = ({ title, className }) => {
   const { history } = useRouter();
   return (
-    <div className={twMerge("flex gap-2 items-center lg:hidden", className)}>
+    <div className={twMerge("flex gap-2 items-center lg:hidden self-start", className)}>
       <IconButton variant="link" onClick={() => history.go(-1)}>
         <IconChevronDown className="rotate-90" />
       </IconButton>

--- a/ui/portal/web/src/components/overview/AssetsSection.tsx
+++ b/ui/portal/web/src/components/overview/AssetsSection.tsx
@@ -36,6 +36,7 @@ export const AssetsSection: React.FC<Props> = ({ balances, showAllAssets }) => {
       <div className="flex flex-wrap gap-4 items-center justify-between">
         {sortedCoinsByBalance.map(([denom, coin]) => {
           const amount = balances[denom];
+          if (denom === "dango") return null;
           return (
             <div className="flex gap-2 items-center" key={`preview-asset-${denom}`}>
               <img src={coin.logoURI} alt={coin.name} className="h-7 w-7 drag-none select-none" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjusts alignment in `MobileTitle.tsx` and skips rendering "dango" coin in `AssetsSection.tsx`.
> 
>   - **UI Changes**:
>     - In `MobileTitle.tsx`, added `self-start` to the `div` class for alignment adjustment.
>     - In `AssetsSection.tsx`, added a condition to skip rendering for coins with `denom` equal to "dango".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 5b2218b7480504d4ebf1af71ffc6cc05157ef437. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->