### PR TITLE
refactor: remove two duplicate types between dango-types and indexer crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,6 +3391,7 @@ dependencies = [
  "chrono",
  "clap",
  "dango-indexer-sql",
+ "dango-types",
  "indexer-httpd",
  "indexer-sql",
  "itertools 0.14.0",
@@ -3567,10 +3568,12 @@ name = "dango-types"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-graphql",
  "grug",
  "hyperlane-types",
  "paste",
  "pyth-types",
+ "sea-orm",
  "serde",
  "sha2 0.10.9",
 ]

--- a/dango/httpd/Cargo.toml
+++ b/dango/httpd/Cargo.toml
@@ -16,6 +16,7 @@ async-graphql-actix-web = { workspace = true }
 chrono                  = { workspace = true }
 clap                    = { workspace = true }
 dango-indexer-sql       = { workspace = true }
+dango-types             = { workspace = true, features = ["async-graphql", "sea-orm"] }
 indexer-httpd           = { workspace = true }
 indexer-sql             = { workspace = true }
 itertools               = { workspace = true }

--- a/dango/httpd/Cargo.toml
+++ b/dango/httpd/Cargo.toml
@@ -16,7 +16,7 @@ async-graphql-actix-web = { workspace = true }
 chrono                  = { workspace = true }
 clap                    = { workspace = true }
 dango-indexer-sql       = { workspace = true }
-dango-types             = { workspace = true, features = ["async-graphql", "sea-orm"] }
+dango-types             = { workspace = true, features = ["async-graphql"] }
 indexer-httpd           = { workspace = true }
 indexer-sql             = { workspace = true }
 itertools               = { workspace = true }

--- a/dango/httpd/src/graphql/types/account.rs
+++ b/dango/httpd/src/graphql/types/account.rs
@@ -3,27 +3,10 @@ use {
     async_graphql::*,
     chrono::{DateTime, TimeZone, Utc},
     dango_indexer_sql::entity,
+    dango_types::account_factory,
     indexer_httpd::context::Context,
     sea_orm::{ModelTrait, sqlx::types::uuid},
-    serde::Deserialize,
 };
-
-#[derive(Enum, Copy, Clone, Debug, Deserialize, Eq, PartialEq, Hash)]
-pub enum AccountType {
-    Spot,
-    Margin,
-    Multi,
-}
-
-impl From<entity::accounts::AccountType> for AccountType {
-    fn from(account_type: entity::accounts::AccountType) -> AccountType {
-        match account_type {
-            entity::accounts::AccountType::Spot => AccountType::Spot,
-            entity::accounts::AccountType::Margin => AccountType::Margin,
-            entity::accounts::AccountType::Multi => AccountType::Multi,
-        }
-    }
-}
 
 #[derive(Clone, Debug, SimpleObject, Eq, PartialEq, Hash)]
 #[graphql(complex)]
@@ -34,7 +17,7 @@ pub struct Account {
     pub model: entity::accounts::Model,
     pub account_index: u32,
     pub address: String,
-    pub account_type: AccountType,
+    pub account_type: account_factory::AccountType,
     pub created_at: DateTime<Utc>,
     pub created_block_height: u64,
 }

--- a/dango/httpd/src/graphql/types/account.rs
+++ b/dango/httpd/src/graphql/types/account.rs
@@ -29,7 +29,7 @@ impl From<entity::accounts::Model> for Account {
             model: item.clone(),
             created_at: Utc.from_utc_datetime(&item.created_at),
             address: item.address,
-            account_type: item.account_type.into(),
+            account_type: item.account_type,
             created_block_height: item.created_block_height as u64,
             account_index: item.account_index as u32,
         }

--- a/dango/httpd/src/graphql/types/public_key.rs
+++ b/dango/httpd/src/graphql/types/public_key.rs
@@ -27,7 +27,7 @@ impl From<entity::public_keys::Model> for PublicKey {
             username: item.username,
             key_hash: item.key_hash,
             public_key: item.public_key,
-            key_type: item.key_type.into(),
+            key_type: item.key_type,
             created_block_height: item.created_block_height as u64,
         }
     }

--- a/dango/httpd/src/graphql/types/public_key.rs
+++ b/dango/httpd/src/graphql/types/public_key.rs
@@ -2,25 +2,9 @@ use {
     async_graphql::*,
     chrono::{DateTime, TimeZone, Utc},
     dango_indexer_sql::entity,
+    dango_types::auth,
     sea_orm::ModelTrait,
 };
-
-#[derive(Enum, Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub enum KeyType {
-    Secp256r1,
-    Secp256k1,
-    Ethereum,
-}
-
-impl From<entity::public_keys::KeyType> for KeyType {
-    fn from(key_type: entity::public_keys::KeyType) -> KeyType {
-        match key_type {
-            entity::public_keys::KeyType::Secp256r1 => KeyType::Secp256r1,
-            entity::public_keys::KeyType::Secp256k1 => KeyType::Secp256k1,
-            entity::public_keys::KeyType::Ethereum => KeyType::Ethereum,
-        }
-    }
-}
 
 #[derive(Clone, Debug, SimpleObject, Eq, PartialEq, Hash)]
 #[graphql(complex)]
@@ -30,7 +14,7 @@ pub struct PublicKey {
     pub username: String,
     pub key_hash: String,
     pub public_key: String,
-    pub key_type: KeyType,
+    pub key_type: auth::KeyType,
     pub created_at: DateTime<Utc>,
     pub created_block_height: u64,
 }

--- a/dango/indexer/sql/Cargo.toml
+++ b/dango/indexer/sql/Cargo.toml
@@ -17,7 +17,7 @@ anyhow                      = { workspace = true }
 async-trait                 = { workspace = true }
 borsh                       = { workspace = true }
 dango-indexer-sql-migration = { workspace = true }
-dango-types                 = { workspace = true }
+dango-types                 = { workspace = true, features = ["sea-orm"] }
 grug                        = { workspace = true }
 grug-app                    = { workspace = true }
 grug-math                   = { workspace = true }

--- a/dango/indexer/sql/src/entity/accounts.rs
+++ b/dango/indexer/sql/src/entity/accounts.rs
@@ -1,25 +1,4 @@
-use sea_orm::entity::prelude::*;
-
-#[derive(EnumIter, DeriveActiveEnum, Clone, Debug, PartialEq, Eq, Hash)]
-#[sea_orm(rs_type = "i32", db_type = "Integer")]
-pub enum AccountType {
-    #[sea_orm(num_value = 0)]
-    Spot,
-    #[sea_orm(num_value = 1)]
-    Margin,
-    #[sea_orm(num_value = 2)]
-    Multi,
-}
-
-impl From<dango_types::account_factory::AccountParams> for AccountType {
-    fn from(account: dango_types::account_factory::AccountParams) -> Self {
-        match account {
-            dango_types::account_factory::AccountParams::Spot(_) => AccountType::Spot,
-            dango_types::account_factory::AccountParams::Margin(_) => AccountType::Margin,
-            dango_types::account_factory::AccountParams::Multi(_) => AccountType::Multi,
-        }
-    }
-}
+use {dango_types::account_factory, sea_orm::entity::prelude::*};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Hash)]
 #[sea_orm(table_name = "accounts")]
@@ -29,7 +8,7 @@ pub struct Model {
     pub account_index: i32,
     #[sea_orm(unique)]
     pub address: String,
-    pub account_type: AccountType,
+    pub account_type: account_factory::AccountType,
     pub created_at: DateTime,
     pub created_block_height: i64,
 }

--- a/dango/indexer/sql/src/entity/public_keys.rs
+++ b/dango/indexer/sql/src/entity/public_keys.rs
@@ -1,25 +1,4 @@
-use sea_orm::entity::prelude::*;
-
-#[derive(EnumIter, DeriveActiveEnum, Clone, Debug, PartialEq, Eq, Hash)]
-#[sea_orm(rs_type = "i32", db_type = "Integer")]
-pub enum KeyType {
-    #[sea_orm(num_value = 0)]
-    Secp256r1,
-    #[sea_orm(num_value = 1)]
-    Secp256k1,
-    #[sea_orm(num_value = 2)]
-    Ethereum,
-}
-
-impl From<dango_types::auth::Key> for KeyType {
-    fn from(key: dango_types::auth::Key) -> Self {
-        match key {
-            dango_types::auth::Key::Secp256r1(_) => KeyType::Secp256r1,
-            dango_types::auth::Key::Secp256k1(_) => KeyType::Secp256k1,
-            dango_types::auth::Key::Ethereum(_) => KeyType::Ethereum,
-        }
-    }
-}
+use {dango_types::auth, sea_orm::entity::prelude::*};
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Hash)]
 #[sea_orm(table_name = "users_public_keys")]
@@ -29,7 +8,7 @@ pub struct Model {
     pub username: String,
     pub key_hash: String,
     pub public_key: String,
-    pub key_type: KeyType,
+    pub key_type: auth::KeyType,
     pub created_at: DateTime,
     pub created_block_height: i64,
 }

--- a/dango/indexer/sql/src/hooks/accounts.rs
+++ b/dango/indexer/sql/src/hooks/accounts.rs
@@ -134,7 +134,7 @@ impl Hooks {
                         username: Set(user_register_event.username.to_string()),
                         key_hash: Set(user_register_event.key_hash.to_string()),
                         public_key: Set(user_register_event.key.to_string()),
-                        key_type: Set(user_register_event.key.into()),
+                        key_type: Set(user_register_event.key.ty()),
                         created_at: Set(created_at),
                         created_block_height: Set(block.block.info.height as i64),
                     })
@@ -225,7 +225,7 @@ impl Hooks {
                     username: Set(account_key_added_event.username.to_string()),
                     key_hash: Set(account_key_added_event.key_hash.to_string()),
                     public_key: Set(account_key_added_event.key.to_string()),
-                    key_type: Set(account_key_added_event.key.into()),
+                    key_type: Set(account_key_added_event.key.ty()),
                     created_at: Set(created_at),
                     created_block_height: Set(block.block.info.height as i64),
                 };

--- a/dango/indexer/sql/src/hooks/accounts.rs
+++ b/dango/indexer/sql/src/hooks/accounts.rs
@@ -158,7 +158,7 @@ impl Hooks {
                 let new_account = entity::accounts::ActiveModel {
                     id: Set(new_account_id),
                     address: Set(account_registered_event.address.to_string()),
-                    account_type: Set(account_registered_event.clone().params.into()),
+                    account_type: Set(account_registered_event.clone().params.ty()),
                     account_index: Set(account_registered_event.index as i32),
                     created_at: Set(created_at),
                     created_block_height: Set(block.block.info.height as i64),

--- a/dango/types/Cargo.toml
+++ b/dango/types/Cargo.toml
@@ -9,11 +9,19 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
+[features]
+# Derive async-graphql traits for certain types.
+async-graphql = ["dep:async-graphql"]
+# Derive sea-orm traits for certain types.
+sea-orm = ["dep:sea-orm"]
+
 [dependencies]
 anyhow          = { workspace = true }
+async-graphql   = { workspace = true, optional = true }
 grug            = { workspace = true }
 hyperlane-types = { workspace = true }
 paste           = { workspace = true }
 pyth-types      = { workspace = true }
+sea-orm         = { workspace = true, optional = true }
 serde           = { workspace = true }
 sha2            = { workspace = true }

--- a/dango/types/src/account_factory/account.rs
+++ b/dango/types/src/account_factory/account.rs
@@ -23,17 +23,26 @@ pub struct Account {
 
 /// Types of accounts the protocol supports.
 #[grug::derive(Serde, Borsh)]
-#[derive(Copy, PartialOrd, Ord)]
+#[derive(Copy, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
+#[cfg_attr(
+    feature = "sea-orm",
+    derive(sea_orm::EnumIter, sea_orm::DeriveActiveEnum)
+)]
+#[cfg_attr(feature = "sea-orm", sea_orm(rs_type = "i32", db_type = "Integer"))]
 pub enum AccountType {
     /// A single-signature account that cannot borrow margin loans.
+    #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 0))]
     Spot,
     /// A single-signature account that can borrow margin loans.
     ///
     /// The loans are collateralized by assets held in the account. The account
     /// is capable of rejecting transactions that may cause it to become
     /// insolvent, and carrying out liquidations if necessary.
+    #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 1))]
     Margin,
     /// A multi-signature account. Cannot borrow margin loans.
+    #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 2))]
     Multi,
 }
 

--- a/dango/types/src/auth.rs
+++ b/dango/types/src/auth.rs
@@ -12,6 +12,22 @@ use {
 /// replay protection.
 pub type Nonce = u32;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
+#[cfg_attr(
+    feature = "sea-orm",
+    derive(sea_orm::EnumIter, sea_orm::DeriveActiveEnum)
+)]
+#[cfg_attr(feature = "sea-orm", sea_orm(rs_type = "i32", db_type = "Integer"))]
+pub enum KeyType {
+    #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 0))]
+    Secp256r1,
+    #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 1))]
+    Secp256k1,
+    #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 2))]
+    Ethereum,
+}
+
 /// A public key that can be associated with a [`Username`](crate::auth::Username).
 #[grug::derive(Serde, Borsh)]
 #[derive(Copy)]
@@ -31,6 +47,16 @@ pub enum Key {
     /// sign a message, and extracting the pubkey from the signature. This would
     /// however be a bad UX, and deter the more security-minded users.
     Ethereum(Addr),
+}
+
+impl Key {
+    pub fn ty(&self) -> KeyType {
+        match self {
+            Key::Secp256r1(_) => KeyType::Secp256r1,
+            Key::Secp256k1(_) => KeyType::Secp256k1,
+            Key::Ethereum(_) => KeyType::Ethereum,
+        }
+    }
 }
 
 impl Display for Key {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Consolidated duplicate types between `dango-types` and `indexer` crates, updated dependencies, and refactored code to use unified types.
> 
>   - **Type Consolidation**:
>     - Removed duplicate `AccountType` and `KeyType` enums from `dango/indexer/sql/src/entity/accounts.rs` and `dango/indexer/sql/src/entity/public_keys.rs`.
>     - Updated `dango/httpd/src/graphql/types/account.rs` and `dango/httpd/src/graphql/types/public_key.rs` to use `dango_types::account_factory::AccountType` and `dango_types::auth::KeyType`.
>     - Updated `dango/indexer/sql/src/hooks/accounts.rs` to use `ty()` method for `AccountParams` and `Key`.
>   - **Dependency Updates**:
>     - Added `dango-types` with `async-graphql` feature to `dango/httpd/Cargo.toml`.
>     - Added `dango-types` with `sea-orm` feature to `dango/indexer/sql/Cargo.toml`.
>   - **Feature Flags**:
>     - Added `async-graphql` and `sea-orm` feature flags to `dango/types/Cargo.toml` for deriving traits.
>   - **Miscellaneous**:
>     - Updated `Cargo.lock` to reflect new dependencies.
>     - Removed unused code and comments in `dango/httpd/src/graphql/types/account.rs` and `dango/httpd/src/graphql/types/public_key.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 7ef2f1a329a5a2839c4efa8fdf2b8ff5cb64e9b3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->