### PR TITLE
Add transaction hashes to events

### DIFF
--- a/dango/httpd/src/graphql.rs
+++ b/dango/httpd/src/graphql.rs
@@ -6,6 +6,7 @@ use {
     },
     indexer_sql::dataloaders::{
         block_events::BlockEventsDataLoader, block_transactions::BlockTransactionsDataLoader,
+        event_transaction::EventTransactionDataLoader,
         transaction_events::TransactionEventsDataLoader,
         transaction_grug::FileTransactionDataLoader,
         transaction_messages::TransactionMessagesDataLoader,
@@ -29,6 +30,13 @@ pub fn build_schema(app_ctx: Context) -> AppSchema {
 
     let block_events_loader = DataLoader::new(
         BlockEventsDataLoader {
+            db: app_ctx.db.clone(),
+        },
+        tokio::spawn,
+    );
+
+    let event_transaction_loader = DataLoader::new(
+        EventTransactionDataLoader {
             db: app_ctx.db.clone(),
         },
         tokio::spawn,
@@ -69,5 +77,6 @@ pub fn build_schema(app_ctx: Context) -> AppSchema {
     .data(transaction_messages_loader)
     .data(transaction_events_loader)
     .data(file_transaction_loader)
+    .data(event_transaction_loader)
     .finish()
 }

--- a/grug/types/src/events/flat.rs
+++ b/grug/types/src/events/flat.rs
@@ -71,6 +71,7 @@ impl FlatEventStatus {
     Eq,
     Copy,
     Display,
+    Hash,
 )]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "sea-orm", derive(EnumIter, DeriveActiveEnum))]

--- a/indexer/httpd/src/graphql.rs
+++ b/indexer/httpd/src/graphql.rs
@@ -3,6 +3,7 @@ use {
     async_graphql::{Schema, dataloader::DataLoader, extensions},
     indexer_sql::dataloaders::{
         block_events::BlockEventsDataLoader, block_transactions::BlockTransactionsDataLoader,
+        event_transaction::EventTransactionDataLoader,
         transaction_events::TransactionEventsDataLoader,
         transaction_grug::FileTransactionDataLoader,
         transaction_messages::TransactionMessagesDataLoader,
@@ -28,6 +29,13 @@ pub fn build_schema(app_ctx: Context) -> AppSchema {
 
     let block_events_loader = DataLoader::new(
         BlockEventsDataLoader {
+            db: app_ctx.db.clone(),
+        },
+        tokio::spawn,
+    );
+
+    let event_transaction_loader = DataLoader::new(
+        EventTransactionDataLoader {
             db: app_ctx.db.clone(),
         },
         tokio::spawn,
@@ -68,5 +76,6 @@ pub fn build_schema(app_ctx: Context) -> AppSchema {
     .data(transaction_messages_loader)
     .data(transaction_events_loader)
     .data(file_transaction_loader)
+    .data(event_transaction_loader)
     .finish()
 }

--- a/indexer/sql/src/dataloaders.rs
+++ b/indexer/sql/src/dataloaders.rs
@@ -1,5 +1,6 @@
 pub mod block_events;
 pub mod block_transactions;
+pub mod event_transaction;
 pub mod transaction_events;
 pub mod transaction_grug;
 pub mod transaction_messages;

--- a/indexer/sql/src/dataloaders/event_transaction.rs
+++ b/indexer/sql/src/dataloaders/event_transaction.rs
@@ -1,0 +1,47 @@
+#[cfg(feature = "async-graphql")]
+use async_graphql::{dataloader::*, *};
+use {
+    crate::entity,
+    sea_orm::{DatabaseConnection, entity::prelude::*},
+    std::{collections::HashMap, sync::Arc},
+};
+
+pub struct EventTransactionDataLoader {
+    pub db: DatabaseConnection,
+}
+
+#[cfg(feature = "async-graphql")]
+impl Loader<entity::events::Model> for EventTransactionDataLoader {
+    type Error = Arc<sea_orm::DbErr>;
+    type Value = entity::transactions::Model;
+
+    // This allows to do a single SQL query to fetch all transactions related to a list of events.
+    async fn load(
+        &self,
+        keys: &[entity::events::Model],
+    ) -> Result<HashMap<entity::events::Model, Self::Value>, Self::Error> {
+        let transaction_ids = keys.iter().map(|m| m.transaction_id).collect::<Vec<_>>();
+        let events_by_transaction_id = keys
+            .iter()
+            .flat_map(|m| Some((m.transaction_id?, m.clone())))
+            .collect::<HashMap<_, _>>();
+
+        let transactions_by_transaction_ids: HashMap<uuid::Uuid, Self::Value> =
+            entity::transactions::Entity::find()
+                .filter(entity::transactions::Column::Id.is_in(transaction_ids))
+                .all(&self.db)
+                .await?
+                .into_iter()
+                .map(|t| (t.id, t))
+                .collect();
+
+        Ok(events_by_transaction_id
+            .into_iter()
+            .filter_map(|(id, event)| {
+                transactions_by_transaction_ids
+                    .get(&id)
+                    .map(|transaction| (event, transaction.clone()))
+            })
+            .collect())
+    }
+}

--- a/indexer/sql/src/dataloaders/event_transaction.rs
+++ b/indexer/sql/src/dataloaders/event_transaction.rs
@@ -23,7 +23,7 @@ impl Loader<entity::events::Model> for EventTransactionDataLoader {
         let transaction_ids = keys.iter().map(|m| m.transaction_id).collect::<Vec<_>>();
         let events_by_transaction_id = keys
             .iter()
-            .flat_map(|m| Some((m.transaction_id?, m.clone())))
+            .filter_map(|m| m.transaction_id.map(|id| (id, m.clone())))
             .collect::<HashMap<_, _>>();
 
         let transactions_by_transaction_ids: HashMap<uuid::Uuid, Self::Value> =

--- a/indexer/testing/Cargo.toml
+++ b/indexer/testing/Cargo.toml
@@ -5,28 +5,28 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-actix-codec   = { workspace = true }
-actix-http    = { workspace = true }
-actix-test    = { workspace = true }
-actix-web     = { workspace = true }
-anyhow        = { workspace = true }
-awc           = { workspace = true }
-futures-util  = { workspace = true }
-indexer-httpd = { workspace = true }
-sea-orm       = { workspace = true }
-serde         = { workspace = true }
-serde_json    = { workspace = true }
+actix-codec    = { workspace = true }
+actix-http     = { workspace = true }
+actix-test     = { workspace = true }
+actix-web      = { workspace = true }
+anyhow         = { workspace = true }
+awc            = { workspace = true }
+futures-util   = { workspace = true }
+grug-app       = { workspace = true }
+grug-db-memory = { workspace = true }
+grug-testing   = { workspace = true }
+grug-types     = { workspace = true }
+grug-vm-rust   = { workspace = true }
+indexer-httpd  = { workspace = true }
+indexer-sql    = { workspace = true, features = ["async-graphql", "testing", "tracing"] }
+sea-orm        = { workspace = true }
+serde          = { workspace = true }
+serde_json     = { workspace = true }
+tokio          = { workspace = true }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }
 assertor         = { workspace = true }
-grug-app         = { workspace = true }
-grug-db-memory   = { workspace = true }
 grug-storage     = { workspace = true }
-grug-testing     = { workspace = true }
-grug-types       = { workspace = true }
-grug-vm-rust     = { workspace = true }
 indexer-httpd    = { workspace = true, features = ["testing"] }
-indexer-sql      = { workspace = true, features = ["async-graphql", "testing", "tracing"] }
-tokio            = { workspace = true }
 tracing          = { workspace = true }

--- a/indexer/testing/src/block.rs
+++ b/indexer/testing/src/block.rs
@@ -1,0 +1,59 @@
+use {
+    grug_app::NaiveProposalPreparer,
+    grug_db_memory::MemDb,
+    grug_testing::{MockClient, TestAccounts, TestBuilder},
+    grug_types::{BroadcastClientExt, Coins, Denom},
+    grug_vm_rust::RustVm,
+    indexer_httpd::{context::Context, traits::QueryApp},
+    indexer_sql::{hooks::NullHooks, non_blocking_indexer::NonBlockingIndexer},
+    std::{str::FromStr, sync::Arc},
+    tokio::sync::Mutex,
+};
+
+pub async fn create_block() -> anyhow::Result<(
+    Context,
+    Arc<MockClient<MemDb, RustVm, NaiveProposalPreparer, NonBlockingIndexer<NullHooks>>>,
+    TestAccounts,
+)> {
+    let denom = Denom::from_str("ugrug")?;
+
+    let indexer = indexer_sql::non_blocking_indexer::IndexerBuilder::default()
+        .with_memory_database()
+        .with_keep_blocks(true)
+        .build()?;
+
+    let context = indexer.context.clone();
+    let indexer_path = indexer.indexer_path.clone();
+
+    let (suite, mut accounts) = TestBuilder::new_with_indexer(indexer)
+        .add_account("owner", Coins::new())
+        .add_account("sender", Coins::one(denom.clone(), 30_000)?)
+        .set_owner("owner")
+        .build();
+
+    let chain_id = suite.chain_id().await?;
+
+    let suite = Arc::new(Mutex::new(suite));
+
+    let mock_client =
+        MockClient::new_shared(suite.clone(), grug_testing::BlockCreation::OnBroadcast);
+
+    let sender = accounts["sender"].address;
+
+    mock_client
+        .send_message(
+            &mut accounts["sender"],
+            grug_types::Message::transfer(sender, Coins::one(denom.clone(), 2_000)?)?,
+            grug_types::GasOption::Predefined { gas_limit: 2000 },
+            &chain_id,
+        )
+        .await?;
+
+    suite.lock().await.app.indexer.wait_for_finish();
+
+    let client = Arc::new(mock_client);
+
+    let httpd_context = Context::new(context, suite, client.clone(), indexer_path);
+
+    Ok((httpd_context, client, accounts))
+}

--- a/indexer/testing/src/lib.rs
+++ b/indexer/testing/src/lib.rs
@@ -21,6 +21,8 @@ use {
     std::collections::HashMap,
 };
 
+pub mod block;
+
 #[derive(Serialize, Debug)]
 pub struct GraphQLCustomRequest<'a> {
     pub name: &'a str,

--- a/indexer/testing/tests/graphql/event.rs
+++ b/indexer/testing/tests/graphql/event.rs
@@ -1,0 +1,259 @@
+use {
+    assertor::*,
+    grug_types::{BroadcastClientExt, Coins, Denom, ResultExt},
+    indexer_sql::entity,
+    indexer_testing::{
+        GraphQLCustomRequest, PaginatedResponse, block::create_block, build_app_service,
+        call_graphql, call_ws_graphql_stream, parse_graphql_subscription_response,
+    },
+    std::str::FromStr,
+    tokio::sync::mpsc,
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_returns_events() -> anyhow::Result<()> {
+    let (httpd_context, _client, ..) = create_block().await?;
+
+    let graphql_query = r#"
+      query Events {
+        events {
+          nodes {
+            id
+            parentId
+            transactionId
+            messageId
+            blockHeight
+            createdAt
+            eventIdx
+            type
+            method
+            eventStatus
+            commitmentStatus
+            transactionType
+            transactionIdx
+            messageIdx
+            eventIdx
+            data
+          }
+          edges {
+            node {
+              id
+              parentId
+              transactionId
+              messageId
+              blockHeight
+              createdAt
+              type
+              method
+              eventStatus
+              commitmentStatus
+              transactionType
+              transactionIdx
+              messageIdx
+              data
+              eventIdx
+            }
+            cursor
+          }
+          pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
+        }
+      }
+    "#;
+
+    let request_body = GraphQLCustomRequest {
+        name: "events",
+        query: graphql_query,
+        variables: Default::default(),
+    };
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let app = build_app_service(httpd_context);
+
+                let response =
+                    call_graphql::<PaginatedResponse<entity::events::Model>>(app, request_body)
+                        .await?;
+
+                assert_that!(response.data.edges).is_not_empty();
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_returns_events_transaction_hashes() -> anyhow::Result<()> {
+    let (httpd_context, _client, ..) = create_block().await?;
+
+    let graphql_query = r#"
+      query Events {
+        events {
+          nodes {
+            transaction { hash }
+            blockHeight
+            createdAt
+            type
+            method
+            eventStatus
+            commitmentStatus
+            data
+          }
+          edges {
+            node {
+              transaction { hash }
+              blockHeight
+              createdAt
+              type
+              method
+              eventStatus
+              commitmentStatus
+              data
+            }
+            cursor
+          }
+          pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
+        }
+      }
+    "#;
+
+    let request_body = GraphQLCustomRequest {
+        name: "events",
+        query: graphql_query,
+        variables: Default::default(),
+    };
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let app = build_app_service(httpd_context);
+
+                let response =
+                    call_graphql::<PaginatedResponse<serde_json::Value>>(app, request_body).await?;
+
+                let hashes = response
+                    .data
+                    .edges
+                    .iter()
+                    .flat_map(|edge| edge.node.get("transaction").and_then(|tx| tx.get("hash")))
+                    .collect::<Vec<_>>();
+
+                assert_that!(hashes).is_not_empty();
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn graphql_subscribe_to_events() -> anyhow::Result<()> {
+    let (httpd_context, client, mut accounts) = create_block().await?;
+
+    let graphql_query = r#"
+      subscription Events {
+        events {
+          id
+          parentId
+          transactionId
+          messageId
+          transactionType
+          transactionIdx
+          messageIdx
+          eventIdx
+          blockHeight
+          createdAt
+          type
+          method
+          eventStatus
+          commitmentStatus
+          data
+        }
+      }
+    "#;
+
+    let request_body = GraphQLCustomRequest {
+        name: "events",
+        query: graphql_query,
+        variables: Default::default(),
+    };
+
+    let (crate_block_tx, mut rx) = mpsc::channel::<u32>(1);
+
+    // Can't call this from LocalSet so using channels instead.
+    tokio::spawn(async move {
+        while rx.recv().await.is_some() {
+            let to = accounts["owner"].address;
+
+            let chain_id = client.chain_id().await;
+
+            client
+                .send_message(
+                    &mut accounts["sender"],
+                    grug_types::Message::transfer(
+                        to,
+                        Coins::one(Denom::from_str("ugrug")?, 2_000)?,
+                    )?,
+                    grug_types::GasOption::Predefined { gas_limit: 2000 },
+                    &chain_id,
+                )
+                .await
+                .should_succeed();
+
+            // Enabling this here will cause the test to hang
+            // suite.app.indexer.wait_for_finish();
+        }
+
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let name = request_body.name;
+                let (_srv, _ws, framed) =
+                    call_ws_graphql_stream(httpd_context, build_app_service, request_body).await?;
+
+                // 1st response is always the existing last block
+                let (framed, response) =
+                    parse_graphql_subscription_response::<Vec<entity::events::Model>>(framed, name)
+                        .await?;
+
+                assert_that!(response.data.first().unwrap().block_height).is_equal_to(1);
+                assert_that!(response.data).is_not_empty();
+
+                crate_block_tx.send(2).await?;
+
+                // 2st response
+                let (framed, response) =
+                    parse_graphql_subscription_response::<Vec<entity::events::Model>>(framed, name)
+                        .await?;
+
+                assert_that!(response.data.first().unwrap().block_height).is_equal_to(2);
+                assert_that!(response.data).is_not_empty();
+
+                crate_block_tx.send(3).await?;
+
+                // 3rd response
+                let (_, response) =
+                    parse_graphql_subscription_response::<Vec<entity::events::Model>>(framed, name)
+                        .await?;
+
+                assert_that!(response.data.first().unwrap().block_height).is_equal_to(3);
+                assert_that!(response.data).is_not_empty();
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}

--- a/indexer/testing/tests/graphql/main.rs
+++ b/indexer/testing/tests/graphql/main.rs
@@ -1,0 +1,1 @@
+pub mod event;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add transaction hashes to events by introducing `EventTransactionDataLoader` and updating GraphQL schema and tests.
> 
>   - **Data Loaders**:
>     - Add `EventTransactionDataLoader` in `indexer/sql/src/dataloaders/event_transaction.rs` to fetch transactions related to events.
>     - Update `dataloaders.rs` to include `event_transaction` module.
>   - **GraphQL Schema**:
>     - Update `build_schema()` in `graphql.rs` files to include `event_transaction_loader`.
>     - Modify `Model` in `events.rs` to include `transaction()` method for fetching transaction hashes.
>   - **Testing**:
>     - Add `graphql_returns_events_transaction_hashes()` and `graphql_subscribe_to_events()` tests in `event.rs` to verify transaction hash retrieval.
>     - Move existing event tests from `httpd.rs` to `event.rs` for better organization.
>   - **Misc**:
>     - Update `Cargo.toml` to include necessary dependencies for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 6049afe6bf88c696e4a042fef140268f3e0eb210. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->