### PR TITLE
dango: set minimum deposit to zero in devnet/testnet genesis

### DIFF
--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -104,6 +104,19 @@ pub fn setup_test_naive(
     Contracts,
     MockValidatorSets,
 ) {
+    setup_test_naive_with_custom_genesis(test_opt, GenesisOption::preset_test())
+}
+
+pub fn setup_test_naive_with_custom_genesis(
+    test_opt: TestOption,
+    genesis_opt: GenesisOption,
+) -> (
+    TestSuite<NaiveProposalPreparer>,
+    TestAccounts,
+    Codes<ContractWrapper>,
+    Contracts,
+    MockValidatorSets,
+) {
     setup_suite_with_db_and_vm(
         MemDb::new(),
         RustVm::new(),
@@ -111,7 +124,7 @@ pub fn setup_test_naive(
         NullIndexer,
         RustVm::genesis_codes(),
         test_opt,
-        GenesisOption::preset_test(),
+        genesis_opt,
     )
 }
 

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -348,7 +348,7 @@ fn onboarding_without_deposit_when_minimum_deposit_is_zero() {
     // The newly created account should have zero balance.
     suite
         .query_balances(&user)
-        .should_succeed_and_equal(Coins::new());
+        .should_succeed_and(|coins| coins.is_empty());
 }
 
 #[test]

--- a/deploy/roles/cometbft/templates/devnet/config/genesis.json
+++ b/deploy/roles/cometbft/templates/devnet/config/genesis.json
@@ -126,9 +126,7 @@
               "multi": "D86E8112F3C4C4442126F8E9F44F16867DA487F29052BF91B810457DB34209A4",
               "spot": "35BE322D094F9D154A8ABA4733B8497F180353BD7AE7B0A15F90B586B549F28B"
             },
-            "minimum_deposit": {
-              "bridge/usdc": "10000000"
-            },
+            "minimum_deposit": {},
             "users": {
               "owner": [
                 "06E54A648823A1F12E1F03FED193C9FE0C030A65507FF09066BF9E067CD375D2",

--- a/deploy/roles/cometbft/templates/testnet/config/genesis.json
+++ b/deploy/roles/cometbft/templates/testnet/config/genesis.json
@@ -126,9 +126,7 @@
               "multi": "D86E8112F3C4C4442126F8E9F44F16867DA487F29052BF91B810457DB34209A4",
               "spot": "35BE322D094F9D154A8ABA4733B8497F180353BD7AE7B0A15F90B586B549F28B"
             },
-            "minimum_deposit": {
-              "bridge/usdc": "10000000"
-            },
+            "minimum_deposit": {},
             "users": {
               "owner": [
                 "06E54A648823A1F12E1F03FED193C9FE0C030A65507FF09066BF9E067CD375D2",

--- a/networks/localdango/configs/cometbft/config/genesis.json
+++ b/networks/localdango/configs/cometbft/config/genesis.json
@@ -126,9 +126,7 @@
               "multi": "D86E8112F3C4C4442126F8E9F44F16867DA487F29052BF91B810457DB34209A4",
               "spot": "35BE322D094F9D154A8ABA4733B8497F180353BD7AE7B0A15F90B586B549F28B"
             },
-            "minimum_deposit": {
-              "bridge/usdc": "10000000"
-            },
+            "minimum_deposit": {},
             "users": {
               "owner": [
                 "06E54A648823A1F12E1F03FED193C9FE0C030A65507FF09066BF9E067CD375D2",


### PR DESCRIPTION
1. Set `minimum_deposit` to zero in the genesis file for localdango, devnet, and testnet.
2. Add a test to ensure `register_user` works without a deposit when `minimum_deposit` is zero.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set `minimum_deposit` to zero in localdango, devnet, and testnet genesis files and add a test for user registration without deposit.
> 
>   - **Genesis Configuration**:
>     - Set `minimum_deposit` to zero in `genesis.json` for `localdango`, `devnet`, and `testnet`.
>   - **Testing**:
>     - Add test `onboarding_without_deposit_when_minimum_deposit_is_zero` in `factory.rs` to verify `register_user` works without deposit when `minimum_deposit` is zero.
>     - Introduce `setup_test_naive_with_custom_genesis()` in `setup.rs` to allow custom genesis options in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 965c85841a9515e955e2065a5951e600dfc482f1. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->