### PR TITLE
tracing: suppress tracing output in `Query` and `CheckTx`

### DIFF
--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -1,16 +1,14 @@
-use crate::TraceOption;
 #[cfg(all(feature = "abci", feature = "tracing"))]
 use data_encoding::BASE64;
 #[cfg(any(feature = "abci", feature = "tracing"))]
 use grug_types::JsonSerExt;
 #[cfg(feature = "abci")]
 use grug_types::{HashExt, JsonDeExt};
-
 use {
     crate::{
         APP_CONFIG, AppError, AppResult, CHAIN_ID, CODES, CONFIG, Db, EventResult, GasTracker,
         Indexer, LAST_FINALIZED_BLOCK, NEXT_CRONJOBS, NaiveProposalPreparer, NaiveQuerier,
-        NullIndexer, ProposalPreparer, QuerierProviderImpl, Vm, catch_and_push_event,
+        NullIndexer, ProposalPreparer, QuerierProviderImpl, TraceOption, Vm, catch_and_push_event,
         catch_and_update_event, do_authenticate, do_backrun, do_configure, do_cron_execute,
         do_execute, do_finalize_fee, do_instantiate, do_migrate, do_transfer, do_upload,
         do_withhold_fee, query_app_config, query_balance, query_balances, query_code, query_codes,

--- a/grug/app/src/event.rs
+++ b/grug/app/src/event.rs
@@ -85,19 +85,18 @@ impl<T> EventResult<T> {
     }
 
     #[cfg(feature = "tracing")]
-    pub fn debug<O>(&self, ok_closure: O, error_msg: &str)
+    pub fn debug<O>(&self, ok_closure: O, error_msg: &str, error_level: tracing::Level)
     where
         O: Fn(&T),
     {
+        use crate::dyn_event;
+
         match self {
             EventResult::Ok(val) => {
                 ok_closure(val);
             },
-            EventResult::Err { error, .. } => {
-                tracing::warn!(err = error.to_string(), error_msg);
-            },
-            EventResult::NestedErr { error, .. } => {
-                tracing::warn!(err = error.to_string(), "Sub error encountered");
+            EventResult::Err { error, .. } | EventResult::NestedErr { error, .. } => {
+                dyn_event!(error_level, err = error.to_string(), error_msg);
             },
         }
     }

--- a/grug/app/src/execute/authenticate.rs
+++ b/grug/app/src/execute/authenticate.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, Vm,
-        call_in_1_out_1_handle_auth_response, catch_and_update_event, catch_event,
+        AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, TraceOption, Vm,
+        call_in_1_out_1_handle_auth_response, catch_and_update_event, catch_event, dyn_event,
     },
     grug_types::{AuthMode, BlockInfo, Context, EvtAuthenticate, Storage, Tx},
 };
@@ -13,19 +13,25 @@ pub fn do_authenticate<VM>(
     block: BlockInfo,
     tx: &Tx,
     mode: AuthMode,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtAuthenticate>
 where
     VM: Vm + Clone + 'static,
     AppError: From<VM::Error>,
 {
-    let evt = _do_authenticate(vm, storage, gas_tracker, block, tx, mode);
+    let evt = _do_authenticate(vm, storage, gas_tracker, block, tx, mode, trace_opt);
 
     #[cfg(feature = "tracing")]
     evt.debug(
         |_| {
-            tracing::info!(sender = tx.sender.to_string(), "Authenticated transaction");
+            dyn_event!(
+                trace_opt.ok_level,
+                sender = tx.sender.to_string(),
+                "Authenticated transaction"
+            );
         },
         "Failed to authenticate transaction",
+        trace_opt.error_level,
     );
 
     evt
@@ -38,6 +44,7 @@ pub fn _do_authenticate<VM>(
     block: BlockInfo,
     tx: &Tx,
     mode: AuthMode,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtAuthenticate>
 where
     VM: Vm + Clone + 'static,
@@ -77,6 +84,7 @@ where
             &ctx,
             tx,
             &mut evt.backrun,
+            trace_opt,
         ),
         evt => guest_event
     }

--- a/grug/app/src/execute/backrun.rs
+++ b/grug/app/src/execute/backrun.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, Vm,
-        call_in_1_out_1_handle_response, catch_and_update_event, catch_event,
+        AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, TraceOption, Vm,
+        call_in_1_out_1_handle_response, catch_and_update_event, catch_event, dyn_event,
     },
     grug_types::{AuthMode, BlockInfo, Context, EvtBackrun, Storage, Tx},
 };
@@ -13,19 +13,25 @@ pub fn do_backrun<VM>(
     block: BlockInfo,
     tx: &Tx,
     mode: AuthMode,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtBackrun>
 where
     VM: Vm + Clone + 'static,
     AppError: From<VM::Error>,
 {
-    let evt = _do_backrun(vm, storage, gas_tracker, block, tx, mode);
+    let evt = _do_backrun(vm, storage, gas_tracker, block, tx, mode, trace_opt);
 
     #[cfg(feature = "tracing")]
     evt.debug(
         |_| {
-            tracing::info!(sender = tx.sender.to_string(), "Backran transaction");
+            dyn_event!(
+                trace_opt.ok_level,
+                sender = tx.sender.to_string(),
+                "Backran transaction"
+            );
         },
         "Failed to backrun transaction",
+        trace_opt.error_level,
     );
 
     evt
@@ -38,6 +44,7 @@ pub fn _do_backrun<VM>(
     block: BlockInfo,
     tx: &Tx,
     mode: AuthMode,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtBackrun>
 where
     VM: Vm + Clone + 'static,
@@ -76,6 +83,7 @@ where
             code_hash,
             &ctx,
             tx,
+            trace_opt,
         ),
         evt => guest_event
     }

--- a/grug/app/src/execute/configure.rs
+++ b/grug/app/src/execute/configure.rs
@@ -27,7 +27,7 @@ pub fn do_configure(
             dyn_event!(
                 trace_opt.error_level,
                 err = err.to_string(),
-                "Failed to updated config"
+                "Failed to update config"
             );
 
             EventResult::err(evt, err)

--- a/grug/app/src/execute/execute.rs
+++ b/grug/app/src/execute/execute.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        _do_transfer, AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, Vm,
-        call_in_1_out_1_handle_response, catch_and_update_event, catch_event,
+        _do_transfer, AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, TraceOption, Vm,
+        call_in_1_out_1_handle_response, catch_and_update_event, catch_event, dyn_event,
     },
     grug_types::{Addr, BlockInfo, Context, EvtExecute, MsgExecute, Storage, btree_map},
 };
@@ -14,6 +14,7 @@ pub fn do_execute<VM>(
     msg_depth: usize,
     sender: Addr,
     msg: MsgExecute,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtExecute>
 where
     VM: Vm + Clone + 'static,
@@ -26,15 +27,21 @@ where
         block,
         msg_depth,
         sender,
-        msg.clone(),
+        msg,
+        trace_opt,
     );
 
     #[cfg(feature = "tracing")]
     evt.debug(
         |evt| {
-            tracing::info!(contract = evt.contract.to_string(), "Executed contract");
+            dyn_event!(
+                trace_opt.ok_level,
+                contract = evt.contract.to_string(),
+                "Executed contract"
+            );
         },
         "Failed to execute contract",
+        trace_opt.error_level,
     );
 
     evt
@@ -48,6 +55,7 @@ fn _do_execute<VM>(
     msg_depth: usize,
     sender: Addr,
     msg: MsgExecute,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtExecute>
 where
     VM: Vm + Clone + 'static,
@@ -76,6 +84,7 @@ where
                 sender,
                 btree_map! { msg.contract => msg.funds.clone() },
                 false,
+                trace_opt,
             ),
             evt => transfer_event
         }
@@ -103,6 +112,7 @@ where
             code_hash,
             &ctx,
             &msg.msg,
+            trace_opt,
         ),
         evt => guest_event
     }

--- a/grug/app/src/execute/migrate.rs
+++ b/grug/app/src/execute/migrate.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        AppError, CHAIN_ID, CODES, CONTRACTS, EventResult, GasTracker, Vm,
-        call_in_1_out_1_handle_response, catch_and_update_event, catch_event,
+        AppError, CHAIN_ID, CODES, CONTRACTS, EventResult, GasTracker, TraceOption, Vm,
+        call_in_1_out_1_handle_response, catch_and_update_event, catch_event, dyn_event,
     },
     grug_types::{
         Addr, BlockInfo, CodeStatus, Context, EvtMigrate, MsgMigrate, StdResult, Storage,
@@ -16,19 +16,34 @@ pub fn do_migrate<VM>(
     msg_depth: usize,
     sender: Addr,
     msg: MsgMigrate,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtMigrate>
 where
     VM: Vm + Clone + 'static,
     AppError: From<VM::Error>,
 {
-    let evt = _do_migrate(vm, storage, gas_tracker, block, msg_depth, sender, msg);
+    let evt = _do_migrate(
+        vm,
+        storage,
+        gas_tracker,
+        block,
+        msg_depth,
+        sender,
+        msg,
+        trace_opt,
+    );
 
     #[cfg(feature = "tracing")]
     evt.debug(
         |evt| {
-            tracing::info!(contract = evt.contract.to_string(), "Migrated contract");
+            dyn_event!(
+                trace_opt.ok_level,
+                contract = evt.contract.to_string(),
+                "Migrated contract"
+            );
         },
         "Failed to migrate contract",
+        trace_opt.error_level,
     );
 
     evt
@@ -42,6 +57,7 @@ fn _do_migrate<VM>(
     msg_depth: usize,
     sender: Addr,
     msg: MsgMigrate,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtMigrate>
 where
     VM: Vm + Clone + 'static,
@@ -131,6 +147,7 @@ where
             msg.new_code_hash,
             &ctx,
             &msg.msg,
+            trace_opt,
         ),
         evt => guest_event
     }

--- a/grug/app/src/execute/reply.rs
+++ b/grug/app/src/execute/reply.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, Vm,
-        call_in_2_out_1_handle_response, catch_and_update_event, catch_event,
+        AppError, CHAIN_ID, CONTRACTS, EventResult, GasTracker, TraceOption, Vm,
+        call_in_2_out_1_handle_response, catch_and_update_event, catch_event, dyn_event,
     },
     grug_types::{Addr, BlockInfo, Context, EvtReply, Json, ReplyOn, Storage, SubMsgResult},
 };
@@ -16,6 +16,7 @@ pub fn do_reply<VM>(
     msg: &Json,
     result: &SubMsgResult,
     reply_on: &ReplyOn,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtReply>
 where
     VM: Vm + Clone + 'static,
@@ -31,14 +32,20 @@ where
         msg,
         result,
         reply_on,
+        trace_opt,
     );
 
     #[cfg(feature = "tracing")]
     evt.debug(
         |_| {
-            tracing::info!(contract = contract.to_string(), "Performed reply");
+            dyn_event!(
+                trace_opt.ok_level,
+                contract = contract.to_string(),
+                "Performed reply"
+            );
         },
         "Failed to perform reply",
+        trace_opt.error_level,
     );
 
     evt
@@ -54,6 +61,7 @@ fn _do_reply<VM>(
     msg: &Json,
     result: &SubMsgResult,
     reply_on: &ReplyOn,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtReply>
 where
     VM: Vm + Clone + 'static,
@@ -93,6 +101,7 @@ where
             &ctx,
             msg,
             result,
+            trace_opt,
         ),
         evt => guest_event
     }

--- a/grug/app/src/execute/transfer.rs
+++ b/grug/app/src/execute/transfer.rs
@@ -1,8 +1,8 @@
 use {
     crate::{
-        AppError, CHAIN_ID, CONFIG, CONTRACTS, EventResult, GasTracker, Vm,
+        AppError, CHAIN_ID, CONFIG, CONTRACTS, EventResult, GasTracker, TraceOption, Vm,
         call_in_0_out_1_handle_response, call_in_1_out_1_handle_response, catch_and_insert_event,
-        catch_and_update_event, catch_event,
+        catch_and_update_event, catch_event, dyn_event,
     },
     grug_types::{
         Addr, BankMsg, BlockInfo, Coins, Context, EvtGuest, EvtTransfer, Hash256, MsgTransfer,
@@ -19,6 +19,7 @@ pub fn do_transfer<VM>(
     sender: Addr,
     msg: MsgTransfer,
     do_receive: bool,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtTransfer>
 where
     VM: Vm + Clone + 'static,
@@ -33,18 +34,21 @@ where
         sender,
         msg.clone(),
         do_receive,
+        trace_opt,
     );
 
     #[cfg(feature = "tracing")]
     evt.debug(
         |_| {
-            tracing::info!(
+            dyn_event!(
+                trace_opt.ok_level,
                 from = sender.to_string(),
                 transfers = ?msg,
                 "Transferred coins"
             );
         },
         "Failed to transfer coins",
+        trace_opt.error_level,
     );
 
     evt
@@ -63,6 +67,7 @@ pub(crate) fn _do_transfer<VM>(
     // - `true` when handling `Message::Transfer`
     // - `false` when handling `Message::{Instantaite,Execute}`
     do_receive: bool,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtTransfer>
 where
     VM: Vm + Clone + 'static,
@@ -107,6 +112,7 @@ where
             code_hash,
             &ctx,
             &msg,
+            trace_opt,
         ),
         evt => bank_guest
     }
@@ -126,6 +132,7 @@ where
                         to,
                         coins,
                         contract_info.code_hash,
+                        trace_opt,
                     ),
                     evt,
                     receive_guests,
@@ -148,6 +155,7 @@ fn _do_receive<VM>(
     to: Addr,
     coins: Coins,
     code_hash: Hash256,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
     VM: Vm + Clone + 'static,
@@ -180,5 +188,6 @@ where
         "receive",
         code_hash,
         &ctx,
+        trace_opt,
     )
 }

--- a/grug/app/src/lib.rs
+++ b/grug/app/src/lib.rs
@@ -12,10 +12,12 @@ mod providers;
 mod query;
 mod state;
 mod submessage;
+#[cfg(feature = "tracing")]
+mod tracing;
 mod traits;
 mod vm;
 
 pub use crate::{
     app::*, error::*, event::*, execute::*, gas::*, indexer::*, proposal_preparer::*, providers::*,
-    query::*, state::*, submessage::*, traits::*, vm::*,
+    query::*, state::*, submessage::*, tracing::*, traits::*, vm::*,
 };

--- a/grug/app/src/submessage.rs
+++ b/grug/app/src/submessage.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{AppError, EventResult, GasTracker, Vm, do_reply, process_msg},
+    crate::{AppError, EventResult, GasTracker, TraceOption, Vm, do_reply, process_msg},
     grug_types::{
         Addr, BlockInfo, Buffer, EventStatus, GenericResult, ReplyOn, Shared, Storage, SubEvent,
         SubEventStatus, SubMessage,
@@ -66,6 +66,7 @@ pub fn handle_submessages<VM>(
     msg_depth: usize,
     sender: Addr,
     submsgs: Vec<SubMessage>,
+    trace_opt: TraceOption,
 ) -> EventResult<Vec<EventStatus<SubEvent>>>
 where
     VM: Vm + Clone + 'static,
@@ -90,6 +91,7 @@ where
             msg_depth + 1, // important: increase message depth
             sender,
             submsg.msg,
+            trace_opt,
         );
 
         match (&submsg.reply_on, result.clone().as_result()) {
@@ -108,6 +110,7 @@ where
                     payload,
                     &GenericResult::Ok(submsg_event.clone()),
                     &submsg.reply_on,
+                    trace_opt,
                 );
 
                 let submsg_event = SubEventStatus::Ok(submsg_event);
@@ -130,6 +133,7 @@ where
                     payload,
                     &GenericResult::Err(err.to_string()),
                     &submsg.reply_on,
+                    trace_opt,
                 );
 
                 let submsg_event = if reply.is_ok() {

--- a/grug/app/src/tracing.rs
+++ b/grug/app/src/tracing.rs
@@ -42,7 +42,7 @@ impl TraceOption {
     /// - `Query`
     /// - `CheckTx`
     pub const MUTE: Self = Self {
-        ok_level: Level::DEBUG,
-        error_level: Level::DEBUG,
+        ok_level: Level::TRACE,
+        error_level: Level::TRACE,
     };
 }

--- a/grug/app/src/tracing.rs
+++ b/grug/app/src/tracing.rs
@@ -1,0 +1,48 @@
+use tracing::Level;
+
+/// Emit a tracing event with a dynamic level.
+///
+/// The `tracing::event!` macro requires the level to be a constant. Use this
+/// macro instead of choose the level dynamically at runtime.
+///
+/// Copied from:
+/// <https://github.com/tokio-rs/tracing/issues/2730#issuecomment-1943022805>
+#[macro_export]
+macro_rules! dyn_event {
+    ($level:expr, $($arg:tt)+) => {
+        match $level {
+            ::tracing::Level::ERROR => ::tracing::error!($($arg)+),
+            ::tracing::Level::WARN  => ::tracing::warn!($($arg)+),
+            ::tracing::Level::INFO  => ::tracing::info!($($arg)+),
+            ::tracing::Level::DEBUG => ::tracing::debug!($($arg)+),
+            ::tracing::Level::TRACE => ::tracing::trace!($($arg)+),
+        }
+    };
+}
+
+#[derive(Clone, Copy)]
+pub struct TraceOption {
+    /// Tracing level to use if an action succeeded.
+    pub ok_level: Level,
+    /// Tracing level to use if an action fails.
+    pub error_level: Level,
+}
+
+impl TraceOption {
+    /// The tracing option to use under the following situtations:
+    ///
+    /// - `InitChain`
+    /// - `FinalizeBlock`
+    pub const LOUD: Self = Self {
+        ok_level: Level::INFO,
+        error_level: Level::WARN,
+    };
+    /// The tracing option to use under the following situations:
+    ///
+    /// - `Query`
+    /// - `CheckTx`
+    pub const MUTE: Self = Self {
+        ok_level: Level::DEBUG,
+        error_level: Level::DEBUG,
+    };
+}

--- a/grug/app/src/vm.rs
+++ b/grug/app/src/vm.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         AppError, AppResult, CODES, CONTRACT_NAMESPACE, EventResult, GasTracker, Instance,
-        QuerierProviderImpl, StorageProvider, Vm, catch_event, handle_submessages,
+        QuerierProviderImpl, StorageProvider, TraceOption, Vm, catch_event, handle_submessages,
     },
     borsh::{BorshDeserialize, BorshSerialize},
     grug_types::{
@@ -144,6 +144,7 @@ pub fn call_in_0_out_1_handle_response<VM>(
     name: &'static str,
     code_hash: Hash256,
     ctx: &Context,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
     VM: Vm + Clone + 'static,
@@ -172,7 +173,16 @@ where
         evt
     };
 
-    handle_response(vm, storage, gas_tracker, msg_depth, ctx, response, evt)
+    handle_response(
+        vm,
+        storage,
+        gas_tracker,
+        msg_depth,
+        ctx,
+        response,
+        evt,
+        trace_opt,
+    )
 }
 
 /// Create a VM instance, call a function that takes exactly one parameter and
@@ -189,6 +199,7 @@ pub fn call_in_1_out_1_handle_response<VM, P>(
     code_hash: Hash256,
     ctx: &Context,
     param: &P,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
     P: BorshSerialize,
@@ -219,7 +230,16 @@ where
         evt
     };
 
-    handle_response(vm, storage, gas_tracker, msg_depth, ctx, response, evt)
+    handle_response(
+        vm,
+        storage,
+        gas_tracker,
+        msg_depth,
+        ctx,
+        response,
+        evt,
+        trace_opt,
+    )
 }
 
 pub fn call_in_1_out_1_handle_auth_response<VM, P>(
@@ -234,6 +254,7 @@ pub fn call_in_1_out_1_handle_auth_response<VM, P>(
     ctx: &Context,
     param: &P,
     backrun: &mut bool,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
     P: BorshSerialize,
@@ -274,6 +295,7 @@ where
         ctx,
         auth_response.response,
         evt,
+        trace_opt,
     )
 }
 
@@ -292,6 +314,7 @@ pub fn call_in_2_out_1_handle_response<VM, P1, P2>(
     ctx: &Context,
     param1: &P1,
     param2: &P2,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
     P1: BorshSerialize,
@@ -324,7 +347,16 @@ where
         evt
     };
 
-    handle_response(vm, storage, gas_tracker, msg_depth, ctx, response, evt)
+    handle_response(
+        vm,
+        storage,
+        gas_tracker,
+        msg_depth,
+        ctx,
+        response,
+        evt,
+        trace_opt,
+    )
 }
 
 fn create_vm_instance<VM>(
@@ -372,6 +404,7 @@ fn handle_response<VM>(
     ctx: &Context,
     response: Response,
     mut evt: EvtGuest,
+    trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
     VM: Vm + Clone + 'static,
@@ -396,6 +429,7 @@ where
         msg_depth,
         ctx.contract,
         response.submsgs,
+        trace_opt,
     )
     .map_merge(evt, |subevents, mut evt| {
         evt.sub_events = subevents;

--- a/indexer/sql/src/entity/events.rs
+++ b/indexer/sql/src/entity/events.rs
@@ -1,8 +1,7 @@
-use crate::dataloaders::event_transaction::EventTransactionDataLoader;
 #[cfg(feature = "async-graphql")]
 use async_graphql::{ComplexObject, Context, Enum, Result, SimpleObject, dataloader::DataLoader};
-
 use {
+    crate::dataloaders::event_transaction::EventTransactionDataLoader,
     grug_types::{FlatCategory, FlatCommitmentStatus, FlatEventStatus},
     sea_orm::entity::prelude::*,
     serde::Deserialize,

--- a/indexer/testing/Cargo.toml
+++ b/indexer/testing/Cargo.toml
@@ -17,7 +17,7 @@ grug-db-memory = { workspace = true }
 grug-testing   = { workspace = true }
 grug-types     = { workspace = true }
 grug-vm-rust   = { workspace = true }
-indexer-httpd  = { workspace = true }
+indexer-httpd  = { workspace = true, features = ["testing"] }
 indexer-sql    = { workspace = true, features = ["async-graphql", "testing", "tracing"] }
 sea-orm        = { workspace = true }
 serde          = { workspace = true }
@@ -28,5 +28,4 @@ tokio          = { workspace = true }
 assert-json-diff = { workspace = true }
 assertor         = { workspace = true }
 grug-storage     = { workspace = true }
-indexer-httpd    = { workspace = true, features = ["testing"] }
 tracing          = { workspace = true }


### PR DESCRIPTION
Tracing outputs in `Query` and `CheckTx` used to be emitted in `INFO` and `WARN` levels. Now moving them both to `TRACE` level.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor tracing output levels for `Query` and `CheckTx` to `TRACE` and introduce `TraceOption` for managing tracing levels.
> 
>   - **Behavior**:
>     - Change tracing output levels for `Query` and `CheckTx` from `INFO` and `WARN` to `TRACE`.
>     - Introduce `TraceOption` struct in `tracing.rs` to manage tracing levels.
>   - **Functions**:
>     - Update `process_tx`, `do_authenticate`, `do_backrun`, `do_configure`, `do_cron_execute`, `do_execute`, `do_finalize_fee`, `do_instantiate`, `do_migrate`, `do_reply`, `do_transfer`, `do_upload`, `do_withhold_fee` to use `TraceOption`.
>     - Modify `handle_submessages` in `submessage.rs` to include `trace_opt` parameter.
>   - **Misc**:
>     - Add `dyn_event!` macro in `tracing.rs` for dynamic tracing level.
>     - Update `Cargo.toml` in `indexer/testing` to include `tracing` feature for `indexer-sql`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for cd490be12b71d3b5cfab30f9f608db711e116e77. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->