### PR TITLE
Add support for batch graphql requests

### DIFF
--- a/dango/httpd/src/routes/graphql.rs
+++ b/dango/httpd/src/routes/graphql.rs
@@ -2,7 +2,7 @@ use {
     crate::graphql::AppSchema,
     actix_web::{HttpRequest, HttpResponse, Resource, web},
     async_graphql::Schema,
-    async_graphql_actix_web::{GraphQLRequest, GraphQLResponse, GraphQLSubscription},
+    async_graphql_actix_web::{GraphQLBatchRequest, GraphQLResponse, GraphQLSubscription},
     indexer_httpd::routes::graphql::graphiql_playgound,
 };
 
@@ -21,11 +21,11 @@ pub fn graphql_route() -> Resource {
 pub(crate) async fn graphql_index(
     schema: web::Data<AppSchema>,
     _req: HttpRequest,
-    gql_request: GraphQLRequest,
+    gql_request: GraphQLBatchRequest,
 ) -> GraphQLResponse {
     let request = gql_request.into_inner();
 
-    schema.execute(request).await.into()
+    schema.execute_batch(request).await.into()
 }
 
 #[tracing::instrument(name = "graphql::graphql_ws", skip_all)]

--- a/indexer/httpd/src/routes/graphql.rs
+++ b/indexer/httpd/src/routes/graphql.rs
@@ -1,8 +1,8 @@
 use {
     crate::graphql::AppSchema,
     actix_web::{HttpRequest, HttpResponse, Resource, http::header, web},
-    async_graphql::{Schema, http::*},
-    async_graphql_actix_web::{GraphQLRequest, GraphQLResponse, GraphQLSubscription},
+    async_graphql::{Schema, http::GraphiQLSource},
+    async_graphql_actix_web::{GraphQLBatchRequest, GraphQLResponse, GraphQLSubscription},
 };
 
 pub fn graphql_route() -> Resource {
@@ -19,11 +19,11 @@ pub fn graphql_route() -> Resource {
 pub(crate) async fn graphql_index(
     schema: web::Data<AppSchema>,
     _req: HttpRequest,
-    gql_request: GraphQLRequest,
+    gql_request: GraphQLBatchRequest,
 ) -> GraphQLResponse {
     let request = gql_request.into_inner();
 
-    schema.execute(request).await.into()
+    schema.execute_batch(request).await.into()
 }
 
 pub async fn graphiql_playgound() -> HttpResponse {

--- a/indexer/testing/src/lib.rs
+++ b/indexer/testing/src/lib.rs
@@ -23,7 +23,7 @@ use {
 
 pub mod block;
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct GraphQLCustomRequest<'a> {
     pub name: &'a str,
     pub query: &'a str,
@@ -90,6 +90,57 @@ pub struct PageInfo {
     pub has_previous_page: bool,
 }
 
+pub async fn call_batch_graphql<R>(
+    app: App<
+        impl ServiceFactory<
+            ServiceRequest,
+            Response = ServiceResponse<impl MessageBody>,
+            Config = (),
+            InitError = (),
+            Error = actix_web::Error,
+        > + 'static,
+    >,
+    requests_body: Vec<GraphQLCustomRequest<'_>>,
+) -> anyhow::Result<Vec<GraphQLCustomResponse<R>>>
+where
+    R: DeserializeOwned,
+{
+    let app = actix_web::test::init_service(app).await;
+
+    let request = actix_web::test::TestRequest::post()
+        .uri("/graphql")
+        .set_json(&requests_body)
+        .to_request();
+
+    let graphql_response = actix_web::test::call_and_read_body(&app, request).await;
+
+    // When I need to debug the response
+    // println!("text response: \n{:#?}", graphql_response);
+
+    let graphql_responses: Vec<GraphQLResponse> = serde_json::from_slice(&graphql_response)?;
+
+    // When I need to debug the response
+    // println!("GraphQLResponses: {:#?}", graphql_responses);
+
+    graphql_responses
+        .into_iter()
+        .enumerate()
+        .map(|(index, mut graphql_response)| {
+            if let Some(data) = graphql_response.data.remove(requests_body[index].name) {
+                Ok(GraphQLCustomResponse {
+                    data: serde_json::from_value(data)?,
+                    errors: graphql_response.errors,
+                })
+            } else {
+                Err(anyhow!(
+                    "can't find {} in response",
+                    requests_body[index].name
+                ))
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
 pub async fn call_graphql<R>(
     app: App<
         impl ServiceFactory<
@@ -105,31 +156,9 @@ pub async fn call_graphql<R>(
 where
     R: DeserializeOwned,
 {
-    let app = actix_web::test::init_service(app).await;
-
-    let request = actix_web::test::TestRequest::post()
-        .uri("/graphql")
-        .set_json(&request_body)
-        .to_request();
-
-    let graphql_response = actix_web::test::call_and_read_body(&app, request).await;
-
-    // When I need to debug the response
-    // println!("text response: \n{:#?}", graphql_response);
-
-    let mut graphql_response: GraphQLResponse = serde_json::from_slice(&graphql_response)?;
-
-    // When I need to debug the response
-    // println!("GraphQLResponse: {:#?}", graphql_response);
-
-    if let Some(data) = graphql_response.data.remove(request_body.name) {
-        Ok(GraphQLCustomResponse {
-            data: serde_json::from_value(data)?,
-            errors: graphql_response.errors,
-        })
-    } else {
-        Err(anyhow!("can't find {} in response", request_body.name))
-    }
+    call_batch_graphql::<R>(app, vec![request_body])
+        .await
+        .and_then(|mut responses| responses.pop().ok_or_else(|| anyhow!("no response found")))
 }
 
 pub async fn call_api<R>(

--- a/indexer/testing/tests/graphql/block.rs
+++ b/indexer/testing/tests/graphql/block.rs
@@ -1,0 +1,108 @@
+use {
+    assertor::*,
+    indexer_testing::{
+        GraphQLCustomRequest, PaginatedResponse, block::create_block, build_app_service,
+        call_batch_graphql, call_graphql,
+    },
+};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_returns_blocks() -> anyhow::Result<()> {
+    let (httpd_context, _client, ..) = create_block().await?;
+
+    let graphql_query = r#"
+      query Blocks {
+        blocks {
+          nodes {
+            id
+            blockHeight
+          }
+          edges {
+            node {
+              id
+              blockHeight
+            }
+            cursor
+          }
+          pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
+        }
+      }
+    "#;
+
+    let request_body = GraphQLCustomRequest {
+        name: "blocks",
+        query: graphql_query,
+        variables: Default::default(),
+    };
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let app = build_app_service(httpd_context);
+
+                let response =
+                    call_graphql::<PaginatedResponse<grug_types::Json>>(app, request_body).await?;
+
+                assert_that!(response.data.edges).is_not_empty();
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graphql_returns_batched_blocks() -> anyhow::Result<()> {
+    let (httpd_context, _client, ..) = create_block().await?;
+
+    let graphql_query = r#"
+      query Blocks {
+        blocks {
+          nodes {
+            id
+            blockHeight
+          }
+          edges {
+            node {
+              id
+              blockHeight
+            }
+            cursor
+          }
+          pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
+        }
+      }
+    "#;
+
+    let request_body = GraphQLCustomRequest {
+        name: "blocks",
+        query: graphql_query,
+        variables: Default::default(),
+    };
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let app = build_app_service(httpd_context);
+
+                let responses =
+                    call_batch_graphql::<PaginatedResponse<grug_types::Json>>(app, vec![
+                        request_body.clone(),
+                        request_body,
+                    ])
+                    .await?;
+
+                assert_that!(responses[0].data.edges).is_not_empty();
+                assert_that!(responses[1].data.edges).is_not_empty();
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}

--- a/indexer/testing/tests/graphql/main.rs
+++ b/indexer/testing/tests/graphql/main.rs
@@ -1,1 +1,2 @@
+pub mod block;
 pub mod event;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for batch GraphQL requests and update tests to verify batch processing.
> 
>   - **Batch GraphQL Support**:
>     - Replace `GraphQLRequest` with `GraphQLBatchRequest` in `graphql_index()` in `dango/httpd/src/routes/graphql.rs` and `indexer/httpd/src/routes/graphql.rs`.
>     - Use `schema.execute_batch()` instead of `schema.execute()` in `graphql_index()` in both files.
>   - **Testing**:
>     - Add `graphql_returns_batched_blocks()` test in `indexer/testing/tests/graphql/block.rs` to verify batch request handling.
>     - Modify `call_graphql()` to use `call_batch_graphql()` in `indexer/testing/src/lib.rs`.
>     - Rename `call_graphql()` to `call_batch_graphql()` and adjust its logic to handle multiple requests in `indexer/testing/src/lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 21587b57d3172bd7803fb06a18cb220139c4adab. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->