### PR TITLE
Fix block compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5552,6 +5552,7 @@ dependencies = [
  "assertor",
  "borsh 1.5.7",
  "glob",
+ "grug",
  "grug-app",
  "grug-math",
  "grug-types",

--- a/indexer/disk-saver/Cargo.toml
+++ b/indexer/disk-saver/Cargo.toml
@@ -13,7 +13,7 @@ version       = { workspace = true }
 path = "src/lib.rs"
 
 [features]
-tracing = ["dep:tracing"]
+tracing = ["dep:tracing", "grug-app/tracing"]
 
 [dependencies]
 anyhow                = { workspace = true }
@@ -35,5 +35,6 @@ uuid                  = { workspace = true }
 
 [dev-dependencies]
 assertor           = { workspace = true }
+grug               = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/indexer/disk-saver/src/persistence.rs
+++ b/indexer/disk-saver/src/persistence.rs
@@ -109,8 +109,12 @@ impl DiskPersistence {
             return Ok(false);
         }
 
-        // Define the path for the temporary compressed file
-        let compressed_path = self.file_path.with_extension("xz");
+        #[cfg(feature = "tracing")]
+        tracing::debug!(?self.file_path, "Compressing file");
+
+        // Define the path for the compressed file
+        let mut compressed_path = self.file_path.clone();
+        compressed_path.as_mut_os_string().push(".xz");
 
         // This shouldn't happen since if compressed file already exists,
         // we should have `self.compressed` to true.
@@ -130,6 +134,16 @@ impl DiskPersistence {
             lzma_compress(&mut reader, &mut writer)?;
         }
 
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            from_file = %self.file_path.display(),
+            to_file = %compressed_path.display(),
+            "Compressed file",
+        );
+
+        // Delete the non-compressed file
+        std::fs::remove_file(&self.file_path)?;
+
         self.file_path = compressed_path;
         self.compressed = true;
 
@@ -140,6 +154,9 @@ impl DiskPersistence {
         if !self.compressed {
             return Ok(());
         }
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(?self.file_path, "Decompressing file");
 
         // Define the path for the temporary decompressed file
         let decompressed_path = self.file_path.with_extension(""); // Remove extension
@@ -155,6 +172,16 @@ impl DiskPersistence {
             // Use lzma_decompress to decompress the input file into the output file
             lzma_rs::lzma_decompress(&mut reader, &mut writer)?;
         }
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(
+            from_file = %self.file_path.display(),
+            to_file = %decompressed_path.display(),
+            "Decompressed file",
+        );
+
+        // Delete the compressed file
+        std::fs::remove_file(&self.file_path)?;
 
         self.file_path = decompressed_path;
         self.compressed = true;
@@ -197,7 +224,7 @@ impl DiskPersistence {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, assertor::*};
+    use {super::*, assertor::*, grug::setup_tracing_subscriber};
 
     #[derive(BorshSerialize, BorshDeserialize, Default)]
     struct Block {
@@ -207,6 +234,8 @@ mod tests {
 
     #[test]
     fn test_disk_automatic_compression() {
+        setup_tracing_subscriber(tracing::Level::INFO);
+
         let temp_file = NamedTempFile::new().expect("Failed to create a temp file");
         let mut temp_filename = temp_file.path().to_path_buf();
         let temp_filename2 = temp_file.path().to_path_buf();
@@ -233,6 +262,8 @@ mod tests {
 
     #[test]
     fn test_disk_later_compression() {
+        setup_tracing_subscriber(tracing::Level::DEBUG);
+
         let temp_file = NamedTempFile::new().expect("Failed to create a temp file");
         let mut temp_filename = temp_file.path().to_path_buf();
         let temp_filename2 = temp_file.path().to_path_buf();
@@ -251,10 +282,42 @@ mod tests {
         // This test if the file_path is properly set when we ask to compress
         // but the file already exists uncompressed.
         let mut disk_persistence = DiskPersistence::new(temp_filename2, true);
-        assert_that!(disk_persistence.file_path).is_equal_to(temp_filename);
+        assert_that!(&disk_persistence.file_path).is_equal_to(&temp_filename);
         assert!(!disk_persistence.compressed);
 
         // Ensure calling compress on a compressed file does something
         assert!(disk_persistence.compress().expect("Can't compress"));
+
+        assert!(
+            !temp_filename.exists(),
+            "Compressed file should not exist: {}",
+            temp_filename.display()
+        );
+
+        temp_filename.set_extension("borsh.xz");
+        assert!(
+            temp_filename.exists(),
+            "Compressed file should exist: {}",
+            temp_filename.display()
+        );
+
+        disk_persistence
+            .decompress()
+            .expect("Failed to decompress file");
+
+        assert!(
+            !temp_filename.exists(),
+            "Compressed file should not exist: {}",
+            temp_filename.display()
+        );
+
+        // This removes the `.xz` extension but leaves the `.borsh` extension
+        temp_filename.set_extension("");
+
+        assert!(
+            temp_filename.exists(),
+            "Decompressed file should exist: {}",
+            temp_filename.display()
+        );
     }
 }

--- a/indexer/disk-saver/src/persistence.rs
+++ b/indexer/disk-saver/src/persistence.rs
@@ -114,7 +114,7 @@ impl DiskPersistence {
 
         // Define the path for the compressed file
         let mut compressed_path = self.file_path.clone();
-        compressed_path.as_mut_os_string().push(".xz");
+        compressed_path.set_extension("borsh.xz");
 
         // This shouldn't happen since if compressed file already exists,
         // we should have `self.compressed` to true.

--- a/indexer/sql/Cargo.toml
+++ b/indexer/sql/Cargo.toml
@@ -26,7 +26,7 @@ borsh                 = { workspace = true }
 futures               = { workspace = true }
 grug-app              = { workspace = true }
 grug-types            = { workspace = true, features = ["sea-orm"] }
-indexer-disk-saver    = { workspace = true }
+indexer-disk-saver    = { workspace = true, features = ["tracing"] }
 indexer-sql-migration = { workspace = true }
 itertools             = { workspace = true }
 sea-orm               = { workspace = true }

--- a/indexer/sql/src/block_to_index.rs
+++ b/indexer/sql/src/block_to_index.rs
@@ -93,6 +93,7 @@ impl BlockToIndex {
             ?compressed,
             "Compressed block file"
         );
+
         Ok(())
     }
 

--- a/indexer/sql/src/block_to_index.rs
+++ b/indexer/sql/src/block_to_index.rs
@@ -81,7 +81,7 @@ impl BlockToIndex {
 
     pub fn compress_file(file_path: PathBuf) -> error::Result<()> {
         #[cfg(feature = "tracing")]
-        tracing::info!(?file_path, "Compressing block file");
+        tracing::debug!(?file_path, "Compressing block file");
 
         let mut file = DiskPersistence::new(file_path.clone(), false);
 

--- a/indexer/sql/src/block_to_index.rs
+++ b/indexer/sql/src/block_to_index.rs
@@ -80,7 +80,19 @@ impl BlockToIndex {
     }
 
     pub fn compress_file(file_path: PathBuf) -> error::Result<()> {
-        DiskPersistence::new(file_path, false).compress()?;
+        #[cfg(feature = "tracing")]
+        tracing::info!(?file_path, "Compressing block file");
+
+        let mut file = DiskPersistence::new(file_path.clone(), false);
+
+        let compressed = file.compress()?;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            ?file.file_path,
+            ?compressed,
+            "Compressed block file"
+        );
         Ok(())
     }
 

--- a/indexer/sql/src/non_blocking_indexer.rs
+++ b/indexer/sql/src/non_blocking_indexer.rs
@@ -587,7 +587,7 @@ where
                     }
                 }).await {
                     #[cfg(feature = "tracing")]
-                    tracing::error!(error = %err, "can't spawn blocking task to compress block in post_indexing");
+                    tracing::error!(error = %err, "spawn_blocking error compressing block file");
                 }
             }
 

--- a/indexer/testing/Cargo.toml
+++ b/indexer/testing/Cargo.toml
@@ -17,7 +17,7 @@ grug-db-memory = { workspace = true }
 grug-testing   = { workspace = true }
 grug-types     = { workspace = true }
 grug-vm-rust   = { workspace = true }
-indexer-httpd  = { workspace = true, features = ["testing"] }
+indexer-httpd  = { workspace = true, features = ["testing", "tracing"] }
 indexer-sql    = { workspace = true, features = ["async-graphql", "testing", "tracing"] }
 sea-orm        = { workspace = true }
 serde          = { workspace = true }

--- a/indexer/testing/tests/indexing.rs
+++ b/indexer/testing/tests/indexing.rs
@@ -7,6 +7,7 @@ use {
         ResultExt,
     },
     grug_vm_rust::ContractBuilder,
+    indexer_httpd::graphql::query::block,
     indexer_sql::{block_to_index::BlockToIndex, entity},
     replier::{ExecuteMsg, ReplyMsg},
     sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder},
@@ -516,4 +517,61 @@ fn index_block_events() {
             .expect("Can't fetch events");
         assert_that!(events).is_not_empty();
     });
+}
+
+/// Ensure the indexed blocks are compressed on disk.
+#[test]
+fn blocks_on_disk_compressed() {
+    let indexer = indexer_sql::non_blocking_indexer::IndexerBuilder::default()
+        .with_memory_database()
+        .with_keep_blocks(true)
+        .build()
+        .expect("Can't create indexer");
+
+    let (mut suite, mut accounts) = TestBuilder::new_with_indexer(indexer)
+        .add_account("owner", Coin::new("usdc", 100_000).unwrap())
+        .add_account("sender", Coins::new())
+        .set_owner("owner")
+        .build();
+
+    // Just create a block.
+    let replier_code = ContractBuilder::new(Box::new(replier::instantiate))
+        .with_execute(Box::new(replier::execute))
+        .with_query(Box::new(replier::query))
+        .with_reply(Box::new(replier::reply))
+        .build();
+
+    let _ = suite
+        .upload_and_instantiate(
+            &mut accounts["owner"],
+            replier_code,
+            &Empty {},
+            "salt",
+            Some("label"),
+            None,
+            Coins::default(),
+        )
+        .should_succeed()
+        .address;
+
+    // Force the runtime to wait for the async indexer task to finish
+    suite.app.indexer.wait_for_finish();
+
+    let mut block_path = suite.app.indexer.indexer_path.block_path(1);
+
+    block_path.set_extension("borsh.xz");
+
+    assert!(
+        block_path.exists(),
+        "Compressed block_file should exist: {}",
+        block_path.display()
+    );
+
+    block_path.set_extension("");
+
+    assert!(
+        !block_path.exists(),
+        "Decompressed block_file should not exist: {}",
+        block_path.display()
+    );
 }

--- a/indexer/testing/tests/indexing.rs
+++ b/indexer/testing/tests/indexing.rs
@@ -7,7 +7,6 @@ use {
         ResultExt,
     },
     grug_vm_rust::ContractBuilder,
-    indexer_httpd::graphql::query::block,
     indexer_sql::{block_to_index::BlockToIndex, entity},
     replier::{ExecuteMsg, ReplyMsg},
     sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances block compression handling and adds tracing for better debugging in the indexer, with updated tests and dependencies.
> 
>   - **Compression and Decompression**:
>     - `DiskPersistence` in `persistence.rs` now sets file extension to `.borsh.xz` for compressed files.
>     - Adds file deletion after compression and decompression in `persistence.rs`.
>     - Updates `compress()` and `decompress()` methods to handle file paths and extensions correctly.
>   - **Tracing**:
>     - Adds tracing logs in `persistence.rs`, `block_to_index.rs`, and `non_blocking_indexer.rs` for compression, decompression, and indexing operations.
>     - Updates feature flags in `Cargo.toml` files to include `tracing`.
>   - **Testing**:
>     - Adds `blocks_on_disk_compressed` test in `indexing.rs` to verify block compression.
>     - Updates existing tests in `persistence.rs` to check file existence and extensions after operations.
>   - **Dependencies**:
>     - Adds `grug` to `Cargo.lock` and `Cargo.toml` files.
>     - Updates `indexer-disk-saver` and `indexer-sql` to include `tracing` feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 0b54f389939c32197261fb04da0ad1820b25b4ba. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->