### PR TITLE
Add fromAccount/toAccount

### DIFF
--- a/dango/httpd/src/graphql/types.rs
+++ b/dango/httpd/src/graphql/types.rs
@@ -1,4 +1,0 @@
-pub mod account;
-pub mod public_key;
-pub mod transfer;
-pub mod user;

--- a/dango/indexer/sql/src/entity/accounts.rs
+++ b/dango/indexer/sql/src/entity/accounts.rs
@@ -58,6 +58,20 @@ impl Model {
     }
 }
 
+impl Model {
+    // to avoid unused function warning when async-graphql feature is not enabled
+    #[allow(dead_code)]
+    pub async fn find_account_by_address(
+        db: &DatabaseConnection,
+        address: &str,
+    ) -> Result<Option<Self>, DbErr> {
+        Entity::find()
+            .filter(Column::Address.eq(address))
+            .one(db)
+            .await
+    }
+}
+
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
     #[sea_orm(

--- a/dango/indexer/sql/src/entity/transfers.rs
+++ b/dango/indexer/sql/src/entity/transfers.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "async-graphql")]
-use async_graphql::{ComplexObject, Context, ErrorExtensions, Result, SimpleObject};
+use async_graphql::{
+    ComplexObject, Context, ErrorExtensions, Result as GraphQLResult, SimpleObject,
+};
 use {
     sea_orm::entity::prelude::*,
     serde::{Deserialize, Serialize},
@@ -30,7 +32,10 @@ pub struct Model {
 #[cfg(feature = "async-graphql")]
 #[ComplexObject]
 impl Model {
-    pub async fn accounts(&self, ctx: &Context<'_>) -> Result<Vec<crate::entity::accounts::Model>> {
+    pub async fn accounts(
+        &self,
+        ctx: &Context<'_>,
+    ) -> GraphQLResult<Vec<crate::entity::accounts::Model>> {
         let db = ctx.data::<DatabaseConnection>()?;
 
         let accounts = crate::entity::accounts::Entity::find()
@@ -45,12 +50,13 @@ impl Model {
         Ok(accounts)
     }
 
-    pub async fn from_account(&self, ctx: &Context<'_>) -> Result<crate::entity::accounts::Model> {
+    pub async fn from_account(
+        &self,
+        ctx: &Context<'_>,
+    ) -> GraphQLResult<crate::entity::accounts::Model> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        let account = crate::entity::accounts::Entity::find()
-            .filter(crate::entity::accounts::Column::Address.eq(&self.from_address))
-            .one(db)
+        self.find_account_by_address(db, &self.from_address)
             .await?
             .ok_or_else(|| {
                 async_graphql::Error::new(format!(
@@ -58,17 +64,16 @@ impl Model {
                     self.from_address
                 ))
                 .extend_with(|_err, e| e.set("code", "NOT_FOUND"))
-            })?;
-
-        Ok(account)
+            })
     }
 
-    pub async fn to_account(&self, ctx: &Context<'_>) -> Result<crate::entity::accounts::Model> {
+    pub async fn to_account(
+        &self,
+        ctx: &Context<'_>,
+    ) -> GraphQLResult<crate::entity::accounts::Model> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        let account = crate::entity::accounts::Entity::find()
-            .filter(crate::entity::accounts::Column::Address.eq(&self.to_address))
-            .one(db)
+        self.find_account_by_address(db, &self.to_address)
             .await?
             .ok_or_else(|| {
                 async_graphql::Error::new(format!(
@@ -76,9 +81,20 @@ impl Model {
                     self.to_address
                 ))
                 .extend_with(|_err, e| e.set("code", "NOT_FOUND"))
-            })?;
+            })
+    }
+}
 
-        Ok(account)
+impl Model {
+    async fn find_account_by_address(
+        &self,
+        db: &DatabaseConnection,
+        address: &str,
+    ) -> Result<Option<crate::entity::accounts::Model>, sea_orm::DbErr> {
+        crate::entity::accounts::Entity::find()
+            .filter(crate::entity::accounts::Column::Address.eq(address))
+            .one(db)
+            .await
     }
 }
 

--- a/dango/indexer/sql/src/entity/transfers.rs
+++ b/dango/indexer/sql/src/entity/transfers.rs
@@ -85,6 +85,7 @@ impl Model {
     }
 }
 
+#[cfg(feature = "async-graphql")]
 impl Model {
     async fn find_account_by_address(
         &self,

--- a/dango/indexer/sql/src/entity/transfers.rs
+++ b/dango/indexer/sql/src/entity/transfers.rs
@@ -45,32 +45,28 @@ impl Model {
         Ok(accounts)
     }
 
-    pub async fn from_accounts(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Vec<crate::entity::accounts::Model>> {
+    pub async fn from_account(&self, ctx: &Context<'_>) -> Result<crate::entity::accounts::Model> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        let accounts = crate::entity::accounts::Entity::find()
+        let account = crate::entity::accounts::Entity::find()
             .filter(crate::entity::accounts::Column::Address.eq(&self.from_address))
-            .all(db)
-            .await?;
+            .one(db)
+            .await?
+            .expect("account not found, this is not expected");
 
-        Ok(accounts)
+        Ok(account)
     }
 
-    pub async fn to_accounts(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Vec<crate::entity::accounts::Model>> {
+    pub async fn to_account(&self, ctx: &Context<'_>) -> Result<crate::entity::accounts::Model> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        let accounts = crate::entity::accounts::Entity::find()
+        let account = crate::entity::accounts::Entity::find()
             .filter(crate::entity::accounts::Column::Address.eq(&self.to_address))
-            .all(db)
-            .await?;
+            .one(db)
+            .await?
+            .expect("account not found, this is not expected");
 
-        Ok(accounts)
+        Ok(account)
     }
 }
 

--- a/dango/indexer/sql/src/entity/transfers.rs
+++ b/dango/indexer/sql/src/entity/transfers.rs
@@ -56,7 +56,7 @@ impl Model {
     ) -> GraphQLResult<crate::entity::accounts::Model> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        self.find_account_by_address(db, &self.from_address)
+        crate::entity::accounts::Model::find_account_by_address(db, &self.from_address)
             .await?
             .ok_or_else(|| {
                 async_graphql::Error::new(format!(
@@ -73,7 +73,7 @@ impl Model {
     ) -> GraphQLResult<crate::entity::accounts::Model> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        self.find_account_by_address(db, &self.to_address)
+        crate::entity::accounts::Model::find_account_by_address(db, &self.to_address)
             .await?
             .ok_or_else(|| {
                 async_graphql::Error::new(format!(
@@ -82,20 +82,6 @@ impl Model {
                 ))
                 .extend_with(|_err, e| e.set("code", "NOT_FOUND"))
             })
-    }
-}
-
-#[cfg(feature = "async-graphql")]
-impl Model {
-    async fn find_account_by_address(
-        &self,
-        db: &DatabaseConnection,
-        address: &str,
-    ) -> Result<Option<crate::entity::accounts::Model>, sea_orm::DbErr> {
-        crate::entity::accounts::Entity::find()
-            .filter(crate::entity::accounts::Column::Address.eq(address))
-            .one(db)
-            .await
     }
 }
 

--- a/dango/indexer/sql/src/entity/transfers.rs
+++ b/dango/indexer/sql/src/entity/transfers.rs
@@ -73,7 +73,7 @@ impl Model {
             .ok_or_else(|| {
                 async_graphql::Error::new(format!(
                     "account with address {} not found. This is not expected.",
-                    self.from_address
+                    self.to_address
                 ))
                 .extend_with(|_err, e| e.set("code", "NOT_FOUND"))
             })?;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance GraphQL API with specific account retrieval methods for transfers and refactor error handling.
> 
>   - **GraphQL Enhancements**:
>     - Added `from_account()` and `to_account()` methods in `transfers.rs` to fetch specific accounts by address.
>     - Updated `accounts()` method in `transfers.rs` to use `GraphQLResult`.
>   - **Refactoring**:
>     - Removed `types.rs` file as it was not used.
>     - Replaced `Result` with `GraphQLResult` in `transfers.rs` for better error handling.
>   - **Misc**:
>     - Added `find_account_by_address()` in `accounts.rs` to fetch account by address.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for dc8d1dc5f875202558c298c850e2ff10788ff95f. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->