### PR TITLE
[LEF-109] give indexer hooks access to querier

### DIFF
--- a/dango/indexer/sql/src/error.rs
+++ b/dango/indexer/sql/src/error.rs
@@ -10,4 +10,7 @@ pub enum Error {
 
     #[error("serde error: {0}")]
     Serde(#[from] serde_json::Error),
+
+    #[error("grug error: {0}")]
+    Std(#[from] grug::StdError),
 }

--- a/dango/indexer/sql/src/hooks.rs
+++ b/dango/indexer/sql/src/hooks.rs
@@ -5,6 +5,7 @@ use {
     },
     async_trait::async_trait,
     dango_indexer_sql_migration::{Migrator, MigratorTrait},
+    grug_app::QuerierProvider,
     grug_types::{FlatCommitmentStatus, FlatEvent, FlatEventStatus, FlatEvtTransfer},
     indexer_sql::{
         Context, block_to_index::BlockToIndex, entity as main_entity, hooks::Hooks as HooksTrait,
@@ -31,9 +32,10 @@ impl HooksTrait for Hooks {
         &self,
         context: Context,
         block: BlockToIndex,
+        querier: Box<dyn QuerierProvider>,
     ) -> Result<(), Self::Error> {
         self.save_transfers(&context, &block).await?;
-        self.save_accounts(&context, &block).await?;
+        self.save_accounts(&context, &block, &*querier).await?;
 
         Ok(())
     }

--- a/dango/indexer/sql/src/hooks/accounts.rs
+++ b/dango/indexer/sql/src/hooks/accounts.rs
@@ -4,8 +4,14 @@ use {
         error::Error,
         hooks::Hooks,
     },
-    dango_types::account_factory::{self, AccountParams},
+    dango_types::{
+        DangoQuerier,
+        account_factory::{
+            AccountParams, AccountRegistered, KeyDisowned, KeyOwned, UserRegistered,
+        },
+    },
     grug::{EventName, Inner, JsonDeExt},
+    grug_app::QuerierProvider,
     grug_types::{FlatCommitmentStatus, FlatEvent, SearchEvent},
     indexer_sql::{Context, block_to_index::BlockToIndex},
     sea_orm::{
@@ -19,7 +25,10 @@ impl Hooks {
         &self,
         context: &Context,
         block: &BlockToIndex,
+        querier: &dyn QuerierProvider,
     ) -> Result<(), Error> {
+        let account_factory = querier.query_account_factory()?;
+
         let mut user_registered_events = Vec::new();
         let mut account_registered_events = Vec::new();
         let mut account_key_added_events = Vec::new();
@@ -52,39 +61,29 @@ impl Hooks {
                 };
 
                 match event.ty.as_str() {
-                    account_factory::UserRegistered::EVENT_NAME => {
-                        let Ok(event) = event
-                            .data
-                            .deserialize_json::<account_factory::UserRegistered>()
-                        else {
+                    UserRegistered::EVENT_NAME if event.contract == account_factory => {
+                        let Ok(event) = event.data.deserialize_json::<UserRegistered>() else {
                             continue;
                         };
 
                         user_registered_events.push(event.clone());
                     },
-                    account_factory::AccountRegistered::EVENT_NAME => {
-                        let Ok(event) = event
-                            .data
-                            .deserialize_json::<account_factory::AccountRegistered>()
-                        else {
+                    AccountRegistered::EVENT_NAME if event.contract == account_factory => {
+                        let Ok(event) = event.data.deserialize_json::<AccountRegistered>() else {
                             continue;
                         };
 
                         account_registered_events.push(event);
                     },
-                    account_factory::KeyOwned::EVENT_NAME => {
-                        let Ok(event) = event.data.deserialize_json::<account_factory::KeyOwned>()
-                        else {
+                    KeyOwned::EVENT_NAME if event.contract == account_factory => {
+                        let Ok(event) = event.data.deserialize_json::<KeyOwned>() else {
                             continue;
                         };
 
                         account_key_added_events.push(event);
                     },
-                    account_factory::KeyDisowned::EVENT_NAME => {
-                        let Ok(event) = event
-                            .data
-                            .deserialize_json::<account_factory::KeyDisowned>()
-                        else {
+                    KeyDisowned::EVENT_NAME if event.contract == account_factory => {
+                        let Ok(event) = event.data.deserialize_json::<KeyDisowned>() else {
                             continue;
                         };
 

--- a/dango/indexer/sql/src/hooks/accounts.rs
+++ b/dango/indexer/sql/src/hooks/accounts.rs
@@ -60,29 +60,33 @@ impl Hooks {
                     continue;
                 };
 
+                if event.contract != account_factory {
+                    continue;
+                }
+
                 match event.ty.as_str() {
-                    UserRegistered::EVENT_NAME if event.contract == account_factory => {
+                    UserRegistered::EVENT_NAME => {
                         let Ok(event) = event.data.deserialize_json::<UserRegistered>() else {
                             continue;
                         };
 
                         user_registered_events.push(event.clone());
                     },
-                    AccountRegistered::EVENT_NAME if event.contract == account_factory => {
+                    AccountRegistered::EVENT_NAME => {
                         let Ok(event) = event.data.deserialize_json::<AccountRegistered>() else {
                             continue;
                         };
 
                         account_registered_events.push(event);
                     },
-                    KeyOwned::EVENT_NAME if event.contract == account_factory => {
+                    KeyOwned::EVENT_NAME => {
                         let Ok(event) = event.data.deserialize_json::<KeyOwned>() else {
                             continue;
                         };
 
                         account_key_added_events.push(event);
                     },
-                    KeyDisowned::EVENT_NAME if event.contract == account_factory => {
+                    KeyDisowned::EVENT_NAME => {
                         let Ok(event) = event.data.deserialize_json::<KeyDisowned>() else {
                             continue;
                         };

--- a/dango/testing/benches/benchmarks.rs
+++ b/dango/testing/benches/benchmarks.rs
@@ -35,7 +35,7 @@ where
     T: Into<Binary>,
     PP: ProposalPreparer,
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error>,
 {
     // Deploy 200 accounts.

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -246,7 +246,7 @@ where
     ) where
         PP: ProposalPreparer,
         DB: Db,
-        VM: Vm + Clone + 'static,
+        VM: Vm + Clone + Send + Sync + 'static,
         ID: Indexer,
         AppError: From<PP::Error> + From<DB::Error> + From<VM::Error> + From<ID::Error>,
     {
@@ -285,7 +285,7 @@ where
     where
         PP: ProposalPreparer,
         DB: Db,
-        VM: Vm + Clone + 'static,
+        VM: Vm + Clone + Send + Sync + 'static,
         ID: Indexer,
         AppError: From<PP::Error> + From<DB::Error> + From<VM::Error> + From<ID::Error>,
     {

--- a/dango/testing/src/hyperlane.rs
+++ b/dango/testing/src/hyperlane.rs
@@ -56,7 +56,7 @@ where
 impl<DB, VM, PP, ID> HyperlaneTestSuite<DB, VM, PP, ID>
 where
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     PP: ProposalPreparer,
     ID: Indexer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -271,7 +271,7 @@ pub fn setup_suite_with_db_and_vm<DB, VM, PP, ID>(
 )
 where
     DB: Db,
-    VM: Vm + GenesisCodes + Clone + 'static,
+    VM: Vm + GenesisCodes + Clone + Send + Sync + 'static,
     ID: Indexer,
     PP: grug_app::ProposalPreparer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,

--- a/dango/types/src/querier.rs
+++ b/dango/types/src/querier.rs
@@ -1,6 +1,6 @@
 use {
     crate::config::AppConfig,
-    grug::{Addr, QuerierExt, QuerierWrapper, StdResult},
+    grug::{Addr, Querier, QuerierExt, StdResult},
 };
 
 /// An extension trait that adds some useful, Dango-specific methods to
@@ -29,7 +29,10 @@ pub trait DangoQuerier {
     }
 }
 
-impl DangoQuerier for QuerierWrapper<'_> {
+impl<Q> DangoQuerier for Q
+where
+    Q: Querier,
+{
     fn query_dango_config(&self) -> StdResult<AppConfig> {
         self.query_app_config()
     }

--- a/grug/app/src/abci.rs
+++ b/grug/app/src/abci.rs
@@ -26,7 +26,7 @@ use {
 impl<DB, VM, PP, ID> Service<Request> for App<DB, VM, PP, ID>
 where
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     ID: Indexer,
     PP: ProposalPreparer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,
@@ -49,7 +49,7 @@ where
 impl<DB, VM, PP, ID> App<DB, VM, PP, ID>
 where
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     ID: Indexer,
     PP: ProposalPreparer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,

--- a/grug/app/src/execute/authenticate.rs
+++ b/grug/app/src/execute/authenticate.rs
@@ -18,7 +18,7 @@ pub fn do_authenticate<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtAuthenticate>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_authenticate(vm, storage, gas_tracker, block, tx, mode, trace_opt);
@@ -49,7 +49,7 @@ pub fn _do_authenticate<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtAuthenticate>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtAuthenticate::base(tx.sender);

--- a/grug/app/src/execute/backrun.rs
+++ b/grug/app/src/execute/backrun.rs
@@ -18,7 +18,7 @@ pub fn do_backrun<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtBackrun>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_backrun(vm, storage, gas_tracker, block, tx, mode, trace_opt);
@@ -49,7 +49,7 @@ pub fn _do_backrun<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtBackrun>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtBackrun::base(tx.sender);

--- a/grug/app/src/execute/cron.rs
+++ b/grug/app/src/execute/cron.rs
@@ -19,7 +19,7 @@ pub fn do_cron_execute<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtCron>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_cron_execute(
@@ -60,7 +60,7 @@ fn _do_cron_execute<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtCron>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtCron::base(contract, time, next);

--- a/grug/app/src/execute/execute.rs
+++ b/grug/app/src/execute/execute.rs
@@ -19,7 +19,7 @@ pub fn do_execute<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtExecute>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_execute(
@@ -60,7 +60,7 @@ fn _do_execute<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtExecute>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtExecute::base(sender, msg.contract, msg.funds.clone(), msg.msg.clone());

--- a/grug/app/src/execute/finalize.rs
+++ b/grug/app/src/execute/finalize.rs
@@ -19,7 +19,7 @@ pub fn do_finalize_fee<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtFinalize>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_finalize_fee(
@@ -64,7 +64,7 @@ pub fn _do_finalize_fee<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtFinalize>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtFinalize::base(tx.sender, tx.gas_limit, outcome.gas_used);

--- a/grug/app/src/execute/instantiate.rs
+++ b/grug/app/src/execute/instantiate.rs
@@ -23,7 +23,7 @@ pub fn do_instantiate<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtInstantiate>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_instantiate(
@@ -64,7 +64,7 @@ pub fn _do_instantiate<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtInstantiate>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     // Compute the contract address, and make sure there isn't already a

--- a/grug/app/src/execute/migrate.rs
+++ b/grug/app/src/execute/migrate.rs
@@ -21,7 +21,7 @@ pub fn do_migrate<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtMigrate>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_migrate(
@@ -62,7 +62,7 @@ fn _do_migrate<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtMigrate>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtMigrate::base(sender, msg.contract, msg.msg.clone(), msg.new_code_hash);

--- a/grug/app/src/execute/reply.rs
+++ b/grug/app/src/execute/reply.rs
@@ -21,7 +21,7 @@ pub fn do_reply<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtReply>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_reply(
@@ -66,7 +66,7 @@ fn _do_reply<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtReply>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtReply::base(contract, reply_on.clone());

--- a/grug/app/src/execute/transfer.rs
+++ b/grug/app/src/execute/transfer.rs
@@ -24,7 +24,7 @@ pub fn do_transfer<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtTransfer>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_transfer(
@@ -72,7 +72,7 @@ pub(crate) fn _do_transfer<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtTransfer>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtTransfer::base(sender, msg.clone());
@@ -160,7 +160,7 @@ fn _do_receive<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     #[allow(clippy::redundant_closure_call)]

--- a/grug/app/src/execute/withhold.rs
+++ b/grug/app/src/execute/withhold.rs
@@ -18,7 +18,7 @@ pub fn do_withhold_fee<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtWithhold>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = _do_withhold_fee(vm, storage, gas_tracker, block, tx, mode, trace_opt);
@@ -49,7 +49,7 @@ pub fn _do_withhold_fee<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtWithhold>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut evt = EvtWithhold::base(tx.sender, tx.gas_limit);

--- a/grug/app/src/indexer.rs
+++ b/grug/app/src/indexer.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{AppError, Indexer},
+    crate::{AppError, Indexer, QuerierProvider},
     grug_types::{Block, BlockOutcome},
     std::{
         convert::Infallible,
@@ -34,7 +34,11 @@ impl Indexer for NullIndexer {
         Ok(())
     }
 
-    fn post_indexing(&self, _block_height: u64) -> Result<(), Self::Error> {
+    fn post_indexing(
+        &self,
+        _block_height: u64,
+        _querier: Box<dyn QuerierProvider>,
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/grug/app/src/query.rs
+++ b/grug/app/src/query.rs
@@ -30,7 +30,7 @@ pub fn query_balance<VM>(
     req: QueryBalanceRequest,
 ) -> AppResult<Coin>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     _query_bank(
@@ -53,7 +53,7 @@ pub fn query_balances<VM>(
     req: QueryBalancesRequest,
 ) -> AppResult<Coins>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     _query_bank(
@@ -76,7 +76,7 @@ pub fn query_supply<VM>(
     req: QuerySupplyRequest,
 ) -> AppResult<Coin>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     _query_bank(
@@ -99,7 +99,7 @@ pub fn query_supplies<VM>(
     req: QuerySuppliesRequest,
 ) -> AppResult<Coins>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     _query_bank(
@@ -122,7 +122,7 @@ fn _query_bank<VM>(
     msg: &BankQuery,
 ) -> AppResult<BankQueryResponse>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let cfg = CONFIG.load(&storage)?;
@@ -239,7 +239,7 @@ pub fn query_wasm_smart<VM>(
     req: QueryWasmSmartRequest,
 ) -> AppResult<Json>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let chain_id = CHAIN_ID.load(&storage)?;

--- a/grug/app/src/submessage.rs
+++ b/grug/app/src/submessage.rs
@@ -69,7 +69,7 @@ pub fn handle_submessages<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<Vec<EventStatus<SubEvent>>>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let mut events = vec![];

--- a/grug/app/src/traits/indexer.rs
+++ b/grug/app/src/traits/indexer.rs
@@ -1,5 +1,7 @@
 use grug_types::{Block, BlockOutcome, Storage};
 
+use crate::QuerierProvider;
+
 /// This is the trait that the indexer must implement. It is used by the Grug core to index blocks
 pub trait Indexer {
     type Error: ToString;
@@ -22,5 +24,9 @@ pub trait Indexer {
     fn index_block(&self, block: &Block, block_outcome: &BlockOutcome) -> Result<(), Self::Error>;
 
     /// Called after indexing the block, allowing for DB transactions to be committed
-    fn post_indexing(&self, block_height: u64) -> Result<(), Self::Error>;
+    fn post_indexing(
+        &self,
+        block_height: u64,
+        querier: Box<dyn QuerierProvider>,
+    ) -> Result<(), Self::Error>;
 }

--- a/grug/app/src/vm.rs
+++ b/grug/app/src/vm.rs
@@ -24,7 +24,7 @@ pub fn call_in_0_out_1<VM, R>(
 ) -> AppResult<R>
 where
     R: BorshDeserialize,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     // Create the VM instance
@@ -62,7 +62,7 @@ pub fn call_in_1_out_1<VM, P, R>(
 where
     P: BorshSerialize,
     R: BorshDeserialize,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     // Create the VM instance
@@ -105,7 +105,7 @@ where
     P1: BorshSerialize,
     P2: BorshSerialize,
     R: BorshDeserialize,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     // Create the VM instance
@@ -147,7 +147,7 @@ pub fn call_in_0_out_1_handle_response<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = EvtGuest::base(ctx.contract, name);
@@ -203,7 +203,7 @@ pub fn call_in_1_out_1_handle_response<VM, P>(
 ) -> EventResult<EvtGuest>
 where
     P: BorshSerialize,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = EvtGuest::base(ctx.contract, name);
@@ -258,7 +258,7 @@ pub fn call_in_1_out_1_handle_auth_response<VM, P>(
 ) -> EventResult<EvtGuest>
 where
     P: BorshSerialize,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = EvtGuest::base(ctx.contract, name);
@@ -319,7 +319,7 @@ pub fn call_in_2_out_1_handle_response<VM, P1, P2>(
 where
     P1: BorshSerialize,
     P2: BorshSerialize,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     let evt = EvtGuest::base(ctx.contract, name);
@@ -370,7 +370,7 @@ fn create_vm_instance<VM>(
     code_hash: Hash256,
 ) -> AppResult<VM::Instance>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     // Load the program code from storage and deserialize
@@ -407,7 +407,7 @@ fn handle_response<VM>(
     trace_opt: TraceOption,
 ) -> EventResult<EvtGuest>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     evt.contract_events = response

--- a/grug/testing/src/balance_tracker.rs
+++ b/grug/testing/src/balance_tracker.rs
@@ -28,7 +28,7 @@ where
 impl<DB, VM, PP, ID> BalanceTracker<'_, DB, VM, PP, ID>
 where
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     PP: ProposalPreparer,
     ID: Indexer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,

--- a/grug/testing/src/builder.rs
+++ b/grug/testing/src/builder.rs
@@ -538,7 +538,7 @@ where
     M1: Serialize,
     M2: Serialize,
     M3: Serialize,
-    VM: TestVm + Clone + 'static,
+    VM: TestVm + Clone + Send + Sync + 'static,
     PP: ProposalPreparer,
     ID: Indexer,
     AppError: From<VM::Error> + From<PP::Error> + From<ID::Error> + From<DB::Error>,

--- a/grug/testing/src/client.rs
+++ b/grug/testing/src/client.rs
@@ -301,7 +301,7 @@ async fn next_block<DB, VM, PP, ID>(
 ) -> anyhow::Result<()>
 where
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     PP: ProposalPreparer,
     ID: Indexer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -66,7 +66,7 @@ impl TestSuite {
 
 impl<VM> TestSuite<MemDb, VM, NaiveProposalPreparer, NullIndexer>
 where
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     AppError: From<VM::Error>,
 {
     /// Create a new test suite with `MemDb`, `NaiveProposalPreparer`, and the
@@ -125,7 +125,7 @@ where
 impl<DB, VM, PP, ID> TestSuite<DB, VM, PP, ID>
 where
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     PP: ProposalPreparer,
     ID: Indexer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,
@@ -629,7 +629,7 @@ where
 impl<DB, VM, PP, ID> Querier for TestSuite<DB, VM, PP, ID>
 where
     DB: Db,
-    VM: Vm + Clone + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
     PP: ProposalPreparer,
     ID: Indexer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error> + From<ID::Error>,

--- a/indexer/sql/src/hooks.rs
+++ b/indexer/sql/src/hooks.rs
@@ -1,6 +1,7 @@
 use {
     crate::{block_to_index::BlockToIndex, context::Context},
     async_trait::async_trait,
+    grug_app::QuerierProvider,
     std::convert::Infallible,
 };
 
@@ -16,6 +17,7 @@ pub trait Hooks {
         &self,
         _context: Context,
         _block: BlockToIndex,
+        _querier: Box<dyn QuerierProvider>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/indexer/sql/src/non_blocking_indexer.rs
+++ b/indexer/sql/src/non_blocking_indexer.rs
@@ -8,7 +8,7 @@ use {
         indexer_path::IndexerPath,
         pubsub::{MemoryPubSub, PostgresPubSub, PubSubType},
     },
-    grug_app::{Indexer, LAST_FINALIZED_BLOCK},
+    grug_app::{Indexer, LAST_FINALIZED_BLOCK, QuerierProvider},
     grug_types::{Block, BlockOutcome, Defined, MaybeDefined, Storage, Undefined},
     sea_orm::{DatabaseConnection, TransactionTrait},
     std::{
@@ -518,7 +518,11 @@ where
         })
     }
 
-    fn post_indexing(&self, block_height: u64) -> error::Result<()> {
+    fn post_indexing(
+        &self,
+        block_height: u64,
+        querier: Box<dyn QuerierProvider>,
+    ) -> error::Result<()> {
         if !self.indexing {
             bail!("can't index after shutdown");
         }
@@ -565,7 +569,7 @@ where
                 break;
             }
 
-            hooks.post_indexing(context.clone(), block_to_index).await.map_err(|e| {
+            hooks.post_indexing(context.clone(), block_to_index, querier).await.map_err(|e| {
                 #[cfg(feature = "tracing")]
                 tracing::error!(block_height, error = e.to_string(), "`post_indexing` hooks failed");
 
@@ -732,6 +736,7 @@ mod tests {
             &self,
             _context: Context,
             _block: BlockToIndex,
+            _querier: Box<dyn QuerierProvider>,
         ) -> Result<(), Self::Error> {
             Ok(())
         }


### PR DESCRIPTION
This allows the indexer hooks to query the chain during `post_indexing`.

The main complexity is the querier needs to be `Send + Sync`, which involves a lot of trait bounds throughout the codebase to be changed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow indexer hooks to access the querier during post-indexing by adding a `QuerierProvider` parameter to the `post_indexing` method and updating `VM` trait bounds to `Send + Sync`.
> 
>   - **Indexer Hooks**:
>     - Add `QuerierProvider` parameter to `post_indexing` in `Indexer` trait in `grug/app/src/traits/indexer.rs` and its implementations in `grug/app/src/indexer.rs` and `indexer/sql/src/hooks.rs`.
>     - Update `post_indexing` method in `NonBlockingIndexer` in `indexer/sql/src/non_blocking_indexer.rs` to use `QuerierProvider`.
>   - **Trait Bounds**:
>     - Update `VM` trait bounds to `Vm + Clone + Send + Sync + 'static` in multiple files, including `grug/app/src/abci.rs`, `grug/app/src/app.rs`, and `grug/app/src/providers/querier.rs`.
>   - **Testing**:
>     - Update test files such as `dango/testing/benches/benchmarks.rs` and `dango/testing/src/account.rs` to reflect changes in trait bounds and `post_indexing` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 3e88526cde0b7b15e1c9082629262e08a2c88d9a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->