### PR TITLE
fix: expanded messages in tx explorer

### DIFF
--- a/ui/applets/kit/src/components/AccordionItem.tsx
+++ b/ui/applets/kit/src/components/AccordionItem.tsx
@@ -17,7 +17,7 @@ type AccordionItemProps = {
     text?: string;
     icon?: string;
   };
-  defaultExpand?: boolean;
+  defaultExpanded?: boolean;
   onChange?: (isOpen: boolean) => void;
   expanded?: boolean;
 };
@@ -28,10 +28,10 @@ export const AccordionItem: React.FC<PropsWithChildren<AccordionItemProps>> = ({
   text,
   icon,
   expanded,
-  defaultExpand,
+  defaultExpanded,
   onChange,
 }) => {
-  const [isOpen, setIsOpen] = useControlledState<boolean>(expanded, onChange, defaultExpand);
+  const [isOpen, setIsOpen] = useControlledState<boolean>(expanded, onChange, defaultExpanded);
 
   return (
     <div

--- a/ui/portal/web/src/components/explorer/TransactionExplorer.tsx
+++ b/ui/portal/web/src/components/explorer/TransactionExplorer.tsx
@@ -170,7 +170,7 @@ const Messages: React.FC = () => {
               key={orderIdx}
               text={methodName}
               classNames={{ text: "capitalize" }}
-              defaultExpand
+              defaultExpanded
             >
               <div className="p-4 bg-gray-700 shadow-account-card  rounded-md text-white-100">
                 <JsonVisualizer json={JSON.stringify(message)} collapsed={1} />


### PR DESCRIPTION
This PR closes: LEF-128
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `AccordionItem` with controlled state support and updates `TransactionExplorer` to expand messages by default.
> 
>   - **AccordionItem Enhancements**:
>     - Added `defaultExpanded`, `onChange`, and `expanded` props to `AccordionItem` in `AccordionItem.tsx`.
>     - Utilized `useControlledState` hook for managing open state.
>   - **TransactionExplorer Updates**:
>     - In `TransactionExplorer.tsx`, moved events section below messages in `Messages` component.
>     - Set `defaultExpanded` to true for `AccordionItem` in messages section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 581400e2312d905f037c4bc0036434cd459e5e8d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->