### PR TITLE
refactor(dango): improve readability by splitting `liquidity_pool.rs` into separate files

### DIFF
--- a/dango/dex/src/core.rs
+++ b/dango/dex/src/core.rs
@@ -1,3 +1,4 @@
+pub mod geometric;
 mod liquidity_pool;
 mod market_order;
 mod merged_orders;
@@ -5,6 +6,7 @@ mod order_filling;
 mod order_matching;
 mod router;
 mod types;
+pub mod xyk;
 
 pub use {
     liquidity_pool::*, market_order::*, merged_orders::*, order_filling::*, order_matching::*,

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -28,6 +28,8 @@ pub fn add_subsequent_liquidity(
     let deposit_value = oracle_value(oracle_querier, &deposit)?;
     let reserve_value = oracle_value(oracle_querier, reserve)?;
 
+    reserve.merge(deposit)?;
+
     Ok(deposit_value.checked_div(reserve_value.checked_add(deposit_value)?)?)
 }
 

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -1,0 +1,138 @@
+use {
+    crate::core::xyk,
+    dango_oracle::OracleQuerier,
+    grug::{
+        Bounded, CoinPair, Inner, IsZero, MultiplyFraction, Number, NumberConst, StdResult,
+        Udec128, Uint128, ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
+    },
+    std::iter,
+};
+
+// FIXME: Use oracle price to compute amoutn of intial LP tokens.
+pub fn add_initial_liquidity(
+    mut reserve: CoinPair,
+    deposit: CoinPair,
+) -> anyhow::Result<(CoinPair, Uint128)> {
+    reserve.merge(deposit)?;
+
+    let mint_amount = xyk::normalized_invariant(&reserve)?;
+
+    Ok((reserve, mint_amount))
+}
+
+pub fn add_subsequent_liquidity(
+    oracle_querier: &mut OracleQuerier,
+    reserve: &mut CoinPair,
+    deposit: CoinPair,
+) -> anyhow::Result<Udec128> {
+    let deposit_value = oracle_value(oracle_querier, &deposit)?;
+    let reserve_value = oracle_value(oracle_querier, reserve)?;
+
+    Ok(deposit_value.checked_div(reserve_value.checked_add(deposit_value)?)?)
+}
+
+pub fn swap_exact_amount_in() -> StdResult<Uint128> {
+    // FIXME
+    todo!();
+}
+
+pub fn swap_exact_amount_out() -> StdResult<Uint128> {
+    // FIXME
+    todo!();
+}
+
+pub fn reflect_curve(
+    mut base_reserve: Uint128,
+    mut quote_reserve: Uint128,
+    ratio: Bounded<Udec128, ZeroExclusiveOneInclusive>,
+    order_spacing: Udec128,
+    swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
+) -> StdResult<(
+    Box<dyn Iterator<Item = (Udec128, Uint128)>>,
+    Box<dyn Iterator<Item = (Udec128, Uint128)>>,
+)> {
+    // FIXME: use oracle price instead
+    let marginal_price = Udec128::checked_from_ratio(quote_reserve, base_reserve)?;
+
+    // Construct bid price iterator with decreasing prices.
+    let bids = {
+        let one_sub_fee_rate = Udec128::ONE.checked_sub(*swap_fee_rate)?;
+        let bid_starting_price = marginal_price.checked_mul(one_sub_fee_rate)?;
+        let mut maybe_price = Some(bid_starting_price);
+
+        let bid_prices = iter::from_fn(move || {
+            let price = match maybe_price {
+                Some(price) if price.is_non_zero() => price,
+                _ => return None,
+            };
+
+            maybe_price = price.checked_sub(order_spacing).ok();
+
+            Some(price)
+        });
+
+        let bid_sizes_in_quote = iter::from_fn(move || {
+            let size = match quote_reserve.checked_mul_dec(ratio.into_inner()) {
+                Ok(size_in_quote) => size_in_quote,
+                Err(_) => return None,
+            };
+
+            quote_reserve.checked_sub_assign(size).ok()?;
+
+            Some(size)
+        });
+
+        bid_prices
+            .zip(bid_sizes_in_quote)
+            .filter_map(|(price, size_in_quote)| {
+                let size = size_in_quote.checked_div_dec_floor(price).ok()?;
+                Some((price, size))
+            })
+    };
+
+    // Construct ask price iterator with increasing prices.
+    let asks = {
+        let one_plus_fee_rate = Udec128::ONE.checked_add(*swap_fee_rate)?;
+        let ask_starting_price = marginal_price.checked_mul(one_plus_fee_rate)?;
+        let mut maybe_price = Some(ask_starting_price);
+
+        let ask_prices = iter::from_fn(move || {
+            let price = match maybe_price {
+                Some(price) if price.is_non_zero() => price,
+                _ => return None,
+            };
+            maybe_price = price.checked_add(order_spacing).ok();
+            Some(price)
+        });
+
+        // Construct ask size placing `ratio` of the remaining liquidity of
+        // base reserve into each order.
+        let ask_sizes = iter::from_fn(move || {
+            let size = match base_reserve.checked_mul_dec(ratio.into_inner()) {
+                Ok(size) => size,
+                Err(_) => return None,
+            };
+            base_reserve.checked_sub_assign(size).ok()?;
+            Some(size)
+        });
+
+        ask_prices.zip(ask_sizes)
+    };
+
+    Ok((Box::new(bids), Box::new(asks)))
+}
+
+fn oracle_value(
+    oracle_querier: &mut OracleQuerier,
+    coin_pair: &CoinPair,
+) -> anyhow::Result<Udec128> {
+    let first = coin_pair.first();
+    let first_price = oracle_querier.query_price(first.denom, None)?;
+    let first_value = first_price.value_of_unit_amount(*first.amount)?;
+
+    let second = coin_pair.second();
+    let second_price = oracle_querier.query_price(second.denom, None)?;
+    let second_value = second_price.value_of_unit_amount(*second.amount)?;
+
+    Ok(first_value.checked_add(second_value)?)
+}

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -2,22 +2,15 @@ use {
     crate::core::xyk,
     dango_oracle::OracleQuerier,
     grug::{
-        Bounded, CoinPair, IsZero, MultiplyFraction, Number, NumberConst, StdResult, Udec128,
-        Uint128, ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
+        Bounded, CoinPair, IsZero, MathResult, MultiplyFraction, Number, NumberConst, StdResult,
+        Udec128, Uint128, ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
     },
     std::iter,
 };
 
-// FIXME: Use oracle price to compute amoutn of intial LP tokens.
-pub fn add_initial_liquidity(
-    mut reserve: CoinPair,
-    deposit: CoinPair,
-) -> anyhow::Result<(CoinPair, Uint128)> {
-    reserve.merge(deposit)?;
-
-    let mint_amount = xyk::normalized_invariant(&reserve)?;
-
-    Ok((reserve, mint_amount))
+pub fn add_initial_liquidity(deposit: &CoinPair) -> MathResult<Uint128> {
+    // FIXME: Use oracle price to compute amoutn of intial LP tokens.
+    xyk::normalized_invariant(deposit)
 }
 
 pub fn add_subsequent_liquidity(

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -2,8 +2,8 @@ use {
     crate::core::xyk,
     dango_oracle::OracleQuerier,
     grug::{
-        Bounded, CoinPair, Inner, IsZero, MultiplyFraction, Number, NumberConst, StdResult,
-        Udec128, Uint128, ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
+        Bounded, CoinPair, IsZero, MultiplyFraction, Number, NumberConst, StdResult, Udec128,
+        Uint128, ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
     },
     std::iter,
 };
@@ -42,8 +42,8 @@ pub fn swap_exact_amount_out() -> StdResult<Uint128> {
 }
 
 pub fn reflect_curve(
-    mut base_reserve: Uint128,
-    mut quote_reserve: Uint128,
+    base_reserve: Uint128,
+    quote_reserve: Uint128,
     ratio: Bounded<Udec128, ZeroExclusiveOneInclusive>,
     order_spacing: Udec128,
     swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
@@ -59,35 +59,22 @@ pub fn reflect_curve(
         let one_sub_fee_rate = Udec128::ONE.checked_sub(*swap_fee_rate)?;
         let bid_starting_price = marginal_price.checked_mul(one_sub_fee_rate)?;
         let mut maybe_price = Some(bid_starting_price);
+        let mut remaining_quote = quote_reserve;
 
-        let bid_prices = iter::from_fn(move || {
-            let price = match maybe_price {
-                Some(price) if price.is_non_zero() => price,
-                _ => return None,
-            };
+        iter::from_fn(move || {
+            let price = maybe_price?;
+            if price.is_zero() {
+                return None;
+            }
+
+            let size_in_quote = remaining_quote.checked_mul_dec(*ratio).ok()?;
+            let size = size_in_quote.checked_div_dec_floor(price).ok()?;
 
             maybe_price = price.checked_sub(order_spacing).ok();
+            remaining_quote.checked_sub_assign(size_in_quote).ok()?;
 
-            Some(price)
-        });
-
-        let bid_sizes_in_quote = iter::from_fn(move || {
-            let size = match quote_reserve.checked_mul_dec(ratio.into_inner()) {
-                Ok(size_in_quote) => size_in_quote,
-                Err(_) => return None,
-            };
-
-            quote_reserve.checked_sub_assign(size).ok()?;
-
-            Some(size)
-        });
-
-        bid_prices
-            .zip(bid_sizes_in_quote)
-            .filter_map(|(price, size_in_quote)| {
-                let size = size_in_quote.checked_div_dec_floor(price).ok()?;
-                Some((price, size))
-            })
+            Some((price, size))
+        })
     };
 
     // Construct ask price iterator with increasing prices.
@@ -95,28 +82,17 @@ pub fn reflect_curve(
         let one_plus_fee_rate = Udec128::ONE.checked_add(*swap_fee_rate)?;
         let ask_starting_price = marginal_price.checked_mul(one_plus_fee_rate)?;
         let mut maybe_price = Some(ask_starting_price);
+        let mut remaining_base = base_reserve;
 
-        let ask_prices = iter::from_fn(move || {
-            let price = match maybe_price {
-                Some(price) if price.is_non_zero() => price,
-                _ => return None,
-            };
+        iter::from_fn(move || {
+            let price = maybe_price?;
+            let size = remaining_base.checked_mul_dec(*ratio).ok()?;
+
             maybe_price = price.checked_add(order_spacing).ok();
-            Some(price)
-        });
+            remaining_base.checked_sub_assign(size).ok()?;
 
-        // Construct ask size placing `ratio` of the remaining liquidity of
-        // base reserve into each order.
-        let ask_sizes = iter::from_fn(move || {
-            let size = match base_reserve.checked_mul_dec(ratio.into_inner()) {
-                Ok(size) => size,
-                Err(_) => return None,
-            };
-            base_reserve.checked_sub_assign(size).ok()?;
-            Some(size)
-        });
-
-        ask_prices.zip(ask_sizes)
+            Some((price, size))
+        })
     };
 
     Ok((Box::new(bids), Box::new(asks)))

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -50,10 +50,14 @@ pub trait PassiveLiquidityPool {
     /// - The funds withdrawn from the pool.
     fn remove_liquidity(
         &self,
-        reserve: CoinPair,
+        mut reserve: CoinPair,
         lp_token_supply: Uint128,
         lp_burn_amount: Uint128,
-    ) -> anyhow::Result<(CoinPair, CoinPair)>;
+    ) -> anyhow::Result<(CoinPair, CoinPair)> {
+        let refund = reserve.split(lp_burn_amount, lp_token_supply)?;
+
+        Ok((reserve, refund))
+    }
 
     /// Perform a swap with an exact amount of input and a variable output.
     ///
@@ -213,17 +217,6 @@ impl PassiveLiquidityPool for PairParams {
 
             Ok((reserve, mint_amount))
         }
-    }
-
-    fn remove_liquidity(
-        &self,
-        mut reserve: CoinPair,
-        lp_token_supply: Uint128,
-        lp_burn_amount: Uint128,
-    ) -> anyhow::Result<(CoinPair, CoinPair)> {
-        let refund = reserve.split(lp_burn_amount, lp_token_supply)?;
-
-        Ok((reserve, refund))
     }
 
     fn swap_exact_amount_in(

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -6,16 +6,8 @@ use {
     std::{cmp, iter},
 };
 
-pub fn add_initial_liquidity(
-    mut reserve: CoinPair,
-    deposit: CoinPair,
-) -> anyhow::Result<(CoinPair, Uint128)> {
-    reserve.merge(deposit)?;
-
-    // TODO: apply a scaling factor? e.g. 1,000,000 LP tokens per unit of invariant.
-    let mint_amount = normalized_invariant(&reserve)?;
-
-    Ok((reserve, mint_amount))
+pub fn add_initial_liquidity(deposit: &CoinPair) -> MathResult<Uint128> {
+    normalized_invariant(deposit)
 }
 
 pub fn add_subsequent_liquidity(

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -1,0 +1,189 @@
+use {
+    grug::{
+        Bounded, CoinPair, IsZero, MathResult, MultiplyFraction, MultiplyRatio, Number,
+        NumberConst, StdResult, Udec128, Uint128, ZeroExclusiveOneExclusive,
+    },
+    std::{cmp, iter},
+};
+
+pub fn add_initial_liquidity(
+    mut reserve: CoinPair,
+    deposit: CoinPair,
+) -> anyhow::Result<(CoinPair, Uint128)> {
+    reserve.merge(deposit)?;
+
+    // TODO: apply a scaling factor? e.g. 1,000,000 LP tokens per unit of invariant.
+    let mint_amount = normalized_invariant(&reserve)?;
+
+    Ok((reserve, mint_amount))
+}
+
+pub fn add_subsequent_liquidity(
+    reserve: &mut CoinPair,
+    deposit: CoinPair,
+) -> anyhow::Result<Udec128> {
+    let invariant_before = normalized_invariant(reserve)?;
+
+    // Add the used funds to the pool reserves.
+    reserve.merge(deposit)?;
+
+    // Compute the proportional increase in the invariant.
+    let invariant_after = normalized_invariant(reserve)?;
+    let invariant_ratio = Udec128::checked_from_ratio(invariant_after, invariant_before)?;
+
+    // Compute the mint ratio from the invariant ratio based on the curve type.
+    // This ensures that an unbalances provision will be equivalent to a swap
+    // followed by a balancedliquidity provision.
+    Ok(invariant_ratio.checked_sub(Udec128::ONE)?)
+}
+
+pub fn swap_exact_amount_in(
+    input_amount: Uint128,
+    input_reserve: Uint128,
+    output_reserve: Uint128,
+    swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
+) -> MathResult<Uint128> {
+    // Solve A * B = (A + input_amount) * (B - output_amount) for output_amount
+    // => output_amount = B - (A * B) / (A + input_amount)
+    // Round so that user takes the loss.
+    let output_amount =
+        output_reserve.checked_sub(input_reserve.checked_multiply_ratio_ceil(
+            output_reserve,
+            input_reserve.checked_add(input_amount)?,
+        )?)?;
+
+    // Apply swap fee. Round so that user takes the loss.
+    output_amount.checked_mul_dec_floor(Udec128::ONE - *swap_fee_rate)
+}
+
+pub fn swap_exact_amount_out(
+    output_amount: Uint128,
+    input_reserve: Uint128,
+    output_reserve: Uint128,
+    swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
+) -> MathResult<Uint128> {
+    // Apply swap fee. In SwapExactIn we multiply ask by (1 - fee) to get the
+    // offer amount after fees. So in this case we need to divide ask by (1 - fee)
+    // to get the ask amount after fees.
+    // Round so that user takes the loss.
+    let output_amount_before_fee =
+        output_amount.checked_div_dec_ceil(Udec128::ONE - *swap_fee_rate)?;
+
+    // Solve A * B = (A + input_amount) * (B - output_amount) for input_amount
+    // => input_amount = (A * B) / (B - output_amount) - A
+    // Round so that user takes the loss.
+    Uint128::ONE
+        .checked_multiply_ratio_floor(
+            input_reserve.checked_mul(output_reserve)?,
+            output_reserve.checked_sub(output_amount_before_fee)?,
+        )?
+        .checked_sub(input_reserve)
+}
+
+pub fn reflect_curve(
+    base_reserve: Uint128,
+    quote_reserve: Uint128,
+    order_spacing: Udec128,
+    swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
+) -> StdResult<(
+    Box<dyn Iterator<Item = (Udec128, Uint128)>>,
+    Box<dyn Iterator<Item = (Udec128, Uint128)>>,
+)> {
+    // Compute the marginal price. We will place orders above and below this price.
+    let marginal_price = Udec128::checked_from_ratio(quote_reserve, base_reserve)?;
+
+    // Construct the bid order iterator.
+    // Start from the marginal price minus the swap fee rate.
+    let one_sub_fee_rate = Udec128::ONE.checked_sub(*swap_fee_rate)?;
+    let mut maybe_price = marginal_price.checked_mul(one_sub_fee_rate).ok();
+    let mut prev_size = Uint128::ZERO;
+    let mut prev_size_quote = Uint128::ZERO;
+    let bids = iter::from_fn(move || {
+        // Terminate if price is less or equal to zero.
+        let price = match maybe_price {
+            Some(price) if price.is_non_zero() => price,
+            _ => return None,
+        };
+
+        // Compute the total order size (in base asset) at this price.
+        let quote_reserve_div_price = quote_reserve.checked_div_dec(price).ok()?;
+        let mut size = quote_reserve_div_price.checked_sub(base_reserve).ok()?;
+
+        // Compute the order size (in base asset) at this price.
+        //
+        // This is the difference between the total order size at
+        // this price, and that at the previous price.
+        let mut amount = size.checked_sub(prev_size).ok()?;
+
+        // Compute the total order size (in quote asset) at this price.
+        let mut amount_quote = amount.checked_mul_dec_ceil(price).ok()?;
+        let mut size_quote = prev_size_quote.checked_add(amount_quote).ok()?;
+
+        // If total order size (in quote asset) is greater than the
+        // reserve, cap it to the reserve size.
+        if size_quote > quote_reserve {
+            size_quote = quote_reserve;
+            amount_quote = size_quote.checked_sub(prev_size_quote).ok()?;
+            amount = amount_quote.checked_div_dec_floor(price).ok()?;
+            size = prev_size.checked_add(amount).ok()?;
+        }
+
+        // If order size is zero, we have ran out of liquidity.
+        // Terminate the iterator.
+        if amount.is_zero() {
+            return None;
+        }
+
+        // Update the iterator state.
+        prev_size = size;
+        prev_size_quote = size_quote;
+        maybe_price = price.checked_sub(order_spacing).ok();
+
+        Some((price, amount))
+    });
+
+    // Construct the ask order iterator.
+    let one_plus_fee_rate = Udec128::ONE.checked_add(*swap_fee_rate)?;
+    let mut maybe_price = marginal_price.checked_mul(one_plus_fee_rate).ok();
+    let mut prev_size = Uint128::ZERO;
+    let asks = iter::from_fn(move || {
+        let price = maybe_price?;
+
+        // Compute the total order size (in base asset) at this price.
+        let quote_reserve_div_price = quote_reserve.checked_div_dec(price).ok()?;
+        let size = base_reserve.checked_sub(quote_reserve_div_price).ok()?;
+
+        // If total order size (in base asset) exceeds the base asset
+        // reserve, cap it to the reserve size.
+        let size = cmp::min(size, base_reserve);
+
+        // Compute the order size (in base asset) at this price.
+        //
+        // This is the difference between the total order size at
+        // this price, and that at the previous price.
+        let amount = size.checked_sub(prev_size).ok()?;
+
+        // If order size is zero, we have ran out of liquidity.
+        // Terminate the iterator.
+        if amount.is_zero() {
+            return None;
+        }
+
+        // Update the iterator state.
+        prev_size = size;
+        maybe_price = price.checked_add(order_spacing).ok();
+
+        Some((price, amount))
+    });
+
+    Ok((Box::new(bids), Box::new(asks)))
+}
+
+/// Compute `sqrt(A * B)`, where `A` and `B` are the reserve amount of the two
+/// assets in an xyk pool.
+pub fn normalized_invariant(reserve: &CoinPair) -> MathResult<Uint128> {
+    let a = *reserve.first().amount;
+    let b = *reserve.second().amount;
+
+    a.checked_mul(b)?.checked_sqrt()
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `liquidity_pool.rs` by splitting it into `geometric.rs` and `xyk.rs` for improved readability and maintainability, without changing functionality.
> 
>   - **Refactor**:
>     - Split `liquidity_pool.rs` into `geometric.rs` and `xyk.rs` for better readability.
>     - Move `add_initial_liquidity`, `add_subsequent_liquidity`, `swap_exact_amount_in`, `swap_exact_amount_out`, and `reflect_curve` to `geometric.rs` and `xyk.rs`.
>   - **Functionality**:
>     - `geometric.rs` handles geometric liquidity operations using oracle values.
>     - `xyk.rs` handles xyk liquidity operations using normalized invariants.
>   - **Code Organization**:
>     - Update `PassiveLiquidityPool` in `liquidity_pool.rs` to use functions from `geometric.rs` and `xyk.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 3396911d83dc5ae527f421357b4120b7393e7466. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->