### PR TITLE
feat(grug): non-archival `DiskDb`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,8 +1475,6 @@ dependencies = [
  "static_assertions_next",
  "tempfile",
  "thiserror 1.0.69",
- "tracing",
- "tracing-futures",
  "url",
  "uuid",
 ]

--- a/dango/cli/src/config.rs
+++ b/dango/cli/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
 pub struct GrugConfig {
     pub wasm_cache_capacity: usize,
     pub query_gas_limit: u64,
+    pub archive_mode: bool,
 }
 
 impl Default for GrugConfig {
@@ -21,6 +22,7 @@ impl Default for GrugConfig {
         Self {
             wasm_cache_capacity: 1000,
             query_gas_limit: 100_000_000,
+            archive_mode: false,
         }
     }
 }

--- a/dango/cli/src/db.rs
+++ b/dango/cli/src/db.rs
@@ -1,6 +1,10 @@
 use {
-    crate::home_directory::HomeDirectory, clap::Subcommand, colored::Colorize,
-    grug_app::PrunableDb, grug_db_disk::DiskDb, std::fs,
+    crate::{config::Config, home_directory::HomeDirectory},
+    clap::Subcommand,
+    colored::Colorize,
+    grug_app::PrunableDb,
+    grug_db_disk::DiskDb,
+    std::fs,
 };
 
 #[derive(Subcommand)]
@@ -22,7 +26,7 @@ pub enum DbCmd {
 }
 
 impl DbCmd {
-    pub fn run(self, dir: HomeDirectory) -> anyhow::Result<()> {
+    pub fn run(self, dir: HomeDirectory, cfg: Config) -> anyhow::Result<()> {
         let data_dir = dir.data_dir();
 
         if !data_dir.exists() {
@@ -42,7 +46,9 @@ impl DbCmd {
                     )?;
                 }
 
-                Ok(DiskDb::open(data_dir)?.prune(up_to_version)?)
+                let db = DiskDb::open(data_dir, cfg.grug.archive_mode)?;
+
+                Ok(db.prune(up_to_version)?)
             },
             DbCmd::Reset { yes } => {
                 if !yes {

--- a/dango/cli/src/main.rs
+++ b/dango/cli/src/main.rs
@@ -80,8 +80,8 @@ async fn main() -> anyhow::Result<()> {
     // Set up tracing, depending on whether Sentry is enabled or not.
     let filter = SuppressingLevelFilter::from_inner(cfg.log_level.parse()?);
     if cfg.sentry.enabled {
-        let _sentry_guard = sentry::init((cfg.sentry.dsn, sentry::ClientOptions {
-            environment: Some(cfg.sentry.environment.into()),
+        let _sentry_guard = sentry::init((cfg.sentry.dsn.clone(), sentry::ClientOptions {
+            environment: Some(cfg.sentry.environment.clone().into()),
             release: sentry::release_name!(),
             sample_rate: cfg.sentry.sample_rate,
             traces_sample_rate: cfg.sentry.traces_sample_rate,
@@ -105,11 +105,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     match cli.command {
-        Command::Db(cmd) => cmd.run(app_dir),
+        Command::Db(cmd) => cmd.run(app_dir, cfg),
         Command::Indexer(cmd) => cmd.run(app_dir).await,
         Command::Keys(cmd) => cmd.run(app_dir.keys_dir()),
         Command::Query(cmd) => cmd.run(app_dir).await,
-        Command::Start(cmd) => cmd.run(app_dir).await,
+        Command::Start(cmd) => cmd.run(app_dir, cfg).await,
         #[cfg(feature = "testing")]
         Command::Test(cmd) => cmd.run().await,
         Command::Tx(cmd) => cmd.run(app_dir).await,

--- a/dango/cli/src/start.rs
+++ b/dango/cli/src/start.rs
@@ -5,7 +5,6 @@ use {
     },
     anyhow::anyhow,
     clap::Parser,
-    config_parser::parse_config,
     dango_genesis::GenesisCodes,
     dango_httpd::{graphql::build_schema, server::config_app},
     dango_proposal_preparer::ProposalPreparer,
@@ -26,14 +25,11 @@ use {
 pub struct StartCmd;
 
 impl StartCmd {
-    pub async fn run(self, app_dir: HomeDirectory) -> anyhow::Result<()> {
+    pub async fn run(self, app_dir: HomeDirectory, cfg: Config) -> anyhow::Result<()> {
         tracing::info!("Using git commit: {GIT_COMMIT}");
 
-        // Parse the config file.
-        let cfg: Config = parse_config(app_dir.config_file())?;
-
         // Open disk DB.
-        let db = DiskDb::open(app_dir.data_dir())?;
+        let db = DiskDb::open(app_dir.data_dir(), cfg.grug.archive_mode)?;
 
         // Create Rust VM contract codes.
         let codes = HybridVm::genesis_codes();

--- a/dango/testing/benches/benchmarks.rs
+++ b/dango/testing/benches/benchmarks.rs
@@ -7,6 +7,7 @@ use {
     dango_types::{
         account::single,
         account_factory::{self, AccountParams, Salt},
+        constants::dango,
     },
     grug::{Addr, Binary, Coins, HashExt, JsonSerExt, Message, NonEmpty, ResultExt, Tx},
     grug_app::{AppError, Db, ProposalPreparer, Vm},
@@ -51,7 +52,7 @@ where
                     )),
                 },
                 if i < 100 {
-                    Coins::one("uusdc", 100_000_000).unwrap()
+                    Coins::one(dango::DENOM.clone(), 123).unwrap()
                 } else {
                     Coins::new()
                 },
@@ -90,7 +91,8 @@ where
             );
 
             // Sign the transaction.
-            let msg = Message::transfer(receiver, Coins::one("uusdc", 123).unwrap()).unwrap();
+            let msg = Message::transfer(receiver, Coins::one(dango::DENOM.clone(), 123).unwrap())
+                .unwrap();
 
             let (data, credential) = accounts
                 .owner
@@ -156,7 +158,7 @@ fn sends(c: &mut Criterion) {
                 // Create a random folder for this iteration.
                 let dir = TempDataDir::new(&format!("__dango_bench_sends_{}", random_string(8)));
                 let (mut suite, accounts, codes, contracts, _) =
-                    setup_benchmark_hybrid(&dir, false, 100);
+                    setup_benchmark_hybrid(&dir, true, 100);
 
                 let txs = do_send(&mut suite, accounts, codes, contracts);
 

--- a/dango/testing/benches/benchmarks.rs
+++ b/dango/testing/benches/benchmarks.rs
@@ -129,7 +129,8 @@ fn sends(c: &mut Criterion) {
             || {
                 // Create a random folder for this iteration.
                 let dir = TempDataDir::new(&format!("__dango_bench_sends_{}", random_string(8)));
-                let (mut suite, accounts, codes, contracts, _) = setup_benchmark_wasm(&dir, 100);
+                let (mut suite, accounts, codes, contracts, _) =
+                    setup_benchmark_wasm(&dir, false, 100);
 
                 let txs = do_send(&mut suite, accounts, codes, contracts);
 
@@ -154,7 +155,8 @@ fn sends(c: &mut Criterion) {
             || {
                 // Create a random folder for this iteration.
                 let dir = TempDataDir::new(&format!("__dango_bench_sends_{}", random_string(8)));
-                let (mut suite, accounts, codes, contracts, _) = setup_benchmark_hybrid(&dir, 100);
+                let (mut suite, accounts, codes, contracts, _) =
+                    setup_benchmark_hybrid(&dir, false, 100);
 
                 let txs = do_send(&mut suite, accounts, codes, contracts);
 

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -187,6 +187,7 @@ pub fn setup_test_with_indexer() -> (
 /// Used for running benchmarks with the hybrid VM.
 pub fn setup_benchmark_hybrid(
     dir: &TempDataDir,
+    archive_mode: bool,
     wasm_cache_size: usize,
 ) -> (
     TestSuite<NaiveProposalPreparer, DiskDb, HybridVm, NullIndexer>,
@@ -195,7 +196,7 @@ pub fn setup_benchmark_hybrid(
     Contracts,
     MockValidatorSets,
 ) {
-    let db = DiskDb::open(dir).unwrap();
+    let db = DiskDb::open(dir, archive_mode).unwrap();
     let codes = HybridVm::genesis_codes();
     let vm = HybridVm::new(wasm_cache_size, [
         codes.account_factory.to_bytes().hash256(),
@@ -232,6 +233,7 @@ pub fn setup_benchmark_hybrid(
 /// Used for running benchmarks with the Wasm VM.
 pub fn setup_benchmark_wasm(
     dir: &TempDataDir,
+    archive_mode: bool,
     wasm_cache_size: usize,
 ) -> (
     TestSuite<NaiveProposalPreparer, DiskDb, WasmVm, NullIndexer>,
@@ -240,7 +242,7 @@ pub fn setup_benchmark_wasm(
     Contracts,
     MockValidatorSets,
 ) {
-    let db = DiskDb::open(dir).unwrap();
+    let db = DiskDb::open(dir, archive_mode).unwrap();
     let vm = WasmVm::new(wasm_cache_size);
 
     setup_suite_with_db_and_vm(

--- a/deploy/roles/dango/templates/devnet/config/app.toml
+++ b/deploy/roles/dango/templates/devnet/config/app.toml
@@ -10,11 +10,30 @@ log_level = "info"
 
 [grug]
 
-# Capacity of the wasm module cache; zero means to not use a cache.
-wasm_cache_capacity = 1000
+# Whether to enable archive on the database.
+#
+# Under archive mode, application states of historical block heights are
+# preserved. This allows for querying the chain at historical heights, which can
+# be useful for some use cases. As a tradeoff, disk usage is significantly
+# higher, and disk reads (especially iterations) are slower.
+#
+# You may choose to prune states of older heights using the CLI command:
+#
+# ```bash
+# dango db prune [up-to-height]
+# ```
+#
+# Under non-archive mode, only the state of the latest height is preserved.
+#
+# It's important to note that a database with archive mode is NOT compatible
+# with one with non-archive mode. They come with different formats.
+archive_mode = false
 
 # Gas limit when serving query requests.
 query_gas_limit = 100000000
+
+# Capacity of the wasm module cache; zero means to not use a cache.
+wasm_cache_capacity = 1000
 
 ################################################################################
 ###                          Indexer Configuration                           ###

--- a/deploy/roles/dango/templates/testnet/config/app.toml
+++ b/deploy/roles/dango/templates/testnet/config/app.toml
@@ -10,11 +10,30 @@ log_level = "info"
 
 [grug]
 
-# Capacity of the wasm module cache; zero means to not use a cache.
-wasm_cache_capacity = 1000
+# Whether to enable archive on the database.
+#
+# Under archive mode, application states of historical block heights are
+# preserved. This allows for querying the chain at historical heights, which can
+# be useful for some use cases. As a tradeoff, disk usage is significantly
+# higher, and disk reads (especially iterations) are slower.
+#
+# You may choose to prune states of older heights using the CLI command:
+#
+# ```bash
+# dango db prune [up-to-height]
+# ```
+#
+# Under non-archive mode, only the state of the latest height is preserved.
+#
+# It's important to note that a database with archive mode is NOT compatible
+# with one with non-archive mode. They come with different formats.
+archive_mode = false
 
 # Gas limit when serving query requests.
 query_gas_limit = 100000000
+
+# Capacity of the wasm module cache; zero means to not use a cache.
+wasm_cache_capacity = 1000
 
 ################################################################################
 ###                          Indexer Configuration                           ###

--- a/grug/db/disk/src/db.rs
+++ b/grug/db/disk/src/db.rs
@@ -77,6 +77,12 @@ pub(crate) const MERKLE_TREE: MerkleTree = MerkleTree::new_default();
 /// and maybe our implementation will converge with Sei's some time later.
 pub struct DiskDb {
     pub(crate) inner: Arc<DiskDbInner>,
+    /// Whether the DB is operating in **archival mode**.
+    ///
+    /// In archival mode, states from historical versions are preserved, unless
+    /// pruned by calling the `Db::prune` method. Otherwise, only the state at
+    /// the latest version is kept.
+    archive_mode: bool,
 }
 
 pub(crate) struct DiskDbInner {
@@ -95,16 +101,17 @@ pub(crate) struct PendingData {
 
 impl DiskDb {
     /// Create a DiskDb instance by opening a physical RocksDB instance.
-    pub fn open<P>(data_dir: P) -> DbResult<Self>
+    pub fn open<P>(data_dir: P, archive_mode: bool) -> DbResult<Self>
     where
         P: AsRef<Path>,
     {
-        // Note: For default and state commitment CFs, don't enable timestamping;
-        // for state storage column family, enable timestamping.
+        // Note:
+        // - For default and state commitment CFs, don't enable timestamping.
+        // - For state storage column family, enable timestamping _if archive mode is enabled_.
         let db = DBWithThreadMode::open_cf_with_opts(&new_db_options(), data_dir, [
             (CF_NAME_DEFAULT, Options::default()),
-            (CF_NAME_PREIMAGES, new_cf_options_with_ts()),
-            (CF_NAME_STATE_STORAGE, new_cf_options_with_ts()),
+            (CF_NAME_PREIMAGES, new_cf_options(archive_mode)),
+            (CF_NAME_STATE_STORAGE, new_cf_options(archive_mode)),
             (CF_NAME_STATE_COMMITMENT, Options::default()),
         ])?;
 
@@ -113,6 +120,7 @@ impl DiskDb {
                 db,
                 pending_data: RwLock::new(None),
             }),
+            archive_mode,
         })
     }
 }
@@ -121,6 +129,7 @@ impl Clone for DiskDb {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
+            archive_mode: self.archive_mode,
         }
     }
 }
@@ -172,7 +181,12 @@ impl Db for DiskDb {
 
         Ok(StateStorage {
             inner: Arc::clone(&self.inner),
-            version,
+            // Do not specify the version unless in archival mode.
+            version: if self.archive_mode {
+                Some(version)
+            } else {
+                None
+            },
         })
     }
 
@@ -225,9 +239,19 @@ impl Db for DiskDb {
 
         // Commit hashed KVs to state commitment.
         // The DB writes here are kept in the in-memory `PendingData`.
-        let mut buffer = Buffer::new(self.state_commitment(), None);
-        let root_hash = MERKLE_TREE.apply_raw(&mut buffer, old_version, new_version, &batch)?;
-        let (_, pending) = buffer.disassemble();
+        let (root_hash, (_, pending)) = {
+            let mut buffer = Buffer::new(self.state_commitment(), None);
+            let root_hash = MERKLE_TREE.apply_raw(&mut buffer, old_version, new_version, &batch)?;
+
+            // Unless in archival mode, prune the orphaned nodes.
+            if !self.archive_mode {
+                if old_version > 0 {
+                    MERKLE_TREE.prune(&mut buffer, old_version)?;
+                }
+            }
+
+            (root_hash, buffer.disassemble())
+        };
 
         *(self.inner.pending_data.write()?) = Some(PendingData {
             version: new_version,
@@ -245,7 +269,57 @@ impl Db for DiskDb {
             .write()?
             .take()
             .ok_or(DbError::PendingDataNotSet)?;
+
         let mut batch = WriteBatch::default();
+        if self.archive_mode {
+            self.prepare_archival_batch(pending, &mut batch);
+        } else {
+            self.prepare_non_archival_batch(pending, &mut batch);
+        };
+
+        Ok(self.inner.db.write(batch)?)
+    }
+}
+
+impl DiskDb {
+    fn prepare_non_archival_batch(&self, pending: PendingData, batch: &mut WriteBatch) {
+        // Set the old and new versions (note: use little endian).
+        let cf = cf_default(&self.inner.db);
+        batch.put_cf(&cf, LATEST_VERSION_KEY, pending.version.to_le_bytes());
+        batch.put_cf(&cf, OLDEST_VERSION_KEY, pending.version.to_le_bytes());
+
+        // Writes in state commitment
+        let cf = cf_state_commitment(&self.inner.db);
+        for (key, op) in pending.state_commitment {
+            if let Op::Insert(value) = op {
+                batch.put_cf(&cf, key, value);
+            } else {
+                batch.delete_cf(&cf, key);
+            }
+        }
+
+        // Writes in preimages (note: without timestamping).
+        let cf = cf_preimages(&self.inner.db);
+        for (key, op) in &pending.state_storage {
+            if let Op::Insert(_) = op {
+                batch.put_cf(&cf, key.hash256(), key);
+            } else {
+                batch.delete_cf(&cf, key.hash256());
+            }
+        }
+
+        // Writes in state storage (note: without timestamping)
+        let cf = cf_state_storage(&self.inner.db);
+        for (key, op) in pending.state_storage {
+            if let Op::Insert(value) = op {
+                batch.put_cf(&cf, key, value);
+            } else {
+                batch.delete_cf(&cf, key);
+            }
+        }
+    }
+
+    fn prepare_archival_batch(&self, pending: PendingData, batch: &mut WriteBatch) {
         let ts = U64Timestamp::from(pending.version);
 
         // Set the new version (note: use little endian)
@@ -282,8 +356,6 @@ impl Db for DiskDb {
                 batch.delete_cf_with_ts(&cf, key, ts);
             }
         }
-
-        Ok(self.inner.db.write(batch)?)
     }
 }
 
@@ -307,7 +379,12 @@ impl PrunableDb for DiskDb {
     }
 
     fn prune(&self, up_to_version: u64) -> DbResult<()> {
-        let ts = U64Timestamp::from(up_to_version);
+        // Pruning is only supported in archival mode.
+        let ts = if self.archive_mode {
+            U64Timestamp::from(up_to_version)
+        } else {
+            return Err(DbError::NotArchival);
+        };
 
         // Prune state storage.
         //
@@ -453,12 +530,12 @@ impl Storage for StateCommitment {
 #[derive(Clone)]
 pub struct StateStorage {
     inner: Arc<DiskDbInner>,
-    version: u64,
+    version: Option<u64>,
 }
 
 impl Storage for StateStorage {
     fn read(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let opts = new_read_options(Some(self.version), None, None);
+        let opts = new_read_options(self.version, None, None);
         self.inner
             .db
             .get_cf_opt(&cf_state_storage(&self.inner.db), key, &opts)
@@ -473,7 +550,7 @@ impl Storage for StateStorage {
         max: Option<&[u8]>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Record> + 'a> {
-        let opts = new_read_options(Some(self.version), min, max);
+        let opts = new_read_options(self.version, min, max);
         let mode = into_iterator_mode(order);
         let iter = self
             .inner
@@ -494,7 +571,7 @@ impl Storage for StateStorage {
         max: Option<&[u8]>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'a> {
-        let opts = new_read_options(Some(self.version), min, max);
+        let opts = new_read_options(self.version, min, max);
         let mode = into_iterator_mode(order);
         let iter = self
             .inner
@@ -515,7 +592,7 @@ impl Storage for StateStorage {
         max: Option<&[u8]>,
         order: Order,
     ) -> Box<dyn Iterator<Item = Vec<u8>> + 'a> {
-        let opts = new_read_options(Some(self.version), min, max);
+        let opts = new_read_options(self.version, min, max);
         let mode = into_iterator_mode(order);
         let iter = self
             .inner
@@ -563,16 +640,20 @@ fn new_db_options() -> Options {
     opts
 }
 
-fn new_cf_options_with_ts() -> Options {
+fn new_cf_options(archive_mode: bool) -> Options {
     let mut opts = Options::default();
-    // Must use a timestamp-enabled comparator
-    opts.set_comparator_with_ts(
-        U64Comparator::NAME,
-        U64Timestamp::SIZE,
-        Box::new(U64Comparator::compare),
-        Box::new(U64Comparator::compare_ts),
-        Box::new(U64Comparator::compare_without_ts),
-    );
+
+    // If archive mode is enabled, use a timestamp-enabled comparator.
+    if archive_mode {
+        opts.set_comparator_with_ts(
+            U64Comparator::NAME,
+            U64Timestamp::SIZE,
+            Box::new(U64Comparator::compare),
+            Box::new(U64Comparator::compare_ts),
+            Box::new(U64Comparator::compare_without_ts),
+        );
+    }
+
     opts
 }
 
@@ -779,7 +860,7 @@ mod tests {
     #[test]
     fn disk_db_works() {
         let path = TempDataDir::new("_grug_disk_db_works");
-        let db = DiskDb::open(&path).unwrap();
+        let db = DiskDb::open(&path, true).unwrap();
 
         // Write a batch. The very first batch have version 0.
         let batch = Batch::from([
@@ -964,7 +1045,7 @@ mod tests {
     #[test]
     fn disk_db_pruning_works() {
         let path = TempDataDir::new("_grug_disk_db_pruning_works");
-        let db = DiskDb::open(&path).unwrap();
+        let db = DiskDb::open(&path, true).unwrap();
 
         // Apply a few batches. Same test data as used in the JMT test.
         for batch in [
@@ -1026,6 +1107,49 @@ mod tests {
                 err.to_string()
                     .contains("data not found! type: grug_jmt::node::Node")
             }));
+        }
+    }
+
+    #[test]
+    fn non_archive_mode_works() {
+        let path = TempDataDir::new("_grug_disk_non_archive_mode_works");
+        let db = DiskDb::open(&path, false).unwrap();
+
+        // Write the same two batches as in the previous tests.
+        for batch in [
+            Batch::from([
+                (b"donald".to_vec(), Op::Insert(b"trump".to_vec())),
+                (b"jake".to_vec(), Op::Insert(b"shepherd".to_vec())),
+                (b"joe".to_vec(), Op::Insert(b"biden".to_vec())),
+                (b"larry".to_vec(), Op::Insert(b"engineer".to_vec())),
+            ]),
+            Batch::from([
+                (b"donald".to_vec(), Op::Insert(b"duck".to_vec())),
+                (b"joe".to_vec(), Op::Delete),
+                (b"pumpkin".to_vec(), Op::Insert(b"cat".to_vec())),
+            ]),
+        ] {
+            db.flush_and_commit(batch).unwrap();
+        }
+
+        // Both oldest and latest versions should be 1.
+        assert_eq!(db.oldest_version(), Some(1));
+        assert_eq!(db.latest_version(), Some(1));
+
+        // Check the content of state storage is correct.
+        for ((found_key, found_value), (key, value)) in db
+            .state_storage(Some(1))
+            .unwrap()
+            .scan(None, None, Order::Ascending)
+            .zip([
+                ("donald", "duck"),
+                ("jake", "shepherd"),
+                ("larry", "engineer"),
+                ("pumpkin", "cat"),
+            ])
+        {
+            assert_eq!(found_key, key.as_bytes());
+            assert_eq!(found_value, value.as_bytes());
         }
     }
 }

--- a/grug/db/disk/src/db.rs
+++ b/grug/db/disk/src/db.rs
@@ -82,7 +82,7 @@ pub struct DiskDb {
     /// In archival mode, states from historical versions are preserved, unless
     /// pruned by calling the `Db::prune` method. Otherwise, only the state at
     /// the latest version is kept.
-    archive_mode: bool,
+    pub(crate) archive_mode: bool,
 }
 
 pub(crate) struct DiskDbInner {

--- a/grug/db/disk/src/db.rs
+++ b/grug/db/disk/src/db.rs
@@ -244,10 +244,8 @@ impl Db for DiskDb {
             let root_hash = MERKLE_TREE.apply_raw(&mut buffer, old_version, new_version, &batch)?;
 
             // Unless in archival mode, prune the orphaned nodes.
-            if !self.archive_mode {
-                if old_version > 0 {
-                    MERKLE_TREE.prune(&mut buffer, old_version)?;
-                }
+            if !self.archive_mode && old_version > 0 {
+                MERKLE_TREE.prune(&mut buffer, old_version)?;
             }
 
             (root_hash, buffer.disassemble())

--- a/grug/db/disk/src/error.rs
+++ b/grug/db/disk/src/error.rs
@@ -30,6 +30,9 @@ pub enum DbError {
         "requested version ({version}) is older than the oldest available version ({oldest_version})"
     )]
     VersionTooOld { version: u64, oldest_version: u64 },
+
+    #[error("this operation is not supported unless in archive mode")]
+    NotArchival,
 }
 
 impl<'a> From<PoisonError<RwLockReadGuard<'a, Option<PendingData>>>> for DbError {

--- a/grug/db/disk/src/ics23.rs
+++ b/grug/db/disk/src/ics23.rs
@@ -32,6 +32,14 @@ impl IbcDb for DiskDb {
             })
         };
 
+        let new_read_options = || {
+            if self.archive_mode {
+                new_read_options(Some(version), None, None)
+            } else {
+                new_read_options(None, None, None)
+            }
+        };
+
         let proof = match state_storage.read(&key) {
             // Value is found. Generate an ICS-23 existence proof.
             Some(value) => CommitmentProofInner::Exist(generate_existence_proof(key, value)?),
@@ -48,7 +56,7 @@ impl IbcDb for DiskDb {
                 let cf = cf_preimages(&self.inner.db);
                 let key_hash = key.hash256();
 
-                let opts = new_read_options(Some(version), None, None);
+                let opts = new_read_options();
                 let mode = IteratorMode::From(&key_hash, Direction::Reverse);
                 let left = self
                     .inner
@@ -62,7 +70,7 @@ impl IbcDb for DiskDb {
                     })
                     .transpose()?;
 
-                let opts = new_read_options(Some(version), None, None);
+                let opts = new_read_options();
                 let mode = IteratorMode::From(&key_hash, Direction::Forward);
                 let right = self
                     .inner
@@ -100,7 +108,7 @@ mod tests {
     #[test]
     fn ics23_prove_works() {
         let path = TempDataDir::new("_grug_disk_db_ics23_proving_works");
-        let db = DiskDb::open(&path).unwrap();
+        let db = DiskDb::open(&path, false).unwrap();
 
         // Same test data as used in JMT crate.
         let (_, maybe_root) = db
@@ -174,7 +182,7 @@ mod tests {
     #[test]
     fn ics23_prove_after_deletion() {
         let path = TempDataDir::new("__grug_disk_db_ics23_prove_after_deletion");
-        let db = DiskDb::open(&path).unwrap();
+        let db = DiskDb::open(&path, false).unwrap();
 
         // Apply batch at version 0.
         let _ = db
@@ -218,7 +226,7 @@ mod tests {
             deletes2 in prop::collection::vec(any::<prop::sample::Selector>(), 0..50)
         ) {
             let path = TempDataDir::new("_grug_disk_db_ics23_proving_works");
-            let db = DiskDb::open(&path).unwrap();
+            let db = DiskDb::open(&path, true).unwrap();
             let mut state = BTreeMap::new();
 
             // --------------------------- version 0 ---------------------------

--- a/networks/localdango/configs/dango/config/app.toml
+++ b/networks/localdango/configs/dango/config/app.toml
@@ -10,11 +10,30 @@ log_level = "info"
 
 [grug]
 
-# Capacity of the wasm module cache; zero means to not use a cache.
-wasm_cache_capacity = 1000
+# Whether to enable archive on the database.
+#
+# Under archive mode, application states of historical block heights are
+# preserved. This allows for querying the chain at historical heights, which can
+# be useful for some use cases. As a tradeoff, disk usage is significantly
+# higher, and disk reads (especially iterations) are slower.
+#
+# You may choose to prune states of older heights using the CLI command:
+#
+# ```bash
+# dango db prune [up-to-height]
+# ```
+#
+# Under non-archive mode, only the state of the latest height is preserved.
+#
+# It's important to note that a database with archive mode is NOT compatible
+# with one with non-archive mode. They come with different formats.
+archive_mode = false
 
 # Gas limit when serving query requests.
 query_gas_limit = 100000000
+
+# Capacity of the wasm module cache; zero means to not use a cache.
+wasm_cache_capacity = 1000
 
 ################################################################################
 ###                          Indexer Configuration                           ###

--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,4186 @@
+
+running 1 test
+test ics23::tests::proptest_ics23_prove_works ... FAILED
+
+successes:
+
+successes:
+
+failures:
+
+---- ics23::tests::proptest_ics23_prove_works stdout ----
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:281:71:
+called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }
+proptest: Aborting shrinking after the PROPTEST_MAX_SHRINK_ITERS environment variable or ProptestConfig.max_shrink_iters iterations (set 1024 to a large(r) value to shrink more; current configuration: 1024 iterations)
+
+thread 'ics23::tests::proptest_ics23_prove_works' panicked at grug/db/disk/src/ics23.rs:211:5:
+Test failed: called `Result::unwrap()` on an `Err` value: VersionTooOld { version: 0, oldest_version: 1 }.
+minimal failing input: (inserts1, deletes1) = (
+    {
+        "wjutqchox": "ypzfo",
+        "rsxqqvhob": "g",
+        "jstz": "chnfnb",
+        "kxlphst": "cm",
+        "wqgcegkmv": "dht",
+        "cjrifm": "lhkyabzwib",
+        "kx": "re",
+        "rscw": "jueznox",
+        "zesvei": "bivdvbf",
+        "sk": "zyjkmx",
+        "honio": "gkpwd",
+        "r": "gclpn",
+        "ye": "uovgakp",
+        "oeak": "s",
+        "tahpn": "ggkcgei",
+        "izxqlhe": "jgzlwchrw",
+        "vniv": "yfitykrnm",
+        "dwgg": "tr",
+        "repwyup": "rmtzgqqzi",
+        "gxkunjym": "smvik",
+        "mayadt": "p",
+        "xykwauccq": "ymplq",
+        "w": "zsvmhwm",
+        "zydwmqx": "oopdragl",
+        "jepahb": "g",
+        "wu": "italjukwu",
+        "gzlwatwa": "cdzwqjozg",
+        "tg": "y",
+        "osg": "hvoap",
+        "ak": "cfiw",
+        "merymkfnvd": "xwibkruynd",
+        "l": "pkzjskyqsq",
+        "sexzjlbhic": "wqnzspaqr",
+        "g": "ov",
+        "d": "qyangkob",
+        "ge": "tpkphaqalb",
+        "jldhavowmc": "joqd",
+        "qpqk": "kjizwzfr",
+        "ahwemmjz": "tpill",
+        "wqopbgklg": "x",
+        "szznm": "gvxbpbjn",
+        "kcfoqdkw": "wg",
+        "lucohyfgjd": "djtjbr",
+        "u": "avjnjqojb",
+        "zqixg": "gizy",
+        "ixotlw": "ow",
+        "fz": "ikaqok",
+        "jsjjqta": "edyvxlt",
+        "zwzkafdblo": "yphads",
+        "nvsrgoymqt": "kclpvk",
+        "xhywtxt": "uwhmxgbsro",
+        "zlahlwdu": "pssdmztxq",
+        "vkajn": "vpv",
+        "mfis": "u",
+        "fonndi": "zsyztrdvt",
+        "kh": "g",
+        "rzzf": "c",
+        "gnotdcbge": "rts",
+        "ktgxjl": "klb",
+        "j": "ovo",
+        "bnet": "burpwykl",
+        "pwohksztx": "yqvmillh",
+        "eiiqib": "fgmjwu",
+        "ezdwhba": "jvwxviota",
+        "omr": "e",
+        "jbvxwlezl": "h",
+        "i": "yqbpdhdir",
+        "kawm": "b",
+        "jubetkqrm": "pfpisdyeb",
+        "bolxvv": "ddplffhn",
+        "bcypzh": "jtfvuhgb",
+        "pe": "ld",
+        "hxhnmqf": "sr",
+        "m": "tqhiq",
+        "fdvwrck": "s",
+    },
+    [
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+        Selector {
+            rng: TestRng {
+                rng: ChaCha(
+                    ChaCha20Rng {
+                        rng: BlockRng {
+                            core: ChaChaXCore {},
+                            result_len: 64,
+                            index: 64,
+                        },
+                    },
+                ),
+            },
+            bias_increment: 0,
+        },
+    ],
+), inserts2 = {
+    "ga": "cuzsnvmvu",
+    "hdkr": "pbrxyoc",
+    "jrxnk": "qnslsb",
+    "ld": "rsstdh",
+    "yb": "tuhisbw",
+    "nxullumdb": "ozuguotql",
+    "etehnykfbh": "ajpcq",
+    "uhozimlxdp": "f",
+    "c": "x",
+    "yv": "pnvfaur",
+    "lq": "e",
+    "ivji": "jpquxugub",
+    "k": "wfrc",
+    "ywzvtqq": "zffugnhutc",
+    "us": "gysocif",
+    "df": "edu",
+    "couvblpurr": "nvbhdftzjl",
+    "rnuihxvva": "tcs",
+    "hjiylq": "bqi",
+    "xdhw": "aoq",
+    "rinmifaf": "pqabsfkrlc",
+    "meuwdgvbow": "bogjjc",
+    "nlyo": "igozdr",
+    "xdlhasdvee": "vsnbvll",
+    "uhikfe": "nkda",
+    "ntdx": "nayme",
+    "rbn": "lkmmdxqdg",
+    "rzalen": "hfify",
+    "jmyb": "aevy",
+    "ybmwmv": "tylhe",
+    "omydazdk": "kwh",
+    "p": "jtlrd",
+    "n": "ilfw",
+    "wedb": "dmufibc",
+    "ezrgl": "cu",
+    "ihsxnl": "igfnpnzo",
+    "gboqxbm": "oyqkj",
+    "gdpe": "pkgbsjw",
+    "vk": "q",
+    "ajmviyqp": "w",
+    "fdh": "lsejse",
+    "s": "ijv",
+    "vhrdml": "lmhaaywfy",
+    "g": "hckqbss",
+    "adqz": "ko",
+    "azjjcmkz": "grwhh",
+    "cbgg": "qpbfvsvjo",
+    "mwwmmakla": "nfvfd",
+    "nuga": "pv",
+    "vauxllr": "fnljs",
+    "expg": "uyi",
+    "ejwdlp": "hqncngtifv",
+    "junwaxdz": "pvxlzc",
+    "ytmqiwtc": "gfza",
+    "ekddchiml": "wnymsvdm",
+    "ecolpgr": "jrefchdg",
+    "r": "h",
+    "bbrkkav": "lrphzuyvrt",
+    "yusxthlgrj": "aqpwrleg",
+    "h": "mei",
+    "heqrss": "qsprjjc",
+    "pgbqextd": "rajq",
+    "fzsojofcg": "bdtf",
+    "xuixcylyy": "huohighb",
+    "igmswyzlv": "se",
+    "tnfuxbw": "colundyvl",
+    "cvcicdr": "aumzye",
+    "vwahd": "h",
+    "cti": "owegspsu",
+    "nolynv": "lekgkslr",
+    "unjwpiliy": "yseoq",
+    "tjlye": "am",
+    "kktxjyf": "lsivvc",
+    "oywjbaidcf": "x",
+    "bcocfz": "xgpoqpul",
+    "yahyuocakw": "dx",
+    "zkowkpf": "rwbrc",
+    "cfguoc": "mzkicidqh",
+    "rreb": "mixf",
+    "lvu": "lyjuvt",
+    "b": "rdemnqdi",
+    "rumjfj": "ne",
+    "lqxhovbg": "bcekgqx",
+    "bchyhxj": "pyx",
+    "ybtkaim": "losjlxk",
+    "usalqwuqax": "yvpakzuf",
+    "jduxyjsns": "tk",
+    "pklw": "worsuoiu",
+    "dnbdpaby": "so",
+    "vvxuhyuml": "divif",
+}, deletes2 = [
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+    Selector {
+        rng: TestRng {
+            rng: ChaCha(
+                ChaCha20Rng {
+                    rng: BlockRng {
+                        core: ChaChaXCore {},
+                        result_len: 64,
+                        index: 64,
+                    },
+                },
+            ),
+        },
+        bias_increment: 0,
+    },
+]
+	successes: 0
+	local rejects: 0
+	global rejects: 0
+
+
+
+failures:
+    ics23::tests::proptest_ics23_prove_works
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5 filtered out; finished in 24.69s
+


### PR DESCRIPTION
Currently the `DiskDb` is archival by default, meaning all historical states are kept, unless pruned (using the `DiskDb::prune` method, accessible through the `dango db prune` CLI command). This generates a huge amount of data. Our testnet-2 node already takes close to 1TB of disk space. This growth rate isn't sustainable.

Instead, I want to make archival mode optional--the DB only keeps the latest state, unless specifically requested to keep the historical states as well.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce non-archival mode for `DiskDb`, updating configurations, tests, and CLI to support optional archival mode.
> 
>   - **Behavior**:
>     - `DiskDb` now supports non-archival mode, keeping only the latest state unless `archive_mode` is true.
>     - `DiskDb::open` in `db.rs` now takes an `archive_mode` parameter.
>     - `prune` function in `db.rs` is restricted to archival mode only.
>   - **Configuration**:
>     - Added `archive_mode` boolean to `GrugConfig` in `config.rs`.
>     - Updated `app.toml` in `devnet`, `testnet`, and `localdango` to include `archive_mode` setting.
>   - **Tests**:
>     - Added `non_archive_mode_works` test in `db.rs` to verify non-archival mode functionality.
>     - Updated existing tests to include `archive_mode` parameter where applicable.
>   - **Misc**:
>     - Removed `tracing` and `tracing-futures` dependencies from `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b45b0b1c1f45cce32ca0a2ec1505928a11853ef9. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->