### PR TITLE
Fix fromAccount/toAccount

### DIFF
--- a/dango/indexer/sql/src/entity/transfers.rs
+++ b/dango/indexer/sql/src/entity/transfers.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "async-graphql")]
-use async_graphql::{
-    ComplexObject, Context, ErrorExtensions, Result as GraphQLResult, SimpleObject,
-};
+use async_graphql::{ComplexObject, Context, Result as GraphQLResult, SimpleObject};
 use {
     sea_orm::entity::prelude::*,
     serde::{Deserialize, Serialize},
@@ -54,35 +52,19 @@ impl Model {
     pub async fn from_account(
         &self,
         ctx: &Context<'_>,
-    ) -> GraphQLResult<crate::entity::accounts::Model> {
+    ) -> GraphQLResult<Option<crate::entity::accounts::Model>> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        crate::entity::accounts::Model::find_account_by_address(db, &self.from_address)
-            .await?
-            .ok_or_else(|| {
-                async_graphql::Error::new(format!(
-                    "account with address {} not found. This is not expected.",
-                    self.from_address
-                ))
-                .extend_with(|_err, e| e.set("code", "NOT_FOUND"))
-            })
+        Ok(crate::entity::accounts::Model::find_account_by_address(db, &self.from_address).await?)
     }
 
     pub async fn to_account(
         &self,
         ctx: &Context<'_>,
-    ) -> GraphQLResult<crate::entity::accounts::Model> {
+    ) -> GraphQLResult<Option<crate::entity::accounts::Model>> {
         let db = ctx.data::<DatabaseConnection>()?;
 
-        crate::entity::accounts::Model::find_account_by_address(db, &self.to_address)
-            .await?
-            .ok_or_else(|| {
-                async_graphql::Error::new(format!(
-                    "account with address {} not found. This is not expected.",
-                    self.to_address
-                ))
-                .extend_with(|_err, e| e.set("code", "NOT_FOUND"))
-            })
+        Ok(crate::entity::accounts::Model::find_account_by_address(db, &self.to_address).await?)
     }
 }
 

--- a/dango/testing/tests/httpd/transfers.rs
+++ b/dango/testing/tests/httpd/transfers.rs
@@ -53,9 +53,11 @@ async fn graphql_returns_transfer_and_accounts() -> anyhow::Result<()> {
             amount
             denom
             createdAt
-            accounts { address }
+            accounts { address users { username }}
+            fromAccount { address users { username }}
+            toAccount { address users { username }}
           }
-          edges { node { id idx blockHeight txHash fromAddress toAddress amount denom createdAt accounts { address } } cursor }
+          edges { node { id idx blockHeight txHash fromAddress toAddress amount denom createdAt accounts { address users { username }} fromAccount { address users { username }} toAccount { address users { username }} } cursor }
           pageInfo { hasPreviousPage hasNextPage startCursor endCursor }
         }
       }

--- a/dango/types/src/account_factory/account.rs
+++ b/dango/types/src/account_factory/account.rs
@@ -30,7 +30,7 @@ pub struct Account {
     feature = "sea-orm",
     derive(sea_orm::EnumIter, sea_orm::DeriveActiveEnum)
 )]
-#[cfg_attr(feature = "sea-orm", sea_orm(rs_type = "i32", db_type = "Integer"))]
+#[cfg_attr(feature = "sea-orm", sea_orm(rs_type = "i16", db_type = "Integer"))]
 pub enum AccountType {
     /// A single-signature account that cannot borrow margin loans.
     #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 0))]

--- a/dango/types/src/account_factory/account.rs
+++ b/dango/types/src/account_factory/account.rs
@@ -30,7 +30,10 @@ pub struct Account {
     feature = "sea-orm",
     derive(sea_orm::EnumIter, sea_orm::DeriveActiveEnum)
 )]
-#[cfg_attr(feature = "sea-orm", sea_orm(rs_type = "i16", db_type = "Integer"))]
+#[cfg_attr(
+    feature = "sea-orm",
+    sea_orm(rs_type = "i16", db_type = "SmallInteger")
+)]
 pub enum AccountType {
     /// A single-signature account that cannot borrow margin loans.
     #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 0))]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `from_account` and `to_account` to return `Option`, update GraphQL query, and change `AccountType` enum to use `i16`.
> 
>   - **Behavior**:
>     - `from_account` and `to_account` in `transfers.rs` now return `Option` instead of erroring when account not found.
>     - GraphQL query in `transfers.rs` updated to include `fromAccount` and `toAccount` fields.
>   - **Enums**:
>     - Change `AccountType` enum in `account.rs` to use `i16` instead of `i32` for `sea_orm` integration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for d82d0ac24abd3cdd3b474d3b432474db1910bf50. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->