### PR TITLE
feat(ui): notification transfer navigate

### DIFF
--- a/sdk/dango/src/types/indexer.ts
+++ b/sdk/dango/src/types/indexer.ts
@@ -1,4 +1,4 @@
-import type { Address, Json, UID } from "@left-curve/sdk/types";
+import type { Address, Hex, Json, UID } from "@left-curve/sdk/types";
 import type { AccountTypes } from "./account.js";
 
 export type IndexedBlock = {
@@ -45,6 +45,8 @@ export type IndexedMessage = {
 };
 
 export type IndexedTransferEvent = {
+  id: UID;
+  txHash: Hex;
   fromAddress: Address;
   toAddress: Address;
   createdAt: string;

--- a/ui/portal/web/src/components/notifications/Notification.tsx
+++ b/ui/portal/web/src/components/notifications/Notification.tsx
@@ -80,7 +80,7 @@ const NotificationTransfer: React.FC<NotificationTransferProps> = ({ notificatio
         className="flex items-start gap-2 max-w-full overflow-hidden cursor-pointer"
         onClick={(event) => {
           const element = event.target as HTMLElement;
-          if (element.closest(".address-visualizer") || element.closest("remove-notification")) {
+          if (element.closest(".address-visualizer") || element.closest(".remove-notification")) {
             return;
           }
           onNavigate(`/tx/${txHash}`);

--- a/ui/portal/web/src/components/notifications/Notification.tsx
+++ b/ui/portal/web/src/components/notifications/Notification.tsx
@@ -60,7 +60,7 @@ const NotificationTransfer: React.FC<NotificationTransferProps> = ({ notificatio
   const navigate = useNavigate();
   const { settings, setNotificationMenuVisibility } = useApp();
   const { deleteNotification } = useNotifications();
-  const { coin, type, fromAddress, toAddress, amount } = notification.data;
+  const { coin, type, fromAddress, toAddress, amount, txHash } = notification.data;
   const { formatNumberOptions } = settings;
   const isSent = type === "sent";
 
@@ -76,7 +76,16 @@ const NotificationTransfer: React.FC<NotificationTransferProps> = ({ notificatio
 
   return (
     <div className="flex items-end justify-between gap-2 p-2 rounded-lg hover:bg-rice-100 max-w-full group">
-      <div className="flex items-start gap-2 max-w-full overflow-hidden">
+      <div
+        className="flex items-start gap-2 max-w-full overflow-hidden cursor-pointer"
+        onClick={(event) => {
+          const element = event.target as HTMLElement;
+          if (element.closest(".address-visualizer") || element.closest("remove-notification")) {
+            return;
+          }
+          onNavigate(`/tx/${txHash}`);
+        }}
+      >
         <IconInfo className="text-gray-700 w-5 h-5 flex-shrink-0" />
 
         <div className="flex flex-col max-w-[calc(100%)] overflow-hidden">
@@ -96,20 +105,30 @@ const NotificationTransfer: React.FC<NotificationTransferProps> = ({ notificatio
               <span>
                 {m["notifications.notification.transfer.direction.first"]({ direction: type })}
               </span>
-              <AddressVisualizer address={originAddress} withIcon onClick={onNavigate} />
+              <AddressVisualizer
+                classNames={{ container: "address-visualizer" }}
+                address={originAddress}
+                withIcon
+                onClick={onNavigate}
+              />
             </div>
             <div className="flex flex-wrap items-center gap-1">
               <span>
                 {m["notifications.notification.transfer.direction.second"]({ direction: type })}
               </span>
-              <AddressVisualizer address={targetAddress} withIcon onClick={onNavigate} />{" "}
+              <AddressVisualizer
+                classNames={{ container: "address-visualizer" }}
+                address={targetAddress}
+                withIcon
+                onClick={onNavigate}
+              />{" "}
             </div>
           </div>
         </div>
       </div>
       <div className="flex flex-col diatype-sm-medium text-gray-500 min-w-fit items-center relative">
         <IconClose
-          className="absolute w-6 h-6 cursor-pointer group-hover:block hidden top-[-26px]"
+          className="absolute w-6 h-6 cursor-pointer group-hover:block hidden top-[-26px] remove-notification"
           onClick={() => deleteNotification(notification.id)}
         />
         <p>{formatNotificationTimestamp(new Date(notification.createdAt))}</p>

--- a/ui/store/src/subscriptions.ts
+++ b/ui/store/src/subscriptions.ts
@@ -84,9 +84,8 @@ const transferSubscriptionExecutor: SubscriptionExecutor<"transfer"> = ({
 }) => {
   return client.transferSubscription({
     ...params,
-    next: ({ sentTransfers, receivedTransfers }) => {
+    next: (event) => {
       const currentListeners = getListeners();
-      const event = (sentTransfers?.at(0) || receivedTransfers?.at(0)) as IndexedTransferEvent;
       currentListeners.forEach((listener) => listener(event));
     },
   });

--- a/ui/store/src/types/subscriptions.ts
+++ b/ui/store/src/types/subscriptions.ts
@@ -1,5 +1,4 @@
 import type {
-  Address,
   IndexedAccountEvent,
   IndexedBlock,
   IndexedTransferEvent,
@@ -15,8 +14,8 @@ export type SubscriptionSchema = [
   },
   {
     key: "transfer";
-    params: { address: Address };
-    listener: (event: IndexedTransferEvent) => void;
+    params: { username: Username; sinceBlockHeight?: number };
+    listener: (event: { transfers: IndexedTransferEvent[] }) => void;
   },
   {
     key: "account";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update transfer subscription to use `username` and add transaction navigation in notifications.
> 
>   - **Behavior**:
>     - `transferSubscription` in `transfer.ts` now uses `username` and optional `sinceBlockHeight` instead of `address`.
>     - GraphQL query updated to fetch `transfers` by `username` and `sinceBlockHeight`.
>     - Notifications now include `txHash` and navigate to transaction details on click in `Notification.tsx`.
>   - **Types**:
>     - `IndexedTransferEvent` in `indexer.ts` now includes `id` and `txHash`.
>     - `TransferSubscriptionParameters` updated to use `username` in `transfer.ts`.
>   - **UI**:
>     - `NotificationTransfer` component updated to handle `txHash` and navigate to `/tx/{txHash}` on click in `Notification.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 8bb10471b73ca4ccf11faec882ba8d0690605cfe. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->