### PR TITLE
dex: use oracle prices to determine how many LP tokens to mint

### DIFF
--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -178,11 +178,11 @@ impl PassiveLiquidityPool for PairParams {
 
         // In case the deposit is asymmetrical, we need to apply a deposit fee.
         //
-        // This is to prevent an attach where a user deposits asymmetrical, then
-        // immediately withdraw symmetrical, essentially accomplishing a swap
-        // without paying any fee.
+        // This is to prevent an attach where a user deposits asymmetrically,
+        // then immediately withdraw symmetrically, essentially accomplishing a
+        // swap without paying the swap fee.
         //
-        // We determine the fee rate based oracle price as follows:
+        // We determine the deposit fee rate based oracle price as follows:
         //
         // - Suppose the pool's reserve is `A` dollars of the 1st asset and `B`
         //   dollars of the 2nd asset.

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -352,7 +352,7 @@ impl PassiveLiquidityPool for PairParams {
 /// Compute `|a - b|`.
 fn abs_diff<T>(a: T, b: T) -> <T as Sub>::Output
 where
-    T: PartialOrd + Sub, // TODO: do we use PartialOrd or Ord?
+    T: Ord + Sub,
 {
     if a > b {
         a - b

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -146,8 +146,8 @@ impl PassiveLiquidityPool for PairParams {
         {
             let deposit_denoms = (deposit.first().denom, deposit.second().denom);
             let reserve_denoms = (reserve.first().denom, reserve.second().denom);
-            assert_eq!(
-                deposit_denoms, reserve_denoms,
+            ensure!(
+                deposit_denoms == reserve_denoms,
                 "deposit denoms {deposit_denoms:?} don't match reserve denoms {reserve_denoms:?}",
             );
         }

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -178,7 +178,7 @@ impl PassiveLiquidityPool for PairParams {
 
         // In case the deposit is asymmetrical, we need to apply a deposit fee.
         //
-        // This is to prevent an attach where a user deposits asymmetrically,
+        // This is to prevent an attack where a user deposits asymmetrically,
         // then immediately withdraw symmetrically, essentially accomplishing a
         // swap without paying the swap fee.
         //


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Use oracle prices to determine USD value for minting LP tokens and apply fees for asymmetrical deposits in DEX.
> 
>   - **Behavior**:
>     - Use oracle prices to determine USD value of deposits for minting LP tokens in `add_initial_liquidity()` and `add_subsequent_liquidity()` in `geometric.rs`.
>     - Apply deposit fee for asymmetrical deposits based on oracle prices in `add_liquidity()` in `liquidity_pool.rs`.
>   - **Functions**:
>     - Add `oracle_value()` in `geometric.rs` to calculate USD value of `CoinPair` using `OracleQuerier`.
>     - Modify `add_liquidity()` in `liquidity_pool.rs` to handle initial liquidity with oracle prices.
>   - **Tests**:
>     - Update tests in `dex.rs` to register oracle prices and validate new LP token minting logic.
>     - Add test cases for asymmetrical deposit fee logic and oracle price integration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 990f0b360d1ec6e2b3f5965cdd8ac7ad97dd0f22. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->