### PR TITLE
fix(ui): no notification styles & typo

### DIFF
--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -420,7 +420,7 @@
   "notifications": {
     "title": "Notifications",
     "noNotifications": {
-      "title": "No Notifications yet",
+      "title": "No notifications yet",
       "description": "When you approve, trade, or transfer tokens, your transaction will appear here"
     },
     "notification": {

--- a/ui/portal/web/src/components/notifications/Notifications.tsx
+++ b/ui/portal/web/src/components/notifications/Notifications.tsx
@@ -38,7 +38,7 @@ export const Notifications: React.FC<NotificationsProps> = (props) => {
 
   if (!hasNotifications) {
     return (
-      <div className="min-h-[19rem] flex flex-col gap-4 items-center justify-center px-4 py-6 text-center relative bg-[url('./images/notifications/bubble-bg.svg')] bg-[-11rem_4rem] bg-no-repeat rounded-xl ">
+      <div className="min-h-[19rem] flex flex-col shadow-account-card gap-4 items-center justify-center px-4 py-6 text-center relative bg-[url('./images/notifications/bubble-bg.svg')] bg-[-11rem_4rem] bg-no-repeat rounded-xl ">
         <img
           src="/images/notifications/no-notifications.svg"
           alt="no-notifications"
@@ -66,7 +66,7 @@ export const Notifications: React.FC<NotificationsProps> = (props) => {
       ) : null}
       <ResizerContainer
         layoutId="notifications"
-        className={twMerge("bg-transparent py-1 px-1 rounded-xl shadow-lg", className)}
+        className={twMerge("bg-transparent py-1 px-1 rounded-xl shadow-account-card", className)}
       >
         <AnimatePresence key={currentPage} mode="wait">
           <motion.div


### PR DESCRIPTION
This PR fix:
- LEF-153
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in notification title and updates styling for no-notification state in `Notifications.tsx`.
> 
>   - **UI Fixes**:
>     - Corrects typo in `en.json`: "No Notifications yet" to "No notifications yet".
>     - Updates `Notifications.tsx` to add `shadow-account-card` class for styling when no notifications are present.
>     - Changes `ResizerContainer` class in `Notifications.tsx` to use `shadow-account-card` for consistent styling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 0813cb69d5ac985ad4e947a443bc1a87b73805d5. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->