### PR TITLE
margin: return early in `compute_health` if the account has zero debt

### DIFF
--- a/dango/account/margin/src/query.rs
+++ b/dango/account/margin/src/query.rs
@@ -18,7 +18,7 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = core::query_health(ctx.querier, ctx.contract, &app_cfg)?;
             res.to_json_value()
         },
-        QueryMsg::Health {} => {
+        QueryMsg::Health { skip_if_no_debt } => {
             let oracle = ctx.querier.query_oracle()?;
             let mut oracle_querier = OracleQuerier::new_remote(oracle, ctx.querier);
             let res = core::query_and_compute_health(
@@ -27,6 +27,7 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
                 ctx.contract,
                 ctx.block.timestamp,
                 None,
+                skip_if_no_debt,
             )?;
             res.to_json_value()
         },

--- a/dango/testing/tests/margin.rs
+++ b/dango/testing/tests/margin.rs
@@ -463,9 +463,13 @@ fn liquidation_works_with_multiple_debt_denoms() {
         .should_succeed();
 
     // Query account's health
-    suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
-        .should_succeed_and(|health| health.utilization_rate < Udec128::ONE);
+    let health = suite
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            skip_if_no_debt: false,
+        })
+        .unwrap()
+        .unwrap();
+    assert!(health.utilization_rate < Udec128::ONE);
 
     // Update the oracle price of ETH to go from $71k to $96k, making the account undercollateralised
     register_fixed_price(
@@ -479,9 +483,13 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            skip_if_no_debt: false,
+        })
+        .unwrap()
         .unwrap();
     assert!(health.utilization_rate > Udec128::ONE);
+
     let debts_before = health.debts;
     // Add one microunit as debt may have increased by the time we liquidate due to interest
     let usdc_repay_amount = debts_before.amount_of(&usdc::DENOM).into_inner() + 1;
@@ -565,7 +573,10 @@ fn liquidation_works_with_multiple_debt_denoms() {
 
     // Query account's health
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            skip_if_no_debt: false,
+        })
+        .unwrap()
         .unwrap();
     let app_config: AppConfig = suite.query_app_config().unwrap();
 
@@ -737,7 +748,10 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health and ensure the limit order is counted as collateral
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            skip_if_no_debt: false,
+        })
+        .unwrap()
         .unwrap();
     assert_eq!(
         health.total_adjusted_collateral_value,
@@ -777,7 +791,10 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health to ensure it is undercollateralised
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            skip_if_no_debt: false,
+        })
+        .unwrap()
         .unwrap();
     assert!(health.utilization_rate > Udec128::ONE);
 
@@ -825,7 +842,10 @@ fn limit_orders_are_counted_as_collateral_and_can_be_liquidated() {
 
     // Query account's health to ensure it has been liquidated
     let health = suite
-        .query_wasm_smart(margin_account.address(), QueryHealthRequest {})
+        .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+            skip_if_no_debt: false,
+        })
+        .unwrap()
         .unwrap();
     assert!(health.limit_order_collaterals.is_empty());
     assert!(health.limit_order_outputs.is_empty());
@@ -1249,7 +1269,10 @@ proptest! {
 
         // Check margin accounts health
         let margin_account_health = suite
-            .query_wasm_smart(margin_account.address(), QueryHealthRequest { })
+            .query_wasm_smart(margin_account.address(), QueryHealthRequest {
+                skip_if_no_debt: false,
+            })
+            .unwrap()
             .unwrap();
 
         // Get liquidators total account value before liquidation

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -57,8 +57,13 @@ pub enum QueryMsg {
     #[returns(HealthData)]
     HealthData {},
     /// Compute the health of the margin account.
-    #[returns(HealthResponse)]
-    Health {},
+    #[returns(Option<HealthResponse>)]
+    Health {
+        /// If the account has zero debt, then skip the rest of the computation
+        /// involving collateral value and utilization rate, since the account
+        /// is necessarily healthy if there is no debt.
+        skip_if_no_debt: bool,
+    },
 }
 
 #[grug::derive(Serde)]


### PR DESCRIPTION
closes: #332
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add early return in `compute_health` for zero debt accounts with `skip_if_no_debt` parameter, updating related functions and tests.
> 
>   - **Behavior**:
>     - Add `skip_if_no_debt` parameter to `query_and_compute_health` and `compute_health` in `core.rs` to return early if account has zero debt.
>     - Modify `liquidate` in `execute.rs` to handle `None` response from `query_and_compute_health` and return an error if account has no debt.
>   - **Query**:
>     - Update `QueryMsg::Health` in `margin.rs` to include `skip_if_no_debt` parameter.
>   - **Tests**:
>     - Update tests in `margin.rs` to include `skip_if_no_debt` parameter in `QueryHealthRequest`.
>     - Ensure tests handle `None` response correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b903bf198db4c5d81cd6615541abff5d9800b575. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->