### PR TITLE
refactor: better types in price and price feed

### DIFF
--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -397,7 +397,7 @@ mod tests {
             constants::{eth, usdc},
             oracle::PrecisionedPrice,
         },
-        grug::{Bounded, Coins, Inner, coin_pair, coins, hash_map},
+        grug::{Bounded, Coins, Inner, Timestamp, coin_pair, coins, hash_map},
         std::collections::HashMap,
         test_case::test_case,
     };
@@ -603,13 +603,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         });
@@ -669,13 +669,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         });
@@ -719,13 +719,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         },
@@ -751,13 +751,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         },

--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -197,7 +197,7 @@ mod tests {
     use {
         super::*,
         dango_types::constants::{eth, usdc},
-        grug::{ResultExt, hash_map},
+        grug::{ResultExt, Timestamp, hash_map},
         test_case::test_case,
     };
 
@@ -206,7 +206,7 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(2000),
                 Udec128::new_percent(2000),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         };
@@ -217,13 +217,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(2000),
                 Udec128::new_percent(2000),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(1000),
                 Udec128::new_percent(1000),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         };

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -16,7 +16,8 @@ use {
     grug::{
         Addr, Addressable, BalanceChange, Bounded, Coin, CoinPair, Coins, Denom, Fraction, Inner,
         MaxLength, Message, MultiplyFraction, NonEmpty, NonZero, NumberConst, QuerierExt,
-        ResultExt, Signer, StdResult, Udec128, Uint128, UniqueVec, btree_map, coin_pair, coins,
+        ResultExt, Signer, StdResult, Timestamp, Udec128, Uint128, UniqueVec, btree_map, coin_pair,
+        coins,
     },
     hyperlane_types::constants::ethereum,
     std::{
@@ -294,7 +295,7 @@ fn dex_works(
                 usdc::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -308,7 +309,7 @@ fn dex_works(
                 dango::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -1249,7 +1250,7 @@ fn provide_liquidity(
                     denom => PriceSource::Fixed {
                         humanized_price: price,
                         precision: 6,
-                        timestamp: 1730802926,
+                        timestamp: Timestamp::from_seconds(1730802926),
                     },
                 }),
                 Coins::new(),
@@ -1386,7 +1387,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
                 dango::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -1401,7 +1402,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
                 usdc::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -2570,7 +2571,7 @@ fn curve_on_orderbook(
                 usdc::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -2586,7 +2587,7 @@ fn curve_on_orderbook(
                 eth::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::new_percent(2000),
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -2711,7 +2712,7 @@ fn volume_tracking_works() {
                 usdc::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -2727,7 +2728,7 @@ fn volume_tracking_works() {
                 dango::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -3032,7 +3033,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                 usdc::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -3048,7 +3049,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                 dango::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -3064,7 +3065,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                 eth::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::from_str("85248.71").unwrap(),
                     precision: 8,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),
@@ -5035,13 +5036,13 @@ fn market_order_clearing(
                 usdc::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
                 dango::DENOM.clone() => PriceSource::Fixed {
-                   humanized_price: Udec128::ONE,
-                   precision: 6,
-                   timestamp: 1730802926,
-               },
+                    humanized_price: Udec128::ONE,
+                    precision: 6,
+                    timestamp: Timestamp::from_seconds(1730802926),
+                },
             }),
             Coins::new(),
         )

--- a/dango/testing/tests/lending.rs
+++ b/dango/testing/tests/lending.rs
@@ -18,8 +18,8 @@ use {
     },
     grug::{
         Addressable, Binary, Coins, Denom, Duration, JsonSerExt, Message, MsgConfigure,
-        MultiplyFraction, NonEmpty, NumberConst, QuerierExt, ResultExt, Sign, Udec128, Udec256,
-        Uint128, btree_map, coins,
+        MultiplyFraction, NonEmpty, NumberConst, QuerierExt, ResultExt, Sign, Timestamp, Udec128,
+        Udec256, Uint128, btree_map, coins,
     },
     grug_app::NaiveProposalPreparer,
     grug_vm_rust::VmError,
@@ -87,7 +87,7 @@ fn feed_oracle_usdc_price(
 
         assert_eq!(current_price.precision(), precision);
 
-        assert_eq!(current_price.timestamp, 1730802926);
+        assert_eq!(current_price.timestamp, Timestamp::from_seconds(1730802926));
     }
 }
 
@@ -196,7 +196,7 @@ fn indexes_are_updated_when_interest_rate_model_is_updated() {
                 usdc::DENOM.clone() => PriceSource::Fixed {
                     humanized_price: Udec128::ONE,
                     precision: 6,
-                    timestamp: 1730802926,
+                    timestamp: Timestamp::from_seconds(1730802926),
                 },
             }),
             Coins::new(),

--- a/dango/testing/tests/margin.rs
+++ b/dango/testing/tests/margin.rs
@@ -18,8 +18,8 @@ use {
     grug::{
         Addr, Addressable, Binary, CheckedContractEvent, Coins, Denom, Inner, IsZero, JsonDeExt,
         JsonSerExt, Message, MsgConfigure, MultiplyFraction, NextNumber, NonEmpty, Number,
-        NumberConst, PrevNumber, QuerierExt, QuerierWrapper, ResultExt, SearchEvent, Udec128,
-        Uint128, btree_map, coins,
+        NumberConst, PrevNumber, QuerierExt, QuerierWrapper, ResultExt, SearchEvent, Timestamp,
+        Udec128, Uint128, btree_map, coins,
     },
     grug_app::NaiveProposalPreparer,
     proptest::{collection::vec, prelude::*, proptest},
@@ -181,7 +181,7 @@ fn register_fixed_price(
                 denom => dango_types::oracle::PriceSource::Fixed {
                     humanized_price,
                     precision,
-                    timestamp: 0,
+                    timestamp: Timestamp::from_seconds(0),
                 }
             }),
             Coins::default(),
@@ -871,7 +871,8 @@ fn test_denom(index: usize) -> impl Strategy<Value = TestDenom> {
     )
         .prop_map(|(denom, precision, price)| TestDenom {
             denom,
-            initial_price: PrecisionlessPrice::new(price, price, 0u64).with_precision(precision),
+            initial_price: PrecisionlessPrice::new(price, price, Timestamp::from_seconds(0))
+                .with_precision(precision),
         })
 }
 

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -7,7 +7,7 @@ use {
     },
     grug::{
         Addr, Binary, Coins, Inner, MockApi, NonEmpty, QuerierExt, ResultExt, StorageQuerier,
-        Udec128, btree_map,
+        Timestamp, Udec128, btree_map,
     },
     grug_app::NaiveProposalPreparer,
     pyth_client::{PythClientCache, PythClientTrait},
@@ -83,7 +83,7 @@ fn oracle() {
 
         assert_eq!(current_price.precision(), 8);
 
-        assert_eq!(current_price.timestamp, 1730209108);
+        assert_eq!(current_price.timestamp, Timestamp::from_seconds(1730209108));
     }
 
     // Push an updated price
@@ -115,7 +115,7 @@ fn oracle() {
             Udec128::from_str("68739.90600000").unwrap()
         );
 
-        assert_eq!(current_price.timestamp, 1730804420);
+        assert_eq!(current_price.timestamp, Timestamp::from_seconds(1730804420));
     }
 
     // Push an outdated price. it should not be updated
@@ -147,7 +147,7 @@ fn oracle() {
             Udec128::from_str("68739.90600000").unwrap()
         );
 
-        assert_eq!(current_price.timestamp, 1730804420);
+        assert_eq!(current_price.timestamp, Timestamp::from_seconds(1730804420));
     }
 }
 

--- a/dango/types/src/oracle/price.rs
+++ b/dango/types/src/oracle/price.rs
@@ -14,7 +14,10 @@ pub type PrecisionlessPrice = Price<Undefined<Precision>>;
 pub type PrecisionedPrice = Price<Defined<Precision>>;
 
 #[grug::derive(Serde, Borsh)]
-pub struct Price<P: MaybeDefined<Precision> = Defined<Precision>> {
+pub struct Price<P>
+where
+    P: MaybeDefined<Precision>,
+{
     /// The price of the token in its humanized form. I.e. the price of 1 ATOM,
     /// rather than 1 uatom.
     pub humanized_price: Udec128,

--- a/dango/types/src/oracle/price.rs
+++ b/dango/types/src/oracle/price.rs
@@ -120,13 +120,13 @@ impl TryFrom<PriceFeed> for PrecisionlessPrice {
         let price_unchecked = value.get_price_unchecked();
         let price = Udec128::checked_from_atomics::<u128>(
             price_unchecked.price.try_into()?,
-            price_unchecked.expo.try_into()?,
+            (-price_unchecked.expo).try_into()?,
         )?;
 
         let ema_unchecked = value.get_ema_price_unchecked();
         let ema = Udec128::checked_from_atomics::<u128>(
             ema_unchecked.price.try_into()?,
-            ema_unchecked.expo.try_into()?,
+            (-ema_unchecked.expo).try_into()?,
         )?;
 
         let timestamp = Timestamp::from_seconds(price_unchecked.publish_time.try_into()?);

--- a/dango/types/src/oracle/price.rs
+++ b/dango/types/src/oracle/price.rs
@@ -1,15 +1,20 @@
 use {
     anyhow::anyhow,
-    grug::{Defined, MultiplyFraction, Number, StdResult, Timestamp, Udec128, Uint128, Undefined},
+    grug::{
+        Defined, MaybeDefined, MultiplyFraction, Number, StdResult, Timestamp, Udec128, Uint128,
+        Undefined,
+    },
     pyth_types::PriceFeed,
 };
 
-pub type PrecisionlessPrice = Price<Undefined<u8>>;
+pub type Precision = u8;
 
-pub type PrecisionedPrice = Price<Defined<u8>>;
+pub type PrecisionlessPrice = Price<Undefined<Precision>>;
+
+pub type PrecisionedPrice = Price<Defined<Precision>>;
 
 #[grug::derive(Serde, Borsh)]
-pub struct Price<P = Defined<u8>> {
+pub struct Price<P: MaybeDefined<Precision> = Defined<Precision>> {
     /// The price of the token in its humanized form. I.e. the price of 1 ATOM,
     /// rather than 1 uatom.
     pub humanized_price: Udec128,
@@ -35,7 +40,7 @@ impl PrecisionlessPrice {
         }
     }
 
-    pub fn with_precision(self, precision: u8) -> Price<Defined<u8>> {
+    pub fn with_precision(self, precision: Precision) -> PrecisionedPrice {
         Price {
             humanized_price: self.humanized_price,
             humanized_ema: self.humanized_ema,
@@ -50,7 +55,7 @@ impl PrecisionedPrice {
         humanized_price: Udec128,
         humanized_ema: Udec128,
         timestamp: Timestamp,
-        precision: u8,
+        precision: Precision,
     ) -> Self {
         Self {
             humanized_price,
@@ -63,7 +68,7 @@ impl PrecisionedPrice {
     /// Returns the number of decimal places of the token that is used to
     /// convert the price from its smallest unit to a humanized form. E.g.
     /// 1 ATOM is 10^6 uatom, so the precision is 6.
-    pub fn precision(&self) -> u8 {
+    pub fn precision(&self) -> Precision {
         self.precision.into_inner()
     }
 

--- a/dango/types/src/oracle/price_source.rs
+++ b/dango/types/src/oracle/price_source.rs
@@ -1,4 +1,5 @@
 use {
+    crate::oracle::Precision,
     grug::{Timestamp, Udec128},
     pyth_types::PythId,
 };
@@ -12,7 +13,7 @@ pub enum PriceSource {
         /// The number of decimal places of the token that is used to convert
         /// the price from its smallest unit to a humanized form. E.g. 1 ATOM
         /// is 10^6 uatom, so the precision is 6.
-        precision: u8,
+        precision: Precision,
         /// The timestamp of the price.
         timestamp: Timestamp,
     },
@@ -23,7 +24,7 @@ pub enum PriceSource {
         /// The number of decimal places of the token that is used to convert
         /// the price from its smallest unit to a humanized form. E.g. 1 ATOM
         /// is 10^6 uatom, so the precision is 6.
-        precision: u8,
+        precision: Precision,
     },
     /// A price source for an LP token of the lending pool.
     LendingLiquidity,

--- a/dango/types/src/oracle/price_source.rs
+++ b/dango/types/src/oracle/price_source.rs
@@ -1,4 +1,7 @@
-use {grug::Udec128, pyth_types::PythId};
+use {
+    grug::{Timestamp, Udec128},
+    pyth_types::PythId,
+};
 
 #[grug::derive(Serde, Borsh)]
 pub enum PriceSource {
@@ -11,7 +14,7 @@ pub enum PriceSource {
         /// is 10^6 uatom, so the precision is 6.
         precision: u8,
         /// The timestamp of the price.
-        timestamp: u64,
+        timestamp: Timestamp,
     },
     /// A price source that uses price feeds from Pyth.
     Pyth {


### PR DESCRIPTION
- use `Timestamp` instead of `u64` for the timestamp
- add a type alias for the precision
- remove the default type (`P = Defined<u8>`) since it's not used; add a trait bound (`MaybeDefined<Precision>`)
- use `.try_into()` instead of `.unsigned_abs()` when converting `i64`/`i32` into `u128`/`u8`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor price-related code to use `Timestamp` and `Precision` types for improved type safety and clarity.
> 
>   - **Types**:
>     - Replace `u64` with `Timestamp` for timestamps in `liquidity_pool.rs`, `oracle_querier.rs`, and `price.rs`.
>     - Introduce `Precision` type alias for precision in `price.rs` and `price_source.rs`.
>   - **Logic**:
>     - Remove default type `P = Defined<u8>` and add `MaybeDefined<Precision>` trait bound in `price.rs`.
>     - Use `.try_into()` instead of `.unsigned_abs()` for converting `i64`/`i32` to `u128`/`u8` in `price.rs`.
>   - **Misc**:
>     - Update tests in `liquidity_pool.rs`, `oracle_querier.rs`, and `dex.rs` to use `Timestamp::from_seconds()`.
>     - Adjust `PrecisionedPrice` and `PrecisionlessPrice` constructors in `price.rs` to use new types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 6ce1481edc10967c5c69b43876a73b8d9a1ffaaa. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->