### PR TITLE
dex: add simulate deposit/withdraw queries and few other minor things

### DIFF
--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -124,7 +124,6 @@ pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
         .add_events(events)?)
 }
 
-#[inline]
 fn clear_orders_of_pair(
     storage: &mut dyn Storage,
     current_block_height: u64,

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -214,7 +214,6 @@ fn provide_liquidity(
 
 /// Withdraw liquidity from a pool. The LP tokens must be sent with the message.
 /// The underlying assets will be returned to the sender.
-
 fn withdraw_liquidity(
     mut ctx: MutableCtx,
     base_denom: Denom,

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -51,7 +51,6 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     }
 }
 
-#[inline]
 fn batch_update_pairs(ctx: MutableCtx, updates: Vec<PairUpdate>) -> anyhow::Result<Response> {
     ensure!(
         ctx.sender == ctx.querier.query_owner()? || ctx.sender == GENESIS_SENDER,
@@ -86,7 +85,6 @@ fn batch_update_pairs(ctx: MutableCtx, updates: Vec<PairUpdate>) -> anyhow::Resu
     Ok(Response::new().add_events(events)?)
 }
 
-#[inline]
 fn batch_update_orders(
     mut ctx: MutableCtx,
     creates_market: Vec<CreateMarketOrderRequest>,
@@ -159,7 +157,6 @@ fn batch_update_orders(
         .add_events(events)?)
 }
 
-#[inline]
 fn provide_liquidity(
     mut ctx: MutableCtx,
     base_denom: Denom,
@@ -217,7 +214,7 @@ fn provide_liquidity(
 
 /// Withdraw liquidity from a pool. The LP tokens must be sent with the message.
 /// The underlying assets will be returned to the sender.
-#[inline]
+
 fn withdraw_liquidity(
     mut ctx: MutableCtx,
     base_denom: Denom,
@@ -265,7 +262,6 @@ fn withdraw_liquidity(
     // TODO: add events
 }
 
-#[inline]
 fn swap_exact_amount_in(
     ctx: MutableCtx,
     route: UniqueVec<PairId>,
@@ -302,7 +298,6 @@ fn swap_exact_amount_in(
         })?)
 }
 
-#[inline]
 fn swap_exact_amount_out(
     mut ctx: MutableCtx,
     route: UniqueVec<PairId>,

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -64,6 +64,14 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = query_orders_by_user(ctx, user, start_after, limit)?;
             res.to_json_value()
         },
+        QueryMsg::Volume { user, since } => {
+            let res = query_volume(ctx, user, since)?;
+            res.to_json_value()
+        },
+        QueryMsg::VolumeByUser { user, since } => {
+            let res = query_volume_by_user(ctx, user, since)?;
+            res.to_json_value()
+        },
         QueryMsg::SimulateSwapExactAmountIn { route, input } => {
             let (_, output) =
                 core::swap_exact_amount_in(ctx.storage, ctx.querier, route.into_inner(), input)?;
@@ -72,14 +80,6 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
         QueryMsg::SimulateSwapExactAmountOut { route, output } => {
             let (_, input) = core::swap_exact_amount_out(ctx.storage, route.into_inner(), output)?;
             input.to_json_value()
-        },
-        QueryMsg::Volume { user, since } => {
-            let res = query_volume(ctx, user, since)?;
-            res.to_json_value()
-        },
-        QueryMsg::VolumeByUser { user, since } => {
-            let res = query_volume_by_user(ctx, user, since)?;
-            res.to_json_value()
         },
     }
     .map_err(Into::into)

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -105,12 +105,10 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
     .map_err(Into::into)
 }
 
-#[inline]
 fn query_pair(ctx: ImmutableCtx, base_denom: Denom, quote_denom: Denom) -> StdResult<PairParams> {
     PAIRS.load(ctx.storage, (&base_denom, &quote_denom))
 }
 
-#[inline]
 fn query_pairs(
     ctx: ImmutableCtx,
     start_after: Option<PairId>,
@@ -135,12 +133,10 @@ fn query_pairs(
         .collect()
 }
 
-#[inline]
 fn query_reserve(ctx: ImmutableCtx, base_denom: Denom, quote_denom: Denom) -> StdResult<CoinPair> {
     RESERVES.load(ctx.storage, (&base_denom, &quote_denom))
 }
 
-#[inline]
 fn query_reserves(
     ctx: ImmutableCtx,
     start_after: Option<PairId>,
@@ -167,7 +163,6 @@ fn query_reserves(
         .collect()
 }
 
-#[inline]
 fn query_order(ctx: ImmutableCtx, order_id: OrderId) -> StdResult<OrderResponse> {
     let (((base_denom, quote_denom), direction, price, _), order) =
         LIMIT_ORDERS.idx.order_id.load(ctx.storage, order_id)?;
@@ -183,7 +178,6 @@ fn query_order(ctx: ImmutableCtx, order_id: OrderId) -> StdResult<OrderResponse>
     })
 }
 
-#[inline]
 fn query_orders(
     ctx: ImmutableCtx,
     start_after: Option<OrderId>,
@@ -212,7 +206,6 @@ fn query_orders(
         .collect()
 }
 
-#[inline]
 fn query_orders_by_pair(
     ctx: ImmutableCtx,
     base_denom: Denom,
@@ -246,7 +239,6 @@ fn query_orders_by_pair(
         .collect()
 }
 
-#[inline]
 fn query_orders_by_user(
     ctx: ImmutableCtx,
     user: Addr,
@@ -282,7 +274,6 @@ fn query_orders_by_user(
         .collect()
 }
 
-#[inline]
 fn query_volume(ctx: ImmutableCtx, user: Addr, since: Option<Timestamp>) -> StdResult<Uint128> {
     let volume_now = VOLUMES
         .prefix(&user)
@@ -310,7 +301,6 @@ fn query_volume(ctx: ImmutableCtx, user: Addr, since: Option<Timestamp>) -> StdR
     Ok(volume_now.checked_sub(volume_since)?)
 }
 
-#[inline]
 fn query_volume_by_user(
     ctx: ImmutableCtx,
     user: Username,
@@ -342,7 +332,6 @@ fn query_volume_by_user(
     Ok(volume_now.checked_sub(volume_since)?)
 }
 
-#[inline]
 fn query_simulate_provide_liquidity(
     ctx: ImmutableCtx,
     base_denom: Denom,
@@ -361,7 +350,6 @@ fn query_simulate_provide_liquidity(
         })
 }
 
-#[inline]
 fn query_simulate_withdraw_liquidity(
     ctx: ImmutableCtx,
     base_denom: Denom,

--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -219,6 +219,22 @@ pub enum QueryMsg {
         /// username's total trading volume will be returned.
         since: Option<Timestamp>,
     },
+    /// Simulate a liquidity provision.
+    /// Returns the amount of LP tokens to be minted.
+    #[returns(Coin)]
+    SimulateProvideLiquidity {
+        base_denom: Denom,
+        quote_denom: Denom,
+        deposit: CoinPair,
+    },
+    /// Simulate a liquidity withdrawal.
+    /// Returns the amount of the two underlying assets to be refunded.
+    #[returns(CoinPair)]
+    SimulateWithdrawLiquidity {
+        base_denom: Denom,
+        quote_denom: Denom,
+        lp_burn_amount: Uint128,
+    },
     /// Simulate a swap with exact input.
     #[returns(Coin)]
     SimulateSwapExactAmountIn { route: SwapRoute, input: Coin },

--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -201,15 +201,6 @@ pub enum QueryMsg {
         start_after: Option<OrderId>,
         limit: Option<u32>,
     },
-    /// Simulate a swap with exact input.
-    #[returns(Coin)]
-    SimulateSwapExactAmountIn { route: SwapRoute, input: Coin },
-    /// Simulate a swap with exact output.
-    #[returns(Coin)]
-    SimulateSwapExactAmountOut {
-        route: SwapRoute,
-        output: NonZero<Coin>,
-    },
     /// Returns the trading volume of a user address since the specified timestamp.
     #[returns(Uint128)]
     Volume {
@@ -227,6 +218,15 @@ pub enum QueryMsg {
         /// The start timestamp to query trading volume for. If not provided,
         /// username's total trading volume will be returned.
         since: Option<Timestamp>,
+    },
+    /// Simulate a swap with exact input.
+    #[returns(Coin)]
+    SimulateSwapExactAmountIn { route: SwapRoute, input: Coin },
+    /// Simulate a swap with exact output.
+    #[returns(Coin)]
+    SimulateSwapExactAmountOut {
+        route: SwapRoute,
+        output: NonZero<Coin>,
     },
 }
 


### PR DESCRIPTION
- add `QueryMsg::Simulate{Provide,Withdraw}Liquidity` queries
- reorder the variants of `QueryMsg`
- remove the `#[inline]` decorators (unnecessary, compiler is smart enough to take care of inlining functions)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add simulate liquidity queries, reorder `QueryMsg` variants, and remove unnecessary `#[inline]` decorators.
> 
>   - **Queries**:
>     - Add `SimulateProvideLiquidity` and `SimulateWithdrawLiquidity` to `QueryMsg` in `msgs.rs`.
>     - Implement `query_simulate_provide_liquidity()` and `query_simulate_withdraw_liquidity()` in `query.rs`.
>   - **Reordering**:
>     - Reorder variants of `QueryMsg` in `msgs.rs`.
>   - **Code Cleanup**:
>     - Remove `#[inline]` decorators from functions in `cron.rs`, `execute.rs`, and `query.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 81c2d525891435a53f3ba58c226907b033de00ac. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->