### PR TITLE
Change paginate_models impl to generic

### DIFF
--- a/dango/indexer/httpd/src/graphql/query/account.rs
+++ b/dango/indexer/httpd/src/graphql/query/account.rs
@@ -76,7 +76,7 @@ impl AccountQuery {
     > {
         let app_ctx = ctx.data::<Context>()?;
 
-        paginate_models::<AccountCursor, entity::accounts::Entity, SortBy>(
+        paginate_models(
             app_ctx,
             after,
             before,

--- a/dango/indexer/httpd/src/graphql/query/transfer.rs
+++ b/dango/indexer/httpd/src/graphql/query/transfer.rs
@@ -84,7 +84,7 @@ impl TransferQuery {
     > {
         let app_ctx = ctx.data::<Context>()?;
 
-        paginate_models::<TransferCursor, entity::transfers::Entity, SortBy>(
+        paginate_models(
             app_ctx,
             after,
             before,
@@ -155,7 +155,6 @@ impl TransferQuery {
                                     )),
                             );
                     }
-
                     Ok(query)
                 })
             },

--- a/indexer/httpd/src/graphql/query/block.rs
+++ b/indexer/httpd/src/graphql/query/block.rs
@@ -89,7 +89,7 @@ impl BlockQuery {
     > {
         let app_ctx = ctx.data::<Context>()?;
 
-        paginate_models::<BlockCursor, entity::blocks::Entity, SortBy>(
+        paginate_models(
             app_ctx,
             after,
             before,

--- a/indexer/httpd/src/graphql/query/event.rs
+++ b/indexer/httpd/src/graphql/query/event.rs
@@ -69,7 +69,7 @@ impl EventQuery {
     > {
         let app_ctx = ctx.data::<Context>()?;
 
-        paginate_models::<EventCursor, entity::events::Entity, SortBy>(
+        paginate_models(
             app_ctx,
             after,
             before,

--- a/indexer/httpd/src/graphql/query/message.rs
+++ b/indexer/httpd/src/graphql/query/message.rs
@@ -73,7 +73,7 @@ impl MessageQuery {
     > {
         let app_ctx = ctx.data::<Context>()?;
 
-        paginate_models::<MessageCursor, entity::messages::Entity, SortBy>(
+        paginate_models(
             app_ctx,
             after,
             before,

--- a/indexer/httpd/src/graphql/query/transaction.rs
+++ b/indexer/httpd/src/graphql/query/transaction.rs
@@ -77,7 +77,7 @@ impl TransactionQuery {
     > {
         let app_ctx = ctx.data::<Context>()?;
 
-        paginate_models::<TransactionCursor, entity::transactions::Entity, SortBy>(
+        paginate_models(
             app_ctx,
             after,
             before,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `paginate_models` function more generic and simplify its usage across multiple query files.
> 
>   - **Functionality**:
>     - Change `paginate_models` in `pagination.rs` to be more generic by adding type parameters `F` and `Fut` for `update_query`.
>     - Remove explicit type parameters in `paginate_models` calls in `account.rs`, `transfer.rs`, and `block.rs`.
>   - **Code Simplification**:
>     - Remove unused import `Pin` from `pagination.rs`.
>     - Minor formatting change in `transfer.rs` by removing an extra line.
>   - **Consistency**:
>     - Ensure consistent usage of `paginate_models` across `event.rs`, `message.rs`, and `transaction.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 6daa78cc779cac932c997fc5beb008533ea76b71. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->