### PR TITLE
[LEF-170] dex: events revamp

### DIFF
--- a/dango/dex/src/core/types.rs
+++ b/dango/dex/src/core/types.rs
@@ -1,4 +1,7 @@
-use grug::{Addr, Udec128, Uint128};
+use {
+    dango_types::dex::OrderKind,
+    grug::{Addr, Udec128, Uint128},
+};
 
 #[grug::derive(Borsh, Serde)]
 pub enum Order {
@@ -11,6 +14,13 @@ impl Order {
         match self {
             Order::Market(order) => order.user,
             Order::Limit(order) => order.user,
+        }
+    }
+
+    pub fn kind(&self) -> OrderKind {
+        match self {
+            Order::Market(_) => OrderKind::Market,
+            Order::Limit(_) => OrderKind::Limit,
         }
     }
 }

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -9,7 +9,7 @@ use {
     dango_types::{
         DangoQuerier,
         account_factory::Username,
-        dex::{Direction, OrderFilled, OrdersMatched},
+        dex::{Direction, LimitOrdersMatched, OrderFilled},
         taxman::{self, FeeType},
     },
     grug::{
@@ -252,7 +252,7 @@ fn clear_orders_of_pair(
         // Here we choose the midpoint.
         let clearing_price = lower_price.checked_add(higher_price)?.checked_mul(HALF)?;
 
-        events.push(OrdersMatched {
+        events.push(LimitOrdersMatched {
             base_denom: base_denom.clone(),
             quote_denom: quote_denom.clone(),
             clearing_price,
@@ -386,15 +386,16 @@ fn clear_orders_of_pair(
             // Emit event for filled user orders to be used by the frontend
             events.push(OrderFilled {
                 user: order.user(),
-                order_id,
+                id: order_id,
+                kind: order.kind(),
+                base_denom: base_denom.clone(),
+                quote_denom: quote_denom.clone(),
+                direction: order_direction,
                 clearing_price,
                 filled,
                 refund,
                 fee,
                 cleared,
-                base_denom: base_denom.clone(),
-                quote_denom: quote_denom.clone(),
-                direction: order_direction,
             })?;
 
             if let Order::Limit(limit_order) = order {

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -9,8 +9,7 @@ use {
         DangoQuerier, bank,
         dex::{
             CancelOrderRequest, CreateLimitOrderRequest, CreateMarketOrderRequest, ExecuteMsg,
-            InstantiateMsg, LP_NAMESPACE, NAMESPACE, PairId, PairUpdate, SwapExactAmountIn,
-            SwapExactAmountOut,
+            InstantiateMsg, LP_NAMESPACE, NAMESPACE, PairId, PairUpdate, Swapped,
         },
     },
     grug::{
@@ -260,6 +259,7 @@ fn swap_exact_amount_in(
     minimum_output: Option<Uint128>,
 ) -> anyhow::Result<Response> {
     let input = ctx.funds.into_one_coin()?;
+
     let (reserves, output) =
         core::swap_exact_amount_in(ctx.storage, ctx.querier, route, input.clone())?;
 
@@ -283,7 +283,7 @@ fn swap_exact_amount_in(
 
     Ok(Response::new()
         .add_message(Message::transfer(ctx.sender, output.clone())?)
-        .add_event(SwapExactAmountIn {
+        .add_event(Swapped {
             user: ctx.sender,
             input,
             output,
@@ -313,7 +313,7 @@ fn swap_exact_amount_out(
     // here, because we already ensure it's non-zero.
     Ok(Response::new()
         .add_message(Message::transfer(ctx.sender, ctx.funds)?)
-        .add_event(SwapExactAmountOut {
+        .add_event(Swapped {
             user: ctx.sender,
             input,
             output: output.into_inner(),

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -9,8 +9,8 @@ use {
         DangoQuerier, bank,
         dex::{
             CancelOrderRequest, CreateLimitOrderRequest, CreateMarketOrderRequest, ExecuteMsg,
-            InstantiateMsg, LP_NAMESPACE, NAMESPACE, PairId, PairUpdate, PairUpdated,
-            SwapExactAmountIn, SwapExactAmountOut,
+            InstantiateMsg, LP_NAMESPACE, NAMESPACE, PairId, PairUpdate, SwapExactAmountIn,
+            SwapExactAmountOut,
         },
     },
     grug::{
@@ -57,8 +57,6 @@ fn batch_update_pairs(ctx: MutableCtx, updates: Vec<PairUpdate>) -> anyhow::Resu
         "only the owner can update a trading pair parameters"
     );
 
-    let mut events = EventBuilder::with_capacity(updates.len());
-
     for update in updates {
         ensure!(
             update
@@ -75,14 +73,9 @@ fn batch_update_pairs(ctx: MutableCtx, updates: Vec<PairUpdate>) -> anyhow::Resu
             (&update.base_denom, &update.quote_denom),
             &update.params,
         )?;
-
-        events.push(PairUpdated {
-            base_denom: update.base_denom,
-            quote_denom: update.quote_denom,
-        })?;
     }
 
-    Ok(Response::new().add_events(events)?)
+    Ok(Response::new())
 }
 
 fn batch_update_orders(

--- a/dango/dex/src/execute/order_creation.rs
+++ b/dango/dex/src/execute/order_creation.rs
@@ -2,7 +2,7 @@ use {
     crate::{INCOMING_ORDERS, LimitOrder, MARKET_ORDERS, MarketOrder, NEXT_ORDER_ID, PAIRS},
     anyhow::ensure,
     dango_types::dex::{
-        CreateLimitOrderRequest, CreateMarketOrderRequest, Direction, OrderKind, OrderSubmitted,
+        CreateLimitOrderRequest, CreateMarketOrderRequest, Direction, OrderCreated, OrderKind,
     },
     grug::{Addr, Coin, Coins, EventBuilder, MultiplyFraction, Storage},
 };
@@ -41,7 +41,7 @@ pub(super) fn create_limit_order(
         order_id = !order_id;
     }
 
-    events.push(OrderSubmitted {
+    events.push(OrderCreated {
         user,
         id: order_id,
         kind: OrderKind::Limit,
@@ -104,7 +104,7 @@ pub(super) fn create_market_order(
 
     let (order_id, _) = NEXT_ORDER_ID.increment(storage)?;
 
-    events.push(OrderSubmitted {
+    events.push(OrderCreated {
         user,
         id: order_id,
         kind: OrderKind::Market,

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -4,13 +4,6 @@ use {
 };
 
 #[grug::derive(Serde)]
-#[grug::event("pair_updated")]
-pub struct PairUpdated {
-    pub base_denom: Denom,
-    pub quote_denom: Denom,
-}
-
-#[grug::derive(Serde)]
 #[grug::event("order_submitted")]
 pub struct OrderSubmitted {
     pub order_id: OrderId,

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -54,16 +54,8 @@ pub struct OrderFilled {
 }
 
 #[grug::derive(Serde)]
-#[grug::event("swap_exact_amount_in")]
-pub struct SwapExactAmountIn {
-    pub user: Addr,
-    pub input: Coin,
-    pub output: Coin,
-}
-
-#[grug::derive(Serde)]
-#[grug::event("swap_exact_amount_out")]
-pub struct SwapExactAmountOut {
+#[grug::event("swapped")]
+pub struct Swapped {
     pub user: Addr,
     pub input: Coin,
     pub output: Coin,

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -41,7 +41,7 @@ pub struct OrderCanceled {
 }
 
 #[grug::derive(Serde)]
-#[grug::event("orders_matched")]
+#[grug::event("limit_orders_matched")]
 pub struct LimitOrdersMatched {
     pub base_denom: Denom,
     pub quote_denom: Denom,

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -10,8 +10,8 @@ pub enum OrderKind {
 }
 
 #[grug::derive(Serde)]
-#[grug::event("order_submitted")]
-pub struct OrderSubmitted {
+#[grug::event("order_created")]
+pub struct OrderCreated {
     pub user: Addr,
     pub id: OrderId,
     pub kind: OrderKind,


### PR DESCRIPTION
1. Remove the `PairUpdated` event (we don't use it anywhere).
2. Merge `SwapExactAmount{In,Out}` into a single `Swapped` event.
3. Rename `OrderSubmitted` to `OrderCreated`.
4. Rename `OrdersMatched` to `LimitOrdersMatched`.
5. Modify `Order{Created,Canceled,Filled}` to support market orders.
6. Emit these events for market orders.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Revamp DEX events by merging, renaming, and updating them to support market orders and remove unused events.
> 
>   - **Events**:
>     - Remove `PairUpdated` event.
>     - Merge `SwapExactAmountIn` and `SwapExactAmountOut` into `Swapped` event in `execute.rs`.
>     - Rename `OrderSubmitted` to `OrderCreated` and `OrdersMatched` to `LimitOrdersMatched` in `events.rs`.
>     - Modify `OrderCreated`, `OrderCanceled`, and `OrderFilled` to support market orders in `events.rs`.
>   - **Order Management**:
>     - Add `OrderKind` enum to differentiate between market and limit orders in `types.rs`.
>     - Update `Order` struct in `types.rs` to include `kind()` method.
>     - Modify `create_limit_order()` and `create_market_order()` in `order_creation.rs` to emit `OrderCreated` event.
>     - Update `cancel_limit_order()` and `cancel_market_order()` in `order_cancellation.rs` to emit `OrderCanceled` event.
>   - **Misc**:
>     - Update `clear_orders_of_pair()` in `cron.rs` to emit `LimitOrdersMatched` event.
>     - Remove event handling for `PairUpdated` in `execute.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 879c01dcbc8c35585326b2a779f4bcd8256af3c3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->