### PR TITLE
fix: avoid overflow on market order max slippage

### DIFF
--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -58,11 +58,11 @@ where
         // Calculate the cutoff price for the current market order
         let cutoff_price = match market_order_direction {
             Direction::Bid => Udec128::ONE
-                .checked_add(market_order.max_slippage)?
-                .checked_mul(best_price)?,
+                .saturating_add(market_order.max_slippage)
+                .saturating_mul(best_price),
             Direction::Ask => Udec128::ONE
-                .checked_sub(market_order.max_slippage)?
-                .checked_mul(best_price)?,
+                .saturating_sub(market_order.max_slippage)
+                .saturating_mul(best_price),
         };
 
         // The direction of the comparison depends on whether the market order


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `checked_add` and `checked_mul` with `saturating_add` and `saturating_mul` in `market_order.rs` to prevent overflow in `cutoff_price` calculation.
> 
>   - **Behavior**:
>     - Replace `checked_add` with `saturating_add` and `checked_mul` with `saturating_mul` in `market_order.rs` for `cutoff_price` calculation.
>     - Prevents overflow when calculating `cutoff_price` for market orders with `max_slippage`.
>   - **Functions**:
>     - Affects `match_and_fill_market_orders()` in `market_order.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 237c147c6d2cdf88c5702802236e7a52974142e3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->