### PR TITLE
[LEF-145] Add swap exact out to geometric pool

### DIFF
--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -132,9 +132,8 @@ pub fn swap_exact_amount_out(
     // offer amount after fees. So in this case we need to divide ask by (1 - fee)
     // to get the ask amount after fees.
     // Round so that user takes the loss.
-    let output_amount_before_fee = output
-        .amount
-        .checked_div_dec_ceil(Udec128::ONE - *swap_fee_rate)?;
+    let one_sub_fee_rate = Udec128::ONE - *swap_fee_rate;
+    let output_amount_before_fee = output.amount.checked_div_dec_ceil(one_sub_fee_rate)?;
 
     let (passive_bids, passive_asks) = reflect_curve(
         oracle_querier,

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -147,13 +147,9 @@ pub fn swap_exact_amount_out(
         swap_fee_rate,
     )?;
 
-    println!("output_amount_before_fee: {output_amount_before_fee}");
-
     let input_amount = if output.denom == *base_denom {
-        println!("bid_exact_amount_out");
         bid_exact_amount_out(output_amount_before_fee, passive_asks)?
     } else if output.denom == *quote_denom {
-        println!("ask_exact_amount_out");
         ask_exact_amount_out(output_amount_before_fee, passive_bids)?
     } else {
         unreachable!(
@@ -173,19 +169,11 @@ fn bid_exact_amount_out(
     let mut input_amount = Uint128::ZERO;
 
     for (price, size) in passive_asks {
-        println!("remaining_bid: {remaining_bid}");
-        println!("size: {size}");
-        println!("price: {price}");
-
         let matched_amount = cmp::min(size, remaining_bid);
-        println!("matched_amount: {matched_amount}");
         remaining_bid.checked_sub_assign(matched_amount)?;
 
         let matched_amount_in_quote = matched_amount.checked_mul_dec_ceil(price)?;
-        println!("matched_amount_in_quote: {matched_amount_in_quote}");
         input_amount.checked_add_assign(matched_amount_in_quote)?;
-
-        println!("input_amount: {input_amount}");
 
         if remaining_bid.is_zero() {
             return Ok(input_amount);
@@ -203,20 +191,12 @@ fn ask_exact_amount_out(
     let mut input_amount = Uint128::ZERO;
 
     for (price, size) in passive_bids {
-        println!("remaining_ask_in_quote: {remaining_ask_in_quote}");
-        println!("size: {size}");
-        println!("price: {price}");
-
         let bid_size_in_quote = size.checked_mul_dec(price)?;
-        println!("bid_size_in_quote: {bid_size_in_quote}");
         let matched_amount_in_quote = cmp::min(bid_size_in_quote, remaining_ask_in_quote);
-        println!("matched_amount_in_quote: {matched_amount_in_quote}");
         remaining_ask_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
         let matched_amount_in_base = matched_amount_in_quote.checked_div_dec_ceil(price)?;
-        println!("matched_amount_in_base: {matched_amount_in_base}");
         input_amount.checked_add_assign(matched_amount_in_base)?;
-        println!("input_amount: {input_amount}");
 
         if remaining_ask_in_quote.is_zero() {
             return Ok(input_amount);

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -833,13 +833,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         },
@@ -865,13 +865,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         },
@@ -897,13 +897,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         },
@@ -929,13 +929,13 @@ mod tests {
             eth::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
             usdc::DENOM.clone() => PrecisionedPrice::new(
                 Udec128::new_percent(100),
                 Udec128::new_percent(100),
-                1730802926,
+                Timestamp::from_seconds(1730802926),
                 6,
             ),
         },

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -98,6 +98,9 @@ pub trait PassiveLiquidityPool {
     /// The output asset must be one of the reserve assets, otherwise error.
     fn swap_exact_amount_out(
         &self,
+        oracle_querier: &mut OracleQuerier,
+        base_denom: &Denom,
+        quote_denom: &Denom,
         reserve: CoinPair,
         output: Coin,
     ) -> anyhow::Result<(CoinPair, Coin)>;
@@ -299,6 +302,9 @@ impl PassiveLiquidityPool for PairParams {
 
     fn swap_exact_amount_out(
         &self,
+        oracle_querier: &mut OracleQuerier,
+        base_denom: &Denom,
+        quote_denom: &Denom,
         mut reserve: CoinPair,
         output: Coin,
     ) -> anyhow::Result<(CoinPair, Coin)> {
@@ -325,7 +331,19 @@ impl PassiveLiquidityPool for PairParams {
                 output_reserve,
                 self.swap_fee_rate,
             )?,
-            PassiveLiquidity::Geometric { .. } => geometric::swap_exact_amount_out()?,
+            PassiveLiquidity::Geometric {
+                ratio,
+                order_spacing,
+            } => geometric::swap_exact_amount_out(
+                oracle_querier,
+                base_denom,
+                quote_denom,
+                &output,
+                &reserve,
+                ratio,
+                order_spacing,
+                self.swap_fee_rate,
+            )?,
         };
 
         let input = Coin {

--- a/dango/dex/src/core/router.rs
+++ b/dango/dex/src/core/router.rs
@@ -41,15 +41,12 @@ pub fn swap_exact_amount_in(
 
 pub fn swap_exact_amount_out(
     storage: &dyn Storage,
-    querier: QuerierWrapper,
+    oracle_querier: &mut OracleQuerier<'_>,
     route: UniqueVec<PairId>,
     output: NonZero<Coin>,
 ) -> anyhow::Result<(HashMap<PairId, CoinPair>, Coin)> {
     let mut reserves = HashMap::new();
     let mut input = output.into_inner();
-
-    let oracle_address = querier.query_oracle()?;
-    let mut oracle_querier = OracleQuerier::new_remote(oracle_address, querier);
 
     for pair in route.into_iter().rev() {
         // Load the pair's parameters.
@@ -60,7 +57,7 @@ pub fn swap_exact_amount_out(
 
         // Perform the swap.
         (reserve, input) = params.swap_exact_amount_out(
-            &mut oracle_querier,
+            oracle_querier,
             &pair.base_denom,
             &pair.quote_denom,
             reserve,

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -303,8 +303,13 @@ fn swap_exact_amount_out(
     route: UniqueVec<PairId>,
     output: NonZero<Coin>,
 ) -> anyhow::Result<Response> {
+    // Create the oracle querier with max staleness.
+    let mut oracle_querier = OracleQuerier::new_remote(ctx.querier.query_oracle()?, ctx.querier)
+        .with_no_older_than(ctx.block.timestamp - MAX_ORACLE_STALENESS);
+
+    // Perform the swap.
     let (reserves, input) =
-        core::swap_exact_amount_out(ctx.storage, ctx.querier, route, output.clone())?;
+        core::swap_exact_amount_out(ctx.storage, &mut oracle_querier, route, output.clone())?;
 
     // The user must have sent no less than the required input amount.
     // Any extra is refunded.

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -303,7 +303,8 @@ fn swap_exact_amount_out(
     route: UniqueVec<PairId>,
     output: NonZero<Coin>,
 ) -> anyhow::Result<Response> {
-    let (reserves, input) = core::swap_exact_amount_out(ctx.storage, route, output.clone())?;
+    let (reserves, input) =
+        core::swap_exact_amount_out(ctx.storage, ctx.querier, route, output.clone())?;
 
     // The user must have sent no less than the required input amount.
     // Any extra is refunded.

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -384,6 +384,9 @@ fn query_simulate_swap_exact_amount_out(
     route: SwapRoute,
     output: NonZero<Coin>,
 ) -> anyhow::Result<Coin> {
-    core::swap_exact_amount_out(ctx.storage, route.into_inner(), output)
+    let mut oracle_querier = OracleQuerier::new_remote(ctx.querier.query_oracle()?, ctx.querier)
+        .with_no_older_than(ctx.block.timestamp - MAX_ORACLE_STALENESS);
+
+    core::swap_exact_amount_out(ctx.storage, &mut oracle_querier, route.into_inner(), output)
         .map(|(_updated_reserves, input)| input)
 }


### PR DESCRIPTION
Fixes LEF-145
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `swap_exact_amount_out` to geometric pool, updating related functions and adding tests.
> 
>   - **Behavior**:
>     - Adds `swap_exact_amount_out` function to `geometric.rs` for swaps with fixed output amount.
>     - Updates `swap_exact_amount_out` in `liquidity_pool.rs` to use the new geometric function.
>     - Modifies `swap_exact_amount_out` in `router.rs` and `execute.rs` to handle new geometric pool logic.
>   - **Tests**:
>     - Adds test cases for `swap_exact_amount_out` in `liquidity_pool.rs` to validate geometric pool swaps.
>     - Updates `query.rs` to simulate `swap_exact_amount_out` for testing purposes.
>   - **Misc**:
>     - Removes unused import `StdResult` from `geometric.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 7c1a9eedb9907bac765328b6a94ea8162658d383. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->