### PR TITLE
chore: address a new lint introduced in rust 1.88

### DIFF
--- a/dango/cli/src/indexer.rs
+++ b/dango/cli/src/indexer.rs
@@ -106,8 +106,8 @@ impl IndexerCmd {
 
                             if block_text.contains(&text) || block_results.contains(&text) {
                                 println!("Found in block {block}:");
-                                println!("Block: {:#?}", block_text);
-                                println!("Block Outcome: {:#?}", block_results);
+                                println!("Block: {block_text:#?}");
+                                println!("Block Outcome: {block_results:#?}");
                             }
                         });
                     });

--- a/dango/testing/tests/margin.rs
+++ b/dango/testing/tests/margin.rs
@@ -877,7 +877,7 @@ struct Debt {
 
 /// Proptest strategy for generating a single Denom
 fn denom(index: usize) -> impl Strategy<Value = Denom> {
-    Just(Denom::from_str(&format!("denom{}", index)).unwrap())
+    Just(Denom::from_str(&format!("denom{index}")).unwrap())
 }
 
 /// Proptest strategy for generating a single TestDenom

--- a/grug/app/src/abci.rs
+++ b/grug/app/src/abci.rs
@@ -197,10 +197,10 @@ where
                     .enumerate()
                     .map(|(id, cron)| {
                         Ok(abci::Event {
-                            kind: format!("cron-{}", id),
+                            kind: format!("cron-{id}"),
                             attributes: vec![abci::EventAttribute::V037(
                                 abci::v0_37::EventAttribute {
-                                    key: format!("cron-{}", id),
+                                    key: format!("cron-{id}"),
                                     value: cron.to_json_string()?,
                                     index: false,
                                 },

--- a/grug/bob-the-builder/src/main.rs
+++ b/grug/bob-the-builder/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
 
     println!("contracts to build:");
     for member in &members {
-        println!("- {}", member);
+        println!("- {member}");
     }
 
     // Build the crates.

--- a/grug/math/src/dec.rs
+++ b/grug/math/src/dec.rs
@@ -846,10 +846,10 @@ mod tests {
                 let dec = bt(_0d, dec(base));
 
                 let serialized_str = serde_json::to_string(&dec).unwrap();
-                assert_eq!(serialized_str, format!("\"{}\"", base));
+                assert_eq!(serialized_str, format!("\"{base}\""));
 
                 let serialized_vec = serde_json::to_vec(&dec).unwrap();
-                assert_eq!(serialized_vec, format!("\"{}\"", base).as_bytes());
+                assert_eq!(serialized_vec, format!("\"{base}\"").as_bytes());
 
                 let parsed: Dec::<_, 18> = serde_json::from_str(&serialized_str).unwrap();
                 assert_eq!(parsed, dec);

--- a/grug/math/src/int.rs
+++ b/grug/math/src/int.rs
@@ -451,7 +451,7 @@ pub mod tests {
         }
         method = |_, samples| {
             for (number, str) in samples {
-                assert_eq!(format!("{}", number), str);
+                assert_eq!(format!("{number}"), str);
             }
         }
     );
@@ -484,7 +484,7 @@ pub mod tests {
         method = |_0, samples| {
             for (padded_str, compare) in samples {
                 let uint = bt(_0, Int::from_str(padded_str).unwrap());
-                assert_eq!(format!("{}", uint), compare);
+                assert_eq!(format!("{uint}"), compare);
             }
         }
     );
@@ -509,10 +509,10 @@ pub mod tests {
                 let original = bt(_0, Int::from_str(sample).unwrap());
 
                 let serialized_str = serde_json::to_string(&original).unwrap();
-                assert_eq!(serialized_str, format!("\"{}\"", sample));
+                assert_eq!(serialized_str, format!("\"{sample}\""));
 
                 let serialized_vec = serde_json::to_vec(&original).unwrap();
-                assert_eq!(serialized_vec, format!("\"{}\"", sample).as_bytes());
+                assert_eq!(serialized_vec, format!("\"{sample}\"").as_bytes());
 
                 let parsed: Int::<_> = serde_json::from_str(&serialized_str).unwrap();
                 assert_eq!(parsed, original);

--- a/grug/storage/src/prefix.rs
+++ b/grug/storage/src/prefix.rs
@@ -585,7 +585,7 @@ mod test {
 
         // set some data, we care about "foo" prefix
         for i in 0..1000u32 {
-            storage.write(&concat(&[0, 3], format!("foo{}", i).as_bytes()), b"1");
+            storage.write(&concat(&[0, 3], format!("foo{i}").as_bytes()), b"1");
         }
 
         assert_eq!(
@@ -602,7 +602,7 @@ mod test {
 
         // set less data
         for i in 0..5u32 {
-            storage.write(&concat(&[0, 3], format!("foo{}", i).as_bytes()), b"1");
+            storage.write(&concat(&[0, 3], format!("foo{i}").as_bytes()), b"1");
         }
 
         assert_eq!(

--- a/grug/testing/tests/reply.rs
+++ b/grug/testing/tests/reply.rs
@@ -131,7 +131,7 @@ mod replier {
     pub fn reply(ctx: SudoCtx, msg: ReplyMsg, res: SubMsgResult) -> StdResult<Response> {
         let msg = match (res, msg) {
             (GenericResult::Err(wee), ReplyMsg::Fail(execute_msg)) => {
-                println!("replying with error: {}", wee);
+                println!("replying with error: {wee}");
                 execute_msg
             },
             (GenericResult::Ok(_), ReplyMsg::Ok(execute_msg)) => execute_msg,

--- a/grug/types/src/coin_pair.rs
+++ b/grug/types/src/coin_pair.rs
@@ -204,8 +204,7 @@ impl CoinPair {
             self.second_mut().amount.checked_add_assign(other.amount)?;
         } else {
             return Err(StdError::invalid_coins(format!(
-                "can't add coin {} to coin pair {:?}",
-                other, self
+                "can't add coin {other} to coin pair {self:?}"
             )));
         }
 
@@ -223,8 +222,7 @@ impl CoinPair {
             self.second_mut().amount.checked_sub_assign(other.amount)?;
         } else {
             return Err(StdError::invalid_coins(format!(
-                "can't subtract coin {} from coin pair {:?}",
-                other, self
+                "can't subtract coin {other} from coin pair {self:?}"
             )));
         }
 

--- a/grug/vm/wasm/src/environment.rs
+++ b/grug/vm/wasm/src/environment.rs
@@ -483,7 +483,7 @@ mod test {
             (Err(result), Err(output)) => {
                 assert_eq!(result.to_string(), output.to_string());
             },
-            _ => panic!("Mismatched results: \n{:?}, \n{:?}", result, output),
+            _ => panic!("Mismatched results:\n{result:?},\n{output:?}"),
         }
     }
 

--- a/indexer/client/src/client.rs
+++ b/indexer/client/src/client.rs
@@ -135,7 +135,7 @@ impl BlockClient for HttpClient {
 
     async fn query_block(&self, height: Option<u64>) -> Result<Block, Self::Error> {
         let path = match height {
-            Some(height) => format!("api/block/info/{}", height),
+            Some(height) => format!("api/block/info/{height}"),
             None => "api/block/info".to_string(),
         };
 
@@ -144,7 +144,7 @@ impl BlockClient for HttpClient {
 
     async fn query_block_outcome(&self, height: Option<u64>) -> Result<BlockOutcome, Self::Error> {
         let path = match height {
-            Some(height) => format!("api/block/result/{}", height),
+            Some(height) => format!("api/block/result/{height}"),
             None => "api/block/result".to_string(),
         };
 

--- a/indexer/httpd/src/bin/build_graphql_schema.rs
+++ b/indexer/httpd/src/bin/build_graphql_schema.rs
@@ -18,5 +18,5 @@ fn main() {
     let sdl = schema.sdl();
     std::fs::write(&filename, sdl).unwrap();
 
-    println!("Schema generated successfully at: {:?}", filename);
+    println!("Schema generated successfully at: {filename:?}");
 }

--- a/indexer/httpd/src/graphql/query/grug.rs
+++ b/indexer/httpd/src/graphql/query/grug.rs
@@ -39,7 +39,7 @@ impl GrugQuery {
         let value = if let Some(value) = value {
             Binary::from(value).to_string()
         } else {
-            return Err(Error::new(format!("Key not found: {}", key)));
+            return Err(Error::new(format!("Key not found: {key}")));
         };
 
         Ok(Store {

--- a/indexer/httpd/src/routes/api/blocks.rs
+++ b/indexer/httpd/src/routes/api/blocks.rs
@@ -28,7 +28,7 @@ fn _block_by_height(block_height: u64, app_ctx: &Context) -> Result<HttpResponse
     let block_filename = app_ctx.indexer_path.block_path(block_height);
 
     if !BlockToIndex::exists(block_filename.clone()) {
-        println!("Block not found: {:?}", block_filename);
+        println!("Block not found: {block_filename:?}");
         return Ok(HttpResponse::NotFound().body("Block not found"));
     }
 

--- a/indexer/httpd/src/server.rs
+++ b/indexer/httpd/src/server.rs
@@ -122,7 +122,7 @@ where
                     async move {
                         let metrics2 = metrics_handler2.render();
                         let metrics = metrics_handler.render();
-                        let combined = format!("{}\n{}", metrics, metrics2);
+                        let combined = format!("{metrics}\n{metrics2}");
 
                         HttpResponse::Ok()
                             .content_type("text/plain; version=0.0.4")

--- a/indexer/sql/src/error.rs
+++ b/indexer/sql/src/error.rs
@@ -59,7 +59,7 @@ impl From<IndexerError> for AppError {
 
 impl<T> From<std::sync::PoisonError<T>> for IndexerError {
     fn from(err: std::sync::PoisonError<T>) -> Self {
-        IndexerError::Poison(format!("Poisoned mutex: {:?}", err))
+        IndexerError::Poison(err.to_string())
     }
 }
 

--- a/indexer/testing/tests/graphql/datetime.rs
+++ b/indexer/testing/tests/graphql/datetime.rs
@@ -55,15 +55,13 @@ async fn graphql_returns_iso_8601() -> anyhow::Result<()> {
                 // Verify that it ends with Z (UTC time zone indicator).
                 assert!(
                     created_at.ends_with('Z'),
-                    "`createdAt` should end with Z for UTC time zone: {}",
-                    created_at
+                    "`createdAt` should end with Z for UTC time zone: {created_at}"
                 );
 
                 // Verify that it can be parsed as a valid RFC 3339 datetime.
                 assert!(
                     chrono::DateTime::parse_from_rfc3339(created_at).is_ok(),
-                    "`createdAt` should be valid RFC 3339 format: {}",
-                    created_at
+                    "`createdAt` should be valid RFC 3339 format: {created_at}"
                 );
 
                 Ok::<(), anyhow::Error>(())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update string formatting to new syntax across multiple files for Rust 1.88 compatibility.
> 
>   - **String Formatting**:
>     - Update to use new format string syntax in `indexer.rs`, `margin.rs`, `abci.rs`, `main.rs`, `dec.rs`, `int.rs`, `prefix.rs`, `reply.rs`, `coin_pair.rs`, `environment.rs`, `client.rs`, `build_graphql_schema.rs`, `grug.rs`, `blocks.rs`, `server.rs`, `error.rs`, `datetime.rs`.
>     - Examples include changing `format!("{}", var)` to `format!("{var}")`.
>   - **Error Handling**:
>     - Update error message formatting in `error.rs` to use new syntax.
>   - **Logging**:
>     - Update logging statements to use new format string syntax in `server.rs` and `blocks.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 0b6cf82ad7a75c00b38502ac511bbea07175af3b. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->