### PR TITLE
fix(ui): pro trade styles

### DIFF
--- a/ui/applets/kit/src/components/AccordionItem.tsx
+++ b/ui/applets/kit/src/components/AccordionItem.tsx
@@ -1,7 +1,5 @@
-import { useState } from "react";
-
 import { AnimatePresence, motion } from "framer-motion";
-import { IconChevronDown } from "./icons/IconChevronDown";
+import { IconChevronDownFill } from "./icons/IconChevronDownFill";
 
 import { twMerge } from "#utils/twMerge.js";
 
@@ -52,7 +50,7 @@ export const AccordionItem: React.FC<PropsWithChildren<AccordionItemProps>> = ({
             classNames?.icon,
           )}
         >
-          {icon ? icon : <IconChevronDown />}
+          {icon ? icon : <IconChevronDownFill className="w-4 h-4" />}
         </div>
       </div>
 

--- a/ui/applets/kit/src/components/CoinSelector.tsx
+++ b/ui/applets/kit/src/components/CoinSelector.tsx
@@ -26,7 +26,7 @@ export const CoinSelector: React.FC<Props> = ({ coins, defaultValue, classNames,
         listboxWrapper: `top-12 ${classNames?.listboxWrapper}`,
         listbox: `${classNames?.listbox}`,
         value: `${classNames?.value}`,
-        trigger: `min-w-14 p-3 bg-transparent shadow-none justify-start ${classNames?.trigger}`,
+        trigger: `min-w-10 p-3 bg-transparent shadow-none justify-start ${classNames?.trigger}`,
         icon: `${classNames?.selectorIcon}`,
       }}
       {...props}

--- a/ui/applets/kit/src/components/ExpandOptions.tsx
+++ b/ui/applets/kit/src/components/ExpandOptions.tsx
@@ -3,7 +3,7 @@ import { Children, useState } from "react";
 import { twMerge } from "#utils/twMerge.js";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { IconChevronDown } from "./icons/IconChevronDown";
+import { IconChevronDownFill } from "./icons/IconChevronDownFill";
 
 import type React from "react";
 import type { PropsWithChildren } from "react";
@@ -33,7 +33,7 @@ export const ExpandOptions: React.FC<PropsWithChildren<ExpandOptionsProps>> = ({
           onClick={() => setOptionExpanded(!isOptionExpanded)}
         >
           <p>{showOptionText}</p>
-          <IconChevronDown
+          <IconChevronDownFill
             className={twMerge(
               "w-4 h-4 transition-all duration-300",
               isOptionExpanded ? "rotate-180" : "rotate-0",

--- a/ui/applets/kit/src/components/Popover.tsx
+++ b/ui/applets/kit/src/components/Popover.tsx
@@ -3,7 +3,7 @@ import React, { useId, useImperativeHandle, useRef } from "react";
 import { Popover as HPopover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { ResizerContainer } from "./ResizerContainer";
-import { IconChevronDown } from "./icons/IconChevronDown";
+import { IconChevronDownFill } from "./icons/IconChevronDownFill";
 
 import { twMerge } from "#utils/twMerge.js";
 
@@ -44,8 +44,8 @@ export const Popover = React.forwardRef<PopoverRef, PopoverProps>(
             >
               {trigger}
               {showArrow && (
-                <IconChevronDown
-                  className={twMerge("transition-all w-5 h-5", open && "rotate-180")}
+                <IconChevronDownFill
+                  className={twMerge("transition-all w-4 h-4", open && "rotate-180")}
                 />
               )}
             </PopoverButton>

--- a/ui/applets/kit/src/components/Range.tsx
+++ b/ui/applets/kit/src/components/Range.tsx
@@ -198,7 +198,7 @@ export const Range: React.FC<RangeProps> = ({
       {label && <div className="text-gray-500 exposure-xs-italic">{label}</div>}
 
       <div className="flex items-center gap-3">
-        <div className="flex flex-col flex-1">
+        <div className="flex flex-col flex-1 px-[10px]">
           <div
             ref={sliderRef}
             className={twMerge(

--- a/ui/applets/kit/src/components/Range.tsx
+++ b/ui/applets/kit/src/components/Range.tsx
@@ -217,7 +217,7 @@ export const Range: React.FC<RangeProps> = ({
             />
             <div
               className={twMerge(
-                "absolute top-1/2 w-4 h-4 rounded-full shadow-md focus:outline-none focus:ring-1 focus:ring-red-bean-600",
+                "absolute top-1/2 w-4 h-4 rounded-full shadow-md focus:outline-none focus:border-red-bean-600",
                 isDisabled
                   ? "bg-gray-300 border-2 border-gray-500"
                   : "bg-white border-2 border-red-bean-500 cursor-grab active:cursor-grabbing",

--- a/ui/applets/kit/src/components/Select.tsx
+++ b/ui/applets/kit/src/components/Select.tsx
@@ -11,7 +11,7 @@ import { useClickAway } from "react-use";
 import { useControlledState } from "#hooks/index.js";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { IconChevronDown } from "./icons/IconChevronDown";
+import { IconChevronDownFill } from "./icons/IconChevronDownFill";
 
 import { tv } from "tailwind-variants";
 import { twMerge } from "#utils/index.js";
@@ -86,7 +86,9 @@ const Root: React.FC<PropsWithChildren<SelectProps>> = (props) => {
                 )?.props.children
               }
             </span>
-            <IconChevronDown className={twMerge(icon(), classNames?.icon)} />
+            <IconChevronDownFill
+              className={twMerge(icon(), classNames?.icon, { "rotate-180": isOpen })}
+            />
           </button>
 
           <motion.div
@@ -183,7 +185,7 @@ export const NativeSelect: React.FC<PropsWithChildren<NativeSelectProps>> = ({
       </select>
       <label htmlFor={selectId} className={trigger({ className: classNames?.trigger })}>
         <span>{SelectedItem?.props.children}</span>
-        <IconChevronDown className={twMerge("w-[20px] h-[20px] transition-all duration-300")} />
+        <IconChevronDownFill className={twMerge("w-4 h-4 transition-all duration-300")} />
       </label>
     </div>
   );
@@ -196,7 +198,7 @@ const selectVariants = tv({
       "rounded-md overflow-hidden max-h-[12rem] w-full transition-all z-50 shadow-account-card top-[3.375rem] bg-rice-25 absolute",
     trigger:
       "w-full inline-flex tap-highlight-transparent flex-row items-center justify-between px-4 py-3 gap-3 outline-none shadow-account-card diatype-m-regular h-[46px] rounded-md bg-rice-25",
-    icon: "top-[10px] right-4 absolute pointer-events-none w-[20px] h-[20px] transition-all duration-300",
+    icon: "top-1/2 -translate-y-1/2 right-4 absolute pointer-events-none w-4 h-4 transition-all duration-300",
   },
   variants: {
     isDisabled: {

--- a/ui/applets/kit/src/components/Select.tsx
+++ b/ui/applets/kit/src/components/Select.tsx
@@ -183,9 +183,7 @@ export const NativeSelect: React.FC<PropsWithChildren<NativeSelectProps>> = ({
       </select>
       <label htmlFor={selectId} className={trigger({ className: classNames?.trigger })}>
         <span>{SelectedItem?.props.children}</span>
-        <IconChevronDown
-          className={twMerge("min-w-[20px] min-h-[20px] transition-all duration-300")}
-        />
+        <IconChevronDown className={twMerge("w-[20px] h-[20px] transition-all duration-300")} />
       </label>
     </div>
   );
@@ -198,7 +196,7 @@ const selectVariants = tv({
       "rounded-md overflow-hidden max-h-[12rem] w-full transition-all z-50 shadow-account-card top-[3.375rem] bg-rice-25 absolute",
     trigger:
       "w-full inline-flex tap-highlight-transparent flex-row items-center justify-between px-4 py-3 gap-3 outline-none shadow-account-card diatype-m-regular h-[46px] rounded-md bg-rice-25",
-    icon: "top-[10px] right-4 absolute pointer-events-none min-w-[20px] min-h-[20px] transition-all duration-300",
+    icon: "top-[10px] right-4 absolute pointer-events-none w-[20px] h-[20px] transition-all duration-300",
   },
   variants: {
     isDisabled: {

--- a/ui/applets/kit/src/components/Tabs.tsx
+++ b/ui/applets/kit/src/components/Tabs.tsx
@@ -126,7 +126,7 @@ const tabsVariants = tv({
           "bg-green-bean-400 [box-shadow:0px_4px_6px_2px_#1919191F] w-full h-full rounded-[10px]",
       },
       "line-red": {
-        base: "",
+        base: "p-0",
         button: "border-b-[1px] border-gray-100",
         "animated-element": "bg-red-bean-400 w-full h-[2px] bottom-[-1px]",
       },

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -30,7 +30,7 @@ export const OrderBookOverview: React.FC = () => {
         keys={isLg ? ["order book", "trades"] : ["graph", "order book", "trades"]}
         fullWidth
         onTabChange={(tab) => setActiveTab(tab as "order book" | "trades")}
-        classNames={{ button: "exposure-xs-italic" }}
+        classNames={{ button: "exposure-xs-italic pt-0", base: "p-0" }}
       />
       {activeTab === "graph" && <TradingViewChart />}
       {activeTab === "order book" && <OrderBook />}

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -21,7 +21,7 @@ export const OrderBookOverview: React.FC = () => {
   return (
     <ResizerContainer
       layoutId="order-book-section"
-      className="p-4 shadow-card-shadow bg-rice-25 flex flex-col gap-2 w-full xl:[width:clamp(279px,20vw,422px)] min-h-[27.25rem] lg:min-h-[37.9rem]"
+      className="p-4 shadow-card-shadow bg-rice-25 flex flex-col gap-2 w-full xl:[width:clamp(279px,20vw,330px)] min-h-[27.25rem] lg:min-h-[37.9rem]"
     >
       <Tabs
         color="line-red"

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -30,7 +30,7 @@ export const OrderBookOverview: React.FC = () => {
         keys={isLg ? ["order book", "trades"] : ["graph", "order book", "trades"]}
         fullWidth
         onTabChange={(tab) => setActiveTab(tab as "order book" | "trades")}
-        classNames={{ button: "exposure-xs-italic pt-0", base: "p-0" }}
+        classNames={{ button: "exposure-xs-italic pt-0" }}
       />
       {activeTab === "graph" && <TradingViewChart />}
       {activeTab === "order book" && <OrderBook />}

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -260,7 +260,7 @@ const ProTradeOrders: React.FC = () => {
           classNames={{ button: "exposure-xs-italic" }}
         />
 
-        <span className="w-full absolute h-[1px] bg-gray-100 bottom-[0.25rem]" />
+        <span className="w-full absolute h-[1px] bg-gray-100 bottom-[1px]" />
       </div>
       <div className="w-full h-full relative">
         {activeTab === "open order" ? (

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -14,7 +14,14 @@ import { useApp } from "~/hooks/useApp";
 import { formatUnits, parseUnits } from "@left-curve/dango/utils";
 import { m } from "~/paraglide/messages";
 
-import { Badge, Cell, IconChevronDown, IconEmptyStar, Table, Tabs } from "@left-curve/applets-kit";
+import {
+  Badge,
+  Cell,
+  IconChevronDownFill,
+  IconEmptyStar,
+  Table,
+  Tabs,
+} from "@left-curve/applets-kit";
 import { AnimatePresence, motion } from "framer-motion";
 import { OrderBookOverview } from "./OrderBookOverview";
 import { SearchToken } from "./SearchToken";
@@ -88,8 +95,8 @@ const ProTradeHeader: React.FC = () => {
             className="cursor-pointer flex items-center justify-center lg:hidden"
             onClick={() => setIsExpanded(!isExpanded)}
           >
-            <IconChevronDown
-              className={twMerge("text-gray-500 w-5 h-5 transition-all", {
+            <IconChevronDownFill
+              className={twMerge("text-gray-500 w-4 h-4 transition-all", {
                 "rotate-180": isExpanded,
               })}
             />

--- a/ui/portal/web/src/components/dex/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/SearchToken.tsx
@@ -2,7 +2,7 @@ import { useAppConfig, useConfig } from "@left-curve/store";
 import { useRef, useState } from "react";
 
 import {
-  IconChevronDown,
+  IconChevronDownFill,
   IconSearch,
   Input,
   Popover,
@@ -33,11 +33,8 @@ const SearchTokenHeader: React.FC<SearchTokenHeaderProps> = ({ pairId, isOpen })
     <div className="flex gap-2 items-center">
       <img src={baseCoin.logoURI} alt={baseCoin.symbol} className="h-6 w-6 drag-none select-none" />
       <p className="diatype-lg-heavy text-gray-700 min-w-fit">{`${baseCoin.symbol}-${quoteCoin.symbol}`}</p>
-      <IconChevronDown
-        className={twMerge(
-          "text-gray-500 w-[20px] h-[20px] transition-all",
-          isOpen ? "rotate-180" : "",
-        )}
+      <IconChevronDownFill
+        className={twMerge("text-gray-500 w-4 h-4 transition-all", isOpen ? "rotate-180" : "")}
       />
     </div>
   );

--- a/ui/portal/web/src/components/dex/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/SearchToken.tsx
@@ -32,7 +32,9 @@ const SearchTokenHeader: React.FC<SearchTokenHeaderProps> = ({ pairId, isOpen })
   return (
     <div className="flex gap-2 items-center">
       <img src={baseCoin.logoURI} alt={baseCoin.symbol} className="h-6 w-6 drag-none select-none" />
-      <p className="diatype-lg-heavy text-gray-700 min-w-fit">{`${baseCoin.symbol}-${quoteCoin.symbol}`}</p>
+      <p className="diatype-lg-heavy text-gray-700 min-w-fit">
+        {`${baseCoin.symbol}-${quoteCoin.symbol}`} LP
+      </p>
       <IconChevronDownFill
         className={twMerge(
           "text-gray-500 w-4 h-4 transition-all lg:hidden",

--- a/ui/portal/web/src/components/dex/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/SearchToken.tsx
@@ -2,11 +2,12 @@ import { useAppConfig, useConfig } from "@left-curve/store";
 import { useRef, useState } from "react";
 
 import {
-  IconChevronDownFill,
+  IconChevronDown,
   IconSearch,
   Input,
   Popover,
   Tabs,
+  twMerge,
   useMediaQuery,
 } from "@left-curve/applets-kit";
 import { Sheet } from "react-modal-sheet";
@@ -20,17 +21,24 @@ import type React from "react";
 
 type SearchTokenHeaderProps = {
   pairId: PairId;
+  isOpen?: boolean;
 };
 
-const SearchTokenHeader: React.FC<SearchTokenHeaderProps> = ({ pairId }) => {
+const SearchTokenHeader: React.FC<SearchTokenHeaderProps> = ({ pairId, isOpen }) => {
   const { coins } = useConfig();
   const baseCoin = coins[pairId.baseDenom];
   const quoteCoin = coins[pairId.quoteDenom];
+
   return (
     <div className="flex gap-2 items-center">
       <img src={baseCoin.logoURI} alt={baseCoin.symbol} className="h-6 w-6 drag-none select-none" />
       <p className="diatype-lg-heavy text-gray-700 min-w-fit">{`${baseCoin.symbol}-${quoteCoin.symbol}`}</p>
-      <IconChevronDownFill className="text-gray-500 w-4 h-4 transition-all" />
+      <IconChevronDown
+        className={twMerge(
+          "text-gray-500 w-[20px] h-[20px] transition-all",
+          isOpen ? "rotate-180" : "",
+        )}
+      />
     </div>
   );
 };
@@ -63,7 +71,7 @@ const SearchTokenMenu: React.FC<SearchTokenProps> = ({ pairId, onChangePairId })
           onTabChange={setActiveFilter}
         />
 
-        <span className="w-full absolute h-[1px] bg-gray-100 bottom-[0.25rem]" />
+        <span className="w-full absolute h-[1px] bg-gray-100 bottom-[1px]" />
       </div>
       <SearchTokenTable>
         <SearchTokenTable.Spot
@@ -94,7 +102,7 @@ export const SearchToken: React.FC<SearchTokenProps> = ({ pairId, onChangePairId
         ref={popoverRef}
         classNames={{ menu: "min-w-[45rem]" }}
         showArrow={false}
-        trigger={<SearchTokenHeader pairId={pairId} />}
+        trigger={<SearchTokenHeader pairId={pairId} isOpen={isSearchTokenVisible} />}
         menu={
           <SearchTokenMenu
             pairId={pairId}
@@ -110,7 +118,7 @@ export const SearchToken: React.FC<SearchTokenProps> = ({ pairId, onChangePairId
   return (
     <>
       <div onClick={() => setIsSearchTokenVisible(true)} className="cursor-pointer">
-        <SearchTokenHeader pairId={pairId} />
+        <SearchTokenHeader pairId={pairId} isOpen={isSearchTokenVisible} />
       </div>
       <Sheet
         isOpen={isSearchTokenVisible}

--- a/ui/portal/web/src/components/dex/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/SearchToken.tsx
@@ -34,7 +34,10 @@ const SearchTokenHeader: React.FC<SearchTokenHeaderProps> = ({ pairId, isOpen })
       <img src={baseCoin.logoURI} alt={baseCoin.symbol} className="h-6 w-6 drag-none select-none" />
       <p className="diatype-lg-heavy text-gray-700 min-w-fit">{`${baseCoin.symbol}-${quoteCoin.symbol}`}</p>
       <IconChevronDownFill
-        className={twMerge("text-gray-500 w-4 h-4 transition-all", isOpen ? "rotate-180" : "")}
+        className={twMerge(
+          "text-gray-500 w-4 h-4 transition-all lg:hidden",
+          isOpen ? "rotate-180" : "",
+        )}
       />
     </div>
   );
@@ -98,7 +101,6 @@ export const SearchToken: React.FC<SearchTokenProps> = ({ pairId, onChangePairId
       <Popover
         ref={popoverRef}
         classNames={{ menu: "min-w-[45rem]" }}
-        showArrow={false}
         trigger={<SearchTokenHeader pairId={pairId} isOpen={isSearchTokenVisible} />}
         menu={
           <SearchTokenMenu

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -8,7 +8,7 @@ import {
   Checkbox,
   CoinSelector,
   IconButton,
-  IconChevronDown,
+  IconChevronDownFill,
   IconUser,
   Input,
   Range,
@@ -347,7 +347,7 @@ const Menu: React.FC<TradeMenuProps> = ({ state, controllers, className }) => {
           className="lg:hidden"
           onClick={() => setTradeBarVisibility(false)}
         >
-          <IconChevronDown className="h-6 w-6" />
+          <IconChevronDownFill className="h-4 w-4" />
         </IconButton>
         <Tabs
           layoutId={!isLg ? "tabs-sell-and-buy-mobile" : "tabs-sell-and-buy"}

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -80,7 +80,7 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
           fullWidth
           onTabChange={(tab) => setOperation(tab as "market" | "limit")}
           color="line-red"
-          classNames={{ button: "exposure-xs-italic" }}
+          classNames={{ button: "exposure-xs-italic pt-0" }}
           isDisabled={submission.isPending}
         />
         <div className="flex items-center justify-between gap-2">
@@ -261,6 +261,7 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ state }) => {
         fullWidth
         onTabChange={(tab) => setOperation(tab as "market" | "limit")}
         color="line-red"
+        classNames={{ button: "pt-0" }}
       />
       <div className="flex items-center justify-between gap-2">
         <p className="diatype-xs-medium text-gray-500">Current Position</p>

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -73,16 +73,6 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
   return (
     <div className="w-full flex flex-col justify-between h-full gap-4 flex-1">
       <div className="w-full flex flex-col gap-4 px-4">
-        <Tabs
-          layoutId={!isLg ? "tabs-market-limit-mobile" : "tabs-market-limit"}
-          selectedTab={operation}
-          keys={["market", "limit"]}
-          fullWidth
-          onTabChange={(tab) => setOperation(tab as "market" | "limit")}
-          color="line-red"
-          classNames={{ button: "exposure-xs-italic pt-0" }}
-          isDisabled={submission.isPending}
-        />
         <div className="flex items-center justify-between gap-2">
           <p className="diatype-xs-regular text-gray-500">
             {m["dex.protrade.spot.availableToTrade"]()}
@@ -335,14 +325,26 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ state }) => {
 const Menu: React.FC<TradeMenuProps> = ({ state, controllers, className }) => {
   const { isLg } = useMediaQuery();
   const { setTradeBarVisibility, setSidebarVisibility } = useApp();
-  const { action, changeAction, type, submission } = state;
+  const { action, changeAction, type, submission, operation, setOperation } = state;
 
   return (
     <div className={twMerge("w-full flex items-center flex-col gap-4 relative", className)}>
       <div className="w-full flex items-center justify-between px-4 gap-2">
+        <Tabs
+          layoutId={!isLg ? "tabs-market-limit-mobile" : "tabs-market-limit"}
+          selectedTab={operation}
+          keys={["market", "limit"]}
+          fullWidth
+          onTabChange={(tab) => setOperation(tab as "market" | "limit")}
+          color="line-red"
+          classNames={{ button: "exposure-xs-italic pt-0" }}
+          isDisabled={submission.isPending}
+        />
+      </div>
+      <div className="w-full flex items-center justify-between px-4 gap-2">
         <IconButton
           variant="utility"
-          size="lg"
+          size="md"
           type="button"
           className="lg:hidden"
           onClick={() => setTradeBarVisibility(false)}
@@ -361,7 +363,7 @@ const Menu: React.FC<TradeMenuProps> = ({ state, controllers, className }) => {
         />
         <IconButton
           variant="utility"
-          size="lg"
+          size="md"
           type="button"
           className="lg:hidden"
           onClick={() => [setTradeBarVisibility(false), setSidebarVisibility(true)]}

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -123,8 +123,7 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
           startContent={
             <CoinSelector
               classNames={{
-                trigger: "!diatype-lg-medium text-gray-500",
-                selectorIcon: "w-4 h-4",
+                trigger: "text-gray-500",
               }}
               onChange={changeSizeCoin}
               value={sizeCoin.denom}

--- a/ui/portal/web/src/components/earn/PoolLiquidity.tsx
+++ b/ui/portal/web/src/components/earn/PoolLiquidity.tsx
@@ -25,7 +25,7 @@ import Big from "big.js";
 import { m } from "~/paraglide/messages";
 
 import type { PairUpdate } from "@left-curve/dango/types";
-import type { PropsWithChildren } from "react";
+import { useEffect, type PropsWithChildren } from "react";
 import { Modals } from "../modals/RootModal";
 import { MobileTitle } from "../foundation/MobileTitle";
 
@@ -431,6 +431,12 @@ const PoolLiquidityWithdraw: React.FC = () => {
 const PoolLiquidityHeaderTabs: React.FC = () => {
   const { state } = usePoolLiquidity();
   const { action, onChangeAction, userHasLiquidity } = state;
+
+  useEffect(() => {
+    if (!userHasLiquidity) {
+      onChangeAction("deposit");
+    }
+  }, [userHasLiquidity]);
 
   return (
     <Tabs

--- a/ui/portal/web/src/components/earn/PoolLiquidity.tsx
+++ b/ui/portal/web/src/components/earn/PoolLiquidity.tsx
@@ -1,4 +1,10 @@
-import { numberMask, Skeleton, useInputs } from "@left-curve/applets-kit";
+import {
+  IconArrowDown,
+  IconChevronRight,
+  numberMask,
+  Skeleton,
+  useInputs,
+} from "@left-curve/applets-kit";
 import { usePoolLiquidityState, usePrices } from "@left-curve/store";
 import { useApp } from "~/hooks/useApp";
 
@@ -21,6 +27,7 @@ import { m } from "~/paraglide/messages";
 import type { PairUpdate } from "@left-curve/dango/types";
 import type { PropsWithChildren } from "react";
 import { Modals } from "../modals/RootModal";
+import { MobileTitle } from "../foundation/MobileTitle";
 
 const [PoolLiquidityProvider, usePoolLiquidity] = createContext<{
   state: ReturnType<typeof usePoolLiquidityState>;
@@ -59,6 +66,7 @@ const PoolLiquidityContainer: React.FC<PropsWithChildren<PoolLiquidityProps>> = 
           state.userHasLiquidity ? "md:max-w-[50.1875rem]" : "md:max-w-[25rem]",
         )}
       >
+        <MobileTitle title={`Pool: ${state.coins.base.symbol}-${state.coins.quote.symbol}`} />
         {children}
       </motion.div>
     </PoolLiquidityProvider>

--- a/ui/portal/web/src/components/foundation/AccountCard.tsx
+++ b/ui/portal/web/src/components/foundation/AccountCard.tsx
@@ -8,7 +8,7 @@ import {
   Badge,
   BorrowBar,
   IconButton,
-  IconChevronDown,
+  IconChevronDownFill,
   IconClose,
   TextCopy,
   TruncateText,
@@ -90,7 +90,7 @@ const AccountCard: React.FC<AccountCardProps> = ({
               {isSelectorActive ? (
                 <IconClose className="w-5 h-5" />
               ) : (
-                <IconChevronDown className="w-5 h-5" />
+                <IconChevronDownFill className="w-4 h-4" />
               )}
             </motion.span>
           </IconButton>

--- a/ui/portal/web/src/components/foundation/AssetCard.tsx
+++ b/ui/portal/web/src/components/foundation/AssetCard.tsx
@@ -56,7 +56,7 @@ export const AssetCard: React.FC<Props> = ({ coin }) => {
         <div className="flex flex-col items-end">
           <p className="text-gray-900 diatype-m-bold">{price}</p>
           <IconChevronDownFill
-            className={twMerge("w-3 h-3 text-gray-200 transition-all", {
+            className={twMerge("w-4 h-4 text-gray-200 transition-all", {
               "rotate-180": isExpanded,
             })}
           />

--- a/ui/portal/web/src/components/foundation/SearchMenu.tsx
+++ b/ui/portal/web/src/components/foundation/SearchMenu.tsx
@@ -169,7 +169,7 @@ const Body: React.FC<SearchMenuBodyProps> = ({ isVisible, hideMenu, searchResult
           animate={{ height: "auto" }}
           exit={{ height: 0 }}
           transition={{ duration: 0.1 }}
-          className="menu w-full overflow-hidden md:max-h-[25.15rem] lg:overflow-y-auto"
+          className="menu w-full overflow-hidden md:max-h-[25.15rem] lg:overflow-y-auto scrollbar-thin scrollbar-thumb-rice-100 scrollbar-track-transparent"
         >
           <motion.div
             className="lg:p-1 w-full flex items-center flex-col gap-1"

--- a/ui/portal/web/src/pages/(app)/_app.earn.index.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.earn.index.lazy.tsx
@@ -1,5 +1,9 @@
 import { createLazyFileRoute, useNavigate } from "@tanstack/react-router";
+
+import { m } from "~/paraglide/messages";
+
 import { Earn } from "~/components/earn/Earn";
+import { MobileTitle } from "~/components/foundation/MobileTitle";
 
 export const Route = createLazyFileRoute("/(app)/_app/earn/")({
   component: EarnApplet,
@@ -9,6 +13,7 @@ function EarnApplet() {
   const navigate = useNavigate();
   return (
     <div className="w-full md:max-w-[76rem] mx-auto flex flex-col pt-6 mb-16">
+      <MobileTitle title={m["earn.title"]()} />
       <Earn
         navigate={({ baseSymbol, quoteSymbol }) =>
           navigate({

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
@@ -61,7 +61,7 @@ function ProTradeApplet() {
           </div>
           <ProTrade.Orders />
         </div>
-        <div className="hidden lg:flex pt-4 w-full lg:w-[331px] xl:[width:clamp(279px,20vw,422px)] lg:bg-rice-25 shadow-card-shadow z-20 max-h-[calc(100vh-76px)] md:sticky top-[76px]">
+        <div className="hidden lg:flex pt-4 w-full lg:w-[331px] xl:[width:clamp(279px,20vw,330px)] lg:bg-rice-25 shadow-card-shadow z-20 max-h-[calc(100vh-76px)] md:sticky top-[76px]">
           <ProTrade.TradeMenu />
         </div>
       </ProTrade>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `IconChevronDown` with `IconChevronDownFill` and make minor style adjustments across multiple UI components for improved consistency.
> 
>   - **Icons**:
>     - Replace `IconChevronDown` with `IconChevronDownFill` in `AccordionItem.tsx`, `ExpandOptions.tsx`, `Popover.tsx`, `Select.tsx`, `Tabs.tsx`, `OrderBookOverview.tsx`, `ProTrade.tsx`, `SearchToken.tsx`, `TradeMenu.tsx`, `AccountCard.tsx`, `AssetCard.tsx`.
>   - **Styles**:
>     - Adjust `trigger` min-width in `CoinSelector.tsx` from `min-w-14` to `min-w-10`.
>     - Add padding `px-[10px]` to `Range.tsx`.
>     - Modify `Tabs` base style in `Tabs.tsx` to include `p-0` for `line-red` color.
>     - Adjust `OrderBookOverview.tsx` width from `422px` to `330px`.
>     - Add `pt-0` to `Tabs` in `OrderBookOverview.tsx` and `ProTrade.tsx`.
>     - Add `MobileTitle` to `PoolLiquidity.tsx` and `_app.earn.index.lazy.tsx`.
>     - Add scrollbar styles to `SearchMenu.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for efa3662be666c5567adfa9db5a6e58b0a4cdfc1c. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->