### PR TITLE
fix(dango): charge protocol fee on instant swaps

### DIFF
--- a/dango/dex/src/core/router.rs
+++ b/dango/dex/src/core/router.rs
@@ -62,9 +62,11 @@ pub fn swap_exact_amount_out(
     let mut reserves = HashMap::new();
     let mut input = output.clone().into_inner();
 
-    // Add protocol fee to the output amount.
+    // Compute the output amount _before_ applying the protcol fee.
     let one_sub_fee_rate = Udec128::ONE.checked_sub(protocol_fee_rate)?;
     input.amount.checked_div_dec_ceil_assign(one_sub_fee_rate)?;
+
+    // Compute the protocol fee.
     let protocol_fee = input.amount.checked_sub(output.amount)?;
 
     for pair in route.into_iter().rev() {

--- a/dango/dex/src/core/router.rs
+++ b/dango/dex/src/core/router.rs
@@ -2,16 +2,25 @@ use {
     crate::{PAIRS, PassiveLiquidityPool, RESERVES},
     dango_oracle::OracleQuerier,
     dango_types::dex::PairId,
-    grug::{Coin, CoinPair, Inner, NonZero, Storage, UniqueVec},
+    grug::{
+        Coin, CoinPair, Inner, MultiplyFraction, NonZero, Number, Storage, Udec128, Uint128,
+        UniqueVec,
+    },
     std::collections::HashMap,
 };
 
+/// ## Returns
+///
+/// - The updated pool reserves of every pair visited in the route.
+/// - The output after deducting the protocol fee.
+/// - The protocol fee deducted.
 pub fn swap_exact_amount_in(
     storage: &dyn Storage,
     oracle_querier: &mut OracleQuerier<'_>,
+    protocol_fee_rate: Udec128,
     route: UniqueVec<PairId>,
     input: Coin,
-) -> anyhow::Result<(HashMap<PairId, CoinPair>, Coin)> {
+) -> anyhow::Result<(HashMap<PairId, CoinPair>, Coin, Uint128)> {
     let mut reserves = HashMap::new();
     let mut output = input;
 
@@ -36,15 +45,20 @@ pub fn swap_exact_amount_in(
         reserves.insert(pair.clone(), reserve);
     }
 
-    Ok((reserves, output))
+    // Deduct the protocol fee from the output amount.
+    let protocol_fee = output.amount.checked_mul_dec_ceil(protocol_fee_rate)?;
+    output.amount.checked_sub_assign(protocol_fee)?;
+
+    Ok((reserves, output, protocol_fee))
 }
 
 pub fn swap_exact_amount_out(
     storage: &dyn Storage,
     oracle_querier: &mut OracleQuerier<'_>,
+    protocol_fee_rate: Udec128,
     route: UniqueVec<PairId>,
     output: NonZero<Coin>,
-) -> anyhow::Result<(HashMap<PairId, CoinPair>, Coin)> {
+) -> anyhow::Result<(HashMap<PairId, CoinPair>, Coin, Uint128)> {
     let mut reserves = HashMap::new();
     let mut input = output.into_inner();
 
@@ -68,5 +82,9 @@ pub fn swap_exact_amount_out(
         reserves.insert(pair.clone(), reserve);
     }
 
-    Ok((reserves, input))
+    // Apply the protocol fee to the input amount.
+    let protocol_fee = input.amount.checked_mul_dec_ceil(protocol_fee_rate)?;
+    input.amount.checked_add_assign(protocol_fee)?;
+
+    Ok((reserves, input, protocol_fee))
 }

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -278,20 +278,17 @@ fn swap_exact_amount_in(
         input.clone(),
     )?;
 
-    // Ensure the output after fee is above the minimum.
+    // Ensure the output is above the minimum.
     // If not minimum is specified, the output should at least be greater than zero.
     if let Some(minimum_output) = minimum_output {
         ensure!(
             output.amount >= minimum_output,
-            "output amount after fee is below the minimum: {} < {}",
+            "output amount is below the minimum: {} < {}",
             output.amount,
             minimum_output
         );
     } else {
-        ensure!(
-            output.amount.is_non_zero(),
-            "output amount after fee is zero"
-        );
+        ensure!(output.amount.is_non_zero(), "output amount is zero");
     }
 
     // Save the updated pool reserves.

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -330,7 +330,7 @@ fn swap_exact_amount_out(
     let mut oracle_querier = OracleQuerier::new_remote(ctx.querier.query_oracle()?, ctx.querier)
         .with_no_older_than(ctx.block.timestamp - MAX_ORACLE_STALENESS);
 
-    // Perform the swap for the total output needed (user's output + fee)
+    // Perform the swap.
     let (reserves, input, protocol_fee) = core::swap_exact_amount_out(
         ctx.storage,
         &mut oracle_querier,
@@ -359,10 +359,10 @@ fn swap_exact_amount_out(
                 &taxman::ExecuteMsg::Pay {
                     ty: FeeType::Trade,
                     payments: btree_map! {
-                        ctx.sender => coins! { input.denom.clone() => protocol_fee },
+                        ctx.sender => coins! { output.denom.clone() => protocol_fee },
                     },
                 },
-                coins! { input.denom.clone() => protocol_fee },
+                coins! { output.denom.clone() => protocol_fee },
             )?)
         } else {
             None

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -273,7 +273,7 @@ fn swap_exact_amount_in(
     let (reserves, output, protocol_fee) = core::swap_exact_amount_in(
         ctx.storage,
         &mut oracle_querier,
-        *app_cfg.taker_fee_rate,
+        *app_cfg.taker_fee_rate, // Charge the taker fee rate for swaps.
         route,
         input.clone(),
     )?;
@@ -334,7 +334,7 @@ fn swap_exact_amount_out(
     let (reserves, input, protocol_fee) = core::swap_exact_amount_out(
         ctx.storage,
         &mut oracle_querier,
-        *app_cfg.taker_fee_rate,
+        *app_cfg.taker_fee_rate, // Charge the taker fee rate for swaps.
         route,
         output.clone(),
     )?;

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -372,11 +372,18 @@ fn query_simulate_swap_exact_amount_in(
     route: SwapRoute,
     input: Coin,
 ) -> anyhow::Result<Coin> {
+    let app_cfg = ctx.querier.query_dango_config()?;
     let mut oracle_querier = OracleQuerier::new_remote(ctx.querier.query_oracle()?, ctx.querier)
         .with_no_older_than(ctx.block.timestamp - MAX_ORACLE_STALENESS);
 
-    core::swap_exact_amount_in(ctx.storage, &mut oracle_querier, route.into_inner(), input)
-        .map(|(_updated_reserves, output)| output)
+    core::swap_exact_amount_in(
+        ctx.storage,
+        &mut oracle_querier,
+        *app_cfg.taker_fee_rate,
+        route.into_inner(),
+        input,
+    )
+    .map(|(_, output, _)| output)
 }
 
 fn query_simulate_swap_exact_amount_out(
@@ -384,9 +391,16 @@ fn query_simulate_swap_exact_amount_out(
     route: SwapRoute,
     output: NonZero<Coin>,
 ) -> anyhow::Result<Coin> {
+    let app_cfg = ctx.querier.query_dango_config()?;
     let mut oracle_querier = OracleQuerier::new_remote(ctx.querier.query_oracle()?, ctx.querier)
         .with_no_older_than(ctx.block.timestamp - MAX_ORACLE_STALENESS);
 
-    core::swap_exact_amount_out(ctx.storage, &mut oracle_querier, route.into_inner(), output)
-        .map(|(_updated_reserves, input)| input)
+    core::swap_exact_amount_out(
+        ctx.storage,
+        &mut oracle_querier,
+        *app_cfg.taker_fee_rate,
+        route.into_inner(),
+        output,
+    )
+    .map(|(_, input, _)| input)
 }

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1902,7 +1902,7 @@ fn swap_exact_amount_in(
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
     }],
-    Coin::new(usdc::DENOM.clone(), 500000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 498000).unwrap(),
     coins! {
         dango::DENOM.clone() => 1002006,
     },
@@ -1910,6 +1910,7 @@ fn swap_exact_amount_in(
         (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 1002006).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 2000).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 1000000 + 1002006,
@@ -1929,7 +1930,7 @@ fn swap_exact_amount_in(
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
     }],
-    Coin::new(usdc::DENOM.clone(), 333333).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 331999).unwrap(),
     coins! {
         dango::DENOM.clone() => 500751,
     },
@@ -1937,6 +1938,7 @@ fn swap_exact_amount_in(
         (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 500751).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 1334).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 1000000 + 500751,
@@ -1956,7 +1958,7 @@ fn swap_exact_amount_in(
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
     }],
-    Coin::new(usdc::DENOM.clone(), 250000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 249000).unwrap(),
     coins! {
         dango::DENOM.clone() => 333779,
     },
@@ -1964,6 +1966,7 @@ fn swap_exact_amount_in(
         (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 333779).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 1000).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 1000000 + 333779,
@@ -1983,7 +1986,7 @@ fn swap_exact_amount_in(
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
     }],
-    Coin::new(usdc::DENOM.clone(), 1000000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 996000).unwrap(),
     coins! {
         dango::DENOM.clone() => 1000000,
     },
@@ -1991,6 +1994,7 @@ fn swap_exact_amount_in(
         (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 1000000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 4000).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 2000000,
@@ -2011,7 +2015,7 @@ fn swap_exact_amount_in(
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
     }],
-    Coin::new(usdc::DENOM.clone(), 500000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 498000).unwrap(),
     coins! {
         dango::DENOM.clone() => 999999,
     },
@@ -2019,6 +2023,7 @@ fn swap_exact_amount_in(
         (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 1000000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 2000).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 2000000,
@@ -2039,7 +2044,7 @@ fn swap_exact_amount_in(
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
     }],
-    Coin::new(usdc::DENOM.clone(), 500000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 498000).unwrap(),
     coins! {
         dango::DENOM.clone() => 1100000,
     },
@@ -2047,6 +2052,7 @@ fn swap_exact_amount_in(
         (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 1002006).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 2000).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 1000000 + 1002006,
@@ -2076,7 +2082,7 @@ fn swap_exact_amount_in(
             quote_denom: usdc::DENOM.clone(),
         },
     ],
-    Coin::new(eth::DENOM.clone(), 250000).unwrap(),
+    Coin::new(eth::DENOM.clone(), 249000).unwrap(),
     coins! {
         dango::DENOM.clone() => 1000000,
     },
@@ -2085,6 +2091,7 @@ fn swap_exact_amount_in(
         (eth::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_permille(1),
     },
     Coin::new(dango::DENOM.clone(), 501758).unwrap(),
+    Coin::new(eth::DENOM.clone(), 1000).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 1000000 + 501758,
@@ -2108,7 +2115,7 @@ fn swap_exact_amount_in(
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
     }],
-    Coin::new(usdc::DENOM.clone(), 499950).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 497950).unwrap(),
     coins! {
         dango::DENOM.clone() => 1000000,
     },
@@ -2116,6 +2123,7 @@ fn swap_exact_amount_in(
         (dango::DENOM.clone(), usdc::DENOM.clone()) => Udec128::new_bps(1),
     },
     Coin::new(dango::DENOM.clone(), 1000000).unwrap(),
+    Coin::new(usdc::DENOM.clone(), 2000).unwrap(),
     btree_map! {
         (dango::DENOM.clone(), usdc::DENOM.clone()) => coins! {
             dango::DENOM.clone() => 2000000,
@@ -2131,6 +2139,7 @@ fn swap_exact_amount_out(
     swap_funds: Coins,
     swap_fee_rates: BTreeMap<(Denom, Denom), Udec128>,
     expected_in: Coin,
+    expected_protocol_fee: Coin,
     expected_pool_reserves_after: BTreeMap<(Denom, Denom), Coins>,
 ) {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
@@ -2180,7 +2189,7 @@ fn swap_exact_amount_out(
     // Record user and dex balances
     suite
         .balances()
-        .record_many([&accounts.user1.address(), &contracts.dex]);
+        .record_many([&accounts.user1.address(), &contracts.dex, &contracts.taxman]);
 
     // User swaps
     suite
@@ -2196,7 +2205,7 @@ fn swap_exact_amount_out(
         .should_succeed();
 
     // Assert that the user's balances have changed as expected.
-    let expected_out_coins: Coins = vec![exact_out].try_into().unwrap();
+    let mut expected_out_coins: Coins = vec![exact_out].try_into().unwrap();
     let expected_in_coins: Coins = vec![expected_in].try_into().unwrap();
     suite.balances().should_change(
         &accounts.user1,
@@ -2204,9 +2213,21 @@ fn swap_exact_amount_out(
     );
 
     // Assert that the dex balance has changed by the expected amount.
+    expected_out_coins
+        .insert(expected_protocol_fee.clone())
+        .unwrap();
     suite.balances().should_change(
         &contracts.dex,
         balance_changes_from_coins(expected_in_coins.clone(), expected_out_coins.clone()),
+    );
+
+    // Assert that the taxman balance has changed by the expected amount.
+    suite.balances().should_change(
+        &contracts.taxman,
+        balance_changes_from_coins(
+            vec![expected_protocol_fee].try_into().unwrap(),
+            Coins::new(),
+        ),
     );
 
     // Query pools and assert that the reserves are updated correctly

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1836,7 +1836,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
             dango::DENOM.clone() => 2000000,
             usdc::DENOM.clone() => 500000,
         },
-    } => panics "output amount after fee is below the minimum: 495510 < 500000" ;
+    } => panics "output amount is below the minimum: 495510 < 500000" ;
     "1:1 pool no swap fee one step route input 100% of pool liquidity output is less than minimum output"
 )]
 #[test_case(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduce protocol fee deduction for instant swaps in Dango DEX, updating swap functions and tests accordingly.
> 
>   - **Behavior**:
>     - Add protocol fee deduction in `swap_exact_amount_in` and `swap_exact_amount_out` in `router.rs`.
>     - Update `execute.rs` to pass `protocol_fee_rate` to swap functions and handle fee transfer to taxman.
>     - Modify `query.rs` to simulate swaps with protocol fee.
>   - **Tests**:
>     - Update tests in `dex.rs` to validate protocol fee deduction and transfer.
>     - Adjust expected outcomes in tests to account for protocol fee.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for a5c9222246e5e535c78e4100eadf9e1be9ae795a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->