### PR TITLE
fix(dango): correctly handle market orders that result in zero output when matched

### DIFF
--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -18,7 +18,7 @@ use {
 /// Returns a tuple containing the filling outcomes and all the market orders that
 /// were not filled.
 pub fn match_and_fill_market_orders<M, L>(
-    market_orders: &mut Peekable<M>,
+    mut market_orders: Peekable<M>,
     limit_orders: &mut Peekable<L>,
     market_order_direction: Direction,
     maker_fee_rate: Udec128,

--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -41,7 +41,14 @@ where
     let best_price = match limit_orders.peek_mut() {
         Some(Ok(((price, _), _))) => *price,
         Some(Err(e)) => return Err(e.clone().into()),
-        None => return Ok((Vec::new(), Vec::new())), // Return early if there are no limit orders
+        None => {
+            return Ok((
+                Vec::new(),
+                market_orders
+                    .map(|(_, market_order)| market_order)
+                    .collect(),
+            ));
+        }, // Return early if there are no limit orders
     };
 
     // Iterate over the limit orders and market orders until one of them is exhausted.

--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -8,15 +8,9 @@ use {
     std::{cmp::Ordering, collections::BTreeMap, iter::Peekable},
 };
 
-/// Match and fill market orders against the limit order book. This consumes the
-/// market order iterator fully. If the limit order iterator is exhausted first
-/// all the remaining market orders are returned in the unmatched vector. If the
-/// market order iterator is exhausted first, the remaining limit orders are left
-/// untouched in the limit order iterator, so that they can be matched against other
-/// limit orders.
+/// Match and fill market orders against the limit order book.
 ///
-/// Returns a tuple containing the filling outcomes and all the market orders that
-/// were not filled.
+/// Returns a tuple containing the filling outcomes.
 pub fn match_and_fill_market_orders<M, L>(
     market_orders: &mut Peekable<M>,
     limit_orders: &mut Peekable<L>,

--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -1,7 +1,10 @@
 use {
     crate::{ExtendedOrderId, FillingOutcome, MarketOrder, Order, OrderTrait},
     dango_types::dex::{Direction, OrderId},
-    grug::{MultiplyFraction, Number, NumberConst, Signed, StdResult, Udec128, Uint128, Unsigned},
+    grug::{
+        IsZero, MultiplyFraction, Number, NumberConst, Signed, StdResult, Udec128, Uint128,
+        Unsigned,
+    },
     std::{cmp::Ordering, collections::HashMap, iter::Peekable},
 };
 
@@ -89,7 +92,7 @@ where
         //
         // We round down the result to ensure that the average price of the market order
         // does not exceed the cutoff price.
-        let market_order_amount_to_match_in_base = if !price_is_worse_than_cutoff {
+        let filled_base = if !price_is_worse_than_cutoff {
             market_order_amount_in_base
         } else {
             let extended_market_order_id = ExtendedOrderId::User(*market_order_id);
@@ -137,45 +140,37 @@ where
             market_order_amount_to_match_in_base
         };
 
-        // If the amount to match is zero, skip this market order as it cannot be filled.
-        // We do not refund the market order since that would allow spamming the contract with
-        // tiny market orders at no cost.
-        if market_order_amount_to_match_in_base.is_zero() {
+        // If the amount to match is zero, skip this market order as it cannot
+        // be filled.
+        // We do not refund the market order since that would allow spamming the
+        // contract with tiny market orders at no cost.
+        if filled_base.is_zero() {
             market_orders.next();
             continue;
         }
 
         // If the resulting output of the match for a SELL market order is zero,
         // we skip it because it cannot be filled.
-        match market_order_direction {
-            Direction::Ask
-                if market_order_amount_to_match_in_base
-                    .checked_mul_dec_floor(*price)?
-                    .is_zero() =>
-            {
+        if market_order_direction == Direction::Ask {
+            let filled_quote = filled_base.checked_mul_dec_floor(*price)?;
+            if filled_quote.is_zero() {
                 market_orders.next();
                 continue;
-            },
-            _ => {},
+            }
         }
 
         // For a market ASK order the amount is in terms of the base asset. So we can directly
         // match it against the limit order remaining amount
         let (filled_base, price, limit_order, market_order) =
-            match market_order_amount_to_match_in_base.cmp(limit_order.remaining()) {
+            match filled_base.cmp(limit_order.remaining()) {
                 // The market ask order is smaller than the limit order so we advance the market
                 // orders iterator and decrement the limit order remaining amount
                 Ordering::Less => {
-                    limit_order.fill(market_order_amount_to_match_in_base)?;
+                    limit_order.fill(filled_base)?;
                     market_order.clear();
 
                     // Clone values so we can next the market order iterator
-                    let return_tuple = (
-                        market_order_amount_to_match_in_base,
-                        *price,
-                        *limit_order,
-                        *market_order,
-                    );
+                    let return_tuple = (filled_base, *price, *limit_order, *market_order);
 
                     // Advance the market orders iterator
                     market_orders.next();
@@ -189,12 +184,7 @@ where
                     market_order.clear();
 
                     // Clone values so we can next the limit order iterator
-                    let return_tuple = (
-                        market_order_amount_to_match_in_base,
-                        *price,
-                        *limit_order,
-                        *market_order,
-                    );
+                    let return_tuple = (filled_base, *price, *limit_order, *market_order);
 
                     // Advance the both order iterators
                     limit_orders.next();

--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -151,10 +151,11 @@ where
             market_order_amount_to_match_in_base
         };
 
-        // If the amount to match is zero, skip this market order as it cannot be filled
+        // If the amount to match is zero, skip this market order as it cannot be filled.
+        // We do not refund the market order since that would allow spamming the contract with
+        // tiny market orders at no cost.
         if market_order_amount_to_match_in_base.is_zero() {
-            let (_, unfillable_market_order) = market_orders.next().unwrap();
-            unmatched_market_orders.push(unfillable_market_order);
+            market_orders.next();
             continue;
         }
 
@@ -166,8 +167,7 @@ where
                     .checked_mul_dec_floor(*price)?
                     .is_zero() =>
             {
-                let (_, unfillable_market_order) = market_orders.next().unwrap();
-                unmatched_market_orders.push(unfillable_market_order);
+                market_orders.next();
                 continue;
             },
             _ => {},

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -212,7 +212,7 @@ fn clear_orders_of_pair(
     // Run the market order matching algorithm.
     // 1. Match market BUY orders against resting SELL limit orders.
     // 2. Match market SELL orders against resting BUY limit orders.
-    let market_bid_filling_outcomes = match_and_fill_market_orders(
+    let (market_bid_filling_outcomes, unmatched_market_bids) = match_and_fill_market_orders(
         &mut market_bids,
         &mut merged_ask_iter,
         Direction::Bid,
@@ -220,7 +220,7 @@ fn clear_orders_of_pair(
         taker_fee_rate,
         current_block_height,
     )?;
-    let market_ask_filling_outcomes = match_and_fill_market_orders(
+    let (market_ask_filling_outcomes, unmatched_market_asks) = match_and_fill_market_orders(
         &mut market_asks,
         &mut merged_bid_iter,
         Direction::Ask,
@@ -277,11 +277,11 @@ fn clear_orders_of_pair(
     // ----------------------- 5. Update contract state ------------------------
 
     // Loop over all unmatched market orders and refund the users
-    for (_, market_order) in market_bids {
+    for market_order in unmatched_market_bids {
         refunds.insert(market_order.user, quote_denom.clone(), market_order.amount)?;
     }
 
-    for (_, market_order) in market_asks {
+    for market_order in unmatched_market_asks {
         refunds.insert(market_order.user, base_denom.clone(), market_order.amount)?;
     }
 

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -148,13 +148,13 @@ fn clear_orders_of_pair(
     // --------------------------- 1. Prepare orders ---------------------------
 
     // Load the market orders for this pair.
-    let mut market_bids = MARKET_ORDERS
+    let market_bids = MARKET_ORDERS
         .prefix((base_denom.clone(), quote_denom.clone()))
         .append(Direction::Bid)
         .drain(storage, None, None)?
         .into_iter()
         .peekable();
-    let mut market_asks = MARKET_ORDERS
+    let market_asks = MARKET_ORDERS
         .prefix((base_denom.clone(), quote_denom.clone()))
         .append(Direction::Ask)
         .drain(storage, None, None)?
@@ -221,7 +221,7 @@ fn clear_orders_of_pair(
     // 1. Match market BUY orders against resting SELL limit orders.
     // 2. Match market SELL orders against resting BUY limit orders.
     let (market_bid_filling_outcomes, unmatched_market_bids) = match_and_fill_market_orders(
-        &mut market_bids,
+        market_bids,
         &mut merged_ask_iter,
         Direction::Bid,
         maker_fee_rate,
@@ -229,7 +229,7 @@ fn clear_orders_of_pair(
         current_block_height,
     )?;
     let (market_ask_filling_outcomes, unmatched_market_asks) = match_and_fill_market_orders(
-        &mut market_asks,
+        market_asks,
         &mut merged_bid_iter,
         Direction::Ask,
         maker_fee_rate,

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5386,7 +5386,7 @@ fn market_order_clearing(
     },
     btree_map! {
         eth::DENOM.clone() => BalanceChange::Unchanged,
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
+        usdc::DENOM.clone() => BalanceChange::Decreased(500000),
     }
     ; "limit ask matched with market bid market size limiting factor market order gets refunded"
 )]
@@ -5416,7 +5416,7 @@ fn market_order_clearing(
         usdc::DENOM.clone() => BalanceChange::Decreased(50),
     },
     btree_map! {
-        eth::DENOM.clone() => BalanceChange::Unchanged,
+        eth::DENOM.clone() => BalanceChange::Decreased(9999),
         usdc::DENOM.clone() => BalanceChange::Unchanged,
     }
     ; "limit bid matched with market ask market size limiting factor market order gets refunded"

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5344,21 +5344,13 @@ fn market_order_resulting_in_zero_output_when_matched_is_correctly_refunded(
     // No matching could take place so both users should have unchanged balances
     // since before the market order was created.
     println!("user1 balance check");
-    // suite.balances().should_change(&accounts.user1, btree_map! {
-    //     eth::DENOM.clone() => BalanceChange::Unchanged,
-    //     usdc::DENOM.clone() => BalanceChange::Unchanged,
-    // });
+    suite.balances().should_change(&accounts.user1, btree_map! {
+        eth::DENOM.clone() => BalanceChange::Unchanged,
+        usdc::DENOM.clone() => BalanceChange::Unchanged,
+    });
     println!("user2 balance check");
     suite.balances().should_change(&accounts.user2, btree_map! {
         eth::DENOM.clone() => BalanceChange::Unchanged,
         usdc::DENOM.clone() => BalanceChange::Unchanged,
     });
-}
-
-#[test]
-fn lol() {
-    let a = Udec128::new_bps(1);
-    let b = Uint128::new(10000);
-    let c = b.checked_mul_dec_floor(a).unwrap();
-    println!("c: {}", c);
 }

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5220,7 +5220,7 @@ fn market_order_clearing(
         direction: Direction::Ask,
         amount: NonZero::new_unchecked(Uint128::new(9307)),
         price: Udec128::new(1000000),
-    }, 
+    },
     coins! {
         eth::DENOM.clone() => 9307,
     },
@@ -5230,7 +5230,7 @@ fn market_order_clearing(
         direction: Direction::Bid,
         amount: NonZero::new_unchecked(Uint128::new(500000)),
         max_slippage: Udec128::new_percent(8),
-    }, 
+    },
     coins! {
         usdc::DENOM.clone() => 500000,
     }
@@ -5253,7 +5253,7 @@ fn market_order_clearing(
         direction: Direction::Ask,
         amount: NonZero::new_unchecked(Uint128::new(9999)),
         max_slippage: Udec128::new_percent(8),
-    }, 
+    },
     coins! {
         eth::DENOM.clone() => 9999,
     }
@@ -5276,7 +5276,7 @@ fn market_order_clearing(
         direction: Direction::Ask,
         amount: NonZero::new_unchecked(Uint128::new(500000)),
         max_slippage: Udec128::new_percent(8),
-    }, 
+    },
     coins! {
         eth::DENOM.clone() => 500000,
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix handling of market orders with zero output in `market_order.rs` to prevent unnecessary processing and potential spam.
> 
>   - **Behavior**:
>     - In `market_order.rs`, skip market orders with zero output to prevent unnecessary processing and potential spam.
>     - Ensure market orders resulting in zero output are not refunded to avoid spam.
>   - **Tests**:
>     - Add test cases in `dex.rs` to verify market orders with zero output are handled correctly.
>     - Confirm that market orders with zero output do not affect user balances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ee1a6d7abb5baab49bbccb53bcce0264634684c3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->