### PR TITLE
fix(dango): ensure dex contract doesn't crash or panic if oracle query fails

### DIFF
--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -461,7 +461,7 @@ fn update_trading_volumes(
     volumes: &mut HashMap<Addr, Uint128>,
     volumes_by_username: &mut HashMap<Username, Uint128>,
 ) -> anyhow::Result<()> {
-    // Calculate the vo lume in USD for the filled order. If the oracle query
+    // Calculate the volume in USD for the filled order. If the oracle query
     // fails, we simply skip the volume update, since we want to make sure that
     // the cron_execute function doesn't fail.
     let base_asset_price = match oracle_querier.query_price(base_denom, None) {

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1875,7 +1875,7 @@ fn swap_exact_amount_in(
             &mut accounts.user1,
             contracts.dex,
             &dex::ExecuteMsg::SwapExactAmountIn {
-                route: MaxLength::new_unchecked(UniqueVec::try_from(route).unwrap()),
+                route: MaxLength::new_unchecked(UniqueVec::new_unchecked(route)),
                 minimum_output,
             },
             swap_funds.clone(),
@@ -2204,7 +2204,7 @@ fn swap_exact_amount_out(
             &mut accounts.user1,
             contracts.dex,
             &dex::ExecuteMsg::SwapExactAmountOut {
-                route: MaxLength::new_unchecked(UniqueVec::try_from(route).unwrap()),
+                route: MaxLength::new_unchecked(UniqueVec::new_unchecked(route)),
                 output: NonZero::new(exact_out.clone()).unwrap(),
             },
             swap_funds.clone(),
@@ -2294,13 +2294,10 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
             &mut accounts.user1,
             contracts.dex,
             &dex::ExecuteMsg::SwapExactAmountIn {
-                route: MaxLength::new_unchecked(
-                    UniqueVec::try_from(vec![PairId {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                    }])
-                    .unwrap(),
-                ),
+                route: MaxLength::new_unchecked(UniqueVec::new_unchecked(vec![PairId {
+                    base_denom: dango::DENOM.clone(),
+                    quote_denom: usdc::DENOM.clone(),
+                }])),
                 minimum_output: None,
             },
             coins! {
@@ -2317,13 +2314,10 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
             &mut accounts.user1,
             contracts.dex,
             &dex::ExecuteMsg::SwapExactAmountOut {
-                route: MaxLength::new_unchecked(
-                    UniqueVec::try_from(vec![PairId {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                    }])
-                    .unwrap(),
-                ),
+                route: MaxLength::new_unchecked(UniqueVec::new_unchecked(vec![PairId {
+                    base_denom: dango::DENOM.clone(),
+                    quote_denom: usdc::DENOM.clone(),
+                }])),
                 output: NonZero::new(Coin::new(dango::DENOM.clone(), 50000).unwrap()).unwrap(),
             },
             coins! {

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1375,7 +1375,7 @@ fn provide_liquidity(
 }
 
 #[test]
-fn provide_liquidity_to_geometric_pool_shouwl_fail_without_oracle_price() {
+fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Update pair params

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1,4 +1,5 @@
 use {
+    dango_oracle::{PRICE_SOURCES, PRICES},
     dango_testing::{BridgeOp, TestOption, setup_test_naive},
     dango_types::{
         account::single::Params,
@@ -11,7 +12,7 @@ use {
             QueryOrdersByPairRequest, QueryOrdersRequest, QueryReserveRequest,
         },
         gateway::Remote,
-        oracle::{self, PriceSource},
+        oracle::{self, PrecisionlessPrice, PriceSource},
     },
     grug::{
         Addr, Addressable, BalanceChange, Bounded, Coin, CoinPair, Coins, Denom, Fraction, Inner,
@@ -20,6 +21,7 @@ use {
         coin_pair, coins,
     },
     hyperlane_types::constants::ethereum,
+    pyth_types::constants::USDC_USD_ID,
     std::{
         collections::{BTreeMap, BTreeSet},
         str::FromStr,
@@ -1422,7 +1424,9 @@ fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
                 usdc::DENOM.clone() => 100_000,
             },
         )
-        .should_fail_with_error("data not found! type: (dango_types::oracle::price::Price");
+        .should_fail_with_error(StdError::data_not_found::<(PrecisionlessPrice, u64)>(
+            PRICES.path(USDC_USD_ID).storage_key(),
+        ));
 }
 
 #[test_case(
@@ -2304,9 +2308,9 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 dango::DENOM.clone() => 1000000,
             },
         )
-        .should_fail_with_error(
-            "data not found! type: dango_types::oracle::price_source::PriceSource",
-        );
+        .should_fail_with_error(StdError::data_not_found::<PriceSource>(
+            PRICE_SOURCES.path(&dango::DENOM).storage_key(),
+        ));
 
     // Ensure swap exact amount out fails
     suite
@@ -2324,9 +2328,9 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 usdc::DENOM.clone() => 1000000,
             },
         )
-        .should_fail_with_error(
-            "data not found! type: dango_types::oracle::price_source::PriceSource",
-        );
+        .should_fail_with_error(StdError::data_not_found::<PriceSource>(
+            PRICE_SOURCES.path(&dango::DENOM).storage_key(),
+        ));
 }
 
 #[test_case(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance DEX contract to handle oracle query failures gracefully, preventing crashes and adding tests for verification.
> 
>   - **Behavior**:
>     - `cron_execute` in `cron.rs` now handles oracle query failures gracefully by logging errors and continuing execution.
>     - `clear_orders_of_pair` and `update_trading_volumes` functions updated to handle oracle query errors without panicking.
>   - **Tests**:
>     - Added `provide_liquidity_to_geometric_pool_should_fail_without_oracle_price` and `geometric_pool_swaps_fail_without_oracle_price` tests in `dex.rs` to verify behavior when oracle prices are missing.
>     - Added `cron_execute_gracefully_handles_oracle_price_failure` test in `dex.rs` to ensure `cron_execute` handles oracle failures correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 6ee0ca84a0d5f8a1963aa12a429a6fd3110cc7e9. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->