### PR TITLE
fix(dango): correct minting of geometric pool shares and add tests

### DIFF
--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -31,7 +31,7 @@ pub fn add_subsequent_liquidity(
 
     reserve.merge(deposit)?;
 
-    Ok(deposit_value.checked_div(reserve_value.checked_add(deposit_value)?)?)
+    Ok(deposit_value.checked_div(reserve_value)?)
 }
 
 pub fn swap_exact_amount_in(

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1215,8 +1215,8 @@ fn only_owner_can_create_passive_pool() {
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
     ],
-    Uint128::new(100);
-    "provision at pool ratio"
+    Uint128::new(100)
+    ; "provision at pool ratio"
 )]
 #[test_case(
     coins! {
@@ -1231,8 +1231,8 @@ fn only_owner_can_create_passive_pool() {
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
     ],
-    Uint128::new(50);
-    "provision at half pool balance same ratio"
+    Uint128::new(50)
+    ; "provision at half pool balance same ratio"
 )]
 #[test_case(
     coins! {
@@ -1247,8 +1247,76 @@ fn only_owner_can_create_passive_pool() {
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
     ],
-    Uint128::new(72);
-    "provision at different ratio"
+    Uint128::new(72)
+    ; "provision at different ratio"
+)]
+#[test_case(
+    coins! {
+        dango::DENOM.clone() => 100,
+        usdc::DENOM.clone() => 100,
+    },
+    Udec128::new_permille(5),
+    PassiveLiquidity::Geometric {
+        order_spacing: Udec128::ONE,
+        ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
+    },
+    vec![
+        (dango::DENOM.clone(), Udec128::new(2)),
+        (usdc::DENOM.clone(), Udec128::new(1)),
+    ],
+    Uint128::new(300)
+    ; "geometric pool provision at pool ratio"
+)]
+#[test_case(
+    coins! {
+        dango::DENOM.clone() => 50,
+        usdc::DENOM.clone() => 50,
+    },
+    Udec128::new_permille(5),
+    PassiveLiquidity::Geometric {
+        order_spacing: Udec128::ONE,
+        ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
+    },
+    vec![
+        (dango::DENOM.clone(), Udec128::new(2)),
+        (usdc::DENOM.clone(), Udec128::new(1)),
+    ],
+    Uint128::new(150)
+    ; "geometric pool provision at half pool balance same ratio"
+)]
+#[test_case(
+    coins! {
+        dango::DENOM.clone() => 100,
+        usdc::DENOM.clone() => 50,
+    },
+    Udec128::new_permille(5),
+    PassiveLiquidity::Geometric {
+        order_spacing: Udec128::ONE,
+        ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
+    },
+    vec![
+        (dango::DENOM.clone(), Udec128::new(2)),
+        (usdc::DENOM.clone(), Udec128::new(1)),
+    ],
+    Uint128::new(248)
+    ; "geometric pool provision at different ratio"
+)]
+#[test_case(
+    coins! {
+        dango::DENOM.clone() => 50,
+        usdc::DENOM.clone() => 100,
+    },
+    Udec128::new_permille(5),
+    PassiveLiquidity::Geometric {
+        order_spacing: Udec128::ONE,
+        ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
+    },
+    vec![
+        (dango::DENOM.clone(), Udec128::new(2)),
+        (usdc::DENOM.clone(), Udec128::new(1)),
+    ],
+    Uint128::new(198)
+    ; "geometric pool provision at different ratio 2"
 )]
 fn provide_liquidity(
     provision: Coins,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes minting calculation for geometric pool shares in `add_subsequent_liquidity()` and adds tests for various provision scenarios.
> 
>   - **Behavior**:
>     - Fixes minting calculation in `add_subsequent_liquidity()` in `geometric.rs` by correcting the division logic.
>     - Adds test cases in `dex.rs` for geometric pool provisions at various ratios and balances.
>   - **Tests**:
>     - Adds test cases for geometric pool provision at pool ratio, half pool balance, and different ratios in `dex.rs`.
>     - Ensures tests cover scenarios with different liquidity provisions and ratios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for aba077c043bdfd494d8aa80d66c60956a524e80d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->