### PR TITLE
refactor(dango): multiply initial LP tokens in XYK by 1000000

### DIFF
--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -6,8 +6,10 @@ use {
     std::{cmp, iter},
 };
 
+const INITIAL_LP_TOKEN_MULTIPLIER: Uint128 = Uint128::new(1_000_000u128);
+
 pub fn add_initial_liquidity(deposit: &CoinPair) -> MathResult<Uint128> {
-    normalized_invariant(deposit)
+    normalized_invariant(deposit)?.checked_mul(INITIAL_LP_TOKEN_MULTIPLIER)
 }
 
 pub fn add_subsequent_liquidity(

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1215,7 +1215,7 @@ fn only_owner_can_create_passive_pool() {
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
     ],
-    Uint128::new(100)
+    Uint128::new(100_000_000)
     ; "provision at pool ratio"
 )]
 #[test_case(
@@ -1231,7 +1231,7 @@ fn only_owner_can_create_passive_pool() {
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
     ],
-    Uint128::new(50)
+    Uint128::new(50_000_000)
     ; "provision at half pool balance same ratio"
 )]
 #[test_case(
@@ -1247,7 +1247,7 @@ fn only_owner_can_create_passive_pool() {
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
     ],
-    Uint128::new(72)
+    Uint128::new(72_975_666)
     ; "provision at different ratio"
 )]
 #[test_case(
@@ -1498,7 +1498,7 @@ fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
 }
 
 #[test_case(
-    Uint128::new(99),
+    Uint128::new(99_000_000),
     Udec128::new_permille(5),
     coins! {
         dango::DENOM.clone() => 99,
@@ -1507,7 +1507,7 @@ fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
     "withdrawa all"
 )]
 #[test_case(
-    Uint128::new(50),
+    Uint128::new(50_000_000),
     Udec128::new_permille(5),
     coins! {
         dango::DENOM.clone() => 50,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Multiply initial LP tokens by 1,000,000 in XYK model and update related tests.
> 
>   - **Behavior**:
>     - Multiply initial LP tokens by 1,000,000 in `add_initial_liquidity()` in `xyk.rs`.
>   - **Constants**:
>     - Add `INITIAL_LP_TOKEN_MULTIPLIER` constant in `xyk.rs` set to `1_000_000`.
>   - **Tests**:
>     - Update LP token values in `only_owner_can_create_passive_pool()` and `provide_liquidity_to_geometric_pool_should_fail_without_oracle_price()` in `dex.rs` to reflect new multiplier.
>     - Adjust test cases in `dex.rs` to use scaled LP token values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 259a16ac133b9b6b9ba9b8c4c9744abd5d4bf331. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->