### PR TITLE
dex: replace `FillingOutcome::clearing_price` with `filled_{base,quote}`

### DIFF
--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -1,10 +1,7 @@
 use {
     crate::{ExtendedOrderId, FillingOutcome, MarketOrder, Order, OrderTrait},
     dango_types::dex::{Direction, OrderId},
-    grug::{
-        IsZero, MultiplyFraction, Number, NumberConst, Signed, StdResult, Udec128, Uint128,
-        Unsigned,
-    },
+    grug::{MultiplyFraction, Number, NumberConst, Signed, StdResult, Udec128, Uint128, Unsigned},
     std::{cmp::Ordering, collections::HashMap, iter::Peekable},
 };
 
@@ -95,8 +92,13 @@ where
             let extended_market_order_id = ExtendedOrderId::User(*market_order_id);
             let filling_outcome = filling_outcomes.get_mut(&extended_market_order_id).unwrap();
 
-            let current_avg_price = filling_outcome.clearing_price;
-            let filled = filling_outcome.filled;
+            // Calculate how much of the market order can be filled without the average
+            // price of the market order exceeding the cutoff price.
+            // TODO: optimize the math here. See the jupyter notebook.
+            let current_avg_price = Udec128::checked_from_ratio(
+                filling_outcome.filled_quote,
+                filling_outcome.filled_base,
+            )?;
             let price_ratio = current_avg_price
                 .checked_into_signed()?
                 .checked_sub(cutoff_price.checked_into_signed()?)?
@@ -105,10 +107,8 @@ where
                         .checked_into_signed()?
                         .checked_sub(price.checked_into_signed()?)?,
                 )?;
-
-            // Calculate how much of the market order can be filled without the average
-            // price of the market order exceeding the cutoff price.
-            let market_order_amount_to_match_in_base = filled
+            let market_order_amount_to_match_in_base = filling_outcome
+                .filled_base
                 .checked_mul_dec_floor(price_ratio.checked_into_unsigned()?)?
                 .min(market_order_amount_in_base);
 
@@ -136,7 +136,7 @@ where
 
         // For a market ASK order the amount is in terms of the base asset. So we can directly
         // match it against the limit order remaining amount
-        let (filled_amount, price, limit_order, market_order) =
+        let (filled_base, price, limit_order, market_order) =
             match market_order_amount_to_match_in_base.cmp(limit_order.remaining()) {
                 // The market ask order is smaller than the limit order so we advance the market
                 // orders iterator and decrement the limit order remaining amount
@@ -223,7 +223,7 @@ where
             &mut filling_outcomes,
             limit_order,
             limit_order_direction,
-            filled_amount,
+            filled_base,
             price,
             limit_order_fee_rate,
         )?;
@@ -232,7 +232,7 @@ where
             &mut filling_outcomes,
             Order::Market(market_order),
             market_order_direction,
-            filled_amount,
+            filled_base,
             price,
             taker_fee_rate,
         )?;
@@ -245,7 +245,7 @@ fn update_filling_outcome(
     filling_outcomes: &mut HashMap<ExtendedOrderId, FillingOutcome>,
     order: Order,
     order_direction: Direction,
-    filled_amount: Uint128,
+    filled_base: Uint128,
     price: Udec128,
     fee_rate: Udec128,
 ) -> StdResult<()> {
@@ -254,55 +254,40 @@ fn update_filling_outcome(
         .or_insert_with(|| FillingOutcome {
             order_direction,
             order,
-            filled: Uint128::ZERO,
-            clearing_price: price,
-            cleared: false,
+            filled_base: Uint128::ZERO,
+            filled_quote: Uint128::ZERO,
             refund_base: Uint128::ZERO,
             refund_quote: Uint128::ZERO,
             fee_base: Uint128::ZERO,
             fee_quote: Uint128::ZERO,
         });
 
-    match order {
-        Order::Limit(limit_order) => {
-            filling_outcome.cleared = limit_order.remaining.is_zero();
-        },
-        Order::Market(_) => {
-            filling_outcome.clearing_price = Udec128::checked_from_ratio(
-                filling_outcome
-                    .filled
-                    .checked_mul_dec(filling_outcome.clearing_price)?
-                    .checked_add(filled_amount.checked_mul_dec(price)?)?,
-                filling_outcome.filled.checked_add(filled_amount)?,
-            )?;
-        },
-        Order::Passive(passive_order) => {
-            filling_outcome.cleared = passive_order.remaining.is_zero();
-        },
-    }
+    let filled_quote = filled_base.checked_mul_dec_floor(price)?;
 
-    filling_outcome.filled.checked_add_assign(filled_amount)?;
+    filling_outcome
+        .filled_base
+        .checked_add_assign(filled_base)?;
+    filling_outcome
+        .filled_quote
+        .checked_add_assign(filled_base.checked_mul_dec_floor(price)?)?;
     filling_outcome.order = order;
 
     match order_direction {
         Direction::Bid => {
-            let fee_amount = filled_amount.checked_mul_dec_ceil(fee_rate)?;
+            let fee_base = filled_base.checked_mul_dec_ceil(fee_rate)?;
 
-            filling_outcome.fee_base.checked_add_assign(fee_amount)?;
+            filling_outcome.fee_base.checked_add_assign(fee_base)?;
             filling_outcome
                 .refund_base
-                .checked_add_assign(filled_amount.checked_sub(fee_amount)?)?;
+                .checked_add_assign(filled_base.checked_sub(fee_base)?)?;
         },
         Direction::Ask => {
-            let filled_amount_in_quote = filled_amount.checked_mul_dec_floor(price)?;
-            let fee_amount_in_quote = filled_amount_in_quote.checked_mul_dec_ceil(fee_rate)?;
+            let fee_quote = filled_quote.checked_mul_dec_ceil(fee_rate)?;
 
-            filling_outcome
-                .fee_quote
-                .checked_add_assign(fee_amount_in_quote)?;
+            filling_outcome.fee_quote.checked_add_assign(fee_quote)?;
             filling_outcome
                 .refund_quote
-                .checked_add_assign(filled_amount_in_quote.checked_sub(fee_amount_in_quote)?)?;
+                .checked_add_assign(filled_quote.checked_sub(fee_quote)?)?;
         },
     }
 

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -482,17 +482,6 @@ fn fill_passive_order(
     match order_direction {
         Direction::Bid => {
             inflows.insert((base_denom.clone(), filled_base))?;
-            // Why is this `filled_quote` instead of `refund_quote`?
-            //
-            // Because a trader who places a BUY order must make a
-            // deposit of the amount `amount * limit_price`.
-            // Then, when the order is filled, the trader gets refunded
-            // `amount * (limit_price - clearing_price)`.
-            // The _net_ outflow is the difference between the two values,
-            // which is `amount * clearing_price`.
-            //
-            // In comparison, the passive liquidity pool doesn't need to
-            // make a deposit, so the outflow is simply the _net_ outflow.
             outflows.insert((quote_denom.clone(), filled_quote))?;
         },
         Direction::Ask => {

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -13,7 +13,7 @@ use {
         taxman::{self, FeeType},
     },
     grug::{
-        Addr, Api, Coin, Coins, Denom, EventBuilder, Inner, IsZero, Message, Number, NumberConst,
+        Addr, Api, Coins, Denom, EventBuilder, Inner, IsZero, Message, Number, NumberConst,
         Order as IterationOrder, Response, StdError, StdResult, Storage, SudoCtx, TransferBuilder,
         Udec128, Uint128,
     },
@@ -440,19 +440,6 @@ fn fill_user_order(
     fees: &mut Coins,
     fee_payments: &mut TransferBuilder,
 ) -> StdResult<()> {
-    let refund = Coins::try_from([
-        Coin {
-            denom: base_denom.clone(),
-            amount: refund_base,
-        },
-        Coin {
-            denom: quote_denom.clone(),
-            amount: refund_quote,
-        },
-    ])?;
-
-    refunds.insert_many(user, refund.clone())?;
-
     // Handle fees.
     if fee_base.is_non_zero() {
         fees.insert((base_denom.clone(), fee_base))?;
@@ -464,7 +451,9 @@ fn fill_user_order(
         fee_payments.insert(user, quote_denom.clone(), fee_quote)?;
     }
 
-    Ok(())
+    // Handle refunds.
+    refunds.insert(user, base_denom.clone(), refund_base)?;
+    refunds.insert(user, quote_denom.clone(), refund_quote)
 }
 
 fn fill_passive_order(

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -1,6 +1,6 @@
 use {
     crate::dex::{Direction, OrderId},
-    grug::{Addr, Coin, Coins, Denom, Udec128, Uint128},
+    grug::{Addr, Coin, Denom, Udec128, Uint128},
 };
 
 #[grug::derive(Serde)]
@@ -60,17 +60,14 @@ pub struct OrderFilled {
     pub base_denom: Denom,
     pub quote_denom: Denom,
     pub direction: Direction,
+    pub filled_base: Uint128,
+    pub filled_quote: Uint128,
+    pub refund_base: Uint128,
+    pub refund_quote: Uint128,
+    pub fee_base: Uint128,
+    pub fee_quote: Uint128,
     /// The price at which the order was executed.
     pub clearing_price: Udec128,
-    /// The amount that was filled.
-    ///
-    /// This can be either denominated in the base or the quote asset, depending
-    /// on order type.
-    pub filled: Uint128,
-    /// The amount of coins returned to the user.
-    pub refund: Coins,
-    /// The amount of protocol fee collected.
-    pub fee: Option<Coin>,
     /// Whether the order was _completed_ filled and cleared from the book.
     pub cleared: bool,
 }


### PR DESCRIPTION
The `clearing_price` is only used in events. Using the amount of base/quote assets filled is more natural. We can compute the clearing price only later when emitting the event.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replace `clearing_price` with `filled_base` and `filled_quote` in `FillingOutcome`, computing `clearing_price` when needed, and update related functions and events.
> 
>   - **Behavior**:
>     - Replace `clearing_price` with `filled_base` and `filled_quote` in `FillingOutcome`.
>     - Compute `clearing_price` when emitting events, e.g., in `clear_orders_of_pair()` in `cron.rs`.
>   - **Functions**:
>     - Update `match_and_fill_market_orders()` and `update_filling_outcome()` in `market_order.rs` to use `filled_base` and `filled_quote`.
>     - Modify `fill_bids()` and `fill_asks()` in `order_filling.rs` to calculate and use `filled_base` and `filled_quote`.
>   - **Events**:
>     - Update `OrderFilled` event in `events.rs` to include `filled_base`, `filled_quote`, `refund_base`, `refund_quote`, `fee_base`, and `fee_quote`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ffbd8651d98b833bc7c3859a3e6e0e2781b8efce. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->