### PR TITLE
chore(ui): hide earn in testnet

### DIFF
--- a/ui/portal/web/constants.config.ts
+++ b/ui/portal/web/constants.config.ts
@@ -20,7 +20,11 @@ export const APPLETS = Array.from(
       } as AppletMetadata;
     }
   },
-).filter(Boolean) as AppletMetadata[];
+).filter((a) => {
+  if (!a) return false;
+  if (a.id === "earn" && import.meta.env.CONFIG_ENVIRONMENT === "test") return false;
+  return true;
+}) as AppletMetadata[];
 
 export const DEFAULT_FAV_APPLETS = APPLETS.filter(({ id }) =>
   ["transfer", "settings", "notifications", "simple-swap", "trade", "earn"].includes(id),

--- a/ui/portal/web/rsbuild.config.ts
+++ b/ui/portal/web/rsbuild.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     },
     define: {
       ...publicVars,
+      "import.meta.env.CONFIG_ENVIRONMENT": `"${process.env.CONFIG_ENVIRONMENT}"`,
       "process.env": {},
       "import.meta.env": {},
     },

--- a/ui/portal/web/rsbuild.config.ts
+++ b/ui/portal/web/rsbuild.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
     },
     define: {
       ...publicVars,
-      "import.meta.env.CONFIG_ENVIRONMENT": `"${process.env.CONFIG_ENVIRONMENT}"`,
+      "import.meta.env.CONFIG_ENVIRONMENT": `"${process.env.CONFIG_ENVIRONMENT || "local"}"`,
       "process.env": {},
       "import.meta.env": {},
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Exclude 'earn' applet in test environments by modifying `APPLETS` filtering in `constants.config.ts` and defining `CONFIG_ENVIRONMENT` in `rsbuild.config.ts`.
> 
>   - **Behavior**:
>     - Modify `APPLETS` filtering in `constants.config.ts` to exclude `earn` applet when `CONFIG_ENVIRONMENT` is `test`.
>   - **Configuration**:
>     - Add `import.meta.env.CONFIG_ENVIRONMENT` definition in `rsbuild.config.ts` to set environment variable from `process.env.CONFIG_ENVIRONMENT` or default to `local`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c1fc74600ba639cb1cdf77eb2feeb85710ec995b. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->