### PR TITLE
[LEF-188] Use SmallInteger for KeyType

### DIFF
--- a/dango/types/src/auth.rs
+++ b/dango/types/src/auth.rs
@@ -19,7 +19,10 @@ pub type Nonce = u32;
     feature = "sea-orm",
     derive(sea_orm::EnumIter, sea_orm::DeriveActiveEnum)
 )]
-#[cfg_attr(feature = "sea-orm", sea_orm(rs_type = "i32", db_type = "Integer"))]
+#[cfg_attr(
+    feature = "sea-orm",
+    sea_orm(rs_type = "i16", db_type = "SmallInteger")
+)]
 pub enum KeyType {
     #[cfg_attr(feature = "sea-orm", sea_orm(num_value = 0))]
     Secp256r1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `KeyType` enum storage type to `SmallInteger` in `auth.rs` for `sea-orm`.
> 
>   - **Behavior**:
>     - Change `KeyType` enum storage type from `Integer` to `SmallInteger` in `auth.rs` when `sea-orm` feature is enabled.
>   - **Enums**:
>     - Update `KeyType` enum in `auth.rs` to use `i16` for `rs_type` and `SmallInteger` for `db_type` with `sea-orm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 87a71f8a581ce1a1b11518758529c48a541f6f7a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->