### PR TITLE
feat: add `Dec::into_int_{floor,ceil}` methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,6 +4798,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "test-case",
  "thiserror 2.0.12",
 ]
 

--- a/grug/math/Cargo.toml
+++ b/grug/math/Cargo.toml
@@ -19,3 +19,4 @@ thiserror = { workspace = true }
 [dev-dependencies]
 proptest   = { workspace = true }
 serde_json = { workspace = true }
+test-case  = { workspace = true }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `into_int_floor()` and `into_int_ceil()` methods to `Dec` for different rounding strategies and include tests.
> 
>   - **Behavior**:
>     - Add `into_int_floor()` and `into_int_ceil()` methods to `Dec` in `conversions.rs` for rounding towards negative and positive infinity, respectively.
>     - `into_int()` method rounds towards zero.
>   - **Testing**:
>     - Add test cases for `into_int()`, `into_int_floor()`, and `into_int_ceil()` in `dec_tests` module.
>     - Add `test-case` as a dev-dependency in `Cargo.toml` and `Cargo.lock` for parameterized tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c00e66a66df9de9391ebc8893b71bf8b9b653e8d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->