### PR TITLE
taxman: only assert sent fund is no less than declared fees

### DIFF
--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -51,12 +51,16 @@ fn pay(ctx: MutableCtx, ty: FeeType, payments: BTreeMap<Addr, Coins>) -> anyhow:
             Ok(acc)
         })?;
 
-    ensure!(
-        ctx.funds == total,
-        "funds do not add up to the total amount of payments! funds: {}, total: {}",
-        ctx.funds,
-        total
-    );
+    for coin in total {
+        let paid = ctx.funds.amount_of(&coin.denom);
+        ensure!(
+            paid >= coin.amount,
+            "sent fund is less than declared payment! denom: {}, declared: {}, sent: {}",
+            coin.denom,
+            coin.amount,
+            paid
+        );
+    }
 
     // For now, nothing to do.
     // In the future, we will implement affiliate fees.

--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -55,7 +55,7 @@ fn pay(ctx: MutableCtx, ty: FeeType, payments: BTreeMap<Addr, Coins>) -> anyhow:
         let paid = ctx.funds.amount_of(&coin.denom);
         ensure!(
             paid >= coin.amount,
-            "sent fund is less than declared payment! denom: {}, declared: {}, sent: {}",
+            "sent fund is less than declared payment! denom: {}, declared: {}, paid: {}",
             coin.denom,
             coin.amount,
             paid


### PR DESCRIPTION
instead of requiring them to be exactly equal.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow sent funds to be greater than or equal to declared fees in `pay()` in `execute.rs`.
> 
>   - **Behavior**:
>     - In `pay()` in `execute.rs`, change fund validation to allow sent funds to be greater than or equal to declared fees.
>     - Previously, funds had to exactly match declared fees, now they can exceed them.
>   - **Error Handling**:
>     - If sent funds are less than declared fees, an error is raised with details on denomination, declared, and paid amounts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 7d7e5bf654aa3747447f1c5c5d175d948b5c5606. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->