### PR TITLE
dex: use decimal numbers to track volumes, refunds, and fees

### DIFF
--- a/dango/account/margin/src/core.rs
+++ b/dango/account/margin/src/core.rs
@@ -11,8 +11,8 @@ use {
         oracle::PrecisionedPrice,
     },
     grug::{
-        Addr, Coin, Coins, Denom, IsZero, MultiplyFraction, Number, NumberConst, QuerierExt,
-        QuerierWrapper, StorageQuerier, Timestamp, Udec128, Uint128,
+        Addr, Coin, Coins, Denom, IsZero, Number, NumberConst, QuerierExt, QuerierWrapper,
+        StorageQuerier, Timestamp, Udec128, Uint128,
     },
     std::{
         cmp::min,
@@ -233,15 +233,15 @@ pub fn compute_health(
             Direction::Bid => (
                 Coin::new(
                     res.quote_denom.clone(),
-                    res.remaining.checked_mul_dec_ceil(res.price)?,
+                    res.remaining.checked_mul(res.price)?.into_int(), // TODO: ceil
                 )?,
-                Coin::new(res.base_denom.clone(), res.remaining)?,
+                Coin::new(res.base_denom.clone(), res.remaining.into_int())?,
             ),
             Direction::Ask => (
-                Coin::new(res.base_denom.clone(), res.remaining)?,
+                Coin::new(res.base_denom.clone(), res.remaining.into_int())?,
                 Coin::new(
                     res.quote_denom.clone(),
-                    res.remaining.checked_mul_dec_floor(res.price)?,
+                    res.remaining.checked_mul(res.price)?.into_int(),
                 )?,
             ),
         };

--- a/dango/account/margin/src/core.rs
+++ b/dango/account/margin/src/core.rs
@@ -233,7 +233,7 @@ pub fn compute_health(
             Direction::Bid => (
                 Coin::new(
                     res.quote_denom.clone(),
-                    res.remaining.checked_mul(res.price)?.into_int(), // TODO: ceil
+                    res.remaining.checked_mul(res.price)?.into_int(),
                 )?,
                 Coin::new(res.base_denom.clone(), res.remaining.into_int())?,
             ),

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -86,7 +86,7 @@ fn bid_exact_amount_in(
         let matched_amount = cmp::min(order.remaining, remaining_bid);
         output_amount.checked_add_assign(matched_amount)?;
 
-        let matched_amount_in_quote = matched_amount.checked_mul(price)?; // TODO: ceil?
+        let matched_amount_in_quote = matched_amount.checked_mul(price)?;
         remaining_bid_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
         if remaining_bid_in_quote.is_zero() {
@@ -172,7 +172,7 @@ fn bid_exact_amount_out(
         let matched_amount = cmp::min(order.remaining, remaining_bid);
         remaining_bid.checked_sub_assign(matched_amount)?;
 
-        let matched_amount_in_quote = matched_amount.checked_mul(price)?; // TODO: ceil?
+        let matched_amount_in_quote = matched_amount.checked_mul(price)?;
         input_amount.checked_add_assign(matched_amount_in_quote)?;
 
         if remaining_bid.is_zero() {
@@ -195,7 +195,7 @@ fn ask_exact_amount_out(
         let matched_amount_in_quote = cmp::min(bid_size_in_quote, remaining_ask_in_quote);
         remaining_ask_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
-        let matched_amount_in_base = matched_amount_in_quote.checked_div(price)?; // TODO: ceil?
+        let matched_amount_in_base = matched_amount_in_quote.checked_div(price)?;
         input_amount.checked_add_assign(matched_amount_in_base)?;
 
         if remaining_ask_in_quote.is_zero() {

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -78,19 +78,19 @@ fn bid_exact_amount_in(
     bid_amount_in_quote: Uint128,
     passive_asks: Box<dyn Iterator<Item = (Udec128, PassiveOrder)>>,
 ) -> anyhow::Result<Uint128> {
-    let mut remaining_bid_in_quote = bid_amount_in_quote;
-    let mut output_amount = Uint128::ZERO;
+    let mut remaining_bid_in_quote = bid_amount_in_quote.checked_into_dec()?;
+    let mut output_amount = Udec128::ZERO;
 
     for (price, order) in passive_asks {
-        let remaining_bid = remaining_bid_in_quote.checked_div_dec_floor(price)?;
+        let remaining_bid = remaining_bid_in_quote.checked_div(price)?;
         let matched_amount = cmp::min(order.remaining, remaining_bid);
         output_amount.checked_add_assign(matched_amount)?;
 
-        let matched_amount_in_quote = matched_amount.checked_mul_dec_ceil(price)?;
+        let matched_amount_in_quote = matched_amount.checked_mul(price)?; // TODO: ceil?
         remaining_bid_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
         if remaining_bid_in_quote.is_zero() {
-            return Ok(output_amount);
+            return Ok(output_amount.into_int());
         }
     }
 
@@ -101,18 +101,18 @@ fn ask_exact_amount_in(
     ask_amount: Uint128,
     passive_bids: Box<dyn Iterator<Item = (Udec128, PassiveOrder)>>,
 ) -> anyhow::Result<Uint128> {
-    let mut remaining_ask = ask_amount;
-    let mut output_amount_in_quote = Uint128::ZERO;
+    let mut remaining_ask = ask_amount.checked_into_dec()?;
+    let mut output_amount_in_quote = Udec128::ZERO;
 
     for (price, order) in passive_bids {
         let matched_amount = cmp::min(order.remaining, remaining_ask);
         remaining_ask.checked_sub_assign(matched_amount)?;
 
-        let matched_amount_in_quote = matched_amount.checked_mul_dec_floor(price)?;
+        let matched_amount_in_quote = matched_amount.checked_mul(price)?;
         output_amount_in_quote.checked_add_assign(matched_amount_in_quote)?;
 
         if remaining_ask.is_zero() {
-            return Ok(output_amount_in_quote);
+            return Ok(output_amount_in_quote.into_int());
         }
     }
 
@@ -165,18 +165,18 @@ fn bid_exact_amount_out(
     bid_amount_base: Uint128,
     passive_asks: Box<dyn Iterator<Item = (Udec128, PassiveOrder)>>,
 ) -> anyhow::Result<Uint128> {
-    let mut remaining_bid = bid_amount_base;
-    let mut input_amount = Uint128::ZERO;
+    let mut remaining_bid = bid_amount_base.checked_into_dec()?;
+    let mut input_amount = Udec128::ZERO;
 
     for (price, order) in passive_asks {
         let matched_amount = cmp::min(order.remaining, remaining_bid);
         remaining_bid.checked_sub_assign(matched_amount)?;
 
-        let matched_amount_in_quote = matched_amount.checked_mul_dec_ceil(price)?;
+        let matched_amount_in_quote = matched_amount.checked_mul(price)?; // TODO: ceil?
         input_amount.checked_add_assign(matched_amount_in_quote)?;
 
         if remaining_bid.is_zero() {
-            return Ok(input_amount);
+            return Ok(input_amount.into_int());
         }
     }
 
@@ -187,19 +187,19 @@ fn ask_exact_amount_out(
     ask_amount_in_quote: Uint128,
     passive_bids: Box<dyn Iterator<Item = (Udec128, PassiveOrder)>>,
 ) -> anyhow::Result<Uint128> {
-    let mut remaining_ask_in_quote = ask_amount_in_quote;
-    let mut input_amount = Uint128::ZERO;
+    let mut remaining_ask_in_quote = ask_amount_in_quote.checked_into_dec()?;
+    let mut input_amount = Udec128::ZERO;
 
     for (price, order) in passive_bids {
-        let bid_size_in_quote = order.remaining.checked_mul_dec(price)?;
+        let bid_size_in_quote = order.remaining.checked_mul(price)?;
         let matched_amount_in_quote = cmp::min(bid_size_in_quote, remaining_ask_in_quote);
         remaining_ask_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
-        let matched_amount_in_base = matched_amount_in_quote.checked_div_dec_ceil(price)?;
+        let matched_amount_in_base = matched_amount_in_quote.checked_div(price)?; // TODO: ceil?
         input_amount.checked_add_assign(matched_amount_in_base)?;
 
         if remaining_ask_in_quote.is_zero() {
-            return Ok(input_amount);
+            return Ok(input_amount.into_int());
         }
     }
 
@@ -263,7 +263,7 @@ pub fn reflect_curve(
                 id,
                 price,
                 amount: size,
-                remaining: size,
+                remaining: size.checked_into_dec().ok()?,
             }))
         })
     };
@@ -288,7 +288,7 @@ pub fn reflect_curve(
                 id,
                 price,
                 amount: size,
-                remaining: size,
+                remaining: size.checked_into_dec().ok()?,
             }))
         })
     };

--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -118,11 +118,11 @@ where
             // to refund the amount that was not filled.
             match market_order_direction {
                 Direction::Bid => {
-                    filling_outcome
-                        .refund_quote
-                        .checked_add_assign(market_order.remaining.checked_sub(
-                        market_order_amount_to_match_in_base.checked_mul(*price)?, // TODO: ceil?
-                    )?)?;
+                    filling_outcome.refund_quote.checked_add_assign(
+                        market_order.remaining.checked_sub(
+                            market_order_amount_to_match_in_base.checked_mul(*price)?,
+                        )?,
+                    )?;
                 },
                 Direction::Ask => {
                     filling_outcome.refund_base.checked_add_assign(
@@ -203,7 +203,7 @@ where
                     // the amount left in the market order will be refunded in `cron_execute`.
                     match market_order_direction {
                         Direction::Bid => {
-                            let fill_amount_in_quote = fill_amount.checked_mul(*price)?; // TODO: ceil?
+                            let fill_amount_in_quote = fill_amount.checked_mul(*price)?;
                             market_order.fill(fill_amount_in_quote)?;
                         },
                         Direction::Ask => {
@@ -285,7 +285,7 @@ fn update_filling_outcome(
 
     match order_direction {
         Direction::Bid => {
-            let fee_base = filled_base.checked_mul(fee_rate)?; // TODO: ceil?
+            let fee_base = filled_base.checked_mul(fee_rate)?;
 
             filling_outcome.fee_base.checked_add_assign(fee_base)?;
             filling_outcome
@@ -293,7 +293,7 @@ fn update_filling_outcome(
                 .checked_add_assign(filled_base.checked_sub(fee_base)?)?;
         },
         Direction::Ask => {
-            let fee_quote = filled_quote.checked_mul(fee_rate)?; // TODO: ceil?
+            let fee_quote = filled_quote.checked_mul(fee_rate)?;
 
             filling_outcome.fee_quote.checked_add_assign(fee_quote)?;
             filling_outcome

--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -1,10 +1,7 @@
 use {
     crate::{ExtendedOrderId, FillingOutcome, MarketOrder, Order, OrderTrait},
     dango_types::dex::{Direction, OrderId},
-    grug::{
-        IsZero, MultiplyFraction, Number, NumberConst, Signed, StdResult, Udec128, Uint128,
-        Unsigned,
-    },
+    grug::{IsZero, Number, NumberConst, Signed, StdResult, Udec128, Unsigned},
     std::{cmp::Ordering, collections::HashMap, iter::Peekable},
 };
 
@@ -74,7 +71,7 @@ where
         };
 
         let market_order_amount_in_base = match market_order_direction {
-            Direction::Bid => market_order.remaining.checked_div_dec_floor(*price)?,
+            Direction::Bid => market_order.remaining.checked_div(*price)?,
             Direction::Ask => market_order.remaining,
         };
 
@@ -101,10 +98,9 @@ where
             // Calculate how much of the market order can be filled without the average
             // price of the market order exceeding the cutoff price.
             // TODO: optimize the math here. See the jupyter notebook.
-            let current_avg_price = Udec128::checked_from_ratio(
-                filling_outcome.filled_quote,
-                filling_outcome.filled_base,
-            )?;
+            let current_avg_price = filling_outcome
+                .filled_quote
+                .checked_div(filling_outcome.filled_base)?;
             let price_ratio = current_avg_price
                 .checked_into_signed()?
                 .checked_sub(cutoff_price.checked_into_signed()?)?
@@ -115,18 +111,18 @@ where
                 )?;
             let market_order_amount_to_match_in_base = filling_outcome
                 .filled_base
-                .checked_mul_dec_floor(price_ratio.checked_into_unsigned()?)?
+                .checked_mul(price_ratio.checked_into_unsigned()?)?
                 .min(market_order_amount_in_base);
 
             // Since the order is only partially filled we update the filling outcome
             // to refund the amount that was not filled.
             match market_order_direction {
                 Direction::Bid => {
-                    filling_outcome.refund_quote.checked_add_assign(
-                        market_order.remaining.checked_sub(
-                            market_order_amount_to_match_in_base.checked_mul_dec_ceil(*price)?,
-                        )?,
-                    )?;
+                    filling_outcome
+                        .refund_quote
+                        .checked_add_assign(market_order.remaining.checked_sub(
+                        market_order_amount_to_match_in_base.checked_mul(*price)?, // TODO: ceil?
+                    )?)?;
                 },
                 Direction::Ask => {
                     filling_outcome.refund_base.checked_add_assign(
@@ -152,7 +148,7 @@ where
         // If the resulting output of the match for a SELL market order is zero,
         // we skip it because it cannot be filled.
         if market_order_direction == Direction::Ask {
-            let filled_quote = filled_base.checked_mul_dec_floor(*price)?;
+            let filled_quote = filled_base.checked_mul(*price)?;
             if filled_quote.is_zero() {
                 market_orders.next();
                 continue;
@@ -207,7 +203,7 @@ where
                     // the amount left in the market order will be refunded in `cron_execute`.
                     match market_order_direction {
                         Direction::Bid => {
-                            let fill_amount_in_quote = fill_amount.checked_mul_dec_ceil(*price)?;
+                            let fill_amount_in_quote = fill_amount.checked_mul(*price)?; // TODO: ceil?
                             market_order.fill(fill_amount_in_quote)?;
                         },
                         Direction::Ask => {
@@ -260,7 +256,7 @@ fn update_filling_outcome(
     filling_outcomes: &mut HashMap<ExtendedOrderId, FillingOutcome>,
     order: Order,
     order_direction: Direction,
-    filled_base: Uint128,
+    filled_base: Udec128,
     price: Udec128,
     fee_rate: Udec128,
 ) -> StdResult<()> {
@@ -269,27 +265,27 @@ fn update_filling_outcome(
         .or_insert_with(|| FillingOutcome {
             order_direction,
             order,
-            filled_base: Uint128::ZERO,
-            filled_quote: Uint128::ZERO,
-            refund_base: Uint128::ZERO,
-            refund_quote: Uint128::ZERO,
-            fee_base: Uint128::ZERO,
-            fee_quote: Uint128::ZERO,
+            filled_base: Udec128::ZERO,
+            filled_quote: Udec128::ZERO,
+            refund_base: Udec128::ZERO,
+            refund_quote: Udec128::ZERO,
+            fee_base: Udec128::ZERO,
+            fee_quote: Udec128::ZERO,
         });
 
-    let filled_quote = filled_base.checked_mul_dec_floor(price)?;
+    let filled_quote = filled_base.checked_mul(price)?;
 
     filling_outcome
         .filled_base
         .checked_add_assign(filled_base)?;
     filling_outcome
         .filled_quote
-        .checked_add_assign(filled_base.checked_mul_dec_floor(price)?)?;
+        .checked_add_assign(filled_base.checked_mul(price)?)?;
     filling_outcome.order = order;
 
     match order_direction {
         Direction::Bid => {
-            let fee_base = filled_base.checked_mul_dec_ceil(fee_rate)?;
+            let fee_base = filled_base.checked_mul(fee_rate)?; // TODO: ceil?
 
             filling_outcome.fee_base.checked_add_assign(fee_base)?;
             filling_outcome
@@ -297,7 +293,7 @@ fn update_filling_outcome(
                 .checked_add_assign(filled_base.checked_sub(fee_base)?)?;
         },
         Direction::Ask => {
-            let fee_quote = filled_quote.checked_mul_dec_ceil(fee_rate)?;
+            let fee_quote = filled_quote.checked_mul(fee_rate)?; // TODO: ceil?
 
             filling_outcome.fee_quote.checked_add_assign(fee_quote)?;
             filling_outcome

--- a/dango/dex/src/core/order_filling.rs
+++ b/dango/dex/src/core/order_filling.rs
@@ -89,7 +89,7 @@ fn fill_bids(
         };
 
         // For bids, the fee is paid in base asset.
-        let fee_base = filled_base.checked_mul(fee_rate)?; // TODO: ceil?
+        let fee_base = filled_base.checked_mul(fee_rate)?;
         let fee_quote = Udec128::ZERO;
 
         // Determine the refund amounts.
@@ -153,7 +153,7 @@ fn fill_asks(
 
         // For asks, the fee is paid in quote asset.
         let fee_base = Udec128::ZERO;
-        let fee_quote = filled_quote.checked_mul(fee_rate)?; // TODO: ceil?
+        let fee_quote = filled_quote.checked_mul(fee_rate)?;
 
         // Determine the refund amounts.
         // For base, since limit orders are good-till-canceled, no need to refund.

--- a/dango/dex/src/core/order_filling.rs
+++ b/dango/dex/src/core/order_filling.rs
@@ -1,7 +1,7 @@
 use {
     crate::{Order, OrderTrait},
     dango_types::dex::Direction,
-    grug::{IsZero, MultiplyFraction, Number, NumberConst, StdResult, Udec128, Uint128},
+    grug::{IsZero, Number, NumberConst, StdResult, Udec128},
 };
 
 #[derive(Debug)]
@@ -10,17 +10,17 @@ pub struct FillingOutcome {
     /// The order with the `filled` amount updated.
     pub order: Order,
     /// Amount this order was filled for, in base asset.
-    pub filled_base: Uint128,
+    pub filled_base: Udec128,
     /// Amount this order was filled for, in quote asset.
-    pub filled_quote: Uint128,
+    pub filled_quote: Udec128,
     /// Amount of base asset that should be refunded to the trader.
-    pub refund_base: Uint128,
+    pub refund_base: Udec128,
     /// Amount of quote asset that should be refunded to the trader.
-    pub refund_quote: Uint128,
+    pub refund_quote: Udec128,
     /// Fee charged in base asset.
-    pub fee_base: Uint128,
+    pub fee_base: Udec128,
     /// Fee charged in quote asset.
-    pub fee_quote: Uint128,
+    pub fee_quote: Udec128,
 }
 
 /// Clear the orders given a clearing price and volume.
@@ -28,7 +28,7 @@ pub fn fill_orders(
     bids: Vec<(Udec128, Order)>,
     asks: Vec<(Udec128, Order)>,
     clearing_price: Udec128,
-    volume: Uint128,
+    volume: Udec128,
     current_block_height: u64,
     maker_fee_rate: Udec128,
     taker_fee_rate: Udec128,
@@ -60,7 +60,7 @@ pub fn fill_orders(
 fn fill_bids(
     bids: Vec<(Udec128, Order)>,
     clearing_price: Udec128,
-    mut volume: Uint128,
+    mut volume: Udec128,
     current_block_height: u64,
     maker_fee_rate: Udec128,
     taker_fee_rate: Udec128,
@@ -72,7 +72,7 @@ fn fill_bids(
         // This would be the order's remaining amount, or the remaining volume,
         // whichever is smaller.
         let filled_base = *order.remaining().min(&volume);
-        let filled_quote = filled_base.checked_mul_dec_floor(order_price)?;
+        let filled_quote = filled_base.checked_mul(order_price)?;
 
         // Deduct the amount filled from the order and the volume.
         order.fill(filled_base)?;
@@ -89,15 +89,15 @@ fn fill_bids(
         };
 
         // For bids, the fee is paid in base asset.
-        let fee_base = filled_base.checked_mul_dec_ceil(fee_rate)?;
-        let fee_quote = Uint128::ZERO;
+        let fee_base = filled_base.checked_mul(fee_rate)?; // TODO: ceil?
+        let fee_quote = Udec128::ZERO;
 
         // Determine the refund amounts.
         // For base, it's the filled amount minus the fee.
         // For quote, in case the order is filled at a price better than the
         // limit price, refund the unused deposit.
         let refund_base = filled_base.checked_sub(fee_base)?;
-        let refund_quote = filled_base.checked_mul_dec_floor(order_price - clearing_price)?;
+        let refund_quote = filled_base.checked_mul(order_price - clearing_price)?;
 
         outcome.push(FillingOutcome {
             order_direction: Direction::Bid,
@@ -122,7 +122,7 @@ fn fill_bids(
 fn fill_asks(
     asks: Vec<(Udec128, Order)>,
     clearing_price: Udec128,
-    mut volume: Uint128,
+    mut volume: Udec128,
     current_block_height: u64,
     maker_fee_rate: Udec128,
     taker_fee_rate: Udec128,
@@ -134,7 +134,7 @@ fn fill_asks(
         // This would be the order's remaining amount, or the remaining volume,
         // whichever is smaller.
         let filled_base = *order.remaining().min(&volume);
-        let filled_quote = filled_base.checked_mul_dec_floor(clearing_price)?;
+        let filled_quote = filled_base.checked_mul(clearing_price)?;
 
         // Deduct the amount filled from the order and the volume.
         order.fill(filled_base)?;
@@ -152,13 +152,13 @@ fn fill_asks(
         };
 
         // For asks, the fee is paid in quote asset.
-        let fee_base = Uint128::ZERO;
-        let fee_quote = filled_quote.checked_mul_dec_ceil(fee_rate)?;
+        let fee_base = Udec128::ZERO;
+        let fee_quote = filled_quote.checked_mul(fee_rate)?; // TODO: ceil?
 
         // Determine the refund amounts.
         // For base, since limit orders are good-till-canceled, no need to refund.
         // For quote, it's the filled amount minus the fee.
-        let refund_base = Uint128::ZERO;
+        let refund_base = Udec128::ZERO;
         let refund_quote = filled_quote.checked_sub(fee_quote)?;
 
         outcome.push(FillingOutcome {

--- a/dango/dex/src/core/order_matching.rs
+++ b/dango/dex/src/core/order_matching.rs
@@ -1,6 +1,6 @@
 use {
     crate::{Order, OrderTrait},
-    grug::{Number, NumberConst, StdResult, Udec128, Uint128},
+    grug::{Number, NumberConst, StdResult, Udec128},
 };
 
 pub struct MatchingOutcome {
@@ -11,7 +11,7 @@ pub struct MatchingOutcome {
     /// to decide which price to use: the lowest, the highest, or the midpoint.
     pub range: Option<(Udec128, Udec128)>,
     /// The amount of trading volume, measured as the amount of the base asset.
-    pub volume: Uint128,
+    pub volume: Udec128,
     /// The BUY orders that have found a match.
     pub bids: Vec<(Udec128, Order)>,
     /// The SELL orders that have found a match.
@@ -37,11 +37,11 @@ where
     let mut bid = bid_iter.next().transpose()?;
     let mut bids = Vec::new();
     let mut bid_is_new = true;
-    let mut bid_volume = Uint128::ZERO;
+    let mut bid_volume = Udec128::ZERO;
     let mut ask = ask_iter.next().transpose()?;
     let mut asks = Vec::new();
     let mut ask_is_new = true;
-    let mut ask_volume = Uint128::ZERO;
+    let mut ask_volume = Udec128::ZERO;
     let mut range = None;
 
     loop {

--- a/dango/dex/src/core/types.rs
+++ b/dango/dex/src/core/types.rs
@@ -33,21 +33,21 @@ pub trait OrderTrait {
     fn created_at_block_height(&self) -> Option<u64>;
 
     /// Return the order's remaining amount as an immutable reference.
-    fn remaining(&self) -> &Uint128;
+    fn remaining(&self) -> &Udec128;
 
     /// Return the order's remaining amount as a mutable reference.
-    fn remaining_mut(&mut self) -> &mut Uint128;
+    fn remaining_mut(&mut self) -> &mut Udec128;
 
     /// Subtract a given amount from the order's remaining amount.
-    fn fill(&mut self, amount: Uint128) -> MathResult<()> {
+    fn fill(&mut self, amount: Udec128) -> MathResult<()> {
         self.remaining_mut().checked_sub_assign(amount)
     }
 
     /// Set the order's remaining amount to zero.
     /// Return the remaining amount prior to clearing.
-    fn clear(&mut self) -> Uint128 {
+    fn clear(&mut self) -> Udec128 {
         let remaining = *self.remaining();
-        *self.remaining_mut() = Uint128::ZERO;
+        *self.remaining_mut() = Udec128::ZERO;
         remaining
     }
 }
@@ -94,7 +94,7 @@ impl OrderTrait for Order {
         }
     }
 
-    fn remaining(&self) -> &Uint128 {
+    fn remaining(&self) -> &Udec128 {
         match self {
             Order::Limit(limit_order) => limit_order.remaining(),
             Order::Market(market_order) => market_order.remaining(),
@@ -102,7 +102,7 @@ impl OrderTrait for Order {
         }
     }
 
-    fn remaining_mut(&mut self) -> &mut Uint128 {
+    fn remaining_mut(&mut self) -> &mut Udec128 {
         match self {
             Order::Limit(limit_order) => limit_order.remaining_mut(),
             Order::Market(market_order) => market_order.remaining_mut(),
@@ -122,7 +122,7 @@ pub struct LimitOrder {
     /// The order's total size, measured in the _base asset_.
     pub amount: Uint128,
     /// Portion of the order that remains unfilled, measured in the _base asset_.
-    pub remaining: Uint128,
+    pub remaining: Udec128,
     /// The block height at which the order was submitted.
     pub created_at_block_height: u64,
 }
@@ -144,11 +144,11 @@ impl OrderTrait for LimitOrder {
         Some(self.created_at_block_height)
     }
 
-    fn remaining(&self) -> &Uint128 {
+    fn remaining(&self) -> &Udec128 {
         &self.remaining
     }
 
-    fn remaining_mut(&mut self) -> &mut Uint128 {
+    fn remaining_mut(&mut self) -> &mut Udec128 {
         &mut self.remaining
     }
 }
@@ -164,7 +164,7 @@ pub struct MarketOrder {
     pub amount: Uint128,
     /// Portion of the order that remains unfilled, measured in the unit as the
     /// `amount` field.
-    pub remaining: Uint128,
+    pub remaining: Udec128,
     /// Max slippage percentage.
     pub max_slippage: Udec128,
 }
@@ -186,11 +186,11 @@ impl OrderTrait for MarketOrder {
         None
     }
 
-    fn remaining(&self) -> &Uint128 {
+    fn remaining(&self) -> &Udec128 {
         &self.remaining
     }
 
-    fn remaining_mut(&mut self) -> &mut Uint128 {
+    fn remaining_mut(&mut self) -> &mut Udec128 {
         &mut self.remaining
     }
 }
@@ -201,7 +201,7 @@ pub struct PassiveOrder {
     pub id: OrderId,
     pub price: Udec128,
     pub amount: Uint128,
-    pub remaining: Uint128,
+    pub remaining: Udec128,
 }
 
 impl OrderTrait for PassiveOrder {
@@ -221,11 +221,11 @@ impl OrderTrait for PassiveOrder {
         None
     }
 
-    fn remaining(&self) -> &Uint128 {
+    fn remaining(&self) -> &Udec128 {
         &self.remaining
     }
 
-    fn remaining_mut(&mut self) -> &mut Uint128 {
+    fn remaining_mut(&mut self) -> &mut Udec128 {
         &mut self.remaining
     }
 }

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -142,7 +142,7 @@ pub fn reflect_curve(
                 id,
                 price,
                 amount,
-                remaining: amount,
+                remaining: amount.checked_into_dec().ok()?,
             }))
         })
     };
@@ -186,7 +186,7 @@ pub fn reflect_curve(
                 id,
                 price,
                 amount,
-                remaining: amount,
+                remaining: amount.checked_into_dec().ok()?,
             }))
         })
     };

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -225,7 +225,6 @@ fn provide_liquidity(
         } else {
             None
         }))
-    // TODO: add event
 }
 
 /// Withdraw liquidity from a pool. The LP tokens must be sent with the message.
@@ -274,7 +273,6 @@ fn withdraw_liquidity(
             )?
         })
         .add_message(Message::transfer(ctx.sender, refunds)?))
-    // TODO: add events
 }
 
 fn swap_exact_amount_in(

--- a/dango/dex/src/execute/order_cancellation.rs
+++ b/dango/dex/src/execute/order_cancellation.rs
@@ -5,10 +5,7 @@ use {
     },
     anyhow::{bail, ensure},
     dango_types::dex::{Direction, OrderCanceled, OrderId, OrderKind},
-    grug::{
-        Addr, Coin, Coins, EventBuilder, MultiplyFraction, Order as IterationOrder, StdResult,
-        Storage,
-    },
+    grug::{Addr, Coin, Coins, EventBuilder, Number, Order as IterationOrder, StdResult, Storage},
 };
 
 /// Cancel all orders that belong to the given user.
@@ -135,11 +132,11 @@ fn cancel_limit_order(
     let refund = match direction {
         Direction::Bid => Coin {
             denom: quote_denom,
-            amount: order.remaining.checked_mul_dec_floor(price)?,
+            amount: order.remaining.checked_mul(price)?.into_int(),
         },
         Direction::Ask => Coin {
             denom: base_denom,
-            amount: order.remaining,
+            amount: order.remaining.into_int(),
         },
     };
 
@@ -147,7 +144,7 @@ fn cancel_limit_order(
         user,
         id: order_id,
         kind: OrderKind::Limit,
-        remaining: order.remaining,
+        remaining: order.remaining.into_int(),
         refund: refund.clone(),
     })?;
 

--- a/dango/dex/src/execute/order_creation.rs
+++ b/dango/dex/src/execute/order_creation.rs
@@ -70,7 +70,7 @@ pub(super) fn create_limit_order(
                 id: order_id,
                 price: order.price,
                 amount: *order.amount,
-                remaining: *order.amount,
+                remaining: order.amount.checked_into_dec()?,
                 created_at_block_height: current_block_height,
             },
         ),
@@ -131,7 +131,7 @@ pub(super) fn create_market_order(
             user,
             id: order_id,
             amount: *order.amount,
-            remaining: *order.amount,
+            remaining: order.amount.checked_into_dec()?,
             max_slippage: order.max_slippage,
         },
     )?;

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -15,7 +15,7 @@ use {
     grug::{
         Addr, Bound, Coin, CoinPair, DEFAULT_PAGE_LIMIT, Denom, ImmutableCtx, Inner, Json,
         JsonSerExt, NonZero, Number, NumberConst, Order as IterationOrder, QuerierExt, StdResult,
-        Timestamp, Uint128,
+        Timestamp, Udec128, Uint128,
     },
     std::collections::BTreeMap,
 };
@@ -277,13 +277,13 @@ fn query_orders_by_user(
 }
 
 #[inline]
-fn query_volume(ctx: ImmutableCtx, user: Addr, since: Option<Timestamp>) -> StdResult<Uint128> {
+fn query_volume(ctx: ImmutableCtx, user: Addr, since: Option<Timestamp>) -> StdResult<Udec128> {
     let volume_now = VOLUMES
         .prefix(&user)
         .values(ctx.storage, None, None, IterationOrder::Descending)
         .next()
         .transpose()?
-        .unwrap_or(Uint128::ZERO);
+        .unwrap_or(Udec128::ZERO);
 
     let volume_since = if let Some(since) = since {
         VOLUMES
@@ -296,9 +296,9 @@ fn query_volume(ctx: ImmutableCtx, user: Addr, since: Option<Timestamp>) -> StdR
             )
             .next()
             .transpose()?
-            .unwrap_or(Uint128::ZERO)
+            .unwrap_or(Udec128::ZERO)
     } else {
-        Uint128::ZERO
+        Udec128::ZERO
     };
 
     Ok(volume_now.checked_sub(volume_since)?)
@@ -308,13 +308,13 @@ fn query_volume_by_user(
     ctx: ImmutableCtx,
     user: Username,
     since: Option<Timestamp>,
-) -> StdResult<Uint128> {
+) -> StdResult<Udec128> {
     let volume_now = VOLUMES_BY_USER
         .prefix(&user)
         .values(ctx.storage, None, None, IterationOrder::Descending)
         .next()
         .transpose()?
-        .unwrap_or(Uint128::ZERO);
+        .unwrap_or(Udec128::ZERO);
 
     let volume_since = if let Some(since) = since {
         VOLUMES_BY_USER
@@ -327,9 +327,9 @@ fn query_volume_by_user(
             )
             .next()
             .transpose()?
-            .unwrap_or(Uint128::ZERO)
+            .unwrap_or(Udec128::ZERO)
     } else {
-        Uint128::ZERO
+        Udec128::ZERO
     };
 
     Ok(volume_now.checked_sub(volume_since)?)

--- a/dango/dex/src/state.rs
+++ b/dango/dex/src/state.rs
@@ -5,7 +5,7 @@ use {
         dex::{Direction, OrderId, PairParams},
     },
     grug::{
-        Addr, CoinPair, Counter, Denom, IndexedMap, Map, MultiIndex, Timestamp, Udec128, Uint128,
+        Addr, CoinPair, Counter, Denom, IndexedMap, Map, MultiIndex, Timestamp, Udec128,
         UniqueIndex,
     },
 };
@@ -38,10 +38,10 @@ pub const INCOMING_ORDERS: Map<(Addr, OrderId), (LimitOrderKey, LimitOrder)> =
     Map::new("incoming_orders");
 
 /// Stores the total trading volume in USD for each account address and timestamp.
-pub const VOLUMES: Map<(&Addr, Timestamp), Uint128> = Map::new("volume");
+pub const VOLUMES: Map<(&Addr, Timestamp), Udec128> = Map::new("volume");
 
 /// Stores the total trading volume in USD for each username and timestamp.
-pub const VOLUMES_BY_USER: Map<(&Username, Timestamp), Uint128> = Map::new("volume_by_user");
+pub const VOLUMES_BY_USER: Map<(&Username, Timestamp), Udec128> = Map::new("volume_by_user");
 
 /// Storage key for market orders.
 ///

--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -51,12 +51,16 @@ fn pay(ctx: MutableCtx, ty: FeeType, payments: BTreeMap<Addr, Coins>) -> anyhow:
             Ok(acc)
         })?;
 
-    ensure!(
-        ctx.funds == total,
-        "funds do not add up to the total amount of payments! funds: {}, total: {}",
-        ctx.funds,
-        total
-    );
+    for coin in total {
+        let paid = ctx.funds.amount_of(&coin.denom);
+        ensure!(
+            paid >= coin.amount,
+            "sent fund is less than declared payment! denom: {}, declared: {}, sent: {}",
+            coin.denom,
+            coin.amount,
+            paid
+        );
+    }
 
     // For now, nothing to do.
     // In the future, we will implement affiliate fees.

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -3341,6 +3341,7 @@ fn volume_tracking_works() {
         .should_succeed_and_equal(Udec128::new(100));
 }
 
+#[ignore = "this test needs to be updated"]
 #[test]
 fn volume_tracking_works_with_multiple_orders_from_same_user() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -3082,42 +3082,42 @@ fn volume_tracking_works() {
             user: user1_addr_1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user1_addr_1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user1_addr_2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
             user: user1_addr_1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user2_addr_1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user2_addr_2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     // Submit a new order with user1 address 1
     suite
@@ -3168,7 +3168,7 @@ fn volume_tracking_works() {
             user: user1_addr_1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     // Query the volume for username user2, should be 100
     suite
@@ -3176,7 +3176,7 @@ fn volume_tracking_works() {
             user: user2_addr_1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     // Query the volume for user1 address 1, should be 100
     suite
@@ -3184,7 +3184,7 @@ fn volume_tracking_works() {
             user: user1_addr_1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     // Query the volume for user2 address 1, should be 100
     suite
@@ -3192,7 +3192,7 @@ fn volume_tracking_works() {
             user: user2_addr_1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     // Query the volume for user1 address 2, should be zero
     suite
@@ -3200,7 +3200,7 @@ fn volume_tracking_works() {
             user: user1_addr_2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     // Query the volume for user2 address 2, should be zero
     suite
@@ -3208,7 +3208,7 @@ fn volume_tracking_works() {
             user: user2_addr_2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     // Submit a new order with user1 address 2
     suite
@@ -3256,7 +3256,7 @@ fn volume_tracking_works() {
             user: user1_addr_1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(200));
+        .should_succeed_and_equal(Udec128::new(200));
 
     // Query the volume for username user2, should be 200
     suite
@@ -3264,7 +3264,7 @@ fn volume_tracking_works() {
             user: user2_addr_1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(200));
+        .should_succeed_and_equal(Udec128::new(200));
 
     // Query the volume for all addresses, should be 100
     suite
@@ -3272,28 +3272,28 @@ fn volume_tracking_works() {
             user: user1_addr_1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user1_addr_2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user2_addr_1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user2_addr_2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     // Query the volume for both usernames since timestamp after first trade, should be 100
     suite
@@ -3301,14 +3301,14 @@ fn volume_tracking_works() {
             user: user1_addr_1.username.clone(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
             user: user2_addr_1.username.clone(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     // Query the volume for both users address 1 since timestamp after first trade, should be zero
     suite
@@ -3316,14 +3316,14 @@ fn volume_tracking_works() {
             user: user1_addr_1.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user2_addr_1.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     // Query the volume for both users address 2 since timestamp after first trade, should be 100
     suite
@@ -3331,14 +3331,14 @@ fn volume_tracking_works() {
             user: user1_addr_2.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: user2_addr_2.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::new(100));
+        .should_succeed_and_equal(Udec128::new(100));
 }
 
 #[test]
@@ -3470,7 +3470,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(300));
+        .should_succeed_and_equal(Udec128::new(300));
 
     // Query the volume for username user2, should be 300
     suite
@@ -3478,7 +3478,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(300));
+        .should_succeed_and_equal(Udec128::new(300));
 
     // Query the volume for user1 address, should be 300
     suite
@@ -3486,7 +3486,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(300));
+        .should_succeed_and_equal(Udec128::new(300));
 
     // Query the volume for user2 address, should be 300
     suite
@@ -3494,7 +3494,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(300));
+        .should_succeed_and_equal(Udec128::new(300));
 
     // Query the volume for both usernames since timestamp after first trade, should be zero
     suite
@@ -3502,13 +3502,13 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.username.clone(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
             user: accounts.user2.username.clone(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     // Submit new orders with user1
     suite
@@ -3599,7 +3599,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(700));
+        .should_succeed_and_equal(Udec128::new(700));
 
     // Query the volume for username user2, should be 700
     suite
@@ -3607,7 +3607,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(700));
+        .should_succeed_and_equal(Udec128::new(700));
 
     // Query the volume for user1 address, should be 700
     suite
@@ -3615,7 +3615,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(700));
+        .should_succeed_and_equal(Udec128::new(700));
 
     // Query the volume for user2 address, should be 700
     suite
@@ -3623,7 +3623,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Uint128::new(700));
+        .should_succeed_and_equal(Udec128::new(700));
 
     // Query the volume for both usernames since timestamp after second trade, should be zero
     suite
@@ -3631,13 +3631,13 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.username.clone(),
             since: Some(timestamp_after_second_trade),
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeByUserRequest {
             user: accounts.user2.username.clone(),
             since: Some(timestamp_after_second_trade),
         })
-        .should_succeed_and_equal(Uint128::ZERO);
+        .should_succeed_and_equal(Udec128::ZERO);
 
     // Query the volume for both addresses since timestamp after the first trade, should be 400
     suite
@@ -3645,13 +3645,13 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::new(400));
+        .should_succeed_and_equal(Udec128::new(400));
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: accounts.user2.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Uint128::new(400));
+        .should_succeed_and_equal(Udec128::new(400));
 }
 
 #[test_case(

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -3341,7 +3341,6 @@ fn volume_tracking_works() {
         .should_succeed_and_equal(Udec128::new(100));
 }
 
-#[ignore = "this test needs to be updated"]
 #[test]
 fn volume_tracking_works_with_multiple_orders_from_same_user() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
@@ -3378,7 +3377,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         )
         .should_succeed();
 
-    // Register oracle price source for BTC
+    // Register oracle price source for ETH
     suite
         .execute(
             &mut accounts.owner,
@@ -3394,7 +3393,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         )
         .should_succeed();
 
-    // Submit two orders for DANGO/USDC and one for BTC/USDC with user1
+    // Submit two orders for DANGO/USDC and one for ETH/USDC with user1
     suite
         .execute(
             &mut accounts.user1,
@@ -3471,7 +3470,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(300));
+        .should_succeed_and_equal(Udec128::from_str("300.0001467784").unwrap());
 
     // Query the volume for username user2, should be 300
     suite
@@ -3479,7 +3478,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(300));
+        .should_succeed_and_equal(Udec128::from_str("300.0001467784").unwrap());
 
     // Query the volume for user1 address, should be 300
     suite
@@ -3487,7 +3486,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(300));
+        .should_succeed_and_equal(Udec128::from_str("300.0001467784").unwrap());
 
     // Query the volume for user2 address, should be 300
     suite
@@ -3495,7 +3494,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(300));
+        .should_succeed_and_equal(Udec128::from_str("300.0001467784").unwrap());
 
     // Query the volume for both usernames since timestamp after first trade, should be zero
     suite
@@ -3600,7 +3599,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(700));
+        .should_succeed_and_equal(Udec128::from_str("700.0004403352").unwrap());
 
     // Query the volume for username user2, should be 700
     suite
@@ -3608,7 +3607,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.username.clone(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(700));
+        .should_succeed_and_equal(Udec128::from_str("700.0004403352").unwrap());
 
     // Query the volume for user1 address, should be 700
     suite
@@ -3616,7 +3615,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.address(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(700));
+        .should_succeed_and_equal(Udec128::from_str("700.0004403352").unwrap());
 
     // Query the volume for user2 address, should be 700
     suite
@@ -3624,7 +3623,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user2.address(),
             since: None,
         })
-        .should_succeed_and_equal(Udec128::new(700));
+        .should_succeed_and_equal(Udec128::from_str("700.0004403352").unwrap());
 
     // Query the volume for both usernames since timestamp after second trade, should be zero
     suite
@@ -3646,13 +3645,13 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             user: accounts.user1.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Udec128::new(400));
+        .should_succeed_and_equal(Udec128::from_str("400.0002935568").unwrap());
     suite
         .query_wasm_smart(contracts.dex, dex::QueryVolumeRequest {
             user: accounts.user2.address(),
             since: Some(timestamp_after_first_trade),
         })
-        .should_succeed_and_equal(Udec128::new(400));
+        .should_succeed_and_equal(Udec128::from_str("400.0002935568").unwrap());
 }
 
 #[test_case(
@@ -5484,7 +5483,6 @@ fn market_order_clearing(
         });
 }
 
-#[ignore = "these test cases needs to be updated"] // TODO
 #[test_case(
     CreateLimitOrderRequest {
         base_denom: eth::DENOM.clone(),
@@ -5508,7 +5506,7 @@ fn market_order_clearing(
     },
     btree_map! {
         eth::DENOM.clone() => BalanceChange::Decreased(9307),
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
+        usdc::DENOM.clone() => BalanceChange::Increased(498750),
     },
     btree_map! {
         eth::DENOM.clone() => BalanceChange::Unchanged,
@@ -5538,7 +5536,7 @@ fn market_order_clearing(
         eth::DENOM.clone() => 9999,
     },
     btree_map! {
-        eth::DENOM.clone() => BalanceChange::Unchanged,
+        eth::DENOM.clone() => BalanceChange::Increased(9974),
         usdc::DENOM.clone() => BalanceChange::Decreased(50),
     },
     btree_map! {

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -449,7 +449,7 @@ fn dex_works(
         })
         .unwrap()
         .into_iter()
-        .map(|(order_id, order)| (order_id, order.remaining.into_inner()))
+        .map(|(order_id, order)| (order_id, order.remaining.into_int().into_inner()))
         .collect::<BTreeMap<_, _>>();
     assert_eq!(orders, remaining_orders);
 }
@@ -473,7 +473,7 @@ fn dex_works(
             direction: Direction::Bid,
             price: Udec128::new(1),
             amount: Uint128::new(100),
-            remaining: Uint128::new(100),
+            remaining: Udec128::new(100),
         },
     };
     "one submission no cancellations"
@@ -520,7 +520,7 @@ fn dex_works(
             direction: Direction::Bid,
             price: Udec128::new(1),
             amount: Uint128::new(100),
-            remaining: Uint128::new(100),
+            remaining: Udec128::new(100),
         },
     };
     "two submission cancels one order"
@@ -687,7 +687,7 @@ fn submit_and_cancel_orders(
             direction: Direction::Bid,
             price: Udec128::new(1),
             amount: Uint128::new(100),
-            remaining: Uint128::new(100),
+            remaining: Udec128::new(100),
         },
     };
     "submit one order then cancel it and submit it again"
@@ -719,7 +719,7 @@ fn submit_and_cancel_orders(
             direction: Direction::Bid,
             price: Udec128::new(1),
             amount: Uint128::new(50),
-            remaining: Uint128::new(50),
+            remaining: Udec128::new(50),
         },
     };
     "submit one order then cancel it and place a new order using half of the funds"
@@ -751,7 +751,7 @@ fn submit_and_cancel_orders(
             direction: Direction::Bid,
             price: Udec128::new(1),
             amount: Uint128::new(200),
-            remaining: Uint128::new(200),
+            remaining: Udec128::new(200),
         },
     };
     "submit one order then cancel it and place a new order using more funds"
@@ -783,7 +783,7 @@ fn submit_and_cancel_orders(
             direction: Direction::Bid,
             price: Udec128::new(1),
             amount: Uint128::new(200),
-            remaining: Uint128::new(200),
+            remaining: Udec128::new(200),
         },
     }
     => panics "insufficient funds";
@@ -816,7 +816,7 @@ fn submit_and_cancel_orders(
             direction: Direction::Bid,
             price: Udec128::new(1),
             amount: Uint128::new(150),
-            remaining: Uint128::new(150),
+            remaining: Udec128::new(150),
         },
     };
     "submit one order then cancel it and place a new order excess funds are returned"
@@ -1149,7 +1149,7 @@ fn query_orders_by_pair(
                     queried_order.direction == *direction
                         && queried_order.price == *price
                         && queried_order.amount == *amount
-                        && queried_order.remaining == *amount
+                        && queried_order.remaining == amount.checked_into_dec().unwrap()
                         && queried_order.user == accounts.user1.address()
                 })
         });
@@ -2483,7 +2483,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
         },
     ],
     btree_map! {
-        !1u64 => (Udec128::new_percent(20100), Uint128::from(49751), Direction::Bid),
+        !1u64 => (Udec128::new_percent(20100), Udec128::new(49751), Direction::Bid),
     },
     btree_map! {
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coin_pair! {
@@ -2617,7 +2617,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
         },
     ],
     btree_map! {
-        !1u64 => (Udec128::new_percent(20300), Uint128::from(10000), Direction::Bid),
+        !1u64 => (Udec128::new_percent(20300), Udec128::new(10000), Direction::Bid),
     },
     btree_map! {
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coin_pair! {
@@ -2751,7 +2751,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
         },
     ],
     btree_map! {
-        1u64 => (Udec128::new_percent(19900), Uint128::from(10000), Direction::Ask),
+        1u64 => (Udec128::new_percent(19900), Udec128::new(10000), Direction::Ask),
     },
     btree_map! {
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coin_pair! {
@@ -2837,7 +2837,7 @@ fn curve_on_orderbook(
     pool_liquidity: Coins,
     orders: Vec<Vec<CreateLimitOrderRequest>>,
     order_creation_funds: Vec<Coins>,
-    expected_orders_after_clearing: BTreeMap<OrderId, (Udec128, Uint128, Direction)>,
+    expected_orders_after_clearing: BTreeMap<OrderId, (Udec128, Udec128, Direction)>,
     expected_reserves_after_clearing: BTreeMap<(Denom, Denom), CoinPair>,
     expected_dex_balance_changes: BTreeMap<Denom, BalanceChange>,
     expected_user_balance_changes: Vec<BTreeMap<Denom, BalanceChange>>,
@@ -5476,13 +5476,14 @@ fn market_order_clearing(
                     queried_order.direction == *direction
                         && queried_order.price == *price
                         && queried_order.amount == *amount
-                        && queried_order.remaining == *remaining
+                        && queried_order.remaining == remaining.checked_into_dec().unwrap()
                         && queried_order.user == users[*user_index].address()
                 },
             )
         });
 }
 
+#[ignore = "these test cases needs to be updated"] // TODO
 #[test_case(
     CreateLimitOrderRequest {
         base_denom: eth::DENOM.clone(),

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -48,7 +48,7 @@ pub struct LimitOrdersMatched {
     pub quote_denom: Denom,
     pub clearing_price: Udec128,
     /// Amount matched denominated in the base asset.
-    pub volume: Uint128,
+    pub volume: Udec128,
 }
 
 #[grug::derive(Serde)]
@@ -60,12 +60,12 @@ pub struct OrderFilled {
     pub base_denom: Denom,
     pub quote_denom: Denom,
     pub direction: Direction,
-    pub filled_base: Uint128,
-    pub filled_quote: Uint128,
-    pub refund_base: Uint128,
-    pub refund_quote: Uint128,
-    pub fee_base: Uint128,
-    pub fee_quote: Uint128,
+    pub filled_base: Udec128,
+    pub filled_quote: Udec128,
+    pub refund_base: Udec128,
+    pub refund_quote: Udec128,
+    pub fee_base: Udec128,
+    pub fee_quote: Udec128,
     /// The price at which the order was executed.
     pub clearing_price: Udec128,
     /// Whether the order was _completed_ filled and cleared from the book.

--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -271,7 +271,7 @@ pub struct OrderResponse {
     pub direction: Direction,
     pub price: Udec128,
     pub amount: Uint128,
-    pub remaining: Uint128,
+    pub remaining: Udec128,
 }
 
 /// Response type of the `QueryMsg::OrdersByPair` query.
@@ -281,7 +281,7 @@ pub struct OrdersByPairResponse {
     pub direction: Direction,
     pub price: Udec128,
     pub amount: Uint128,
-    pub remaining: Uint128,
+    pub remaining: Udec128,
 }
 
 /// Response type of the `QueryMsg::OrdersByUser` query.
@@ -292,5 +292,5 @@ pub struct OrdersByUserResponse {
     pub direction: Direction,
     pub price: Udec128,
     pub amount: Uint128,
-    pub remaining: Uint128,
+    pub remaining: Udec128,
 }

--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -202,7 +202,7 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     /// Returns the trading volume of a user address since the specified timestamp.
-    #[returns(Uint128)]
+    #[returns(Udec128)]
     Volume {
         /// The user's address to query trading volume for.
         user: Addr,
@@ -211,7 +211,7 @@ pub enum QueryMsg {
         since: Option<Timestamp>,
     },
     /// Returns the trading volume of a username since the specified timestamp.
-    #[returns(Uint128)]
+    #[returns(Udec128)]
     VolumeByUser {
         /// The username to query trading volume for.
         user: Username,

--- a/dango/types/src/oracle/price.rs
+++ b/dango/types/src/oracle/price.rs
@@ -1,7 +1,7 @@
 use {
     grug::{
-        Defined, MaybeDefined, MultiplyFraction, Number, StdResult, Timestamp, Udec128, Uint128,
-        Undefined,
+        Defined, MaybeDefined, MultiplyFraction, Number, NumberConst, StdResult, Timestamp,
+        Udec128, Uint128, Undefined,
     },
     pyth_types::PriceFeed,
 };
@@ -90,6 +90,13 @@ impl PrecisionedPrice {
                 unit_amount,
                 10u128.pow(self.precision.into_inner() as u32),
             )?)?)
+    }
+
+    pub fn value_of_dec_amount(&self, dec_amount: Udec128) -> StdResult<Udec128> {
+        let factor = Udec128::TEN.checked_pow(self.precision.into_inner() as u32)?;
+        Ok(self
+            .humanized_price
+            .checked_mul(dec_amount.checked_div(factor)?)?)
     }
 
     /// Returns the unit amount of a given value. E.g. if this Price represents

--- a/grug/types/src/dec_coin.rs
+++ b/grug/types/src/dec_coin.rs
@@ -1,0 +1,97 @@
+use {
+    crate::{Coins, Denom, StdError, StdResult},
+    grug_math::{IsZero, Number, Udec128},
+    std::collections::{BTreeMap, btree_map},
+};
+
+/// Like `Coin` but the amount is a decimal.
+pub struct DecCoin {
+    pub denom: Denom,
+    pub amount: Udec128,
+}
+
+impl From<(Denom, Udec128)> for DecCoin {
+    fn from((denom, amount): (Denom, Udec128)) -> Self {
+        Self { denom, amount }
+    }
+}
+
+#[derive(Default)]
+pub struct DecCoins(BTreeMap<Denom, Udec128>);
+
+impl DecCoins {
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn is_non_empty(&self) -> bool {
+        !self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Insert a new coin to the `Coins`.
+    pub fn insert<T>(&mut self, dec_coin: T) -> StdResult<&mut Self>
+    where
+        T: TryInto<DecCoin>,
+        StdError: From<T::Error>,
+    {
+        let dec_coin = dec_coin.try_into()?;
+
+        let Some(amount) = self.0.get_mut(&dec_coin.denom) else {
+            // If the denom doesn't exist, and we are increasing by a non-zero
+            // amount: just create a new record, and we are done.
+            if dec_coin.amount.is_non_zero() {
+                self.0.insert(dec_coin.denom, dec_coin.amount);
+            }
+
+            return Ok(self);
+        };
+
+        amount.checked_add_assign(dec_coin.amount)?;
+
+        Ok(self)
+    }
+
+    /// Insert all coins from another `Coins`.
+    pub fn insert_many(&mut self, dec_coins: DecCoins) -> StdResult<&mut Self> {
+        for (denom, amount) in dec_coins {
+            self.insert(DecCoin { denom, amount })?;
+        }
+
+        Ok(self)
+    }
+}
+
+impl IntoIterator for DecCoins {
+    type IntoIter = btree_map::IntoIter<Denom, Udec128>;
+    type Item = (Denom, Udec128);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl From<DecCoins> for Coins {
+    fn from(dec_coins: DecCoins) -> Self {
+        let map = dec_coins
+            .0
+            .into_iter()
+            .filter_map(|(denom, amount)| {
+                let amount = amount.into_int();
+                if amount.is_non_zero() {
+                    Some((denom, amount))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Coins::new_unchecked(map)
+    }
+}

--- a/grug/types/src/dec_coin.rs
+++ b/grug/types/src/dec_coin.rs
@@ -1,3 +1,7 @@
+//! This is a quick and dirty implementation. In the long term, a better idea
+//! may be to introduce a generic into `Coins`: `Coins<T>` where `T` is either
+//! `Uint128` or `Udec128`.
+
 use {
     crate::{Coins, Denom, StdError, StdResult},
     grug_math::{IsZero, Number, Udec128},

--- a/grug/types/src/dec_coin.rs
+++ b/grug/types/src/dec_coin.rs
@@ -76,6 +76,38 @@ impl DecCoins {
 
         Ok(self)
     }
+
+    pub fn into_coins_floor(self) -> Coins {
+        let map = self
+            .0
+            .into_iter()
+            .filter_map(|(denom, amount)| {
+                let amount = amount.into_int_floor(); // Important: floor the amount.
+                if amount.is_non_zero() {
+                    Some((denom, amount))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Coins::new_unchecked(map)
+    }
+
+    pub fn into_coins_ceil(self) -> Coins {
+        let map = self
+            .0
+            .into_iter()
+            .filter_map(|(denom, amount)| {
+                let amount = amount.into_int_ceil(); // Important: ceil the amount.
+                if amount.is_non_zero() {
+                    Some((denom, amount))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Coins::new_unchecked(map)
+    }
 }
 
 impl<'a> IntoIterator for &'a DecCoins {
@@ -93,24 +125,6 @@ impl IntoIterator for DecCoins {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
-    }
-}
-
-impl From<DecCoins> for Coins {
-    fn from(dec_coins: DecCoins) -> Self {
-        let map = dec_coins
-            .0
-            .into_iter()
-            .filter_map(|(denom, amount)| {
-                let amount = amount.into_int(); // NOTE: round down
-                if amount.is_non_zero() {
-                    Some((denom, amount))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        Coins::new_unchecked(map)
     }
 }
 

--- a/grug/types/src/lib.rs
+++ b/grug/types/src/lib.rs
@@ -14,6 +14,7 @@ mod coin_pair;
 mod coins;
 mod context;
 mod db;
+mod dec_coin;
 mod denom;
 mod empty;
 mod encoded_bytes;
@@ -48,11 +49,11 @@ mod utils;
 
 pub use {
     address::*, app::*, bank::*, binary::*, bound::*, buffer::*, builder::*, bytes::*, cache::*,
-    changeset::*, code::*, coin::*, coin_pair::*, coins::*, context::*, db::*, denom::*, empty::*,
-    encoded_bytes::*, encoders::*, error::*, events::*, ffi::*, git_info::*, hash::*, hashers::*,
-    imports::*, inner::*, jellyfish_merkle::*, json::*, length_bounded::*, lengthy::*, non_zero::*,
-    outcome::*, query::*, response::*, result::*, serializers::*, shared::*, signer::*, status::*,
-    time::*, transfer::*, tx::*, unique_vec::*, utils::*,
+    changeset::*, code::*, coin::*, coin_pair::*, coins::*, context::*, db::*, dec_coin::*,
+    denom::*, empty::*, encoded_bytes::*, encoders::*, error::*, events::*, ffi::*, git_info::*,
+    hash::*, hashers::*, imports::*, inner::*, jellyfish_merkle::*, json::*, length_bounded::*,
+    lengthy::*, non_zero::*, outcome::*, query::*, response::*, result::*, serializers::*,
+    shared::*, signer::*, status::*, time::*, transfer::*, tx::*, unique_vec::*, utils::*,
 };
 
 // ---------------------------------- testing ----------------------------------

--- a/grug/types/src/transfer.rs
+++ b/grug/types/src/transfer.rs
@@ -1,21 +1,31 @@
 use {
-    crate::{Addr, Coin, Coins, Denom, Message, StdResult},
-    grug_math::Uint128,
+    crate::{Addr, Coin, Coins, DecCoin, DecCoins, Denom, Message, StdResult},
+    grug_math::{Udec128, Uint128},
     std::collections::BTreeMap,
 };
 
 #[derive(Default)]
-pub struct TransferBuilder {
-    batch: BTreeMap<Addr, Coins>,
+pub struct TransferBuilder<T = Coins> {
+    batch: BTreeMap<Addr, T>,
 }
 
-impl TransferBuilder {
+impl<T> TransferBuilder<T> {
     pub fn new() -> Self {
         Self {
             batch: BTreeMap::new(),
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.batch.is_empty()
+    }
+
+    pub fn is_non_empty(&self) -> bool {
+        !self.batch.is_empty()
+    }
+}
+
+impl TransferBuilder<Coins> {
     pub fn insert(&mut self, address: Addr, denom: Denom, amount: Uint128) -> StdResult<()> {
         self.batch
             .entry(address)
@@ -32,19 +42,44 @@ impl TransferBuilder {
             .map(|_| ())
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.batch.is_empty()
-    }
-
-    pub fn is_non_empty(&self) -> bool {
-        !self.batch.is_empty()
-    }
-
     pub fn into_batch(self) -> BTreeMap<Addr, Coins> {
         self.batch
     }
 
     pub fn into_message(self) -> Message {
         Message::Transfer(self.batch)
+    }
+}
+
+impl TransferBuilder<DecCoins> {
+    pub fn insert(&mut self, address: Addr, denom: Denom, amount: Udec128) -> StdResult<()> {
+        self.batch
+            .entry(address)
+            .or_default()
+            .insert(DecCoin { denom, amount })
+            .map(|_| ())
+    }
+
+    pub fn insert_many(&mut self, address: Addr, dec_coins: DecCoins) -> StdResult<()> {
+        self.batch
+            .entry(address)
+            .or_default()
+            .insert_many(dec_coins)
+            .map(|_| ())
+    }
+
+    pub fn into_batch(self) -> BTreeMap<Addr, Coins> {
+        self.batch
+            .into_iter()
+            .map(|(addr, dec_coins)| {
+                // Round _down_ decimal amount to integer.
+                let coins = dec_coins.into();
+                (addr, coins)
+            })
+            .collect()
+    }
+
+    pub fn into_message(self) -> Message {
+        Message::Transfer(self.into_batch())
     }
 }

--- a/grug/types/src/transfer.rs
+++ b/grug/types/src/transfer.rs
@@ -73,7 +73,7 @@ impl TransferBuilder<DecCoins> {
             .into_iter()
             .filter_map(|(addr, dec_coins)| {
                 // Round _down_ decimal amount to integer.
-                let coins: Coins = dec_coins.into();
+                let coins = dec_coins.into_coins_floor();
                 if coins.is_non_empty() {
                     Some((addr, coins))
                 } else {

--- a/grug/types/src/transfer.rs
+++ b/grug/types/src/transfer.rs
@@ -4,7 +4,7 @@ use {
     std::collections::BTreeMap,
 };
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct TransferBuilder<T = Coins> {
     batch: BTreeMap<Addr, T>,
 }
@@ -71,10 +71,14 @@ impl TransferBuilder<DecCoins> {
     pub fn into_batch(self) -> BTreeMap<Addr, Coins> {
         self.batch
             .into_iter()
-            .map(|(addr, dec_coins)| {
+            .filter_map(|(addr, dec_coins)| {
                 // Round _down_ decimal amount to integer.
-                let coins = dec_coins.into();
-                (addr, coins)
+                let coins: Coins = dec_coins.into();
+                if coins.is_non_empty() {
+                    Some((addr, coins))
+                } else {
+                    None
+                }
             })
             .collect()
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch volume, refund, and fee calculations from `Uint128` to `Udec128` for improved precision in financial operations across the codebase.
> 
>   - **Behavior**:
>     - Change volume, refund, and fee calculations from `Uint128` to `Udec128` in `geometric.rs`, `market_order.rs`, and `order_filling.rs`.
>     - Update `cron_execute()` in `cron.rs` to handle `DecCoins` for refunds and fees.
>     - Modify `query_volume()` in `query.rs` to return `Udec128`.
>   - **Models**:
>     - Update `OrderTrait` in `types.rs` to use `Udec128` for `remaining` amounts.
>     - Change `FillingOutcome` in `order_filling.rs` to use `Udec128` for all fields.
>   - **Misc**:
>     - Add `dec_coin.rs` for handling decimal coin operations.
>     - Update `TransferBuilder` in `transfer.rs` to support `DecCoins`.
>     - Adjust tests in `dex.rs` to reflect changes in volume and fee calculations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 8f2ae9b3168a3bc9ef8493596814447f5dda1ef9. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->