### PR TITLE
dex: use saturating math for handling market order max slippage

### DIFF
--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -59,11 +59,11 @@ where
         // Calculate the cutoff price for the current market order
         let cutoff_price = match market_order_direction {
             Direction::Bid => Udec128::ONE
-                .checked_add(market_order.max_slippage)?
-                .checked_mul(best_price)?,
+                .saturating_add(market_order.max_slippage)
+                .saturating_mul(best_price),
             Direction::Ask => Udec128::ONE
-                .checked_sub(market_order.max_slippage)?
-                .checked_mul(best_price)?,
+                .saturating_sub(market_order.max_slippage)
+                .saturating_mul(best_price),
         };
 
         // The direction of the comparison depends on whether the market order
@@ -249,7 +249,7 @@ where
             market_order_direction,
             filled_base,
             price,
-            taker_fee_rate,
+            taker_fee_rate, // A market order is always a taker.
         )?;
     }
 


### PR DESCRIPTION
A very big `max_slippage` value, such as 10000000%, while not sensible, isn't illegal. In case a user chooses such a value, we use saturating math to calculate the cutoff price. Using checked math may results in overflow errors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch to saturating math for `max_slippage` in `market_order.rs` to prevent overflow errors with large values.
> 
>   - **Behavior**:
>     - Use saturating math for `max_slippage` in `match_and_fill_market_orders` in `market_order.rs` to prevent overflow errors with large values.
>     - Handles both `Direction::Bid` and `Direction::Ask` cases with `saturating_add` and `saturating_sub` respectively.
>   - **Misc**:
>     - Minor comment update in `match_and_fill_market_orders` regarding taker fee rate.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for d4504c1f0d8e863ff755456f3b514286fef6b327. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->