### PR TITLE
dex: properly handle liquidity fee in instant swaps

### DIFF
--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -35,6 +35,8 @@ pub fn add_subsequent_liquidity(
     Ok(deposit_value.checked_div(reserve_value)?)
 }
 
+/// Note: this function does not concern the liquidity fee.
+/// Liquidity fee logics are found in `PairParams::swap_exact_amount_in`, in `liquidity_pool.rs`.
 pub fn swap_exact_amount_in(
     oracle_querier: &mut OracleQuerier,
     base_denom: &Denom,
@@ -58,19 +60,16 @@ pub fn swap_exact_amount_in(
 
     // Pretend the input is a market order. Match it against the opposite side
     // of the passive limit orders.
-    let output_amount = if input.denom == *base_denom {
-        ask_exact_amount_in(input.amount, passive_bids)?
+    if input.denom == *base_denom {
+        ask_exact_amount_in(input.amount, passive_bids)
     } else if input.denom == *quote_denom {
-        bid_exact_amount_in(input.amount, passive_asks)?
+        bid_exact_amount_in(input.amount, passive_asks)
     } else {
         unreachable!(
             "input denom (`{}`) is neither the base (`{}`) nor the quote (`{}`). this should have been caught earlier.",
             input.denom, base_denom, quote_denom
         );
-    };
-
-    // Apply swap fee. Round so that user takes the loss.
-    Ok(output_amount.checked_mul_dec_floor(Udec128::ONE - *swap_fee_rate)?)
+    }
 }
 
 // NOTE: Always round down (floor) the output amount; always round up (ceil) the input amount.
@@ -119,6 +118,8 @@ fn ask_exact_amount_in(
     bail!("not enough liquidity to fulfill the swap! remaining amount: {remaining_ask}")
 }
 
+/// Note: this function does not concern the liquidity fee.
+/// Liquidity fee logics are found in `PairParams::swap_exact_amount_out`, in `liquidity_pool.rs`.
 pub fn swap_exact_amount_out(
     oracle_querier: &mut OracleQuerier,
     base_denom: &Denom,
@@ -129,13 +130,6 @@ pub fn swap_exact_amount_out(
     order_spacing: Udec128,
     swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
 ) -> anyhow::Result<Uint128> {
-    // Apply swap fee. In SwapExactIn we multiply ask by (1 - fee) to get the
-    // offer amount after fees. So in this case we need to divide ask by (1 - fee)
-    // to get the ask amount after fees.
-    // Round so that user takes the loss.
-    let one_sub_fee_rate = Udec128::ONE - *swap_fee_rate;
-    let output_amount_before_fee = output.amount.checked_div_dec_ceil(one_sub_fee_rate)?;
-
     let (passive_bids, passive_asks) = reflect_curve(
         oracle_querier,
         base_denom,
@@ -147,18 +141,16 @@ pub fn swap_exact_amount_out(
         swap_fee_rate,
     )?;
 
-    let input_amount = if output.denom == *base_denom {
-        bid_exact_amount_out(output_amount_before_fee, passive_asks)?
+    if output.denom == *base_denom {
+        bid_exact_amount_out(output.amount, passive_asks)
     } else if output.denom == *quote_denom {
-        ask_exact_amount_out(output_amount_before_fee, passive_bids)?
+        ask_exact_amount_out(output.amount, passive_bids)
     } else {
         unreachable!(
             "output denom (`{}`) is neither the base (`{}`) nor the quote (`{}`). this should have been caught earlier.",
             output.denom, base_denom, quote_denom
         );
-    };
-
-    Ok(input_amount)
+    }
 }
 
 fn bid_exact_amount_out(

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -32,45 +32,38 @@ pub fn add_subsequent_liquidity(
     Ok(invariant_ratio.checked_sub(Udec128::ONE)?)
 }
 
+/// Note: this function does not concern the liquidity fee.
+/// Liquidity fee logics are found in `PairParams::swap_exact_amount_in`, in `liquidity_pool.rs`.
 pub fn swap_exact_amount_in(
-    input_amount: Uint128,
     input_reserve: Uint128,
     output_reserve: Uint128,
-    swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
+    input_amount: Uint128,
 ) -> MathResult<Uint128> {
     // Solve A * B = (A + input_amount) * (B - output_amount) for output_amount
     // => output_amount = B - (A * B) / (A + input_amount)
     // Round so that user takes the loss.
-    let output_amount =
-        output_reserve.checked_sub(input_reserve.checked_multiply_ratio_ceil(
+    output_reserve.checked_sub(
+        input_reserve.checked_multiply_ratio_ceil(
             output_reserve,
             input_reserve.checked_add(input_amount)?,
-        )?)?;
-
-    // Apply swap fee. Round so that user takes the loss.
-    output_amount.checked_mul_dec_floor(Udec128::ONE - *swap_fee_rate)
+        )?,
+    )
 }
 
+/// Note: this function does not concern the liquidity fee.
+/// Liquidity fee logics are found in `PairParams::swap_exact_amount_out`, in `liquidity_pool.rs`.
 pub fn swap_exact_amount_out(
-    output_amount: Uint128,
     input_reserve: Uint128,
     output_reserve: Uint128,
-    swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
+    output_amount: Uint128,
 ) -> MathResult<Uint128> {
-    // Apply swap fee. In SwapExactIn we multiply ask by (1 - fee) to get the
-    // offer amount after fees. So in this case we need to divide ask by (1 - fee)
-    // to get the ask amount after fees.
-    // Round so that user takes the loss.
-    let output_amount_before_fee =
-        output_amount.checked_div_dec_ceil(Udec128::ONE - *swap_fee_rate)?;
-
     // Solve A * B = (A + input_amount) * (B - output_amount) for input_amount
     // => input_amount = (A * B) / (B - output_amount) - A
     // Round so that user takes the loss.
     Uint128::ONE
         .checked_multiply_ratio_floor(
             input_reserve.checked_mul(output_reserve)?,
-            output_reserve.checked_sub(output_amount_before_fee)?,
+            output_reserve.checked_sub(output_amount)?,
         )?
         .checked_sub(input_reserve)
 }


### PR DESCRIPTION
After this change:
- `xyk::swap_exact_amount_{in,out}` and `geometric::swap_exact_amount_{in,out}` no longer concerns the liquidity fee. `swap_exact_amount_in` returns the **before fee** output amount. `swap_exact_amount_output` intakes the **before fee** output amount.
- Liquidity fee logics are handled in `PairParams::swap_exact_amount_{in,out}`, in `liquidity.rs`.
- The reason for this change is in `PairParams::swap_exact_amount_out`, we need to compare the **before fee** output amount with the pool's reserve. So, the fee logic needs to handle there.
- Note, that `geometric::swap_exact_amount_{in,out}` still takes a `swap_fee_rate` as input parameter. This is because in `reflect_curve` this fee rate is used as the spread. Later we can introduce dedicated parameters for bid/ask spreads.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor liquidity fee handling in swap functions, moving fee logic to `PairParams` in `liquidity_pool.rs` and updating `xyk` and `geometric` modules to handle pre-fee amounts.
> 
>   - **Behavior**:
>     - `xyk::swap_exact_amount_{in,out}` and `geometric::swap_exact_amount_{in,out}` now handle pre-fee amounts. Fee logic moved to `PairParams::swap_exact_amount_{in,out}` in `liquidity_pool.rs`.
>     - `swap_exact_amount_in` returns pre-fee output amount; `swap_exact_amount_out` takes pre-fee output amount.
>     - `geometric::swap_exact_amount_{in,out}` still uses `swap_fee_rate` for spread in `reflect_curve`.
>   - **Functions**:
>     - `PairParams::swap_exact_amount_in` and `swap_exact_amount_out` now apply liquidity fees and update reserves.
>     - `xyk::swap_exact_amount_in` and `swap_exact_amount_out` no longer apply fees.
>     - `geometric::swap_exact_amount_in` and `swap_exact_amount_out` updated to remove fee application.
>   - **Misc**:
>     - Updated comments in `geometric.rs` and `xyk.rs` to reflect fee handling changes.
>     - Adjusted logic in `liquidity_pool.rs` to ensure positive output/input amounts after fees.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 09c7f3228c7a799482fe62603e8151950ab8f8d2. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->