### PR TITLE
[LEF-192] dex: use `Uint64` instead of `u64` as order IDs

### DIFF
--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -4,7 +4,7 @@ use {
     dango_oracle::OracleQuerier,
     grug::{
         Bounded, Coin, CoinPair, Denom, IsZero, MultiplyFraction, Number, NumberConst, Udec128,
-        Uint128, ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
+        Uint64, Uint128, ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
     },
     std::{cmp, iter},
 };
@@ -232,7 +232,7 @@ pub fn reflect_curve(
 
     // Construct bid price iterator with decreasing prices.
     let bids = {
-        let mut id = 0;
+        let mut id = Uint64::ZERO;
         let one_sub_fee_rate = Udec128::ONE.checked_sub(*swap_fee_rate)?;
         let bid_starting_price = marginal_price.checked_mul(one_sub_fee_rate)?;
         let mut maybe_price = Some(bid_starting_price);
@@ -247,7 +247,7 @@ pub fn reflect_curve(
             let size_in_quote = remaining_quote.checked_mul_dec(*ratio).ok()?;
             let size = size_in_quote.checked_div_dec_floor(price).ok()?;
 
-            id += 1;
+            id += Uint64::ONE;
             maybe_price = price.checked_sub(order_spacing).ok();
             remaining_quote.checked_sub_assign(size_in_quote).ok()?;
 
@@ -262,7 +262,7 @@ pub fn reflect_curve(
 
     // Construct ask price iterator with increasing prices.
     let asks = {
-        let mut id = u64::MAX;
+        let mut id = Uint64::MAX;
         let one_plus_fee_rate = Udec128::ONE.checked_add(*swap_fee_rate)?;
         let ask_starting_price = marginal_price.checked_mul(one_plus_fee_rate)?;
         let mut maybe_price = Some(ask_starting_price);
@@ -272,7 +272,7 @@ pub fn reflect_curve(
             let price = maybe_price?;
             let size = remaining_base.checked_mul_dec(*ratio).ok()?;
 
-            id -= 1;
+            id -= Uint64::ONE;
             maybe_price = price.checked_add(order_spacing).ok();
             remaining_base.checked_sub_assign(size).ok()?;
 

--- a/dango/dex/src/core/types.rs
+++ b/dango/dex/src/core/types.rs
@@ -1,6 +1,6 @@
 use {
     dango_types::dex::{OrderId, OrderKind},
-    grug::{Addr, MathResult, Number, NumberConst, Udec128, Uint128},
+    grug::{Addr, MathResult, Number, NumberConst, Udec128, Uint64, Uint128},
 };
 
 /// An identifier type that is extended to represent both real orders from users
@@ -8,9 +8,9 @@ use {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ExtendedOrderId {
     /// An limit or market order created by a user.
-    User(u64),
+    User(Uint64),
     /// A virtual limit order created by the passive pool.
-    Passive(u64),
+    Passive(Uint64),
 }
 
 pub trait OrderTrait {

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -2,7 +2,7 @@ use {
     crate::PassiveOrder,
     grug::{
         Bounded, CoinPair, IsZero, MathResult, MultiplyFraction, MultiplyRatio, Number,
-        NumberConst, Udec128, Uint128, ZeroExclusiveOneExclusive,
+        NumberConst, Udec128, Uint64, Uint128, ZeroExclusiveOneExclusive,
     },
     std::{cmp, iter},
 };
@@ -83,7 +83,7 @@ pub fn reflect_curve(
     // Construct the bid order iterator.
     // Start from the marginal price minus the swap fee rate.
     let bids = {
-        let mut id = 0;
+        let mut id = Uint64::ZERO;
         let one_sub_fee_rate = Udec128::ONE.checked_sub(*swap_fee_rate)?;
         let mut maybe_price = marginal_price.checked_mul(one_sub_fee_rate).ok();
         let mut prev_size = Uint128::ZERO;
@@ -126,7 +126,7 @@ pub fn reflect_curve(
             }
 
             // Update the iterator state.
-            id += 1;
+            id += Uint64::ONE;
             prev_size = size;
             prev_size_quote = size_quote;
             maybe_price = price.checked_sub(order_spacing).ok();
@@ -142,7 +142,7 @@ pub fn reflect_curve(
 
     // Construct the ask order iterator.
     let asks = {
-        let mut id = u64::MAX;
+        let mut id = Uint64::MAX;
         let one_plus_fee_rate = Udec128::ONE.checked_add(*swap_fee_rate)?;
         let mut maybe_price = marginal_price.checked_mul(one_plus_fee_rate).ok();
         let mut prev_size = Uint128::ZERO;
@@ -171,7 +171,7 @@ pub fn reflect_curve(
             }
 
             // Update the iterator state.
-            id -= 1;
+            id -= Uint64::ONE;
             prev_size = size;
             maybe_price = price.checked_add(order_spacing).ok();
 

--- a/dango/dex/src/state.rs
+++ b/dango/dex/src/state.rs
@@ -5,8 +5,8 @@ use {
         dex::{Direction, OrderId, PairParams},
     },
     grug::{
-        Addr, CoinPair, Counter, Denom, IndexedMap, Map, MultiIndex, Timestamp, Udec128, Uint128,
-        UniqueIndex,
+        Addr, CoinPair, Counter, Denom, IndexedMap, Map, MultiIndex, NumberConst, Timestamp,
+        Udec128, Uint64, Uint128, UniqueIndex,
     },
 };
 
@@ -16,7 +16,7 @@ pub const PAIRS: Map<(&Denom, &Denom), PairParams> = Map::new("pair");
 // (base_denom, quote_denom) => coin_pair
 pub const RESERVES: Map<(&Denom, &Denom), CoinPair> = Map::new("reserve");
 
-pub const NEXT_ORDER_ID: Counter<OrderId> = Counter::new("order_id", 1, 1);
+pub const NEXT_ORDER_ID: Counter<OrderId> = Counter::new("order_id", Uint64::ONE, Uint64::ONE);
 
 pub const MARKET_ORDERS: IndexedMap<MarketOrderKey, MarketOrder, MarketOrderIndex> =
     IndexedMap::new("market_order", MarketOrderIndex {

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -122,31 +122,31 @@ fn cannot_submit_orders_in_non_existing_pairs() {
         (Direction::Ask, 30, 10), // 5
     ],
     btree_map! {
-        !3 => 10,
-         6 => 10,
+        OrderId::new(!3) => 10,
+        OrderId::new(6)  => 10,
     },
     btree_map! {
-        !1 => btree_map! {
+        OrderId::new(!1) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(9), // Receives one less due to fee
             usdc::DENOM.clone()  => BalanceChange::Decreased(200),
         },
-        !2 => btree_map! {
+        OrderId::new(!2) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(9), // Receives one less due to fee
             usdc::DENOM.clone()  => BalanceChange::Decreased(200),
         },
-        !3 => btree_map! {
+        OrderId::new(!3) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Unchanged,
             usdc::DENOM.clone()  => BalanceChange::Decreased(100),
         },
-        4 => btree_map! {
+        OrderId::new(4) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(199), // Receives one less due to fee
         },
-        5 => btree_map! {
+        OrderId::new(5) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(199), // Receives one less due to fee
         },
-        6 => btree_map! {
+        OrderId::new(6) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Unchanged,
         },
@@ -164,31 +164,31 @@ fn cannot_submit_orders_in_non_existing_pairs() {
         (Direction::Ask, 25, 10), //  5
     ],
     btree_map! {
-        !3 => 10,
-         6 => 10,
+        OrderId::new(!3) => 10,
+        OrderId::new(6)  => 10,
     },
     btree_map! {
-        !1 => btree_map! {
+        OrderId::new(!1) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(9), // Receives one less due to fee
             usdc::DENOM.clone()  => BalanceChange::Decreased(175),
         },
-        !2 => btree_map! {
+        OrderId::new(!2) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(9), // Receives one less due to fee
             usdc::DENOM.clone()  => BalanceChange::Decreased(175),
         },
-        !3 => btree_map! {
+        OrderId::new(!3) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Unchanged,
             usdc::DENOM.clone()  => BalanceChange::Decreased(100),
         },
-        4 => btree_map! {
+        OrderId::new(4) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(174), // Receives one less due to fee
         },
-        5 => btree_map! {
+        OrderId::new(5) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(174), // Receives one less due to fee
         },
-        6 => btree_map! {
+        OrderId::new(6) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Unchanged,
         },
@@ -207,36 +207,36 @@ fn cannot_submit_orders_in_non_existing_pairs() {
         (Direction::Bid, 30,  5), // !6 - filled
     ],
     btree_map! {
-        !2 =>  5,
-        !3 => 10,
-         6 => 10,
+        OrderId::new(!2) =>  5,
+        OrderId::new(!3) => 10,
+        OrderId::new(6)  => 10,
     },
     btree_map! {
-        !1 => btree_map! {
+        OrderId::new(!1) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(9), // Receives one less due to fee
             usdc::DENOM.clone()  => BalanceChange::Decreased(175),
         },
-        !2 => btree_map! {
+        OrderId::new(!2) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(4),   // half filled, receives one less due to fee
             usdc::DENOM.clone()  => BalanceChange::Decreased(188), // -200 deposit, +12 refund
         },
-        !3 => btree_map! {
+        OrderId::new(!3) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Unchanged,
             usdc::DENOM.clone()  => BalanceChange::Decreased(100),
         },
-        4 => btree_map! {
+        OrderId::new(4) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(174), // Receives one less due to fee
         },
-        5 => btree_map! {
+        OrderId::new(5) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(174),
         },
-        6 => btree_map! {
+        OrderId::new(6) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Unchanged,
         },
-        !7 => btree_map! {
+        OrderId::new(!7) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(4),
             usdc::DENOM.clone()  => BalanceChange::Decreased(88), // -150 deposit, +62 refund
         },
@@ -254,32 +254,32 @@ fn cannot_submit_orders_in_non_existing_pairs() {
         (Direction::Ask, 25, 10), //  5 - unfilled
     ],
     btree_map! {
-        !2 => 10,
-        !3 => 10,
-         6 => 10,
+        OrderId::new(!2) => 10,
+        OrderId::new(!3) => 10,
+        OrderId::new(6)  => 10,
     },
     btree_map! {
-        !1 => btree_map! {
+        OrderId::new(!1) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(19), // Receives one less due to fee
             usdc::DENOM.clone()  => BalanceChange::Decreased(450), // -600 deposit, +150 refund
         },
-        !2 => btree_map! {
+        OrderId::new(!2) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Unchanged,
             usdc::DENOM.clone()  => BalanceChange::Decreased(200),
         },
-        !3 => btree_map! {
+        OrderId::new(!3) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Unchanged,
             usdc::DENOM.clone()  => BalanceChange::Decreased(100),
         },
-        4 => btree_map! {
+        OrderId::new(4) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(224), // Receives one less due to fee
         },
-        5 => btree_map! {
+        OrderId::new(5) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(224),
         },
-        6 => btree_map! {
+        OrderId::new(6) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Unchanged,
         },
@@ -297,32 +297,32 @@ fn cannot_submit_orders_in_non_existing_pairs() {
         (Direction::Ask, 25, 10), //  5 - 50% filled
     ],
     btree_map! {
-        !2 => 10,
-        !3 => 10,
-         6 =>  5,
+        OrderId::new(!2) => 10,
+        OrderId::new(!3) => 10,
+        OrderId::new(6)  =>  5,
     },
     btree_map! {
-        !1 => btree_map! {
+        OrderId::new(!1) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Increased(24),
             usdc::DENOM.clone()  => BalanceChange::Decreased(688), // -750 deposit, +62 refund
         },
-        !2 => btree_map! {
+        OrderId::new(!2) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Unchanged,
             usdc::DENOM.clone()  => BalanceChange::Decreased(200),
         },
-        !3 => btree_map! {
+        OrderId::new(!3) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Unchanged,
             usdc::DENOM.clone()  => BalanceChange::Decreased(100),
         },
-        4 => btree_map! {
+        OrderId::new(4) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(273), // Receives two less due to fee
         },
-        5 => btree_map! {
+        OrderId::new(5) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(273), // Receives two less due to fee
         },
-        6 => btree_map! {
+        OrderId::new(6) => btree_map! {
             dango::DENOM.clone() => BalanceChange::Decreased(10),
             usdc::DENOM.clone()  => BalanceChange::Increased(136), // refund: floor(5 * 27.5) = 137 minus 1 due to fee
         },
@@ -375,7 +375,7 @@ fn dex_works(
         .zip(accounts.users())
         .enumerate()
         .map(|(order_id, ((direction, ..), signer))| {
-            let order_id = (order_id + 1) as OrderId;
+            let order_id = OrderId::new((order_id + 1) as u64);
             match direction {
                 Direction::Bid => (!order_id, signer.address()),
                 Direction::Ask => (order_id, signer.address()),
@@ -466,7 +466,7 @@ fn dex_works(
     coins! { usdc::DENOM.clone() => 100 },
     btree_map! { usdc::DENOM.clone() => BalanceChange::Decreased(100) },
     btree_map! {
-        !1 => OrderResponse {
+        OrderId::new(!1) => OrderResponse {
             user: Addr::mock(1), // Just a placeholder. User1 address is used in assertion.
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
@@ -486,7 +486,7 @@ fn dex_works(
         amount: NonZero::new_unchecked(Uint128::new(100)),
         price: Udec128::new(1),
     }],
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     coins! { usdc::DENOM.clone() => 100 },
     btree_map! { usdc::DENOM.clone() => BalanceChange::Unchanged },
     btree_map! {};
@@ -509,11 +509,11 @@ fn dex_works(
             price: Udec128::new(1),
         },
     ],
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     coins! { usdc::DENOM.clone() => 200 },
     btree_map! { usdc::DENOM.clone() => BalanceChange::Decreased(100) },
     btree_map! {
-        !2 => OrderResponse {
+        OrderId::new(!2) => OrderResponse {
             user: Addr::mock(1), // Just a placeholder. User1 address is used in assertion.
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
@@ -542,7 +542,7 @@ fn dex_works(
             price: Udec128::new(1),
         },
     ],
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1, !2]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1), OrderId::new(!2)]))),
     coins! { usdc::DENOM.clone() => 200 },
     btree_map! { usdc::DENOM.clone() => BalanceChange::Unchanged },
     btree_map! {};
@@ -588,7 +588,7 @@ fn dex_works(
             price: Udec128::new(1),
         },
     ],
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     coins! { usdc::DENOM.clone() => 199 },
     btree_map! {},
     btree_map! {}
@@ -669,7 +669,7 @@ fn submit_and_cancel_orders(
         price: Udec128::new(1),
     }],
     coins! { usdc::DENOM.clone() => 100 },
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     vec![CreateLimitOrderRequest {
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
@@ -680,7 +680,7 @@ fn submit_and_cancel_orders(
     Coins::new(),
     btree_map! { usdc::DENOM.clone() => BalanceChange::Unchanged },
     btree_map! {
-        !2 => OrderResponse {
+        OrderId::new(!2) => OrderResponse {
             user: Addr::mock(1), // Just a placeholder. User1 address is used in assertion.
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
@@ -701,7 +701,7 @@ fn submit_and_cancel_orders(
         price: Udec128::new(1),
     }],
     coins! { usdc::DENOM.clone() => 100 },
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     vec![CreateLimitOrderRequest {
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
@@ -712,7 +712,7 @@ fn submit_and_cancel_orders(
     Coins::new(),
     btree_map! { usdc::DENOM.clone() => BalanceChange::Increased(50) },
     btree_map! {
-        !2 => OrderResponse {
+        OrderId::new(!2) => OrderResponse {
             user: Addr::mock(1), // Just a placeholder. User1 address is used in assertion.
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
@@ -733,7 +733,7 @@ fn submit_and_cancel_orders(
         price: Udec128::new(1),
     }],
     coins! { usdc::DENOM.clone() => 100 },
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     vec![CreateLimitOrderRequest {
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
@@ -744,7 +744,7 @@ fn submit_and_cancel_orders(
     coins! { usdc::DENOM.clone() => 100 },
     btree_map! { usdc::DENOM.clone() => BalanceChange::Decreased(100) },
     btree_map! {
-        !2 => OrderResponse {
+        OrderId::new(!2) => OrderResponse {
             user: Addr::mock(1), // Just a placeholder. User1 address is used in assertion.
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
@@ -765,7 +765,7 @@ fn submit_and_cancel_orders(
         price: Udec128::new(1),
     }],
     coins! { usdc::DENOM.clone() => 100 },
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     vec![CreateLimitOrderRequest {
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
@@ -776,7 +776,7 @@ fn submit_and_cancel_orders(
     Coins::new(),
     btree_map! { usdc::DENOM.clone() => BalanceChange::Decreased(100) },
     btree_map! {
-        !2 => OrderResponse {
+        OrderId::new(!2) => OrderResponse {
             user: Addr::mock(1), // Just a placeholder. User1 address is used in assertion.
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
@@ -798,7 +798,7 @@ fn submit_and_cancel_orders(
         price: Udec128::new(1),
     }],
     coins! { usdc::DENOM.clone() => 100 },
-    Some(CancelOrderRequest::Some(BTreeSet::from([!1]))),
+    Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
     vec![CreateLimitOrderRequest {
         base_denom: dango::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
@@ -809,7 +809,7 @@ fn submit_and_cancel_orders(
     coins! { usdc::DENOM.clone() => 100 },
     btree_map! { usdc::DENOM.clone() => BalanceChange::Decreased(50) },
     btree_map! {
-        !2 => OrderResponse {
+        OrderId::new(!2) => OrderResponse {
             user: Addr::mock(1), // Just a placeholder. User1 address is used in assertion.
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
@@ -918,7 +918,9 @@ fn submit_and_cancel_order_in_same_block() {
         &dex::ExecuteMsg::BatchUpdateOrders {
             creates_market: vec![],
             creates_limit: vec![],
-            cancels: Some(dex::CancelOrderRequest::Some(BTreeSet::from([!1]))),
+            cancels: Some(dex::CancelOrderRequest::Some(BTreeSet::from([
+                OrderId::new(!1),
+            ]))),
         },
         Coins::new(),
     )
@@ -971,10 +973,10 @@ fn submit_and_cancel_order_in_same_block() {
     None,
     None,
     btree_map! {
-        !1 => (Direction::Bid, Udec128::new(30), Uint128::new(10)),
-        !2 => (Direction::Bid, Udec128::new(10), Uint128::new(10)),
-        3 => (Direction::Ask, Udec128::new(40), Uint128::new(10)),
-        4 => (Direction::Ask, Udec128::new(50), Uint128::new(10)),
+        OrderId::new(!1) => (Direction::Bid, Udec128::new(30), Uint128::new(10)),
+        OrderId::new(!2) => (Direction::Bid, Udec128::new(10), Uint128::new(10)),
+        OrderId::new(3)  => (Direction::Ask, Udec128::new(40), Uint128::new(10)),
+        OrderId::new(4)  => (Direction::Ask, Udec128::new(50), Uint128::new(10)),
     };
     "dango/usdc no pagination"
 )]
@@ -991,8 +993,8 @@ fn submit_and_cancel_order_in_same_block() {
     None,
     None,
     btree_map! {
-        !5 => (Direction::Bid, Udec128::new(20), Uint128::new(10)),
-        6 => (Direction::Ask, Udec128::new(25), Uint128::new(10)),
+        OrderId::new(!5) => (Direction::Bid, Udec128::new(20), Uint128::new(10)),
+        OrderId::new(6)  => (Direction::Ask, Udec128::new(25), Uint128::new(10)),
     };
     "eth/usdc no pagination"
 )]
@@ -1009,9 +1011,9 @@ fn submit_and_cancel_order_in_same_block() {
     None,
     Some(3),
     btree_map! {
-        !1 => (Direction::Bid, Udec128::new(30), Uint128::new(10)),
-        !2 => (Direction::Bid, Udec128::new(10), Uint128::new(10)),
-        3 => (Direction::Ask, Udec128::new(40), Uint128::new(10)),
+        OrderId::new(!1) => (Direction::Bid, Udec128::new(30), Uint128::new(10)),
+        OrderId::new(!2) => (Direction::Bid, Udec128::new(10), Uint128::new(10)),
+        OrderId::new(3)  => (Direction::Ask, Udec128::new(40), Uint128::new(10)),
     };
     "dango/usdc with limit no start after"
 )]
@@ -1025,10 +1027,10 @@ fn submit_and_cancel_order_in_same_block() {
         ((eth::DENOM.clone(), usdc::DENOM.clone()), Direction::Ask, 25, 10), //  5
     ],
     (dango::DENOM.clone(), usdc::DENOM.clone()),
-    Some(3),
+    Some(OrderId::new(3)),
     None,
     btree_map! {
-        4 => (Direction::Ask, Udec128::new(50), Uint128::new(10)),
+        OrderId::new(4) => (Direction::Ask, Udec128::new(50), Uint128::new(10)),
     };
     "dango/usdc with start after"
 )]
@@ -1042,11 +1044,11 @@ fn submit_and_cancel_order_in_same_block() {
         ((eth::DENOM.clone(), usdc::DENOM.clone()), Direction::Ask, 25, 10), //  5
     ],
     (dango::DENOM.clone(), usdc::DENOM.clone()),
-    Some(!2),
+    Some(OrderId::new(!2)),
     Some(2),
     btree_map! {
-        !1 => (Direction::Bid, Udec128::new(30), Uint128::new(10)),
-        3 => (Direction::Ask, Udec128::new(40), Uint128::new(10)),
+        OrderId::new(!1) => (Direction::Bid, Udec128::new(30), Uint128::new(10)),
+        OrderId::new(3)  => (Direction::Ask, Udec128::new(40), Uint128::new(10)),
     };
     "dango/usdc with start after and limit"
 )]
@@ -2483,7 +2485,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
         },
     ],
     btree_map! {
-        !1u64 => (Udec128::new_percent(20100), Uint128::from(49751), Direction::Bid),
+        OrderId::new(!1) => (Udec128::new_percent(20100), Uint128::from(49751), Direction::Bid),
     },
     btree_map! {
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coin_pair! {
@@ -2617,7 +2619,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
         },
     ],
     btree_map! {
-        !1u64 => (Udec128::new_percent(20300), Uint128::from(10000), Direction::Bid),
+        OrderId::new(!1) => (Udec128::new_percent(20300), Uint128::from(10000), Direction::Bid),
     },
     btree_map! {
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coin_pair! {
@@ -2751,7 +2753,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
         },
     ],
     btree_map! {
-        1u64 => (Udec128::new_percent(19900), Uint128::from(10000), Direction::Ask),
+        OrderId::new(1) => (Udec128::new_percent(19900), Uint128::from(10000), Direction::Ask),
     },
     btree_map! {
         (eth::DENOM.clone(), usdc::DENOM.clone()) => coin_pair! {
@@ -3701,7 +3703,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        1 => (Direction::Ask, Udec128::new(1), Uint128::new(100_000_000), Uint128::new(100_000_000), 0),
+        OrderId::new(1) => (Direction::Ask, Udec128::new(1), Uint128::new(100_000_000), Uint128::new(100_000_000), 0),
     };
     "One limit ask, one market ask, no match"
 )]
@@ -3752,7 +3754,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        !1 => (Direction::Bid, Udec128::new(1), Uint128::new(100_000_000), Uint128::new(100_000_000), 0),
+        OrderId::new(!1) => (Direction::Bid, Udec128::new(1), Uint128::new(100_000_000), Uint128::new(100_000_000), 0),
     };
     "One limit bid, one market bid, no match"
 )]
@@ -3999,7 +4001,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        1 => (Direction::Ask, Udec128::new(1), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
+        OrderId::new(1) => (Direction::Ask, Udec128::new(1), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
     };
     "One limit ask price 1.0, one market bid, limit order larger size, no fees, no slippage"
 )]
@@ -4050,7 +4052,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        1 => (Direction::Ask, Udec128::new(2), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
+        OrderId::new(1) => (Direction::Ask, Udec128::new(2), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
     };
     "One limit ask price 2.0, one market bid, limit order larger size, no fees, no slippage"
 )]
@@ -4101,7 +4103,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        !1 => (Direction::Bid, Udec128::new(1), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
+        OrderId::new(!1) => (Direction::Bid, Udec128::new(1), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
     };
     "One limit bid price 1.0, one market ask, limit order larger size, no fees, no slippage"
 )]
@@ -4152,7 +4154,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        !1 => (Direction::Bid, Udec128::new(2), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
+        OrderId::new(!1) => (Direction::Bid, Udec128::new(2), Uint128::new(150_000_000), Uint128::new(50_000_000), 0),
     };
     "One limit bid price 2.0, one market ask, limit order larger size, no fees, no slippage"
 )]
@@ -4270,7 +4272,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        2 => (Direction::Ask, Udec128::new_percent(200), Uint128::new(100_000_000), Uint128::new(75_000_000), 1),
+        OrderId::new(2) => (Direction::Ask, Udec128::new_percent(200), Uint128::new(100_000_000), Uint128::new(75_000_000), 1),
     };
     "Two limit asks different prices, one market bid, second limit partially filled, no fees, slippage not exceeded"
 )]
@@ -4339,7 +4341,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        2 => (Direction::Ask, Udec128::new_percent(200), Uint128::new(100_000_000), Uint128::new(75_000_000), 1),
+        OrderId::new(2) => (Direction::Ask, Udec128::new_percent(200), Uint128::new(100_000_000), Uint128::new(75_000_000), 1),
     };
     "Two limit asks different prices, one market bid, second limit partially filled, no fees, slippage exceeded"
 )]
@@ -4408,7 +4410,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        !2 => (Direction::Bid, Udec128::new_percent(50), Uint128::new(100_000_000), Uint128::new(50_000_000), 1),
+        OrderId::new(!2) => (Direction::Bid, Udec128::new_percent(50), Uint128::new(100_000_000), Uint128::new(50_000_000), 1),
     };
     "Two limit bids different prices, one market ask, second limit partially filled, no fees, slippage not exceeded"
 )]
@@ -4477,7 +4479,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        !2 => (Direction::Bid, Udec128::new_percent(10), Uint128::new(100_000_000), Uint128::new(87_500_000), 1),
+        OrderId::new(!2) => (Direction::Bid, Udec128::new_percent(10), Uint128::new(100_000_000), Uint128::new(87_500_000), 1),
     };
     "Two limit bids different prices, one market ask, second limit partially filled, no fees, slippage exceeded"
 )]
@@ -4547,7 +4549,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        1 => (Direction::Ask, Udec128::new_percent(100), Uint128::new(100_000_000), Uint128::new(20_000_000), 0),
+        OrderId::new(1) => (Direction::Ask, Udec128::new_percent(100), Uint128::new(100_000_000), Uint128::new(20_000_000), 0),
     };
     "One limit ask, two market bids, no fees, slippage not exceeded"
 )]
@@ -4617,7 +4619,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
         },
     },
     btree_map! {
-        !1 => (Direction::Bid, Udec128::new_percent(100), Uint128::new(100_000_000), Uint128::new(20_000_000), 0),
+        OrderId::new(!1) => (Direction::Bid, Udec128::new_percent(100), Uint128::new(100_000_000), Uint128::new(20_000_000), 0),
     };
     "One limit bid, two market bids, no fees, slippage not exceeded"
 )]

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{auth::Nonce, dex::OrdersByUserResponse},
+    crate::{
+        auth::Nonce,
+        dex::{OrderId, OrdersByUserResponse},
+    },
     grug::{Bounded, Coins, Denom, Udec128, Udec256, Uint128, ZeroExclusiveOneInclusive},
     std::collections::{BTreeMap, BTreeSet},
 };
@@ -12,7 +15,7 @@ pub type CollateralPower = Bounded<Udec128, ZeroExclusiveOneInclusive>;
 pub struct HealthData {
     pub scaled_debts: BTreeMap<Denom, Udec256>,
     pub collateral_balances: BTreeMap<Denom, Uint128>,
-    pub limit_orders: BTreeMap<u64, OrdersByUserResponse>,
+    pub limit_orders: BTreeMap<OrderId, OrdersByUserResponse>,
 }
 
 /// Output for computing a margin account's health.

--- a/dango/types/src/dex/types.rs
+++ b/dango/types/src/dex/types.rs
@@ -18,10 +18,10 @@ use {
 /// The reason for this, is we need orders to be sorted by **price-time priority**
 /// in the contract's storage. Meaning, orders with the better prices come first;
 /// for those with the same price, the older ones come first. We achieve this by
-/// prefixing the storage key of each order with:
+/// using the following storage key for orders:
 ///
 /// ```plain
-/// direction | price | order_id | ...other subkeys...
+/// direction | price | order_id
 /// ```
 ///
 /// - For bids, we iterate all orders prefixed with `Direction::Bid`, _ascendingly_.

--- a/dango/types/src/dex/types.rs
+++ b/dango/types/src/dex/types.rs
@@ -1,24 +1,63 @@
 use {
     grug::{
-        Bounded, Denom, PrimaryKey, RawKey, StdError, StdResult, Udec128,
+        Bounded, Denom, PrimaryKey, RawKey, StdError, StdResult, Udec128, Uint64,
         ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
     },
     std::ops::Neg,
 };
 
-/// Numerical identifier of an order.
+/// Numerical identifier of an order (limit or market).
 ///
-/// For SELL orders, we count order IDs from 0 up; for BUY orders, from `u64::MAX`
-/// down.
+/// ## Notes
 ///
-/// As such, given our contract storage layout, between two orders of the same
-/// price, the older one is matched first. This follows the principle of
-/// **price-time priority**.
+/// ### Storage layout
+///
+/// For SELL orders, we count order IDs from 0 up; for BUY orders, from
+/// `u64::MAX` down.
+///
+/// The reason for this, is we need orders to be sorted by **price-time priority**
+/// in the contract's storage. Meaning, orders with the better prices come first;
+/// for those with the same price, the older ones come first. We achieve this by
+/// prefixing the storage key of each order with:
+///
+/// ```plain
+/// direction | price | order_id | ...other subkeys...
+/// ```
+///
+/// - For bids, we iterate all orders prefixed with `Direction::Bid`, _ascendingly_.
+/// - For asks, we iterate all orders prefixed with `Direction::Ask`, _descendingly_.
+///
+/// In each case, price-time priority is respected.
+///
+/// See `dango_dex::state::LimitOrderKey` for details.
 ///
 /// Note that this assumes `order_id` never exceeds `u64::MAX / 2`, which is a
 /// safe assumption. If we accept 1 million orders per second, it would take
 /// ~300,000 years to reach `u64::MAX / 2`.
-pub type OrderId = u64;
+///
+/// ### Serialization
+///
+/// JSON uses IEEE-754 64-bit floating point numbers to represent numbers, which
+/// can only represent integers up to `2^53 - 1` without losing precision. For
+/// example,
+///
+/// ```javascript
+/// JSON.stringify({ number: 9007199254740993 })
+/// ```
+///
+/// returns:
+///
+/// ```json
+/// '{"number":9007199254740992}'
+/// ```
+///
+/// The value is off by 1, because `9007199254740993` is bigger than `2^53 - 1`
+/// and thus can't be represented without losing precision.
+///
+/// Since order IDs for asks are counted from top down, they necessarily exceed
+/// `2^53 - 1`. To accurately represent these order IDs, instead of `u64`, we
+/// use `grug::Uint64`, which is serialized as JSON strings.
+pub type OrderId = Uint64;
 
 /// The direction of a trade: buy or sell.
 #[grug::derive(Serde, Borsh)]

--- a/grug/math/src/int.rs
+++ b/grug/math/src/int.rs
@@ -11,8 +11,8 @@ use {
         iter::Sum,
         marker::PhantomData,
         ops::{
-            Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Shl, ShlAssign,
-            Shr, ShrAssign, Sub, SubAssign,
+            Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl,
+            ShlAssign, Shr, ShrAssign, Sub, SubAssign,
         },
         str::FromStr,
     },
@@ -21,7 +21,17 @@ use {
 // ------------------------------- generic type --------------------------------
 
 #[derive(
-    BorshSerialize, BorshDeserialize, Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord,
+    BorshSerialize,
+    BorshDeserialize,
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
 )]
 pub struct Int<U>(pub U);
 
@@ -273,6 +283,17 @@ where
 {
     fn shr_assign(&mut self, rhs: u32) {
         *self = *self >> rhs;
+    }
+}
+
+impl<U> Not for Int<U>
+where
+    U: Not<Output = U>,
+{
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self(!self.0)
     }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change order ID type from `u64` to `Uint64` across the codebase for better serialization and precision.
> 
>   - **Behavior**:
>     - Change order ID type from `u64` to `Uint64` in `geometric.rs`, `xyk.rs`, and `state.rs`.
>     - Update `OrderId` type in `types.rs` to `Uint64` for better serialization and precision.
>     - Modify order creation and management logic to use `Uint64` in `dex.rs` tests.
>   - **Models**:
>     - Update `ExtendedOrderId` in `types.rs` to use `Uint64`.
>     - Change `limit_orders` map key to `Uint64` in `margin.rs`.
>   - **Misc**:
>     - Add `Not` trait implementation for `Int<U>` in `int.rs`.
>     - Update tests in `dex.rs` to reflect `Uint64` usage for order IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ea5d673f2c8a6bb7be20bf8ceefc42b2cb710098. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->