### PR TITLE
fix(ui): margins & tabs

### DIFF
--- a/ui/applets/kit/src/components/Tabs.tsx
+++ b/ui/applets/kit/src/components/Tabs.tsx
@@ -127,7 +127,7 @@ const tabsVariants = tv({
       },
       "line-red": {
         base: "p-0",
-        button: "border-b-[1px] border-gray-100",
+        button: "border-b-[1px] border-gray-100 pt-0",
         "animated-element": "bg-red-bean-400 w-full h-[2px] bottom-[-1px]",
       },
     },

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -30,7 +30,7 @@ export const OrderBookOverview: React.FC = () => {
         keys={isLg ? ["order book", "trades"] : ["graph", "order book", "trades"]}
         fullWidth
         onTabChange={(tab) => setActiveTab(tab as "order book" | "trades")}
-        classNames={{ button: "exposure-xs-italic pt-0" }}
+        classNames={{ button: "exposure-xs-italic" }}
       />
       {activeTab === "graph" && <TradingViewChart />}
       {activeTab === "order book" && <OrderBook />}

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -265,10 +265,10 @@ const ProTradeOrders: React.FC = () => {
           selectedTab={activeTab}
           keys={["open order", "trade history"]}
           onTabChange={(tab) => setActiveTab(tab as "open order" | "trade history")}
-          classNames={{ button: "exposure-xs-italic" }}
+          classNames={{ button: "exposure-xs-italic", base: "z-10" }}
         />
 
-        <span className="w-full absolute h-[1px] bg-gray-100 bottom-[1px]" />
+        <span className="w-full absolute h-[2px] bg-gray-100 bottom-[0px] z-0" />
       </div>
       <div className="w-full h-full relative">
         {activeTab === "open order" ? (

--- a/ui/portal/web/src/components/dex/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/SearchToken.tsx
@@ -64,16 +64,17 @@ const SearchTokenMenu: React.FC<SearchTokenProps> = ({ pairId, onChangePairId })
           </div>
         }
       />
-      <div className="relative overflow-x-auto scrollbar-none">
+      <div className="relative overflow-x-auto scrollbar-none pt-1">
         <Tabs
           color="line-red"
           layoutId="search-token-tabs"
           selectedTab={activeFilter}
           keys={["All", "Spot"]}
           onTabChange={setActiveFilter}
+          classNames={{ base: "z-10" }}
         />
 
-        <span className="w-full absolute h-[1px] bg-gray-100 bottom-[1px]" />
+        <span className="w-full absolute h-[2px] bg-gray-100 bottom-[0px] z-0" />
       </div>
       <SearchTokenTable>
         <SearchTokenTable.Spot

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -250,7 +250,6 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ state }) => {
         fullWidth
         onTabChange={(tab) => setOperation(tab as "market" | "limit")}
         color="line-red"
-        classNames={{ button: "pt-0" }}
       />
       <div className="flex items-center justify-between gap-2">
         <p className="diatype-xs-medium text-gray-500">Current Position</p>
@@ -337,7 +336,7 @@ const Menu: React.FC<TradeMenuProps> = ({ state, controllers, className }) => {
           fullWidth
           onTabChange={(tab) => setOperation(tab as "market" | "limit")}
           color="line-red"
-          classNames={{ button: "exposure-xs-italic pt-0" }}
+          classNames={{ button: "exposure-xs-italic" }}
           isDisabled={submission.isPending}
         />
       </div>


### PR DESCRIPTION
This task fix LEF-199
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI margin and tab styling issues in `Tabs.tsx`, `OrderBookOverview.tsx`, `ProTrade.tsx`, `SearchToken.tsx`, and `TradeMenu.tsx`.
> 
>   - **UI Adjustments**:
>     - In `Tabs.tsx`, added `pt-0` to `button` class for `line-red` variant.
>     - In `OrderBookOverview.tsx`, removed `pt-0` from `button` class in `Tabs`.
>     - In `ProTrade.tsx`, added `base: "z-10"` to `Tabs` and adjusted span height and position.
>     - In `SearchToken.tsx`, added `pt-1` to `div` containing `Tabs`.
>     - In `TradeMenu.tsx`, removed `pt-0` from `button` class in `Tabs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for f8c90a40408b70940d2c6e8264948e67373e415a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->