### PR TITLE
feat(ui): dex cancel modals

### DIFF
--- a/sdk/dango/src/actions/dex/mutations/batchUpdateOrders.ts
+++ b/sdk/dango/src/actions/dex/mutations/batchUpdateOrders.ts
@@ -69,7 +69,7 @@ export async function batchUpdateOrders<transport extends Transport>(
         { name: "amount", type: "string" },
         { name: "price", type: "string" },
       ],
-      ...(cancels && cancels !== "all" ? { CancelSome: [{ name: "some", type: "uint64[]" }] } : {}),
+      ...(cancels && cancels !== "all" ? { CancelSome: [{ name: "some", type: "string[]" }] } : {}),
     },
   };
 

--- a/sdk/dango/src/types/dex.ts
+++ b/sdk/dango/src/types/dex.ts
@@ -212,7 +212,7 @@ export type PairSymbols = {
   quoteSymbol: string;
 };
 
-export type OrderId = number;
+export type OrderId = string;
 
 export type CoinPair = [Coin, Coin];
 

--- a/sdk/dango/src/utils/formatters.ts
+++ b/sdk/dango/src/utils/formatters.ts
@@ -34,6 +34,8 @@ export type FormatNumberOptions = {
   notation?: "standard" | "scientific" | "engineering" | "compact";
   maxFractionDigits?: number;
   minFractionDigits?: number;
+  maxSignificantDigits?: number;
+  minSignificantDigits?: number;
   mask: keyof typeof formatNumberMask;
 };
 
@@ -87,6 +89,8 @@ export function formatNumber(_amount_: number | bigint | string, options: Format
     currency,
     maxFractionDigits = 2,
     minFractionDigits = 2,
+    maxSignificantDigits = 3,
+    minSignificantDigits = 1,
     notation = "standard",
     mask = 1,
   } = options;
@@ -107,6 +111,8 @@ export function formatNumber(_amount_: number | bigint | string, options: Format
     roundingMode: "floor",
     minimumFractionDigits: minFractionDigits,
     maximumFractionDigits: maxFractionDigits,
+    maximumSignificantDigits: maxSignificantDigits,
+    minimumSignificantDigits: minSignificantDigits,
     useGrouping: formatNumberMask[mask].useGrouping,
     ...currencyOptions,
   })

--- a/sdk/grug/src/utils/decimal.ts
+++ b/sdk/grug/src/utils/decimal.ts
@@ -55,9 +55,7 @@ class Decimal {
 
   div(num: string | number | Decimal): Decimal {
     const other = Decimal.from(num);
-    if (other.isZero()) {
-      throw new Error("Cannot divide by zero.");
-    }
+    if (other.isZero()) return new Decimal(0);
     const result = this.inner.div(other.inner);
     return new Decimal(result);
   }

--- a/ui/applets/kit/src/components/Button.tsx
+++ b/ui/applets/kit/src/components/Button.tsx
@@ -148,6 +148,11 @@ const buttonVariants = tv(
           "bg-blue-50 text-blue-200 shadow-btn-shadow-disabled border-[1px] border-solid [border-image-source:linear-gradient(180deg,_rgba(0,_0,_0,_0.04)_8%,_rgba(0,_0,_0,_0.07)_100%)]",
       },
       {
+        variant: "tertiary",
+        isDisabled: true,
+        class: "bg-gray-50 text-gray-200 shadow-btn-shadow-disabled ",
+      },
+      {
         variant: "utility",
         class:
           "bg-rice-100 hover:bg-rice-200 text-rice-700 focus:[box-shadow:0px_0px_0px_3px_#FFF3E1B3] data-[status=active]:[box-shadow:0px_0px_0px_3px_#FFF3E1B3] border-[1px] border-solid [border-image-source:linear-gradient(180deg,_rgba(46,_37,_33,_0.06)_8%,_rgba(46,_37,_33,_0.12)_100%)]",

--- a/ui/applets/kit/src/components/Cell.tsx
+++ b/ui/applets/kit/src/components/Cell.tsx
@@ -110,6 +110,20 @@ const Text: React.FC<CellTextProps> = ({ text, className }) => {
   );
 };
 
+type CellNumberProps = {
+  className?: string;
+  formatOptions: FormatNumberOptions;
+  value: number | string;
+};
+
+const CellNumber: React.FC<CellNumberProps> = ({ value, formatOptions, className }) => {
+  return (
+    <div className={twMerge("flex flex-col gap-1 text-gray-500", className)}>
+      <p>{formatNumber(value, formatOptions)}</p>
+    </div>
+  );
+};
+
 type CellOrderDirectionProps = {
   className?: string;
   direction: Directions;
@@ -313,6 +327,7 @@ export const Cell = Object.assign(Container, {
   Sender,
   Text,
   TxHash,
+  Number: CellNumber,
   OrderDirection,
   TxMessages,
   TxResult,

--- a/ui/applets/kit/src/components/Cell.tsx
+++ b/ui/applets/kit/src/components/Cell.tsx
@@ -300,19 +300,25 @@ const TxMessages: React.FC<CellTxMessagesProps> = ({ messages }) => {
 
 type CellPairNameProps = {
   pairId: PairId;
-  type: string;
+  type?: string;
+  className?: string;
 };
 
-const PairName: React.FC<CellPairNameProps> = ({ pairId, type }) => {
+const PairName: React.FC<CellPairNameProps> = ({ pairId, type, className }) => {
   const { coins } = useConfig();
   const { baseDenom, quoteDenom } = pairId;
   const baseCoin = coins[baseDenom];
   const quoteCoin = coins[quoteDenom];
 
   return (
-    <div className="flex h-full gap-2 diatype-sm-medium justify-start items-center my-auto">
+    <div
+      className={twMerge(
+        "flex h-full gap-2 diatype-sm-medium justify-start items-center my-auto",
+        className,
+      )}
+    >
       <p className="min-w-fit">{`${baseCoin.symbol}-${quoteCoin.symbol}`}</p>
-      <Badge text={type} color="blue" size="s" />
+      {type ? <Badge text={type} color="blue" size="s" /> : null}
     </div>
   );
 };

--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -663,6 +663,7 @@
         "noOpenOrders": "No open orders yet",
         "price": "Price",
         "ordersTable": {
+          "id": "ID",
           "coin": "Coin",
           "size": "Size",
           "type": "Type",

--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -661,13 +661,13 @@
       "allOrdersCancelled": "All orders cancelled",
       "spot": {
         "noOpenOrders": "No open orders yet",
-        "price": "Price",
+        "price": "Limit Price",
         "ordersTable": {
           "id": "ID",
-          "coin": "Coin",
-          "size": "Size",
+          "pair": "Pair",
+          "remaining": "Remaining ({symbol})",
           "type": "Type",
-          "originalSize": "Original Size",
+          "size": "Size ({symbol})",
           "direction": "Direction"
         },
         "24hChange": "24h Change",

--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -272,8 +272,13 @@
     },
     "protradeCloseAllOrders": {
       "title": "Close All Orders",
-      "description": "This will close all your positions and cancel their associated TP/SL orders.",
+      "description": "This will close all your open orders.",
       "action": "Confirm Close Orders"
+    },
+    "proTradeCloseOrder": {
+      "title": "Close Order",
+      "description": "This will close the order.",
+      "action": "Confirm Close Order"
     }
   },
   "signin": {

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -24,13 +24,14 @@ import {
 } from "@left-curve/applets-kit";
 import { EmptyPlaceholder } from "../foundation/EmptyPlaceholder";
 import { AnimatePresence, motion } from "framer-motion";
+import { Modals } from "../modals/RootModal";
 import { OrderBookOverview } from "./OrderBookOverview";
 import { SearchToken } from "./SearchToken";
 import { TradeMenu } from "./TradeMenu";
 import { TradingViewChart } from "./TradingViewChart";
 
 import type { TableColumn } from "@left-curve/applets-kit";
-import type { OrdersByUserResponse, PairId } from "@left-curve/dango/types";
+import type { OrderId, OrdersByUserResponse, PairId } from "@left-curve/dango/types";
 import type { PropsWithChildren } from "react";
 
 const [ProTradeProvider, useProTrade] = createContext<{
@@ -166,16 +167,14 @@ const ProTradeMenu: React.FC = () => {
 };
 
 const ProTradeOrders: React.FC = () => {
-  const { showModal: _ } = useApp();
+  const { showModal } = useApp();
   const { coins } = useConfig();
-  const { account } = useAccount();
-  const { data: signingClient } = useSigningClient();
   const [activeTab, setActiveTab] = useState<"open order" | "trade history">("open order");
 
   const { state } = useProTrade();
   const { orders } = state;
 
-  const columns: TableColumn<OrdersByUserResponse & { id: number }> = [
+  const columns: TableColumn<OrdersByUserResponse & { id: OrderId }> = [
     /*  {
       header: "Time",
       cell: ({ row }) => <Cell.Time date={row.original.time} />,
@@ -231,9 +230,7 @@ const ProTradeOrders: React.FC = () => {
       header: () => (
         <Cell.Action
           isDisabled={!orders.data.length}
-          action={() =>
-            signingClient?.batchUpdateOrders({ cancels: "all", sender: account!.address })
-          }
+          action={() => showModal(Modals.ProTradeCloseAll)}
           label={m["common.cancelAll"]()}
           classNames={{
             cell: "items-end diatype-xs-regular",
@@ -243,12 +240,7 @@ const ProTradeOrders: React.FC = () => {
       ),
       cell: ({ row }) => (
         <Cell.Action
-          action={() =>
-            signingClient?.batchUpdateOrders({
-              sender: account!.address,
-              cancels: { some: [row.original.id] },
-            })
-          }
+          action={() => showModal(Modals.ProTradeCloseOrder, { orderId: row.original.id })}
           label={m["common.cancel"]()}
           classNames={{ cell: "items-end", button: "!exposure-xs-italic m-0 p-0 px-1 h-fit" }}
         />

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -20,7 +20,7 @@ import {
 } from "@left-curve/applets-kit";
 import { Sheet } from "react-modal-sheet";
 
-import { Big } from "big.js";
+import { Decimal, formatNumber } from "@left-curve/dango/utils";
 import { m } from "~/paraglide/messages";
 
 import type { useProTradeState } from "@left-curve/store";
@@ -40,7 +40,6 @@ type TradeMenuProps = {
 const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
   const { settings } = useApp();
   const { formatNumberOptions } = settings;
-  const { isLg } = useMediaQuery();
   const { isConnected } = useAccount();
   const { data: appConfig } = useAppConfig();
 
@@ -78,7 +77,7 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
             {m["dex.protrade.spot.availableToTrade"]()}
           </p>
           <p className="diatype-xs-medium text-gray-700">
-            {availableCoin.amount} {availableCoin.symbol}
+            {formatNumber(availableCoin.amount, { ...formatNumberOptions })} {availableCoin.symbol}
           </p>
         </div>
         {operation === "limit" ? (
@@ -130,7 +129,7 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
           inputEndContent="%"
           value={rangeValue}
           onChange={(v) => {
-            setValue("size", Big(maxSizeAmount).mul(Big(v).div(100)).toString());
+            setValue("size", Decimal(maxSizeAmount).mul(Decimal(v).div(100)).toString());
           }}
         />
       </div>
@@ -171,13 +170,13 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
               <span>{m["dex.protrade.spot.orderSize"]()}</span>
             </p>
             <p className="diatype-xs-medium text-gray-700">
-              {orderAmount.quoteAmount} {quoteCoin.symbol}
+              {formatNumber(orderAmount.quoteAmount, { ...formatNumberOptions })} {quoteCoin.symbol}
             </p>
           </div>
           <div className="flex items-center justify-between gap-2">
             <p className="diatype-xs-regular text-gray-500" />
             <p className="diatype-xs-medium text-gray-700">
-              {orderAmount.baseAmount} {baseCoin.symbol}
+              {formatNumber(orderAmount.baseAmount, { ...formatNumberOptions })} {baseCoin.symbol}
             </p>
           </div>
           {operation === "market" ? (

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -64,6 +64,8 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
 
   const amount = inputs.size?.value || "0";
 
+  const priceAmount = inputs.price?.value || "0";
+
   const rangeValue = useMemo(() => {
     if (maxSizeAmount === 0) return 0;
     return Math.min(100, (+amount / maxSizeAmount) * 100);
@@ -140,6 +142,7 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
               variant={action === "sell" ? "primary" : "tertiary"}
               fullWidth
               size="md"
+              isDisabled={amount === "0" || (operation === "limit" && priceAmount === "0")}
               isLoading={submission.isPending}
               onClick={() => submission.mutateAsync()}
             >

--- a/ui/portal/web/src/components/modals/ProTradeCloseOrder.tsx
+++ b/ui/portal/web/src/components/modals/ProTradeCloseOrder.tsx
@@ -6,12 +6,14 @@ import { m } from "~/paraglide/messages";
 import { useAccount, useSigningClient, useSubmitTx } from "@left-curve/store";
 import { forwardRef } from "react";
 
-export const ProTradeCloseAll = forwardRef(() => {
+import type { OrderId } from "@left-curve/dango/types";
+
+export const ProTradeCloseOrder = forwardRef<void, { orderId: OrderId }>(({ orderId }) => {
   const { hideModal } = useApp();
   const { account } = useAccount();
   const { data: signingClient } = useSigningClient();
 
-  const { isPending, mutateAsync: cancelAllOrders } = useSubmitTx({
+  const { isPending, mutateAsync: cancelOrder } = useSubmitTx({
     submission: {
       success: m["dex.protrade.allOrdersCancelled"](),
       error: m["errors.failureRequest"](),
@@ -19,7 +21,10 @@ export const ProTradeCloseAll = forwardRef(() => {
     mutation: {
       mutationFn: async () => {
         if (!signingClient) throw new Error("No signing client available");
-        await signingClient.batchUpdateOrders({ cancels: "all", sender: account!.address });
+        await signingClient.batchUpdateOrders({
+          cancels: { some: [orderId] },
+          sender: account!.address,
+        });
       },
       onSuccess: () => hideModal(),
     },
@@ -27,9 +32,9 @@ export const ProTradeCloseAll = forwardRef(() => {
 
   return (
     <div className="flex flex-col bg-white-100 md:border border-gray-100 pt-0 md:pt-6 rounded-xl relative p-4 md:p-6 gap-5 w-full md:max-w-[25rem]">
-      <h2 className="text-gray-900 h4-bold w-full">{m["modals.protradeCloseAllOrders.title"]()}</h2>
+      <h2 className="text-gray-900 h4-bold w-full">{m["modals.proTradeCloseOrder.title"]()}</h2>
       <p className="text-gray-500 diatype-sm-regular">
-        {m["modals.protradeCloseAllOrders.description"]()}
+        {m["modals.proTradeCloseOrder.description"]()}
       </p>
       {/* <RadioGroup name="close-positions-all" defaultValue="market-close">
         <Radio value="market-close" label="Market Close" />
@@ -42,8 +47,8 @@ export const ProTradeCloseAll = forwardRef(() => {
       >
         <IconClose />
       </IconButton>
-      <Button fullWidth isLoading={isPending} onClick={() => cancelAllOrders()}>
-        {m["modals.protradeCloseAllOrders.action"]()}
+      <Button fullWidth isLoading={isPending} onClick={() => cancelOrder()}>
+        {m["modals.proTradeCloseOrder.action"]()}
       </Button>
     </div>
   );

--- a/ui/portal/web/src/components/modals/RootModal.tsx
+++ b/ui/portal/web/src/components/modals/RootModal.tsx
@@ -19,6 +19,7 @@ export const Modals = {
   ConfirmSwap: "confirm-swap",
   RenewSession: "renew-session",
   ProTradeCloseAll: "pro-trade-close-all",
+  ProTradeCloseOrder: "pro-trade-close-order",
   ProTradeLimitClose: "pro-trade-limit-close",
   ProSwapMarketClose: "pro-swap-market-close",
   ProSwapEditTPSL: "pro-edit-tpsl",
@@ -86,6 +87,13 @@ const modals: Record<(typeof Modals)[keyof typeof Modals], ModalDefinition> = {
   [Modals.ProTradeCloseAll]: {
     component: lazy(() =>
       import("./ProTradeCloseAll").then(({ ProTradeCloseAll }) => ({ default: ProTradeCloseAll })),
+    ),
+  },
+  [Modals.ProTradeCloseOrder]: {
+    component: lazy(() =>
+      import("./ProTradeCloseOrder").then(({ ProTradeCloseOrder }) => ({
+        default: ProTradeCloseOrder,
+      })),
     ),
   },
   [Modals.ProTradeLimitClose]: {

--- a/ui/store/src/hooks/usePrices.ts
+++ b/ui/store/src/hooks/usePrices.ts
@@ -63,11 +63,10 @@ export function usePrices(parameters: UsePricesParameters = {}) {
     const fromPrice = getPrice(fromAmount, fromDenom);
     const targetPrice = getPrice(1, targetDenom);
 
-    const targetAmount = Decimal(fromPrice).div(targetPrice).toNumber();
+    const targetAmount = Decimal(fromPrice).div(targetPrice).toFixed();
+
     return (
-      parse
-        ? parseUnits(targetAmount.toString(), coins[targetDenom].decimals).toString()
-        : targetAmount
+      parse ? parseUnits(targetAmount, coins[targetDenom].decimals).toString() : targetAmount
     ) as T extends false ? number : string;
   }
 

--- a/ui/store/src/hooks/useProTradeState.ts
+++ b/ui/store/src/hooks/useProTradeState.ts
@@ -104,7 +104,7 @@ export function useProTradeState(parameters: UseProTradeStateParameters) {
       const response = await publicClient.ordersByUser({ user: account.address });
       return Object.entries(response).map(([id, order]) => ({
         ...order,
-        id: +id,
+        id,
       }));
     },
     initialData: [],

--- a/ui/store/src/hooks/useProTradeState.ts
+++ b/ui/store/src/hooks/useProTradeState.ts
@@ -173,7 +173,7 @@ export function useProTradeState(parameters: UseProTradeStateParameters) {
                     direction,
                     price: Decimal(inputs.price.value)
                       .times(Decimal(10).pow(quoteCoin.decimals - baseCoin.decimals))
-                      .toString(),
+                      .toFixed(),
                   },
                 ],
               };

--- a/ui/store/src/hooks/useProTradeState.ts
+++ b/ui/store/src/hooks/useProTradeState.ts
@@ -131,8 +131,8 @@ export function useProTradeState(parameters: UseProTradeStateParameters) {
     if (priceValue === "0") return { baseAmount: "0", quoteAmount: "0" };
 
     return {
-      baseAmount: isBaseSize ? sizeValue : Decimal(sizeValue).divFloor(priceValue).toString(),
-      quoteAmount: isQuoteSize ? sizeValue : Decimal(sizeValue).mul(priceValue).toString(),
+      baseAmount: isBaseSize ? sizeValue : Decimal(sizeValue).divFloor(priceValue).toFixed(),
+      quoteAmount: isQuoteSize ? sizeValue : Decimal(sizeValue).mul(priceValue).toFixed(),
     };
   }, [operation, sizeCoin, pairId, sizeValue, priceValue, needsConversion]);
 


### PR DESCRIPTION
This PR closes: LEF-195, LEF-197 and LEF-198

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add new modals for DEX order cancellation, update order ID type, enhance number formatting, and modify `Decimal` class behavior.
> 
>   - **Modals**:
>     - Add `ProTradeCloseOrder` and `ProTradeCloseAll` modals in `ProTradeCloseOrder.tsx` and `ProTradeCloseAll.tsx` for order cancellation.
>     - Update `RootModal.tsx` to include new modals.
>   - **Types**:
>     - Change `OrderId` type from `number` to `string` in `dex.ts`.
>   - **Utilities**:
>     - Add `maxSignificantDigits` and `minSignificantDigits` to `FormatNumberOptions` in `formatters.ts`.
>     - Modify `Decimal` class in `decimal.ts` to return `Decimal(0)` on division by zero.
>   - **UI Components**:
>     - Add `CellNumber` component in `Cell.tsx` for formatted number display.
>     - Add `tertiary` disabled variant to `Button.tsx`.
>   - **Messages**:
>     - Update `en.json` with new modal messages for order cancellation.
>   - **ProTrade**:
>     - Update `ProTrade.tsx` to use new modals for order cancellation.
>     - Modify `TradeMenu.tsx` to disable button when amount or price is zero.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 71db24a688f1289f2980f6e73702ba49e75b24e6. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->