### PR TITLE
dex: introduce reserve ratio to xyk pool

### DIFF
--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -394,10 +394,14 @@ impl PassiveLiquidityPool for PairParams {
         let quote_reserve = reserve.amount_of(&quote_denom)?;
 
         match self.pool_type {
-            PassiveLiquidity::Xyk { order_spacing } => xyk::reflect_curve(
+            PassiveLiquidity::Xyk {
+                order_spacing,
+                reserve_ratio,
+            } => xyk::reflect_curve(
                 base_reserve,
                 quote_reserve,
                 order_spacing,
+                reserve_ratio,
                 self.swap_fee_rate,
             ),
             PassiveLiquidity::Geometric {
@@ -447,6 +451,7 @@ mod tests {
     #[test_case(
         PassiveLiquidity::Xyk {
             order_spacing: Udec128::ONE,
+            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
         },
         Udec128::new_permille(5),
         coins! {
@@ -483,6 +488,7 @@ mod tests {
     #[test_case(
         PassiveLiquidity::Xyk {
             order_spacing: Udec128::ONE,
+            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
         },
         Udec128::new_percent(1),
         coins! {
@@ -519,6 +525,7 @@ mod tests {
     #[test_case(
         PassiveLiquidity::Xyk {
             order_spacing: Udec128::new_percent(1),
+            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
         },
         Udec128::new_permille(5),
         coins! {
@@ -555,6 +562,7 @@ mod tests {
     #[test_case(
         PassiveLiquidity::Xyk {
             order_spacing: Udec128::new_percent(1),
+            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
         },
         Udec128::new_percent(1),
         coins! {

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -535,6 +535,7 @@ mod tests {
                     lp_denom: Denom::from_str("lp").unwrap(),
                     pool_type: PassiveLiquidity::Xyk {
                         order_spacing: Udec128::ONE,
+                        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
                     },
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                 },

--- a/dango/testing/src/genesis.rs
+++ b/dango/testing/src/genesis.rs
@@ -341,6 +341,7 @@ impl Preset for DexOption {
                         lp_denom: Denom::from_str("dex/pool/dango/usdc").unwrap(),
                         pool_type: PassiveLiquidity::Xyk {
                             order_spacing: Udec128::ONE,
+                            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
                         },
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },
@@ -352,6 +353,7 @@ impl Preset for DexOption {
                         lp_denom: Denom::from_str("dex/pool/btc/usdc").unwrap(),
                         pool_type: PassiveLiquidity::Xyk {
                             order_spacing: Udec128::ONE,
+                            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
                         },
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },
@@ -363,6 +365,7 @@ impl Preset for DexOption {
                         lp_denom: Denom::from_str("dex/pool/eth/usdc").unwrap(),
                         pool_type: PassiveLiquidity::Xyk {
                             order_spacing: Udec128::ONE,
+                            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
                         },
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },
@@ -374,6 +377,7 @@ impl Preset for DexOption {
                         lp_denom: Denom::from_str("dex/pool/sol/usdc").unwrap(),
                         pool_type: PassiveLiquidity::Xyk {
                             order_spacing: Udec128::ONE,
+                            reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
                         },
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1175,6 +1175,7 @@ fn only_owner_can_create_passive_pool() {
                     lp_denom: lp_denom.clone(),
                     pool_type: PassiveLiquidity::Xyk {
                         order_spacing: Udec128::new_bps(1),
+                        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
                     },
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
@@ -1195,6 +1196,7 @@ fn only_owner_can_create_passive_pool() {
                     lp_denom: lp_denom.clone(),
                     pool_type: PassiveLiquidity::Xyk {
                         order_spacing: Udec128::new_bps(1),
+                        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
                     },
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
@@ -1212,6 +1214,7 @@ fn only_owner_can_create_passive_pool() {
     Udec128::new_permille(5),
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
@@ -1228,6 +1231,7 @@ fn only_owner_can_create_passive_pool() {
     Udec128::new_permille(5),
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
@@ -1244,6 +1248,7 @@ fn only_owner_can_create_passive_pool() {
     Udec128::new_permille(5),
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
@@ -2460,6 +2465,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_percent(1),
     coins! {
@@ -2506,6 +2512,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_permille(5),
     coins! {
@@ -2550,6 +2557,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_percent(1),
     coins! {
@@ -2594,6 +2602,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_percent(1),
     coins! {
@@ -2640,6 +2649,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_permille(5),
     coins! {
@@ -2684,6 +2694,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_permille(5),
     coins! {
@@ -2728,6 +2739,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_permille(5),
     coins! {
@@ -2774,6 +2786,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 #[test_case(
     PassiveLiquidity::Xyk {
         order_spacing: Udec128::ONE,
+        reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
     },
     Udec128::new_percent(1),
     coins! {

--- a/dango/types/src/dex/types.rs
+++ b/dango/types/src/dex/types.rs
@@ -1,7 +1,7 @@
 use {
     grug::{
         Bounded, Denom, PrimaryKey, RawKey, StdError, StdResult, Udec128, Uint64,
-        ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive,
+        ZeroExclusiveOneExclusive, ZeroExclusiveOneInclusive, ZeroInclusiveOneExclusive,
     },
     std::ops::Neg,
 };
@@ -128,6 +128,14 @@ pub enum PassiveLiquidity {
         /// This is the price difference between two consecutive orders when
         /// the passive liquidity is reflected onto the orderbook.
         order_spacing: Udec128,
+        /// The portion of reserve that the pool will keep on hand and not use
+        /// to place orders.
+        ///
+        /// This prevents an edge case where a trader makes an extremely large
+        /// trade, reducing one side of the pool's liquidity to zero. This would
+        /// cause any subsequent liquidity provision to fail with a "division by
+        /// zero" error.
+        reserve_ratio: Bounded<Udec128, ZeroInclusiveOneExclusive>,
     },
     /// Places liquidity around the oracle price in a geometric progression,
     /// such that the liquidity assigned to each price point is a fixed ratio of

--- a/deploy/roles/cometbft/templates/devnet/config/genesis.json
+++ b/deploy/roles/cometbft/templates/devnet/config/genesis.json
@@ -300,7 +300,8 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -313,7 +314,8 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -326,7 +328,8 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -339,7 +342,8 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"

--- a/deploy/roles/cometbft/templates/testnet/config/genesis.json
+++ b/deploy/roles/cometbft/templates/testnet/config/genesis.json
@@ -300,7 +300,8 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -313,7 +314,8 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -326,7 +328,8 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -339,7 +342,8 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"

--- a/networks/localdango/configs/cometbft/config/genesis.json
+++ b/networks/localdango/configs/cometbft/config/genesis.json
@@ -300,7 +300,8 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -313,7 +314,8 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -326,7 +328,8 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -339,7 +342,8 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1"
+                      "order_spacing": "1",
+                      "reserve_ratio": "0"
                     }
                   },
                   "swap_fee_rate": "0.003"


### PR DESCRIPTION
If a user makes a very very big order, it's possible that they consume the entirety of the xyk pool's liquidity. The following case was discovered by proptest:

- reserve before:

  ```
  CoinPair([Coin(bridge/eth:106265421), Coin(bridge/usdc:58295192)]) 
  ```

- action:

  ```
  CreateMarketOrder { base_denom: Denom([Part("bridge"), Part("eth")]), quote_denom: Denom([Part("bridge"), Part("usdc")]), direction: Ask, amount: Int(626970560) }
  ```

- reserve after:

  ```
  CoinPair([Coin(bridge/eth:356384922), Coin(bridge/usdc:0)])
  ```

The USDC liquidity is reduced to zero. This has the effect that the next time someone provides liquidity, there's a division-by-zero error when computing `mint_ratio`.

This PR introduces a new parameter to the xyk pool, the `reserve_ratio`. If reserve ratio is 5%, it means the pool will withhold 5% of its liquidity, only use the rest 95% to place orders in the order book. This prevents the pool's reserve to be reduced to zero.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce `reserve_ratio` to xyk pool to prevent liquidity depletion and division-by-zero errors.
> 
>   - **Behavior**:
>     - Introduces `reserve_ratio` to `PassiveLiquidity::Xyk` in `types.rs` to prevent liquidity depletion.
>     - `reflect_curve` in `xyk.rs` now withholds liquidity based on `reserve_ratio`.
>   - **Configuration**:
>     - Updates `genesis.json` in `devnet`, `testnet`, and `localdango` to include `reserve_ratio` for xyk pools.
>   - **Testing**:
>     - Adds `reserve_ratio` to test cases in `liquidity_pool.rs` and `execute.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for d469faa1a75b20abde70b330306705eac58302d1. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->