### PR TITLE
feat(grug): BlockOutcome height field

### DIFF
--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -379,6 +379,7 @@ where
         );
 
         let block_outcome = BlockOutcome {
+            height: block.info.height,
             app_hash: app_hash.unwrap(),
             cron_outcomes,
             tx_outcomes,

--- a/grug/client/src/lib.rs
+++ b/grug/client/src/lib.rs
@@ -165,6 +165,7 @@ impl BlockClient for TendermintRpcClient {
         };
 
         Ok(BlockOutcome {
+            height: response.height.into(),
             app_hash: Hash256::from_inner(response.app_hash.as_bytes().try_into()?),
             tx_outcomes: response
                 .txs_results

--- a/grug/types/src/outcome.rs
+++ b/grug/types/src/outcome.rs
@@ -268,6 +268,8 @@ impl Default for TxEvents {
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 /// Outcome of executing a block.
 pub struct BlockOutcome {
+    /// The block height.
+    pub height: u64,
     /// The Merkle root hash after executing this block.
     pub app_hash: Hash256,
     /// Results of executing the cronjobs.

--- a/indexer/hooked/src/lib.rs
+++ b/indexer/hooked/src/lib.rs
@@ -445,6 +445,7 @@ mod tests {
         };
 
         let outcome = grug_types::BlockOutcome {
+            height: 1,
             app_hash: grug_types::Hash256::ZERO,
             cron_outcomes: vec![],
             tx_outcomes: vec![],
@@ -594,6 +595,7 @@ mod tests {
             txs: vec![],
         };
         let outcome = grug_types::BlockOutcome {
+            height: 42,
             app_hash: grug_types::Hash256::ZERO,
             cron_outcomes: vec![],
             tx_outcomes: vec![],

--- a/indexer/sql/src/block_to_index.rs
+++ b/indexer/sql/src/block_to_index.rs
@@ -160,6 +160,7 @@ mod tests {
         };
 
         let block_outcome = BlockOutcome {
+            height: 10,
             app_hash: Hash::ZERO,
             cron_outcomes: vec![],
             tx_outcomes: vec![],

--- a/indexer/testing/tests/indexing/hooked/block.rs
+++ b/indexer/testing/tests/indexing/hooked/block.rs
@@ -227,6 +227,7 @@ async fn no_sql_index_error_after_restart() {
         hash: Hash::ZERO,
     };
     let block_outcome = BlockOutcome {
+        height: 1,
         app_hash: Hash::ZERO,
         cron_outcomes: vec![],
         tx_outcomes: vec![],

--- a/indexer/testing/tests/indexing/sql/block.rs
+++ b/indexer/testing/tests/indexing/sql/block.rs
@@ -231,6 +231,7 @@ fn no_sql_index_error_after_restart() {
         hash: Hash::ZERO,
     };
     let block_outcome = BlockOutcome {
+        height: 1,
         app_hash: Hash::ZERO,
         cron_outcomes: vec![],
         tx_outcomes: vec![],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `height` field to `BlockOutcome` to include block height in processing outcomes and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `height` field to `BlockOutcome` in `app.rs` and `lib.rs` to include block height in block processing outcomes.
>     - Update `BlockOutcome` struct in `outcome.rs` to include `height` field.
>   - **Tests**:
>     - Update test cases in `hooked/block.rs` and `sql/block.rs` to include `height` in `BlockOutcome`.
>     - Ensure tests verify the correct handling of the `height` field in block outcomes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 3fa8c7a693233880c294b1fcda91a623c7e005da. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->