### PR TITLE
feat(httpd): Unify block not found error

### DIFF
--- a/indexer/httpd/src/routes/api/blocks.rs
+++ b/indexer/httpd/src/routes/api/blocks.rs
@@ -68,7 +68,7 @@ fn _block_results_by_height(block_height: u64, app_ctx: &Context) -> Result<Http
 }
 
 fn check_block_exists(block_filename: PathBuf, height: u64) -> Result<(), Error> {
-    if !BlockToIndex::exists(block_filename.clone()) {
+    if !BlockToIndex::exists(block_filename) {
         Err(actix_web::error::ErrorNotFound(format!(
             "block not found: {}",
             height

--- a/indexer/httpd/src/routes/api/blocks.rs
+++ b/indexer/httpd/src/routes/api/blocks.rs
@@ -70,8 +70,7 @@ fn _block_results_by_height(block_height: u64, app_ctx: &Context) -> Result<Http
 fn check_block_exists(block_filename: PathBuf, height: u64) -> Result<(), Error> {
     if !BlockToIndex::exists(block_filename) {
         Err(actix_web::error::ErrorNotFound(format!(
-            "block not found: {}",
-            height
+            "block not found: {height}",
         )))
     } else {
         Ok(())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor block not found error handling in `blocks.rs` by introducing `check_block_exists` function for unified error messages.
> 
>   - **Error Handling**:
>     - Introduces `check_block_exists` function in `blocks.rs` to handle block not found errors.
>     - Replaces inline block existence checks with `check_block_exists` in `_block_by_height` and `_block_results_by_height`.
>   - **Behavior**:
>     - Unified error message for block not found scenarios, returning 404 with message "block not found: {height}".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 1c1d59cdaaa6497d9591fd4ea80af7b5d9af43b8. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->