### PR TITLE
refractor(grug): Better trait-impl for Dec

### DIFF
--- a/grug/math/src/dec.rs
+++ b/grug/math/src/dec.rs
@@ -464,6 +464,19 @@ macro_rules! generate_decimal {
                 }
             }
 
+            impl crate::FixedPoint<$inner> for $name {
+                const PRECISION: Int<$inner> = $constructor($base_constructor::TEN.pow($precision));
+                const TICK: Self = Self::raw(Int::<$inner>::ONE);
+            }
+
+            impl crate::NumberConst for $name {
+                const MIN: Self = Self::raw(Int::<$inner>::MIN);
+                const MAX: Self = Self::raw(Int::<$inner>::MAX);
+                const ONE: Self = Self::raw(Self::PRECISION);
+                const TEN: Self = Self::raw($constructor($base_constructor::TEN.pow(Self::DECIMAL_PLACES + 1)));
+                const ZERO: Self = Self::raw(Int::<$inner>::ZERO);
+            }
+
         }
     };
     (
@@ -531,11 +544,29 @@ generate_decimal! {
 
 generate_decimal! {
     type              = Unsigned,
+    name              = Udec128_24,
+    precision         = 24,
+    inner_type        = u128,
+    inner_constructor = Uint128::new,
+    doc               = "128-bit unsigned fixed-point number with 24 decimal places.",
+}
+
+generate_decimal! {
+    type              = Unsigned,
     name              = Udec256,
     precision         = 18,
     inner_type        = U256,
     inner_constructor = Uint256::new_from_u128,
     doc               = "256-bit unsigned fixed-point number with 18 decimal places.",
+}
+
+generate_decimal! {
+    type              = Unsigned,
+    name              = Udec256_24,
+    precision         = 24,
+    inner_type        = U256,
+    inner_constructor = Uint256::new_from_u128,
+    doc               = "256-bit unsigned fixed-point number with 24 decimal places.",
 }
 
 generate_decimal! {

--- a/grug/math/src/dec.rs
+++ b/grug/math/src/dec.rs
@@ -476,7 +476,6 @@ macro_rules! generate_decimal {
                 const TEN: Self = Self::raw($constructor($base_constructor::TEN.pow(Self::DECIMAL_PLACES + 1)));
                 const ZERO: Self = Self::raw(Int::<$inner>::ZERO);
             }
-
         }
     };
     (

--- a/grug/math/src/fixed_point.rs
+++ b/grug/math/src/fixed_point.rs
@@ -1,10 +1,4 @@
-use {
-    crate::{
-        Dec128, Dec128_6, Dec256, Int, Int128, Int256, NumberConst, Udec128, Udec128_6, Udec128_9,
-        Udec256, Uint128, Uint256,
-    },
-    bnum::types::{I256, U256},
-};
+use crate::Int;
 
 /// Describes a [fixed-point decimal](https://en.wikipedia.org/wiki/Fixed-point_arithmetic)
 /// number.
@@ -20,40 +14,9 @@ pub trait FixedPoint<U> {
     const TICK: Self;
 }
 
-impl FixedPoint<u128> for Udec128_6 {
-    const PRECISION: Uint128 = Uint128::new(10_u128.pow(Self::DECIMAL_PLACES));
-    const TICK: Self = Self::raw(Uint128::ONE);
-}
+// ------------------------------------ dec ------------------------------------
 
-impl FixedPoint<u128> for Udec128_9 {
-    const PRECISION: Uint128 = Uint128::new(10_u128.pow(Self::DECIMAL_PLACES));
-    const TICK: Self = Self::raw(Uint128::ONE);
-}
-
-impl FixedPoint<u128> for Udec128 {
-    const PRECISION: Uint128 = Uint128::new(10_u128.pow(Self::DECIMAL_PLACES));
-    const TICK: Self = Self::raw(Uint128::ONE);
-}
-
-impl FixedPoint<U256> for Udec256 {
-    const PRECISION: Uint256 = Uint256::new_from_u128(10_u128.pow(Self::DECIMAL_PLACES));
-    const TICK: Self = Self::raw(Uint256::ONE);
-}
-
-impl FixedPoint<i128> for Dec128_6 {
-    const PRECISION: Int128 = Int128::new(10_i128.pow(Self::DECIMAL_PLACES));
-    const TICK: Self = Self::raw(Int128::ONE);
-}
-
-impl FixedPoint<i128> for Dec128 {
-    const PRECISION: Int128 = Int128::new(10_i128.pow(Self::DECIMAL_PLACES));
-    const TICK: Self = Self::raw(Int128::ONE);
-}
-
-impl FixedPoint<I256> for Dec256 {
-    const PRECISION: Int256 = Int256::new_from_i128(10_i128.pow(Self::DECIMAL_PLACES));
-    const TICK: Self = Self::raw(Int256::ONE);
-}
+// Trait auto-impl for all decimals via `generate_decimals` macro.
 
 // ----------------------------------- tests -----------------------------------
 

--- a/grug/math/src/next.rs
+++ b/grug/math/src/next.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        Bytable, Dec128, Dec256, Int64, Int128, Int256, Int512, Udec128, Udec256, Uint64, Uint128,
-        Uint256, Uint512,
-    },
+    crate::{Bytable, Dec, Int, Int64, Int128, Int256, Int512, Uint64, Uint128, Uint256, Uint512},
     bnum::types::{I512, U512},
 };
 
@@ -71,28 +68,16 @@ impl_next_bnum! {
 
 // ----------------------------------- dec -------------------------------------
 
-macro_rules! impl_next_udec {
-    ($this:ty => $next:ty) => {
-        impl NextNumber for $this {
-            type Next = $next;
+impl<U, NP, const S: u32> NextNumber for Dec<U, S>
+where
+    Int<U>: NextNumber<Next = Int<NP>>,
+{
+    type Next = Dec<NP, S>;
 
-            fn into_next(self) -> Self::Next {
-                <$next>::raw(self.0.into_next())
-            }
-        }
-    };
-    ($($this:ty => $next:ty),+ $(,)?) => {
-        $(
-            impl_next_udec!($this => $next);
-        )+
-    };
+    fn into_next(self) -> Self::Next {
+        Dec::raw(self.0.into_next())
+    }
 }
-
-impl_next_udec! {
-    Udec128 => Udec256,
-    Dec128  => Dec256,
-}
-
 // ----------------------------------- tests -----------------------------------
 
 #[cfg(test)]

--- a/grug/math/src/number_const.rs
+++ b/grug/math/src/number_const.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        Dec128, Dec128_6, Dec256, FixedPoint, Int, Int128, Int256, Udec128, Udec128_6, Udec128_9,
-        Udec256, Uint128, Uint256,
-    },
+    crate::Int,
     bnum::types::{I256, I512, U256, U512},
 };
 
@@ -31,63 +28,7 @@ where
 
 // ------------------------------------ dec ------------------------------------
 
-impl NumberConst for Udec128_6 {
-    const MAX: Self = Self::raw(Uint128::MAX);
-    const MIN: Self = Self::raw(Uint128::MIN);
-    const ONE: Self = Self::raw(Self::PRECISION);
-    const TEN: Self = Self::raw(Uint128::new(10_u128.pow(Self::DECIMAL_PLACES + 1)));
-    const ZERO: Self = Self::raw(Uint128::ZERO);
-}
-
-impl NumberConst for Udec128_9 {
-    const MAX: Self = Self::raw(Uint128::MAX);
-    const MIN: Self = Self::raw(Uint128::MIN);
-    const ONE: Self = Self::raw(Self::PRECISION);
-    const TEN: Self = Self::raw(Uint128::new(10_u128.pow(Self::DECIMAL_PLACES + 1)));
-    const ZERO: Self = Self::raw(Uint128::ZERO);
-}
-
-impl NumberConst for Udec128 {
-    const MAX: Self = Self::raw(Uint128::MAX);
-    const MIN: Self = Self::raw(Uint128::MIN);
-    const ONE: Self = Self::raw(Self::PRECISION);
-    const TEN: Self = Self::raw(Uint128::new(10_u128.pow(Self::DECIMAL_PLACES + 1)));
-    const ZERO: Self = Self::raw(Uint128::ZERO);
-}
-
-impl NumberConst for Udec256 {
-    const MAX: Self = Self::raw(Uint256::MAX);
-    const MIN: Self = Self::raw(Uint256::MIN);
-    const ONE: Self = Self::raw(Self::PRECISION);
-    const TEN: Self = Self::raw(Uint256::new_from_u128(
-        10_u128.pow(Self::DECIMAL_PLACES + 1),
-    ));
-    const ZERO: Self = Self::raw(Uint256::ZERO);
-}
-
-impl NumberConst for Dec128_6 {
-    const MAX: Self = Self::raw(Int128::MAX);
-    const MIN: Self = Self::raw(Int128::MIN);
-    const ONE: Self = Self::raw(Self::PRECISION);
-    const TEN: Self = Self::raw(Int128::new(10_i128.pow(Self::DECIMAL_PLACES + 1)));
-    const ZERO: Self = Self::raw(Int128::ZERO);
-}
-
-impl NumberConst for Dec128 {
-    const MAX: Self = Self::raw(Int128::MAX);
-    const MIN: Self = Self::raw(Int128::MIN);
-    const ONE: Self = Self::raw(Self::PRECISION);
-    const TEN: Self = Self::raw(Int128::new(10_i128.pow(Self::DECIMAL_PLACES + 1)));
-    const ZERO: Self = Self::raw(Int128::ZERO);
-}
-
-impl NumberConst for Dec256 {
-    const MAX: Self = Self::raw(Int256::MAX);
-    const MIN: Self = Self::raw(Int256::MIN);
-    const ONE: Self = Self::raw(Self::PRECISION);
-    const TEN: Self = Self::raw(Int256::new_from_i128(10_i128.pow(Self::DECIMAL_PLACES + 1)));
-    const ZERO: Self = Self::raw(Int256::ZERO);
-}
+// Trait auto-impl for all decimals via `generate_decimals` macro.
 
 // ------------------------------ primitive types ------------------------------
 

--- a/grug/math/src/prev.rs
+++ b/grug/math/src/prev.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        Dec128, Dec256, Int64, Int128, Int256, Int512, MathError, MathResult, Udec128, Udec256,
-        Uint64, Uint128, Uint256, Uint512,
+        Dec, Int, Int64, Int128, Int256, Int512, MathError, MathResult, Uint64, Uint128, Uint256,
+        Uint512,
     },
     bnum::{
         BTryFrom,
@@ -76,26 +76,15 @@ impl_prev_bnum! {
 
 // ----------------------------------- dec -------------------------------------
 
-macro_rules! impl_prev_dec {
-    ($this:ty => $prev:ty) => {
-        impl PrevNumber for $this {
-            type Prev = $prev;
+impl<U, PU, const S: u32> PrevNumber for Dec<U, S>
+where
+    Int<U>: PrevNumber<Prev = Int<PU>>,
+{
+    type Prev = Dec<PU, S>;
 
-            fn checked_into_prev(self) -> MathResult<Self::Prev> {
-                self.0.checked_into_prev().map(<$prev>::raw)
-            }
-        }
-    };
-    ($($this:ty => $prev:ty),+ $(,)?) => {
-        $(
-            impl_prev_dec!($this => $prev);
-        )+
-    };
-}
-
-impl_prev_dec! {
-    Udec256 => Udec128,
-    Dec256  => Dec128,
+    fn checked_into_prev(self) -> MathResult<Self::Prev> {
+        self.0.checked_into_prev().map(Dec::raw)
+    }
 }
 
 // ----------------------------------- tests -----------------------------------

--- a/grug/math/src/signed.rs
+++ b/grug/math/src/signed.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        Dec128, Dec256, Int64, Int128, Int256, Int512, MathError, MathResult, Sign, Udec128,
-        Udec256, Uint64, Uint128, Uint256, Uint512,
+        Dec, Int, Int64, Int128, Int256, Int512, MathError, MathResult, Sign, Uint64, Uint128,
+        Uint256, Uint512,
     },
     bnum::cast::As,
 };
@@ -11,6 +11,8 @@ pub trait Signed {
 
     fn checked_into_unsigned(self) -> MathResult<Self::Unsigned>;
 }
+
+// ------------------------------------ int ------------------------------------
 
 macro_rules! impl_checked_into_unsigned_std {
     ($signed:ty => $unsigned:ty) => {
@@ -64,26 +66,17 @@ impl_checked_into_unsigned_bnum! {
     Int512 => Uint512,
 }
 
-macro_rules! impl_checked_into_unsigned_dec {
-    ($signed:ty => $unsigned:ty) => {
-        impl Signed for $signed {
-            type Unsigned = $unsigned;
+// ------------------------------------ dec ------------------------------------
 
-            fn checked_into_unsigned(self) -> MathResult<$unsigned> {
-                self.0.checked_into_unsigned().map(<$unsigned>::raw)
-            }
-        }
-    };
-    ($($signed:ty => $unsigned:ty),+ $(,)?) => {
-        $(
-            impl_checked_into_unsigned_dec!($signed => $unsigned);
-        )+
-    };
-}
+impl<U, UU, const S: u32> Signed for Dec<U, S>
+where
+    Int<U>: Signed<Unsigned = Int<UU>>,
+{
+    type Unsigned = Dec<UU, S>;
 
-impl_checked_into_unsigned_dec! {
-    Dec128 => Udec128,
-    Dec256 => Udec256,
+    fn checked_into_unsigned(self) -> MathResult<Self::Unsigned> {
+        self.0.checked_into_unsigned().map(Dec::raw)
+    }
 }
 
 // ----------------------------------- tests -----------------------------------

--- a/grug/math/src/unsigned.rs
+++ b/grug/math/src/unsigned.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        Dec128, Dec256, Int64, Int128, Int256, Int512, MathError, MathResult, NumberConst, Udec128,
-        Udec256, Uint64, Uint128, Uint256, Uint512,
+        Dec, Int, Int64, Int128, Int256, Int512, MathError, MathResult, NumberConst, Uint64,
+        Uint128, Uint256, Uint512,
     },
     bnum::cast::As,
 };
@@ -61,25 +61,17 @@ impl_checked_into_signed_bnum! {
     Uint512 => Int512,
 }
 
-macro_rules! impl_chekced_into_signed_dec {
-    ($unsigned:ty => $signed:ty) => {
-        impl Unsigned for $unsigned {
-            type Signed = $signed;
-            fn checked_into_signed(self) -> MathResult<$signed> {
-                self.0.checked_into_signed().map(<$signed>::raw)
-            }
-        }
-    };
-    ($($unsigned:ty => $signed:ty),+ $(,)?) => {
-        $(
-            impl_chekced_into_signed_dec!($unsigned => $signed);
-        )+
-    };
-}
+// ------------------------------------ dec ------------------------------------
 
-impl_chekced_into_signed_dec! {
-    Udec128 => Dec128,
-    Udec256 => Dec256,
+impl<U, SU, const S: u32> Unsigned for Dec<U, S>
+where
+    Int<U>: Unsigned<Signed = Int<SU>>,
+{
+    type Signed = Dec<SU, S>;
+
+    fn checked_into_signed(self) -> MathResult<Self::Signed> {
+        self.0.checked_into_signed().map(Dec::raw)
+    }
 }
 
 // ----------------------------------- tests -----------------------------------


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor trait implementations for `Dec` type using macros and add new decimal types with updated tests.
> 
>   - **Traits**:
>     - Implement `FixedPoint` and `NumberConst` traits for `Dec` type using `generate_decimal` macro in `dec.rs`.
>     - Implement `NextNumber` and `PrevNumber` traits for `Dec` type in `next.rs` and `prev.rs` respectively, using generic implementations.
>     - Implement `Signed` and `Unsigned` traits for `Dec` type in `signed.rs` and `unsigned.rs` respectively, using generic implementations.
>   - **New Types**:
>     - Add `Udec128_24` and `Udec256_24` types in `dec.rs` with 24 decimal places.
>   - **Tests**:
>     - Update tests in `fixed_point.rs`, `next.rs`, `number_const.rs`, `prev.rs`, `signed.rs`, and `unsigned.rs` to reflect new trait implementations and types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for f4bb3b0b20975743217531b842650f66f39da73a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->