### PR TITLE
[LEF-180] add tests with `price != 1` to geometric swap exact inout

### DIFF
--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -88,7 +88,7 @@ fn bid_exact_amount_in(
         let matched_amount_in_quote = matched_amount.checked_mul_dec_ceil(price)?;
         remaining_bid_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
-        if remaining_bid_in_quote.is_zero() {
+        if remaining_bid_in_quote.is_zero() || remaining_bid.is_zero() {
             return Ok(output_amount.into_int());
         }
     }

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -183,14 +183,17 @@ fn ask_exact_amount_out(
     let mut input_amount = Udec128::ZERO;
 
     for (price, order) in passive_bids {
-        let remaining_ask = remaining_ask_in_quote.checked_div_dec_ceil(price)?;
+        let remaining_ask = remaining_ask_in_quote.checked_div_dec_floor(price)?;
         let matched_amount = cmp::min(order.remaining, remaining_ask);
         input_amount.checked_add_assign(matched_amount)?;
 
-        let matched_amount_in_quote = matched_amount.checked_mul_dec_floor(price)?;
+        let matched_amount_in_quote = matched_amount.checked_mul_dec_ceil(price)?;
         remaining_ask_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
-        if remaining_ask_in_quote.is_zero() {
+        if remaining_ask_in_quote.is_zero()
+            || remaining_ask.is_zero()
+            || matched_amount_in_quote.is_zero()
+        {
             return Ok(input_amount.into_int());
         }
     }

--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -1,6 +1,6 @@
 use {
     crate::PassiveOrder,
-    anyhow::bail,
+    anyhow::{bail, ensure},
     dango_oracle::OracleQuerier,
     grug::{
         Bounded, Coin, CoinPair, Denom, IsZero, MultiplyFraction, Number, NumberConst, Udec128,
@@ -88,7 +88,10 @@ fn bid_exact_amount_in(
         let matched_amount_in_quote = matched_amount.checked_mul_dec_ceil(price)?;
         remaining_bid_in_quote.checked_sub_assign(matched_amount_in_quote)?;
 
-        if remaining_bid_in_quote.is_zero() || remaining_bid.is_zero() {
+        if remaining_bid_in_quote.is_zero()
+            || remaining_bid.is_zero()
+            || matched_amount_in_quote.is_zero()
+        {
             return Ok(output_amount.into_int());
         }
     }
@@ -110,7 +113,7 @@ fn ask_exact_amount_in(
         let matched_amount_in_quote = matched_amount.checked_mul_dec_floor(price)?;
         output_amount_in_quote.checked_add_assign(matched_amount_in_quote)?;
 
-        if remaining_ask.is_zero() {
+        if remaining_ask.is_zero() || matched_amount_in_quote.is_zero() {
             return Ok(output_amount_in_quote.into_int());
         }
     }
@@ -130,6 +133,14 @@ pub fn swap_exact_amount_out(
     order_spacing: Udec128,
     swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
 ) -> anyhow::Result<Uint128> {
+    let output_reserve = reserve.amount_of(&output.denom)?;
+    ensure!(
+        output_reserve > output.amount,
+        "insufficient liquidity: {} <= {}",
+        output_reserve,
+        output.amount
+    );
+
     let (passive_bids, passive_asks) = reflect_curve(
         oracle_querier,
         base_denom,
@@ -167,7 +178,7 @@ fn bid_exact_amount_out(
         let matched_amount_in_quote = matched_amount.checked_mul_dec_ceil(price)?;
         input_amount.checked_add_assign(matched_amount_in_quote)?;
 
-        if remaining_bid.is_zero() {
+        if remaining_bid.is_zero() || matched_amount_in_quote.is_zero() {
             return Ok(input_amount.into_int());
         }
     }

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -1178,6 +1178,166 @@ mod tests {
         };
         "geometric pool 1:1 price swap out base denom amount matches first order part of second order"
     )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(usdc::DENOM.clone(), 5_000_000).unwrap(),
+        Coin::new(eth::DENOM.clone(), 2_525_252).unwrap(),
+        coin_pair! {
+            usdc::DENOM.clone() => 10000000 - 5_000_000,
+            eth::DENOM.clone() => 10000000 + 2_525_252,
+        };
+        "geometric pool 2:1 price swap out quote denom amount matches first order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(usdc::DENOM.clone(), 5_000_000 + 100_000).unwrap(),
+        Coin::new(eth::DENOM.clone(), 2_525_252 + 67_568).unwrap(),
+        coin_pair! {
+            usdc::DENOM.clone() => 10000000 - 5_000_000 - 100_000,
+            eth::DENOM.clone() => 10000000 + 2_525_252 + 67_568,
+        };
+        "geometric pool 2:1 price swap out quote denom amount matches first and part of second order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(eth::DENOM.clone(), 2_000_000).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4_040_000).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 - 2_000_000,
+            usdc::DENOM.clone() => 10000000 + 4_040_000,
+        };
+        "geometric pool 2:1 price swap out base denom amount matches first order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(eth::DENOM.clone(), 2_000_000).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4_040_000).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 - 2_000_000,
+            usdc::DENOM.clone() => 10000000 + 4_040_000,
+        };
+        "geometric pool 2:1 price swap out base denom amount partially matches first order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(eth::DENOM.clone(), 5_100_000).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 10_352_000).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 - 5_100_000,
+            usdc::DENOM.clone() => 10000000 + 10_352_000,
+        };
+        "geometric pool 2:1 price swap out base denom amount matches first and part of second order"
+    )]
     fn swap_exact_amount_out(
         pool_type: PassiveLiquidity,
         reserve: CoinPair,

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -820,6 +820,198 @@ mod tests {
         };
         "geometric pool 1:1 price swap in quote denom amount matches first order"
     )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(usdc::DENOM.clone(), 5000000).unwrap(),
+        Coin::new(eth::DENOM.clone(), 2475247).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 - 2475247,
+            usdc::DENOM.clone() => 10000000 + 5000000,
+        };
+        "geometric pool 2:1 price swap in quote denom amount partiallymatches first order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(usdc::DENOM.clone(), 10_100_000).unwrap(),
+        Coin::new(eth::DENOM.clone(), 5_000_000).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 - 5_000_000,
+            usdc::DENOM.clone() => 10000000 + 10_100_000,
+        };
+        "geometric pool 2:1 price swap in quote denom amount fully matches first order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(usdc::DENOM.clone(), 11_100_000).unwrap(),
+        Coin::new(eth::DENOM.clone(), 5_000_000 + 396_825).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 - 5_000_000 - 396_825,
+            usdc::DENOM.clone() => 10000000 + 11_100_000,
+        };
+        "geometric pool 2:1 price swap in quote denom amount matches first and part of second order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(eth::DENOM.clone(), 2_500_000).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4_950_000).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 + 2_500_000,
+            usdc::DENOM.clone() => 10000000 - 4_950_000,
+        };
+        "geometric pool 2:1 price swap in base denom amount partially matches first order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(eth::DENOM.clone(), 2_525_252).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4_999_998).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 + 2_525_252,
+            usdc::DENOM.clone() => 10000000 - 4_999_998,
+        };
+        "geometric pool 2:1 price swap in base denom amount almost fully matches first order"
+    )]
+    #[test_case(
+        PassiveLiquidity::Geometric {
+            ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
+            order_spacing: Udec128::new_percent(50),
+        },
+        coin_pair! {
+            eth::DENOM.clone() => 10000000,
+            usdc::DENOM.clone() => 10000000,
+        },
+        hash_map! {
+            eth::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(200),
+                Udec128::new_percent(200),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+            usdc::DENOM.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(100),
+                Udec128::new_percent(100),
+                Timestamp::from_seconds(1730802926),
+                6,
+            ),
+        },
+        Udec128::new_percent(1),
+        Coin::new(eth::DENOM.clone(), 2_525_252 + 100_000).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4_999_998 + 148_000).unwrap(),
+        coin_pair! {
+            eth::DENOM.clone() => 10000000 + 2_525_252 + 100_000,
+            usdc::DENOM.clone() => 10000000 - 4_999_998 - 148_000,
+        };
+        "geometric pool 2:1 price swap in base denom amount matches first and part of second order"
+    )]
     fn swap_exact_amount_in(
         pool_type: PassiveLiquidity,
         reserve: CoinPair,

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -797,10 +797,10 @@ mod tests {
         },
         Udec128::new_percent(1),
         Coin::new(eth::DENOM.clone(), 5000000).unwrap(),
-        Coin::new(usdc::DENOM.clone(), 4900500).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4950000).unwrap(),
         coin_pair! {
             eth::DENOM.clone() => 10000000 + 5000000,
-            usdc::DENOM.clone() => 10000000 - 4900500,
+            usdc::DENOM.clone() => 10000000 - 4950000,
         };
         "geometric pool 1:1 price swap in base denom amount matches first order"
     )]
@@ -829,9 +829,9 @@ mod tests {
         },
         Udec128::new_percent(1),
         Coin::new(usdc::DENOM.clone(), 5000000).unwrap(),
-        Coin::new(eth::DENOM.clone(), 4900990).unwrap(),
+        Coin::new(eth::DENOM.clone(), 4950495).unwrap(),
         coin_pair! {
-            eth::DENOM.clone() => 10000000 - 4900990,
+            eth::DENOM.clone() => 10000000 - 4950495,
             usdc::DENOM.clone() => 10000000 + 5000000,
         };
         "geometric pool 1:1 price swap in quote denom amount matches first order"
@@ -1084,10 +1084,10 @@ mod tests {
             ),
         },
         Udec128::new_percent(1),
-        Coin::new(usdc::DENOM.clone(), 4900500).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4950000).unwrap(),
         Coin::new(eth::DENOM.clone(), 5000000).unwrap(),
         coin_pair! {
-            usdc::DENOM.clone() => 10000000 - 4900500,
+            usdc::DENOM.clone() => 10000000 - 4950000,
             eth::DENOM.clone() => 10000000 + 5000000,
         };
         "geometric pool 1:1 price swap out quote denom amount matches first order"
@@ -1116,11 +1116,11 @@ mod tests {
             ),
         },
         Udec128::new_percent(1),
-        Coin::new(eth::DENOM.clone(), 4900500).unwrap(),
-        Coin::new(usdc::DENOM.clone(), 4999500).unwrap(),
+        Coin::new(eth::DENOM.clone(), 4950495).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4999999).unwrap(),
         coin_pair! {
-            eth::DENOM.clone() => 10000000 - 4900500,
-            usdc::DENOM.clone() => 10000000 + 4999500,
+            eth::DENOM.clone() => 10000000 - 4950495,
+            usdc::DENOM.clone() => 10000000 + 4999999,
         };
         "geometric pool 1:1 price swap out base denom amount matches first order"
     )]
@@ -1148,11 +1148,11 @@ mod tests {
             ),
         },
         Udec128::new_percent(1),
-        Coin::new(usdc::DENOM.clone(), 5050505 + 100000).unwrap(),
-        Coin::new(eth::DENOM.clone(), 5463833).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 4_950_495 + 100_000).unwrap(),
+        Coin::new(eth::DENOM.clone(), 5_153_556).unwrap(),
         coin_pair! {
-            usdc::DENOM.clone() => 10000000 - 5050505 - 100000,
-            eth::DENOM.clone() => 10000000 + 5463833,
+            usdc::DENOM.clone() => 10000000 - 4_950_495 - 100_000,
+            eth::DENOM.clone() => 10000000 + 5_153_556,
         };
         "geometric pool 1:1 price swap out quote denom amount matches first order part of second order"
     )]
@@ -1180,11 +1180,11 @@ mod tests {
             ),
         },
         Udec128::new_percent(1),
-        Coin::new(eth::DENOM.clone(), 5100000).unwrap(),
-        Coin::new(usdc::DENOM.clone(), 5050000 + 228789).unwrap(),
+        Coin::new(eth::DENOM.clone(), 5_000_000 + 100_000).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 5_050_000 + 151_000).unwrap(),
         coin_pair! {
-            eth::DENOM.clone() => 10000000 - 5100000,
-            usdc::DENOM.clone() => 10000000 + 5050000 + 228789,
+            eth::DENOM.clone() => 10000000 - 5_100_000,
+            usdc::DENOM.clone() => 10000000 + 5_050_000 + 151_000,
         };
         "geometric pool 1:1 price swap out base denom amount matches first order part of second order"
     )]
@@ -1212,13 +1212,13 @@ mod tests {
             ),
         },
         Udec128::new_percent(1),
-        Coin::new(usdc::DENOM.clone(), 5_000_000).unwrap(),
-        Coin::new(eth::DENOM.clone(), 2_525_252).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 1_980_000).unwrap(),
+        Coin::new(eth::DENOM.clone(), 1_000_000).unwrap(),
         coin_pair! {
-            usdc::DENOM.clone() => 10000000 - 5_000_000,
-            eth::DENOM.clone() => 10000000 + 2_525_252,
+            usdc::DENOM.clone() => 10000000 - 1_980_000,
+            eth::DENOM.clone() => 10000000 + 1_000_000,
         };
-        "geometric pool 2:1 price swap out quote denom amount matches first order"
+        "geometric pool 2:1 price swap out quote denom amount partially matches first order"
     )]
     #[test_case(
         PassiveLiquidity::Geometric {

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -272,16 +272,6 @@ impl PassiveLiquidityPool for PairParams {
             );
         };
 
-        // Compute the output amount. For XYK we need to deduct the liquidity fee
-        // from the output. Not to be confused with the protocol fee:
-        // - Liquidity fee (also called "swap fee") is paid into the pool.
-        //   It's equivalent to the bid-ask spread in order books.
-        // - Protocol fee is paid to the Dango protocol (specifically, the taxman
-        //   contract). It's equivalent to the maker/taker fee in order books,
-        //   and handled by `core::router::swap_exact_amount_in`.
-        //
-        // For Geometric swap the liquidity fee is implicit in the spread of the
-        // order reflection.
         let output_amount = match self.pool_type {
             PassiveLiquidity::Xyk { .. } => xyk::swap_exact_amount_in(
                 reserve.amount_of(&input.denom)?,

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -1,5 +1,6 @@
 use {
     crate::PassiveOrder,
+    anyhow::ensure,
     grug::{
         Bounded, CoinPair, Exponentiate, IsZero, MathResult, MultiplyFraction, MultiplyRatio,
         Number, NumberConst, Udec128, Uint64, Uint128, ZeroExclusiveOneExclusive,
@@ -39,16 +40,19 @@ pub fn swap_exact_amount_in(
     input_reserve: Uint128,
     output_reserve: Uint128,
     input_amount: Uint128,
+    fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
 ) -> MathResult<Uint128> {
     // Solve A * B = (A + input_amount) * (B - output_amount) for output_amount
     // => output_amount = B - (A * B) / (A + input_amount)
     // Round so that user takes the loss.
-    output_reserve.checked_sub(
-        input_reserve.checked_multiply_ratio_ceil(
+    let output_amount =
+        output_reserve.checked_sub(input_reserve.checked_multiply_ratio_ceil(
             output_reserve,
             input_reserve.checked_add(input_amount)?,
-        )?,
-    )
+        )?)?;
+
+    let one_sub_fee_rate = Udec128::ONE - *fee_rate;
+    output_amount.checked_mul_dec_floor(one_sub_fee_rate)
 }
 
 /// Note: this function does not concern the liquidity fee.
@@ -57,16 +61,28 @@ pub fn swap_exact_amount_out(
     input_reserve: Uint128,
     output_reserve: Uint128,
     output_amount: Uint128,
-) -> MathResult<Uint128> {
+    fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
+) -> anyhow::Result<Uint128> {
+    // Compute the output amount before deducting the liquidity fee.
+    let one_sub_fee_rate = Udec128::ONE - *fee_rate;
+    let output_amount_before_fee = output_amount.checked_div_dec_ceil(one_sub_fee_rate)?;
+
+    ensure!(
+        output_reserve > output_amount_before_fee,
+        "insufficient liquidity: {} <= {}",
+        output_reserve,
+        output_amount_before_fee
+    );
+
     // Solve A * B = (A + input_amount) * (B - output_amount) for input_amount
     // => input_amount = (A * B) / (B - output_amount) - A
     // Round so that user takes the loss.
-    Uint128::ONE
+    Ok(Uint128::ONE
         .checked_multiply_ratio_floor(
             input_reserve.checked_mul(output_reserve)?,
-            output_reserve.checked_sub(output_amount)?,
+            output_reserve.checked_sub(output_amount_before_fee)?,
         )?
-        .checked_sub(input_reserve)
+        .checked_sub(input_reserve)?)
 }
 
 pub fn reflect_curve(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add tests for geometric swap with non-unit prices and fix liquidity fee deduction in swap logic.
> 
>   - **Tests**:
>     - Add tests for geometric swap with `price != 1` in `liquidity_pool.rs`.
>   - **Behavior**:
>     - In `geometric.rs`, `bid_exact_amount_in()` and `ask_exact_amount_in()` now return early if `remaining_bid`, `remaining_ask`, or `matched_amount_in_quote` is zero.
>     - In `geometric.rs`, `swap_exact_amount_out()` ensures output reserve is greater than output amount.
>     - In `xyk.rs`, `swap_exact_amount_in()` and `swap_exact_amount_out()` now deduct liquidity fees correctly.
>   - **Misc**:
>     - Remove redundant liquidity fee deduction in `liquidity_pool.rs` for `swap_exact_amount_in()` and `swap_exact_amount_out()`.
>     - Add `ensure!` checks for sufficient liquidity in `xyk.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for edd44750b521f60cb3767a32a3b8db631bb433c3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

Fixes LEF-164