### PR TITLE
dex: emit `OrderFilled` event also for passive pool

### DIFF
--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -321,7 +321,7 @@ fn clear_orders_of_pair(
         .chain(market_ask_filling_outcomes.into_values())
         .chain(limit_order_filling_outcomes)
     {
-        if let Some((order_id, user)) = order.id_and_user() {
+        let (user, id) = if let Some((order_id, user)) = order.id_and_user() {
             fill_user_order(
                 user,
                 &base_denom,
@@ -334,27 +334,6 @@ fn clear_orders_of_pair(
                 fees,
                 fee_payments,
             )?;
-
-            let clearing_price = filled_quote.checked_div(filled_base)?.convert_precision()?;
-            let cleared = order.remaining().is_zero();
-
-            // Emit event for filled user orders to be used by the frontend
-            events.push(OrderFilled {
-                user,
-                id: order_id,
-                kind: order.kind(),
-                base_denom: base_denom.clone(),
-                quote_denom: quote_denom.clone(),
-                direction: order_direction,
-                filled_base,
-                filled_quote,
-                refund_base,
-                refund_quote,
-                fee_base,
-                fee_quote,
-                clearing_price,
-                cleared,
-            })?;
 
             if let Order::Limit(limit_order) = order {
                 if limit_order.remaining.is_zero() {
@@ -381,6 +360,8 @@ fn clear_orders_of_pair(
                     )?;
                 }
             }
+
+            (user, Some(order_id))
         } else {
             fill_passive_order(
                 &base_denom,
@@ -391,8 +372,32 @@ fn clear_orders_of_pair(
                 &mut inflows,
                 &mut outflows,
             )?;
-        }
 
+            (dex_addr, None)
+        };
+
+        let clearing_price = filled_quote.checked_div(filled_base)?.convert_precision()?;
+        let cleared = order.remaining().is_zero();
+
+        // Emit event for filled orders to be used by the frontend.
+        events.push(OrderFilled {
+            user,
+            id,
+            kind: order.kind(),
+            base_denom: base_denom.clone(),
+            quote_denom: quote_denom.clone(),
+            direction: order_direction,
+            filled_base,
+            filled_quote,
+            refund_base,
+            refund_quote,
+            fee_base,
+            fee_quote,
+            clearing_price,
+            cleared,
+        })?;
+
+        // Record the trader's trading volume.
         update_trading_volumes(
             storage,
             api,

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -397,7 +397,7 @@ fn clear_orders_of_pair(
             cleared,
         })?;
 
-        // Record the trader's trading volume.
+        // Record the order's trading volume.
         update_trading_volumes(
             storage,
             api,

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -55,7 +55,7 @@ pub struct LimitOrdersMatched {
 #[grug::event("order_filled")]
 pub struct OrderFilled {
     pub user: Addr,
-    // `None` if the order if from the passive liquidity pool.
+    // `None` if the order is from the passive liquidity pool.
     pub id: Option<OrderId>,
     pub kind: OrderKind,
     pub base_denom: Denom,

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -55,7 +55,8 @@ pub struct LimitOrdersMatched {
 #[grug::event("order_filled")]
 pub struct OrderFilled {
     pub user: Addr,
-    pub id: OrderId,
+    // `None` if the order if from the passive liquidity pool.
+    pub id: Option<OrderId>,
     pub kind: OrderKind,
     pub base_denom: Denom,
     pub quote_denom: Denom,


### PR DESCRIPTION
Currently we only emit `OrderFilled` event for user orders. This PR makes it also emitted for passive pool orders.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Emit `OrderFilled` event for both user and passive pool orders, updating `OrderFilled` struct to support passive orders.
> 
>   - **Behavior**:
>     - `OrderFilled` event now emitted for both user and passive pool orders in `clear_orders_of_pair()` in `cron.rs`.
>     - `id` field in `OrderFilled` struct in `events.rs` changed to `Option<OrderId>` to handle passive pool orders without an `OrderId`.
>   - **Misc**:
>     - Adjusted logic in `clear_orders_of_pair()` to handle passive orders and emit events accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e2ed99e16a2993f52921bbaf23d666520d810979. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->