### PR TITLE
fix(ui): limit order amount in buy operation

### DIFF
--- a/sdk/grug/src/utils/decimal.ts
+++ b/sdk/grug/src/utils/decimal.ts
@@ -47,6 +47,14 @@ class Decimal {
     return new Decimal(result);
   }
 
+  mulCeil(num: string | number | Decimal): Decimal {
+    const previousRm = Big.RM;
+    Big.RM = Big.roundUp;
+    const result = this.mul(num);
+    Big.RM = previousRm;
+    return result;
+  }
+
   times(num: string | number | Decimal): Decimal {
     const other = Decimal.from(num);
     const result = this.inner.times(other.inner);
@@ -124,8 +132,8 @@ class Decimal {
     return this.inner.toString();
   }
 
-  toFixed(decimalPlaces?: number): string {
-    return this.inner.toFixed(decimalPlaces);
+  toFixed(decimalPlaces?: number, rm?: number): string {
+    return this.inner.toFixed(decimalPlaces, rm as Big.RoundingMode);
   }
 
   toNumber(): number {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limit order amount in buy operations using `mulCeil()` in `useProTradeState.ts` and add `mulCeil()` to `Decimal` class for rounding up.
> 
>   - **Behavior**:
>     - Limit order amount in buy operations using `mulCeil()` in `useProTradeState.ts`.
>     - For limit orders, calculate `amount` using `mulCeil()` to ensure rounding up.
>   - **Decimal Class**:
>     - Add `mulCeil()` method to `Decimal` class in `decimal.ts` for multiplication with rounding up.
>     - Modify `toFixed()` in `Decimal` to accept optional rounding mode.
>   - **Misc**:
>     - Refactor `amount` calculation logic in `useProTradeState.ts` for clarity and precision.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 7fd255ba1f5057be67a474bb89f54062460d7a5d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->