### PR TITLE
fix(dango): ensure mint_amount is non-zero in add_liquidity

### DIFF
--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -248,6 +248,8 @@ impl PassiveLiquidityPool for PairParams {
             mint_amount_before_fee.checked_mul_dec_floor(one_sub_fee_rate)?
         };
 
+        ensure!(mint_amount.is_non_zero(), "mint amount must be non-zero");
+
         Ok((reserve, mint_amount))
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `mint_amount` is non-zero in `add_liquidity()` in `liquidity_pool.rs` to prevent minting zero LP tokens.
> 
>   - **Behavior**:
>     - Add check in `add_liquidity()` in `liquidity_pool.rs` to ensure `mint_amount` is non-zero.
>     - Throws error "mint amount must be non-zero" if `mint_amount` is zero.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 58fd835989777664026685757d629cb1b5cc9bc5. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->