### PR TITLE
fix: don't allow lending deposit that would give zero lp tokens

### DIFF
--- a/dango/lending/src/core/deposit.rs
+++ b/dango/lending/src/core/deposit.rs
@@ -28,9 +28,7 @@ pub fn deposit(
         // Ensure that the user receives at least one LP token
         ensure!(
             amount_scaled.is_non_zero(),
-            "deposit of {} {} is too small to receive any LP tokens",
-            coin.amount,
-            coin.denom
+            "deposit is too small to receive any LP token: {coin}"
         );
 
         lp_tokens.insert((market.supply_lp_denom.clone(), amount_scaled))?;

--- a/dango/lending/src/core/deposit.rs
+++ b/dango/lending/src/core/deposit.rs
@@ -1,5 +1,6 @@
 use {
     crate::{MARKETS, core},
+    anyhow::ensure,
     dango_types::lending::Market,
     grug::{Coins, Denom, IsZero, QuerierWrapper, Storage, Timestamp},
     std::collections::BTreeMap,
@@ -25,13 +26,12 @@ pub fn deposit(
         let amount_scaled = core::into_scaled_collateral(coin.amount, &market)?;
 
         // Ensure that the user receives at least one LP token
-        if amount_scaled.is_zero() {
-            anyhow::bail!(
-                "deposit of {} {} is too small to receive any LP tokens",
-                coin.amount,
-                coin.denom
-            );
-        }
+        ensure!(
+            amount_scaled.is_non_zero(),
+            "deposit of {} {} is too small to receive any LP tokens",
+            coin.amount,
+            coin.denom
+        );
 
         lp_tokens.insert((market.supply_lp_denom.clone(), amount_scaled))?;
 

--- a/dango/lending/src/core/deposit.rs
+++ b/dango/lending/src/core/deposit.rs
@@ -1,7 +1,7 @@
 use {
     crate::{MARKETS, core},
     dango_types::lending::Market,
-    grug::{Coins, Denom, QuerierWrapper, Storage, Timestamp},
+    grug::{Coins, Denom, IsZero, QuerierWrapper, Storage, Timestamp},
     std::collections::BTreeMap,
 };
 
@@ -23,6 +23,16 @@ pub fn deposit(
 
         // Compute the amount of LP tokens to mint
         let amount_scaled = core::into_scaled_collateral(coin.amount, &market)?;
+
+        // Ensure that the user receives at least one LP token
+        if amount_scaled.is_zero() {
+            anyhow::bail!(
+                "deposit of {} {} is too small to receive any LP tokens",
+                coin.amount,
+                coin.denom
+            );
+        }
+
         lp_tokens.insert((market.supply_lp_denom.clone(), amount_scaled))?;
 
         // Save the updated market state.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds validation in `deposit()` to prevent deposits that yield zero LP tokens in `deposit.rs`.
> 
>   - **Behavior**:
>     - Adds validation in `deposit()` in `deposit.rs` to ensure deposits result in at least one LP token.
>     - Uses `ensure!` macro to check `amount_scaled.is_non_zero()` and return an error if false.
>   - **Imports**:
>     - Adds `anyhow::ensure` and `grug::IsZero` to support new validation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 37d5b8055ad203d7b291dd6e56003ef25c06f163. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->