### PR TITLE
feat(ui): hide orderbook & trades section

### DIFF
--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -661,6 +661,7 @@
       }
     },
     "protrade": {
+      "underDevelopment": "Feature in development",
       "allOrdersCancelled": "All orders cancelled",
       "spot": {
         "noOpenOrders": "No open orders yet",

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 
 import { IconLink, ResizerContainer, Tabs, twMerge } from "@left-curve/applets-kit";
 
+import { m } from "~/paraglide/messages";
+
 import type React from "react";
 
 import { mockTrades } from "~/mock";
@@ -33,8 +35,15 @@ export const OrderBookOverview: React.FC = () => {
         classNames={{ button: "exposure-xs-italic" }}
       />
       {activeTab === "graph" && <ChartIQ />}
-      {activeTab === "order book" && <OrderBook />}
-      {activeTab === "trades" && <LiveTrades />}
+      <div className="relative w-full h-full">
+        {activeTab === "order book" && <OrderBook />}
+        {activeTab === "trades" && <LiveTrades />}
+        {(activeTab === "trades" || activeTab === "order book") && (
+          <div className="absolute z-20 top-0 left-0 w-full h-full backdrop-blur-[2px] lg:w-[calc(100%+2rem)] lg:-left-4 flex items-center justify-center exposure-l-italic">
+            {m["dex.protrade.underDevelopment"]()}
+          </div>
+        )}
+      </div>
     </ResizerContainer>
   );
 };


### PR DESCRIPTION
This PR fix LEF-211
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds overlay with 'Feature in development' message to hide order book and trades sections in `OrderBookOverview.tsx`.
> 
>   - **Behavior**:
>     - Adds overlay with 'Feature in development' message in `OrderBookOverview.tsx` when 'order book' or 'trades' tab is active.
>     - Message sourced from `dex.protrade.underDevelopment` in `en.json`.
>   - **Localization**:
>     - Adds `"underDevelopment": "Feature in development"` to `protrade` section in `en.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ac3f4045c59e209083d9523a6c5b851975ff8ce4. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->