### PR TITLE
feat(ui): add chart darkmode & trade fixes

### DIFF
--- a/ui/portal/web/public/global.css
+++ b/ui/portal/web/public/global.css
@@ -168,13 +168,13 @@ body {
 .ciq-day .ciq-nav,
 .ciq-day .chartContainer,
 .ciq-day cq-chart-title {
-  color: #6E6865 !important;
-  background: rgb(255 249 240) !important;
+  color: var(--color-tertiary-500) !important;
+  background: var(--color-surface-secondary-rice) !important;
   border: none;
 }
 
 .ciq-day cq-menu .menu-clickable:not(cq-help) {
-  color: #6E6865;
+  color: var(--color-tertiary-500);
 }
 
 .stx-subholder {
@@ -185,18 +185,19 @@ body {
 .ciq-day cq-dropdown .content,
 cq-drawing-palette .ciq-tool:before,
 cq-drawing-palette .ciq-mini-widget:before {
-  background: rgb(255 249 240);
+  background: var(--color-surface-secondary-rice);
 }
 
 cq-heading {
-  color: rgb(46 37 33);
+  color:  var(--color-secondary-700);
 }
 
 cq-dropdown .content>.item.ciq-active .ciq-switch,
 cq-dropdown .content>.item.ciq-active:hover .ciq-switch,
 .ciq-active .ciq-radio span:after,
 .ciq-radio.ciq-active span:after {
-  background: rgb(249 112 102);
+  /* biome-ignore lint/correctness/noUnknownFunction: <explanation> */
+  background: theme("colors.red-bean.600");
 }
 
 .ciq-active .ciq-radio span:after,
@@ -235,7 +236,7 @@ cq-drawing-palette,
 cq-menu.nav-dropdown:before,
 .ciq-nav cq-toggle:before,
 cq-views .item:hover {
-  background: rgb(255 243 225) !important
+  background: var(--color-surface-tertiary-rice)!important
 }
 
 :host(cq-toggle.active),
@@ -245,22 +246,22 @@ cq-toggle.active {
 
 .stx_current_hr_up,
 .stx_candle_up {
-  background-color: #27AE60;
+  background-color: var(--color-status-success);
 }
 
 .stx_current_hr_down,
 .stx_candle_down {
-  background-color: #EB5757;
+  background-color: var(--color-status-fail);
 }
 
 .cq-down,
 .stx_candle_down {
-  color: #EB5757;
+  color: var(--color-status-fail);
 }
 
 .cq-up,
 .stx_candle_up {
-  color: #27AE60;
+  color: var(--color-status-success);
 }
 
 [cq-tooltip],

--- a/ui/portal/web/public/global.css
+++ b/ui/portal/web/public/global.css
@@ -160,7 +160,7 @@ body {
 }
 
 .react-json-view .variable-value div {
-  /* biome-ignore lint/correctness/noUnknownFunction: <explanation> */
+  /* biome-ignore lint/correctness/noUnknownFunction: theme() is required for dynamic Tailwind color */
   color: theme("colors.white.100") !important;
 }
 
@@ -196,7 +196,7 @@ cq-dropdown .content>.item.ciq-active .ciq-switch,
 cq-dropdown .content>.item.ciq-active:hover .ciq-switch,
 .ciq-active .ciq-radio span:after,
 .ciq-radio.ciq-active span:after {
-  /* biome-ignore lint/correctness/noUnknownFunction: <explanation> */
+  /* biome-ignore lint/correctness/noUnknownFunction: theme() is required for dynamic Tailwind color */
   background: theme("colors.red-bean.600");
 }
 

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -42,15 +42,15 @@ export const OrderBookOverview: React.FC<OrderBookOverviewProps> = ({ state }) =
         classNames={{ button: "exposure-xs-italic" }}
       />
       {activeTab === "graph" && <ChartIQ coins={{ base: baseCoin, quote: quoteCoin }} />}
-      <div className="relative w-full h-full">
-        {activeTab === "order book" && <OrderBook />}
-        {activeTab === "trades" && <LiveTrades />}
-        {(activeTab === "trades" || activeTab === "order book") && (
-          <div className="absolute z-20 top-0 left-0 w-full h-full backdrop-blur-[2px] lg:w-[calc(100%+2rem)] lg:-left-4 flex items-center justify-center exposure-l-italic">
+      {(activeTab === "trades" || activeTab === "order book") && (
+        <div className="relative w-full h-full">
+          {activeTab === "order book" && <OrderBook />}
+          {activeTab === "trades" && <LiveTrades />}
+          <div className="absolute z-20 top-0 left-0 w-full h-full backdrop-blur-[8px] lg:w-[calc(100%+2rem)] lg:-left-4 flex items-center justify-center diatype-mono-lg-bold text-primary-rice">
             {m["dex.protrade.underDevelopment"]()}
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </ResizerContainer>
   );
 };

--- a/ui/portal/web/src/components/foundation/ChartIQ.tsx
+++ b/ui/portal/web/src/components/foundation/ChartIQ.tsx
@@ -663,7 +663,7 @@ export const ChartIQ = ({ coins }) => {
   }, [pairSymbol]);
 
   return (
-    <div className="w-full lg:min-h-[52vh] h-full relative">
+    <div className="w-full min-h-[23.1375rem] lg:min-h-[52vh] h-full relative">
       <cq-context ref={container} className="chart-context">
         <cq-chart-instructions />
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add dark mode support for charts and adjust UI components in trading views.
> 
>   - **Dark Mode Support**:
>     - Added dark mode styles in `global.css` for various UI elements, including charts and tooltips.
>     - Updated color variables for dark mode in `global.css`.
>   - **UI Adjustments**:
>     - Modified `OrderBookOverview.tsx` to adjust the structure of the `OrderBook` and `LiveTrades` components.
>     - Increased backdrop blur in `OrderBookOverview.tsx` from `2px` to `8px`.
>     - Adjusted minimum height of chart container in `ChartIQ.tsx` to `23.1375rem`.
>   - **Misc**:
>     - Updated CSS to use Tailwind's `theme()` function for dynamic colors in `global.css`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e6d44992602a7814133076faaa1e36da60acb95b. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->