### PR TITLE
fix: header threshold

### DIFF
--- a/ui/portal/web/src/components/foundation/Header.tsx
+++ b/ui/portal/web/src/components/foundation/Header.tsx
@@ -47,7 +47,6 @@ export const Header: React.FC<HeaderProps> = ({ isScrolled }) => {
         isScrolled
           ? "lg:bg-surface-primary-rice lg:shadow-account-card"
           : "bg-transparent shadow-none",
-        { "lg:bg-surface-primary-rice lg:shadow-account-card": isProSwap },
       )}
     >
       <div className="gap-4 relative flex flex-wrap lg:flex-nowrap items-center justify-center xl:grid xl:grid-cols-4 max-w-[76rem] mx-auto p-4">

--- a/ui/portal/web/src/pages/(app)/_app.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.tsx
@@ -37,10 +37,13 @@ function LayoutApp() {
 
   useEffect(() => {
     const handleScroll = () => {
+      const isProSwap = location.pathname.includes("trade");
+      const headerThreshold = isProSwap ? 20 : 70;
+
       const scrollTop =
         window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
 
-      setIsScrolled(scrollTop > 70);
+      setIsScrolled(scrollTop > headerThreshold);
     };
 
     window.addEventListener("scroll", handleScroll);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts header scroll threshold dynamically based on page path in `_app.tsx`, affecting `Header` component behavior.
> 
>   - **Behavior**:
>     - Adjusts scroll threshold in `LayoutApp` in `_app.tsx` to be dynamic based on `location.pathname`.
>     - Sets `headerThreshold` to 20 for 'trade' pages, otherwise 70.
>     - Updates `setIsScrolled` logic to use `headerThreshold`.
>   - **Components**:
>     - Removes redundant `isProSwap` logic from `Header.tsx`. 
>     - `Header` component now relies on `isScrolled` prop for styling decisions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 351bd77c819a68b50693f0b1f2d95f547061a024. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->