### PR TITLE
Add a test about seen nonces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,6 +3634,7 @@ dependencies = [
  "grug-db-disk-lite",
  "grug-db-memory",
  "grug-testing",
+ "grug-types",
  "grug-vm-hybrid",
  "grug-vm-rust",
  "grug-vm-wasm",

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -25,6 +25,7 @@ grug-client             = { workspace = true }
 grug-crypto             = { workspace = true }
 grug-db-disk-lite       = { workspace = true }
 grug-db-memory          = { workspace = true }
+grug-types              = { workspace = true, features = ["async-graphql"] }
 grug-vm-hybrid          = { workspace = true }
 grug-vm-rust            = { workspace = true }
 grug-vm-wasm            = { workspace = true }

--- a/dango/testing/tests/httpd/accounts.rs
+++ b/dango/testing/tests/httpd/accounts.rs
@@ -659,7 +659,7 @@ async fn graphql_subscribe_to_accounts_with_username() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn graphql_returns_account_factory_nonces() -> anyhow::Result<()> {
+async fn graphql_returns_account_owner_nonces() -> anyhow::Result<()> {
     let (suite, mut accounts, codes, contracts, validator_sets, _, dango_httpd_context) =
         setup_test_with_indexer().await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);

--- a/indexer/testing/src/lib.rs
+++ b/indexer/testing/src/lib.rs
@@ -115,6 +115,12 @@ where
 {
     let app = actix_web::test::init_service(app).await;
 
+    // When I need to debug the request body
+    // println!(
+    //     "request_body: {}",
+    //     serde_json::to_string_pretty(&requests_body).unwrap()
+    // );
+
     let request = actix_web::test::TestRequest::post()
         .uri("/graphql")
         .set_json(&requests_body)
@@ -123,7 +129,7 @@ where
     let graphql_response = actix_web::test::call_and_read_body(&app, request).await;
 
     // When I need to debug the response
-    println!("text response: \n{graphql_response:#?}");
+    // println!("text response: \n{graphql_response:#?}");
 
     let graphql_responses: Vec<GraphQLResponse> = serde_json::from_slice(&graphql_response)
         .inspect_err(|err| {
@@ -137,7 +143,7 @@ where
         })?;
 
     // When I need to debug the response
-    println!("GraphQLResponses: {:#?}", graphql_responses);
+    // println!("GraphQLResponses: {:#?}", graphql_responses);
 
     graphql_responses
         .into_iter()

--- a/indexer/testing/src/lib.rs
+++ b/indexer/testing/src/lib.rs
@@ -123,7 +123,7 @@ where
     let graphql_response = actix_web::test::call_and_read_body(&app, request).await;
 
     // When I need to debug the response
-    // println!("text response: \n{graphql_response:#?}");
+    println!("text response: \n{graphql_response:#?}");
 
     let graphql_responses: Vec<GraphQLResponse> = serde_json::from_slice(&graphql_response)
         .inspect_err(|err| {
@@ -137,7 +137,7 @@ where
         })?;
 
     // When I need to debug the response
-    // println!("GraphQLResponses: {:#?}", graphql_responses);
+    println!("GraphQLResponses: {:#?}", graphql_responses);
 
     graphql_responses
         .into_iter()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add tests for GraphQL queries on account nonces and balances, and update dependencies to include `grug-types`.
> 
>   - **Tests**:
>     - Add `graphql_returns_account_owner_nonces()` in `accounts.rs` to test GraphQL query for account owner nonces.
>     - Add `graphql_returns_address_balance()` in `accounts.rs` to test GraphQL query for address balance.
>   - **Dependencies**:
>     - Add `grug-types` with `async-graphql` feature to `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for a524a6879a59e589e5fb9bf9973f64e50c61291d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->