### PR TITLE
chore(CI): input for versioning deployment

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -6,6 +6,11 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      faucet_version:
+        required: false
+        description: "Define faucet version for deployment"
+        default: "latest"
 
 jobs:
   deploy-faucet:
@@ -42,4 +47,4 @@ jobs:
         run: |
           cd deploy
           pipx ensurepath
-          ansible-playbook bots.yml --limit 100.96.253.40 -e '{"dango_networks":["devnet"]}' -e faucet_version=0.1.5
+          ansible-playbook bots.yml --limit 100.96.253.40 -e '{"dango_networks":["devnet"]}' -e faucet_version=${{ github.event.inputs.faucet_version }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -442,4 +442,4 @@ jobs:
             -e dango_image_tag=${{ env.GIT_COMMIT }} \
             -e "dango_db_password=$DANGO_DB_PASSWORD" \
             -e '{"dango_networks":["devnet"]}'
-          ansible-playbook bots.yml --limit 100.96.253.40 -e '{"dango_networks":["devnet"]}' -e faucet_version=0.1.5
+          ansible-playbook bots.yml --limit 100.96.253.40 -e '{"dango_networks":["devnet"]}' -e faucet_version=latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `faucet_version` input to `faucet.yml` and update `rust.yml` to use "latest" for faucet version in deployment.
> 
>   - **CI Workflow**:
>     - Add `faucet_version` input to `faucet.yml` for versioning deployment, defaulting to "latest".
>     - Update `rust.yml` to use `faucet_version=latest` in Ansible playbook command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 0e8f6471f36f743f49344a6621b4d694c0b4f3de. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->