### PR TITLE
Remove arbitrary_precision

### DIFF
--- a/dango/testing/tests/indexing/candles.rs
+++ b/dango/testing/tests/indexing/candles.rs
@@ -1,5 +1,4 @@
 use {
-    assert_json_diff::assert_json_eq,
     assertor::*,
     chrono::DateTime,
     dango_genesis::Contracts,
@@ -161,26 +160,14 @@ async fn index_candles_with_real_clickhouse() -> anyhow::Result<()> {
         .await?
         .unwrap();
 
-    let candle_1m_serde =
-        serde_json::from_str::<serde_json::Value>(&serde_json::to_string(&candle_1m).unwrap())
-            .unwrap();
-
-    // `PairPrice` is serialized as u128 for clickhouse
-    let expected_candle = serde_json::json!({
-        "quote_denom": "bridge/usdc",
-        "base_denom": "dango",
-        "close": 2.75e25,
-        "high":  2.75e25,
-        "interval": "1m",
-        "low": 2.75e25,
-        "open": 2.75e25,
-        "time_start": serde_json::Number::from(31536000000000_u64),
-        "volume_base": 25000000,
-        "volume_quote": 687500000,
-        "block_height": 2,
-    });
-
-    assert_json_eq!(candle_1m_serde, expected_candle);
+    assert_that!(candle_1m.quote_denom).is_equal_to("bridge/usdc".to_string());
+    assert_that!(candle_1m.base_denom).is_equal_to("dango".to_string());
+    assert_that!(candle_1m.open).is_equal_to(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1m.high).is_equal_to(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1m.low).is_equal_to(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1m.close).is_equal_to(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1m.volume_base).is_equal_to(Udec128_6::from_str("25.0").unwrap());
+    assert_that!(candle_1m.volume_quote).is_equal_to(Udec128_6::from_str("687.5").unwrap());
 
     Ok(())
 }

--- a/dango/testing/tests/indexing/candles.rs
+++ b/dango/testing/tests/indexing/candles.rs
@@ -1,5 +1,5 @@
 use {
-    assert_json_diff::assert_json_include,
+    assert_json_diff::assert_json_eq,
     assertor::*,
     chrono::DateTime,
     dango_genesis::Contracts,
@@ -161,25 +161,26 @@ async fn index_candles_with_real_clickhouse() -> anyhow::Result<()> {
         .await?
         .unwrap();
 
-    // `PairPrice` is serialized as u128 for clickhouse
-    let expected_candle = serde_json::json!({
-        "quote_denom": "bridge/usdc",
-        "base_denom": "dango",
-        "close": 27500000000000000000000000_u128,
-        "high":  27500000000000000000000000_u128,
-        "interval": "1m",
-        "low": 27500000000000000000000000_u128,
-        "open": 27500000000000000000000000_u128,
-        "time_start": serde_json::Number::from(31536000000000_u64),
-        "volume_base": 25000000,
-        "volume_quote": 687500000,
-    });
-
     let candle_1m_serde =
         serde_json::from_str::<serde_json::Value>(&serde_json::to_string(&candle_1m).unwrap())
             .unwrap();
 
-    assert_json_include!(actual: candle_1m_serde, expected: expected_candle);
+    // `PairPrice` is serialized as u128 for clickhouse
+    let expected_candle = serde_json::json!({
+        "quote_denom": "bridge/usdc",
+        "base_denom": "dango",
+        "close": 2.75e25,
+        "high":  2.75e25,
+        "interval": "1m",
+        "low": 2.75e25,
+        "open": 2.75e25,
+        "time_start": serde_json::Number::from(31536000000000_u64),
+        "volume_base": 25000000,
+        "volume_quote": 687500000,
+        "block_height": 2,
+    });
+
+    assert_json_eq!(candle_1m_serde, expected_candle);
 
     Ok(())
 }

--- a/indexer/clickhouse/Cargo.toml
+++ b/indexer/clickhouse/Cargo.toml
@@ -48,5 +48,4 @@ tracing        = { workspace = true, optional = true }
 [dev-dependencies]
 assertor   = { workspace = true }
 clickhouse = { workspace = true, features = ["test-util"] }
-serde_json = { workspace = true, features = ["arbitrary_precision"] }
 test-case  = { workspace = true }

--- a/indexer/clickhouse/Cargo.toml
+++ b/indexer/clickhouse/Cargo.toml
@@ -36,7 +36,7 @@ indexer-sql    = { workspace = true }
 itertools      = { workspace = true }
 metrics        = { workspace = true, optional = true }
 serde          = { workspace = true }
-serde_json     = { workspace = true, features = ["arbitrary_precision"] }
+serde_json     = { workspace = true }
 strum          = { workspace = true, features = ["derive"] }
 strum_macros   = { workspace = true }
 tempfile       = { workspace = true }

--- a/indexer/clickhouse/src/entities/candle.rs
+++ b/indexer/clickhouse/src/entities/candle.rs
@@ -23,8 +23,8 @@ use {
 #[cfg_attr(feature = "async-graphql", derive(SimpleObject))]
 #[cfg_attr(feature = "async-graphql", graphql(complex))]
 pub struct Candle {
-    quote_denom: String,
-    base_denom: String,
+    pub quote_denom: String,
+    pub base_denom: String,
     #[cfg_attr(feature = "async-graphql", graphql(skip))]
     #[serde(with = "clickhouse::serde::chrono::datetime64::micros")]
     pub time_start: DateTime<Utc>,

--- a/indexer/clickhouse/src/entities/pair_price.rs
+++ b/indexer/clickhouse/src/entities/pair_price.rs
@@ -176,7 +176,6 @@ mod test {
     /// This allows seeing the serialized value of all types.
     /// This test matters, because it's the only way to test that the serde_json
     /// implementation is correct. We'll use serde to inject data into clickhouse.
-    /// This requires the `arbitrary_precision` feature to be working.
     #[test]
     fn test_all_types() {
         let all_types = serde_json::json!({
@@ -185,10 +184,10 @@ mod test {
             "uint128": Uint128::MAX,
             "uint256": Uint256::MAX,
             "volume": Dec128_6::MAX,
+            "a": Udec128_24::MAX,
             "clearing_price": Udec128::MAX,
             "bnum_u128": bnum::types::U128::ONE,
             "bnum_u256": bnum::types::U256::ONE,
-            "u128": u128::MAX,
         });
         let serialized = serde_json::to_string(&all_types).unwrap();
         let _deserialized: serde_json::Value = serde_json::from_str(&serialized).unwrap();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `arbitrary_precision` feature from `serde_json` and update tests for precise decimal handling in `candles.rs`.
> 
>   - **Dependencies**:
>     - Remove `arbitrary_precision` feature from `serde_json` in `Cargo.toml`.
>   - **Tests**:
>     - Replace `assert_json_include` with `assert_that` in `index_candles_with_real_clickhouse()` in `candles.rs`.
>     - Update assertions to use `Udec128_24` and `Udec128_6` for precise decimal comparisons in `candles.rs`.
>   - **Structs**:
>     - Make `quote_denom` and `base_denom` public in `Candle` struct in `candle.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 19cb88e21505722816e8f9b4b68275235fcce8bd. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->