### PR TITLE
fix: support lp on asset table

### DIFF
--- a/ui/applets/kit/src/components/Cell.tsx
+++ b/ui/applets/kit/src/components/Cell.tsx
@@ -38,22 +38,25 @@ type CellAssetProps = Prettify<
 >;
 
 const Asset: React.FC<CellAssetProps> = ({ asset, noImage, denom }) => {
-  const { coins } = useConfig();
+  const { coins, getCoinInfo } = useConfig();
 
-  const coin = asset || coins[denom as keyof typeof coins];
+  const coin = asset || getCoinInfo(denom as string);
 
   if (!coin) return <div className="flex h-full items-center diatype-sm-medium ">-</div>;
 
   return (
     <div className="flex h-full gap-2 diatype-sm-medium justify-start items-center my-auto">
-      {!noImage && (
-        <img
-          src={coin.logoURI}
-          alt={coin.symbol}
-          className="w-7 h-7 select-none drag-none"
-          loading="lazy"
-        />
-      )}
+      {!noImage &&
+        (coin.type === "lp" ? (
+          <PairAssets assets={[coin.base, coin.quote]} />
+        ) : (
+          <img
+            src={coin.logoURI}
+            alt={coin.symbol}
+            className="w-7 h-7 select-none drag-none"
+            loading="lazy"
+          />
+        ))}
       <p className="min-w-fit">{coin.symbol}</p>
     </div>
   );

--- a/ui/portal/web/src/components/explorer/AssetsTable.tsx
+++ b/ui/portal/web/src/components/explorer/AssetsTable.tsx
@@ -13,13 +13,13 @@ export type AssetsTableProps = {
 };
 
 export const AssetsTable: React.FC<AssetsTableProps> = ({ balances }) => {
-  const { coins } = useConfig();
+  const { getCoinInfo } = useConfig();
   const { settings } = useApp();
   const { getPrice } = usePrices();
   const { formatNumberOptions } = settings;
 
   const data = Object.entries(balances).map(([denom, amount]) => {
-    const coin = coins[denom];
+    const coin = getCoinInfo(denom);
     const price = getPrice(formatUnits(amount, coin.decimals).toString(), denom, {
       format: true,
       formatOptions: formatNumberOptions,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Support for LP assets in the asset table by using `getCoinInfo` and displaying `PairAssets` for LP types.
> 
>   - **Behavior**:
>     - In `Cell.tsx`, `getCoinInfo` replaces direct access to `coins` for retrieving coin data.
>     - LP assets now display a `PairAssets` component instead of an image in `Asset` component.
>   - **AssetsTable**:
>     - In `AssetsTable.tsx`, `getCoinInfo` is used to retrieve coin data instead of `coins` object.
>     - Coin data is mapped to include price and amount for table display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c6d20cc4779d0a62a420a49583b721436630c5a8. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->