### PR TITLE
feat(ui): show all applets

### DIFF
--- a/ui/portal/web/src/components/foundation/SearchMenu.tsx
+++ b/ui/portal/web/src/components/foundation/SearchMenu.tsx
@@ -1,4 +1,4 @@
-import { type AppletMetadata, twMerge, useClickAway, useMediaQuery } from "@left-curve/applets-kit";
+import { twMerge, useClickAway, useMediaQuery } from "@left-curve/applets-kit";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { useApp } from "~/hooks/useApp";
@@ -19,6 +19,7 @@ import { Command } from "cmdk";
 import { AnimatePresence, motion } from "framer-motion";
 import { SearchItem } from "./SearchItem";
 
+import type { AppletMetadata } from "@left-curve/applets-kit";
 import type React from "react";
 import type { SearchBarResult } from "~/hooks/useSearchBar";
 

--- a/ui/portal/web/src/components/foundation/SearchMenu.tsx
+++ b/ui/portal/web/src/components/foundation/SearchMenu.tsx
@@ -1,4 +1,4 @@
-import { twMerge, useClickAway, useMediaQuery } from "@left-curve/applets-kit";
+import { type AppletMetadata, twMerge, useClickAway, useMediaQuery } from "@left-curve/applets-kit";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { useApp } from "~/hooks/useApp";
@@ -25,7 +25,8 @@ import type { SearchBarResult } from "~/hooks/useSearchBar";
 const SearchMenu: React.FC = () => {
   const { isLg } = useMediaQuery();
   const { isSearchBarVisible, setSearchBarVisibility } = useApp();
-  const { searchText, setSearchText, isLoading, searchResult, isRefetching } = useSearchBar();
+  const { searchText, setSearchText, isLoading, searchResult, allNotFavApplets, isRefetching } =
+    useSearchBar();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -144,6 +145,8 @@ const SearchMenu: React.FC = () => {
             isVisible={isSearchBarVisible}
             hideMenu={hideMenu}
             searchResult={searchResult}
+            isSearching={!!searchText}
+            allApplets={allNotFavApplets}
             isLoading={isLoading || isRefetching}
           />
         </div>
@@ -154,12 +157,21 @@ const SearchMenu: React.FC = () => {
 
 type SearchMenuBodyProps = {
   isVisible: boolean;
+  isSearching: boolean;
   hideMenu: () => void;
+  allApplets: AppletMetadata[];
   searchResult: SearchBarResult;
   isLoading: boolean;
 };
 
-const Body: React.FC<SearchMenuBodyProps> = ({ isVisible, hideMenu, searchResult, isLoading }) => {
+const Body: React.FC<SearchMenuBodyProps> = ({
+  isVisible,
+  hideMenu,
+  searchResult,
+  isLoading,
+  isSearching,
+  allApplets,
+}) => {
   const navigate = useNavigate();
   const { applets, block, txs, account, contract } = searchResult;
 
@@ -201,8 +213,22 @@ const Body: React.FC<SearchMenuBodyProps> = ({ isVisible, hideMenu, searchResult
                 )}
               </Command.Empty>
               {applets.length ? (
-                <Command.Group heading="Applets">
+                <Command.Group heading="Favorite Applets">
                   {applets.map((applet) => (
+                    <Command.Item
+                      key={applet.title}
+                      value={applet.title}
+                      className="group"
+                      onSelect={() => [navigate({ to: applet.path }), hideMenu()]}
+                    >
+                      <SearchItem.Applet key={applet.title} {...applet} />
+                    </Command.Item>
+                  ))}
+                </Command.Group>
+              ) : null}
+              {!isSearching && allApplets.length ? (
+                <Command.Group heading="Applets">
+                  {allApplets.map((applet) => (
                     <Command.Item
                       key={applet.title}
                       value={applet.title}

--- a/ui/portal/web/src/hooks/useSearchBar.ts
+++ b/ui/portal/web/src/hooks/useSearchBar.ts
@@ -56,7 +56,7 @@ export function useSearchBar(parameters: UseSearchBarParameters = {}) {
 
   const allNotFavApplets = useMemo(() => {
     return Object.values(APPLETS).filter((applet) => !favApplets[applet.id]);
-  }, [APPLETS, favApplets]);
+  }, [favApplets]);
 
   const { data, ...query } = useQuery({
     queryKey: ["searchBar", searchText],

--- a/ui/portal/web/src/hooks/useSearchBar.ts
+++ b/ui/portal/web/src/hooks/useSearchBar.ts
@@ -54,6 +54,10 @@ export function useSearchBar(parameters: UseSearchBarParameters = {}) {
   const queryClient = useQueryClient();
   const client = usePublicClient();
 
+  const allNotFavApplets = useMemo(() => {
+    return Object.values(APPLETS).filter((applet) => !favApplets[applet.id]);
+  }, [APPLETS, favApplets]);
+
   const { data, ...query } = useQuery({
     queryKey: ["searchBar", searchText],
     queryFn: async ({ signal }) => {
@@ -126,5 +130,5 @@ export function useSearchBar(parameters: UseSearchBarParameters = {}) {
     },
   });
 
-  return { searchText, setSearchText, searchResult, ...query };
+  return { searchText, setSearchText, searchResult, allNotFavApplets, ...query };
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Display all applets in the search menu when no search text is present, using `allNotFavApplets`.
> 
>   - **Behavior**:
>     - `SearchMenu.tsx`: Displays all applets when no search text is present, using `allNotFavApplets`.
>     - `useSearchBar.ts`: Adds `allNotFavApplets` to filter and return non-favorite applets.
>   - **Components**:
>     - `Body` component in `SearchMenu.tsx` updated to include `allApplets` and `isSearching` props.
>   - **Hooks**:
>     - `useSearchBar` returns `allNotFavApplets` for non-favorite applet filtering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e46b981d2d17cdbc5eff68a778c7da583c9f7345. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->