### PR TITLE
dex: add tracing messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,6 +3489,7 @@ dependencies = [
  "dango-types",
  "grug",
  "test-case",
+ "tracing",
 ]
 
 [[package]]

--- a/dango/dex/Cargo.toml
+++ b/dango/dex/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # If enabled, Wasm exports won't be created. This allows this contract to be
 # imported into other contracts as a library.
 library = []
+tracing = ["dep:tracing"]
 
 [dependencies]
 anyhow                = { workspace = true }
@@ -23,6 +24,7 @@ dango-account-factory = { workspace = true, features = ["library"] }
 dango-oracle          = { workspace = true, features = ["library"] }
 dango-types           = { workspace = true }
 grug                  = { workspace = true }
+tracing               = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/dango/genesis/Cargo.toml
+++ b/dango/genesis/Cargo.toml
@@ -16,7 +16,7 @@ dango-account-margin  = { workspace = true, features = ["library"] }
 dango-account-multi   = { workspace = true, features = ["library"] }
 dango-account-spot    = { workspace = true, features = ["library"] }
 dango-bank            = { workspace = true, features = ["library"] }
-dango-dex             = { workspace = true, features = ["library"] }
+dango-dex             = { workspace = true, features = ["library", "tracing"] }
 dango-gateway         = { workspace = true, features = ["library"] }
 dango-lending         = { workspace = true, features = ["library"] }
 dango-oracle          = { workspace = true, features = ["library"] }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds tracing functionality to `dango-dex` for detailed logging of order processing stages.
> 
>   - **Behavior**:
>     - Adds `tracing` feature to `dango-dex` in `Cargo.toml` and `dango/genesis/Cargo.toml`.
>     - Inserts `tracing::info!` calls in `clear_orders_of_pair()` in `cron.rs` to log processing stages: processing pairs, processed market orders, matched limit orders, filled limit orders, and updated contract state.
>   - **Dependencies**:
>     - Adds `tracing` as an optional dependency in `dango/dex/Cargo.toml`.
>     - Enables `tracing` feature for `dango-dex` in `dango/genesis/Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 093e3909c75e8534a7d862d972e6e1dbe9159cb9. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->