### PR TITLE
fix(dango): Better clearing price calculation

### DIFF
--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -14,9 +14,9 @@ use {
         taxman::{self, FeeType},
     },
     grug::{
-        Addr, Api, DecCoins, Denom, EventBuilder, Inner, IsZero, Message, NextNumber, Number,
-        NumberConst, Order as IterationOrder, PrevNumber, Response, StdError, StdResult, Storage,
-        SudoCtx, TransferBuilder, Udec128, Udec128_6,
+        Addr, Api, DecCoins, Denom, EventBuilder, Inner, IsZero, Message, Number, NumberConst,
+        Order as IterationOrder, Response, StdError, StdResult, Storage, SudoCtx, TransferBuilder,
+        Udec128, Udec128_6, Udec128_24,
     },
     std::{
         collections::{BTreeSet, HashMap, hash_map::Entry},
@@ -446,20 +446,9 @@ fn clear_orders_of_pair(
         };
 
         // Compute the clearing price.
-        //
-        // Notes:
-        //
-        // 1. `filled_{base,quote}` are in 6 decimals. We must convert them to
-        //    24 decimals first, then to the division. If we do the division
-        //    first then convert, we may lose precision.
-        //
-        // 2. Converting to 24 decimals with 128 bit may overflow, so we also
-        //    convert to 256 bit.
-        let clearing_price = filled_quote
-            .into_next()
-            .convert_precision()?
-            .checked_div(filled_base.into_next())?
-            .checked_into_prev()?;
+
+        let clearing_price = Udec128_24::checked_from_ratio(filled_quote.0, filled_base.0)?;
+
         let cleared = order.remaining().is_zero();
 
         // Emit event for filled orders to be used by the frontend.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved clearing price calculation in `clear_orders_of_pair()` in `cron.rs` using `Udec128_24::checked_from_ratio()` to prevent precision loss and overflow.
> 
>   - **Behavior**:
>     - Improved clearing price calculation in `clear_orders_of_pair()` in `cron.rs` using `Udec128_24::checked_from_ratio()`.
>     - Removed previous multi-step conversion and division process to prevent precision loss and overflow.
>   - **Misc**:
>     - Removed unused imports `NextNumber` and `PrevNumber` from `cron.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 602b274d46c68c364c484b869862711352f8d21e. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->