### PR TITLE
Missing current_market_order assignment

### DIFF
--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -152,7 +152,7 @@ where
         // We do not refund the market order since that would allow spamming the
         // contract with tiny market orders at no cost.
         if filled_base.is_zero() {
-            market_orders.next();
+            current_market_order = market_orders.next();
             continue;
         }
 
@@ -161,7 +161,7 @@ where
         if market_order_direction == Direction::Ask {
             let filled_quote = filled_base.checked_mul(*price)?;
             if filled_quote.is_zero() {
-                market_orders.next();
+                current_market_order = market_orders.next();
                 continue;
             }
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix missing `current_market_order` assignment in `market_order.rs` to prevent incorrect order processing.
> 
>   - **Behavior**:
>     - Fix missing assignment of `current_market_order` in `match_and_fill_market_orders()` in `market_order.rs` when `filled_base` or `filled_quote` is zero.
>     - Ensures `current_market_order` is updated correctly to the next order in the iterator.
>   - **Tests**:
>     - Adds test `panic_case_found_on_testnet` to ensure no panic occurs and correct outcomes are returned when processing market orders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 7703b9170b86028bc0216d90cc3d82d2aea3c066. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->