### PR TITLE
Add caching for candles subscriptions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
         run: rustup run nightly cargo fmt --check --all
 
   check-no-features:
-    needs: [format]
+    needs: [localdango]
     name: Check compiling without features
     runs-on: self-hosted
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
         run: rustup run nightly cargo fmt --check --all
 
   check-no-features:
-    needs: [localdango]
+    needs: [push-manifest]
     name: Check compiling without features
     runs-on: self-hosted
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5864,6 +5864,7 @@ dependencies = [
  "futures",
  "grug",
  "grug-app",
+ "grug-httpd",
  "grug-types",
  "indexer-hooked",
  "indexer-httpd",

--- a/dango/cli/src/start.rs
+++ b/dango/cli/src/start.rs
@@ -289,14 +289,10 @@ impl StartCmd {
             cfg.port
         );
 
-        let clickhouse_context = dango_httpd_context.indexer_clickhouse_context.clone();
-        tokio::spawn(async move {
-            // Update the candle cache automatically
-            indexer_clickhouse::httpd::graphql::update_candle_cache(clickhouse_context).await;
-        });
-
-        let clickhouse_context = dango_httpd_context.indexer_clickhouse_context.clone();
-        clickhouse_context.preload_candle_cache().await?;
+        dango_httpd_context
+            .indexer_clickhouse_context
+            .start_candle_cache()
+            .await?;
 
         dango_httpd::server::run_server(
             &cfg.ip,

--- a/dango/indexer/httpd/src/graphql/subscription/account.rs
+++ b/dango/indexer/httpd/src/graphql/subscription/account.rs
@@ -10,6 +10,8 @@ use {
     },
     std::ops::RangeInclusive,
 };
+#[cfg(feature = "metrics")]
+use {grug_httpd::metrics::GaugeGuard, std::sync::Arc};
 
 #[derive(Default)]
 pub struct AccountSubscription;
@@ -71,32 +73,42 @@ impl AccountSubscription {
 
         let u = username.clone();
 
-        Ok(
-            once(async { Self::get_accounts(app_ctx, block_range, u).await })
-                .chain(
-                    app_ctx
-                        .pubsub
-                        .subscribe_block_minted()
-                        .await?
-                        .then(move |block_height| {
-                            let u = username.clone();
-                            async move {
-                                Self::get_accounts(
-                                    app_ctx,
-                                    block_height as i64..=block_height as i64,
-                                    u,
-                                )
-                                .await
-                            }
-                        }),
-                )
-                .filter_map(|maybe_accounts| async move {
-                    if maybe_accounts.is_empty() {
-                        None
-                    } else {
-                        Some(maybe_accounts)
+        #[cfg(feature = "metrics")]
+        let gauge_guard = Arc::new(GaugeGuard::new(
+            "graphql.subscriptions.active",
+            "accounts",
+            "subscription",
+        ));
+
+        Ok(once({
+            #[cfg(feature = "metrics")]
+            let _guard = gauge_guard.clone();
+
+            async { Self::get_accounts(app_ctx, block_range, u).await }
+        })
+        .chain(
+            app_ctx
+                .pubsub
+                .subscribe_block_minted()
+                .await?
+                .then(move |block_height| {
+                    let u = username.clone();
+
+                    #[cfg(feature = "metrics")]
+                    let _guard = gauge_guard.clone();
+
+                    async move {
+                        Self::get_accounts(app_ctx, block_height as i64..=block_height as i64, u)
+                            .await
                     }
                 }),
         )
+        .filter_map(|maybe_accounts| async move {
+            if maybe_accounts.is_empty() {
+                None
+            } else {
+                Some(maybe_accounts)
+            }
+        }))
     }
 }

--- a/dango/indexer/httpd/src/graphql/subscription/transfer.rs
+++ b/dango/indexer/httpd/src/graphql/subscription/transfer.rs
@@ -8,6 +8,8 @@ use {
     sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder},
     std::ops::RangeInclusive,
 };
+#[cfg(feature = "metrics")]
+use {grug_httpd::metrics::GaugeGuard, std::sync::Arc};
 
 #[derive(Default)]
 pub struct TransferSubscription;
@@ -97,28 +99,42 @@ impl TransferSubscription {
         let a = address.clone();
         let u = username.clone();
 
-        Ok(
-            once(async move { Self::get_transfers(app_ctx, block_range, a, u).await })
-                .chain(
-                    app_ctx
-                        .pubsub
-                        .subscribe_block_minted()
-                        .await?
-                        .then(move |block_height| {
-                            let a = address.clone();
-                            let u = username.clone();
-                            async move {
-                                Self::get_transfers(
-                                    app_ctx,
-                                    block_height as i64..=block_height as i64,
-                                    a,
-                                    u,
-                                )
-                                .await
-                            }
-                        }),
-                )
-                .filter_map(|transfers| async move { transfers }),
+        #[cfg(feature = "metrics")]
+        let gauge_guard = Arc::new(GaugeGuard::new(
+            "graphql.subscriptions.active",
+            "transfers",
+            "subscription",
+        ));
+
+        Ok(once({
+            #[cfg(feature = "metrics")]
+            let _guard = gauge_guard.clone();
+
+            async move { Self::get_transfers(app_ctx, block_range, a, u).await }
+        })
+        .chain(
+            app_ctx
+                .pubsub
+                .subscribe_block_minted()
+                .await?
+                .then(move |block_height| {
+                    let a = address.clone();
+                    let u = username.clone();
+
+                    #[cfg(feature = "metrics")]
+                    let _guard = gauge_guard.clone();
+
+                    async move {
+                        Self::get_transfers(
+                            app_ctx,
+                            block_height as i64..=block_height as i64,
+                            a,
+                            u,
+                        )
+                        .await
+                    }
+                }),
         )
+        .filter_map(|transfers| async move { transfers }))
     }
 }

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -227,6 +227,14 @@ pub async fn setup_test_with_indexer(
         GenesisOption::preset_test(),
     );
 
+    let cc = clickhouse_context.clone();
+    tokio::spawn(async move {
+        // Update the candle cache automatically
+        indexer_clickhouse::httpd::graphql::update_candle_cache(cc).await;
+    });
+
+    clickhouse_context.preload_candle_cache().await.unwrap();
+
     let consensus_client = Arc::new(TendermintRpcClient::new("http://localhost:26657").unwrap());
 
     let indexer_httpd_context = indexer_httpd::context::Context::new(

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -227,13 +227,7 @@ pub async fn setup_test_with_indexer(
         GenesisOption::preset_test(),
     );
 
-    let cc = clickhouse_context.clone();
-    tokio::spawn(async move {
-        // Update the candle cache automatically
-        indexer_clickhouse::httpd::graphql::update_candle_cache(cc).await;
-    });
-
-    clickhouse_context.preload_candle_cache().await.unwrap();
+    clickhouse_context.start_candle_cache().await.unwrap();
 
     let consensus_client = Arc::new(TendermintRpcClient::new("http://localhost:26657").unwrap());
 

--- a/dango/testing/tests/httpd/accounts.rs
+++ b/dango/testing/tests/httpd/accounts.rs
@@ -306,30 +306,36 @@ async fn query_user_multiple_spot_accounts() -> anyhow::Result<()> {
                     .map(|e| e.node)
                     .collect::<Vec<_>>();
 
-                let expected_accounts = serde_json::json!([
-                    {
+                if received_accounts.len() != 2 {
+                    println!("\nReceived accounts: {received_accounts:#?}",);
+                    assert_that!(received_accounts.len()).is_equal_to(2);
+                }
+
+                let expected_account = serde_json::json!(
+                {
+                    "accountType": "spot",
+                    "address": test_account2.address.inner().to_string(),
+                    "users": [
+                        {
+                            "username": "user",
+                        },
+                    ],
+                });
+
+                assert_json_include!(actual: received_accounts[0], expected: expected_account);
+
+                let expected_account = serde_json::json!(
+                {
                         "accountType": "spot",
-                        "createdBlockHeight": 3,
-                        "address": test_account2.address.inner().to_string(),
-                        "users": [
-                            {
-                                "username": "user",
-                            },
-                        ],
-                    },
-                    {
-                        "accountType": "spot",
-                        "createdBlockHeight": 2,
                         "address": test_account1.address.inner().to_string(),
                         "users": [
                             {
                                 "username": "user",
                             },
                         ],
-                    }
-                ]);
+                    });
 
-                assert_json_include!(actual: received_accounts, expected: expected_accounts);
+                assert_json_include!(actual: received_accounts[1], expected: expected_account);
 
                 Ok::<(), anyhow::Error>(())
             })

--- a/dango/testing/tests/httpd/main.rs
+++ b/dango/testing/tests/httpd/main.rs
@@ -29,6 +29,11 @@ fn build_actix_app(
 > {
     let graphql_schema = build_schema(dango_httpd_context.clone());
 
+    let clickhouse_context = dango_httpd_context.indexer_clickhouse_context.clone();
+    tokio::spawn(async move {
+        indexer_clickhouse::httpd::graphql::update_candle_cache(clickhouse_context).await;
+    });
+
     App::new()
         .app_data(web::Data::new(dango_httpd_context.clone()))
         .app_data(web::Data::new(

--- a/dango/testing/tests/httpd/main.rs
+++ b/dango/testing/tests/httpd/main.rs
@@ -29,11 +29,6 @@ fn build_actix_app(
 > {
     let graphql_schema = build_schema(dango_httpd_context.clone());
 
-    let clickhouse_context = dango_httpd_context.indexer_clickhouse_context.clone();
-    tokio::spawn(async move {
-        indexer_clickhouse::httpd::graphql::update_candle_cache(clickhouse_context).await;
-    });
-
     App::new()
         .app_data(web::Data::new(dango_httpd_context.clone()))
         .app_data(web::Data::new(

--- a/grug/httpd/src/lib.rs
+++ b/grug/httpd/src/lib.rs
@@ -4,3 +4,6 @@ pub mod graphql;
 pub mod routes;
 pub mod server;
 pub mod traits;
+
+#[cfg(feature = "metrics")]
+pub mod metrics;

--- a/grug/httpd/src/metrics.rs
+++ b/grug/httpd/src/metrics.rs
@@ -1,0 +1,31 @@
+use metrics::gauge;
+
+/// A guard that increments a gauge when created and decrements it when dropped.
+pub struct GaugeGuard {
+    metric_name: &'static str,
+    operation_name: &'static str,
+    operation_type: &'static str,
+}
+
+impl GaugeGuard {
+    pub fn new(
+        metric_name: &'static str,
+        operation_name: &'static str,
+        operation_type: &'static str,
+    ) -> Self {
+        gauge!(metric_name, "operation_name" => operation_name, "operation_type" => operation_type)
+            .increment(1.0);
+
+        Self {
+            metric_name,
+            operation_name,
+            operation_type,
+        }
+    }
+}
+
+impl Drop for GaugeGuard {
+    fn drop(&mut self) {
+        gauge!(self.metric_name, "operation_name" => self.operation_name, "operation_type" => self.operation_type).decrement(1.0);
+    }
+}

--- a/indexer/clickhouse/Cargo.toml
+++ b/indexer/clickhouse/Cargo.toml
@@ -11,7 +11,7 @@ version       = { workspace = true }
 
 [features]
 async-graphql = ["dep:async-graphql", "dep:indexer-httpd", "grug-types/async-graphql"]
-metrics       = ["dep:metrics", "indexer-httpd/metrics"]
+metrics       = ["dep:metrics", "grug-httpd/metrics", "indexer-httpd/metrics"]
 testing       = ["clickhouse/test-util"]
 tracing       = ["dep:tracing"]
 
@@ -29,6 +29,7 @@ dango-types    = { workspace = true }
 futures        = { workspace = true }
 grug           = { workspace = true }
 grug-app       = { workspace = true }
+grug-httpd     = { workspace = true }
 grug-types     = { workspace = true, features = ["chrono"] }
 indexer-hooked = { workspace = true }
 indexer-httpd  = { workspace = true, optional = true }

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -34,61 +34,6 @@ pub struct CandleCache {
 }
 
 impl CandleCache {
-    /// If the candle is found in the cache and the block height is not greater
-    /// than the last candle's block height, returns the last candle.
-    /// If not found, fetches the latest candle from ClickHouse and
-    /// saves it in the cache, returning it.
-    pub async fn get_or_save_new_candle(
-        &mut self,
-        key: &CandleCacheKey,
-        clickhouse_client: &clickhouse::Client,
-        block_height: Option<u64>,
-    ) -> Result<Option<Candle>, crate::error::IndexerError> {
-        let cached_candle = self.candles.get(key).and_then(|c| c.last());
-
-        // If found in cache and the cache block_height is at least block_height,
-        match (cached_candle, block_height) {
-            (Some(cached_candle), Some(block_height))
-                if cached_candle.block_height >= block_height =>
-            {
-                return Ok(Some(cached_candle.clone()));
-            },
-            (Some(cached_candle), None) => {
-                return Ok(Some(cached_candle.clone()));
-            },
-            _ => {},
-        }
-
-        // Not found in cache, fetch from ClickHouse
-        let query_builder = CandleQueryBuilder::new(
-            key.interval,
-            key.base_denom.clone(),
-            key.quote_denom.clone(),
-        );
-
-        // No candle for this pair and interval
-        let Some(fetched_candle) = query_builder.fetch_one(clickhouse_client).await? else {
-            return Ok(None);
-        };
-
-        // Cache the candle only if the fetched candle is newer
-        if cached_candle.map_or(true, |cached_candle| {
-            cached_candle.block_height < fetched_candle.block_height
-        }) {
-            self.add_candle(key.clone(), fetched_candle.clone());
-            self.compact_keep_n_for_key(key, MAX_ITEMS);
-        }
-
-        // If the fetched candle's block height is less than the provided block height,
-        if let Some(block_height) = block_height {
-            if fetched_candle.block_height < block_height {
-                return Ok(None);
-            }
-        }
-
-        Ok(Some(fetched_candle.clone()))
-    }
-
     pub fn add_candle(&mut self, key: CandleCacheKey, candle: Candle) {
         let candles = self.candles.entry(key).or_default();
 
@@ -143,7 +88,7 @@ impl CandleCache {
     }
 
     /// Updates all existing pairs in the cache for a given block height.
-    /// This will fetch the latest candles.
+    /// This will fetch the latest candles in parallel.
     pub async fn update_pairs(
         &mut self,
         clickhouse_client: &clickhouse::Client,
@@ -207,6 +152,7 @@ impl CandleCache {
         Ok(())
     }
 
+    /// Preloads candles in parallel.
     pub async fn preload_pairs(
         &mut self,
         pairs: &[PairId],
@@ -259,35 +205,6 @@ impl CandleCache {
         Ok(())
     }
 
-    // Keep only the most recent candle
-    pub fn compact(&mut self) {
-        self.candles.retain(|_key, candles| {
-            if candles.is_empty() {
-                false
-            } else {
-                // Keep only the LAST (most recent) candle
-                if let Some(last_candle) = candles.pop() {
-                    candles.clear();
-                    candles.push(last_candle);
-                }
-                true
-            }
-        });
-    }
-
-    // Keep only the most recent candle
-    pub fn compact_for_key(&mut self, key: &CandleCacheKey) {
-        if let Some(candles) = self.candles.get_mut(key) {
-            if !candles.is_empty() {
-                // Keep only the LAST (most recent) candle
-                if let Some(last_candle) = candles.pop() {
-                    candles.clear();
-                    candles.push(last_candle);
-                }
-            }
-        }
-    }
-
     // Keep last N candles
     pub fn compact_keep_n(&mut self, n: usize) {
         self.candles.retain(|_key, candles| {
@@ -300,16 +217,5 @@ impl CandleCache {
                 true
             }
         });
-    }
-
-    // Keep last N candles
-    pub fn compact_keep_n_for_key(&mut self, key: &CandleCacheKey, n: usize) {
-        if let Some(candles) = self.candles.get_mut(key) {
-            if !candles.is_empty() {
-                // Keep only last N candles
-                let start = candles.len().saturating_sub(n);
-                candles.drain(..start);
-            }
-        }
     }
 }

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -214,6 +214,7 @@ impl CandleCache {
                 // Keep only last N candles
                 let start = candles.len().saturating_sub(n);
                 candles.drain(..start);
+
                 true
             }
         });

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "metrics")]
+use metrics::{counter, gauge, histogram};
+
 use {
     crate::entities::{
         CandleInterval,
@@ -7,7 +10,6 @@ use {
     chrono::{DateTime, Utc},
     dango_types::dex::PairId,
     futures::future::join_all,
-    metrics::{counter, gauge, histogram},
     std::{collections::HashMap, time::Instant},
     strum::IntoEnumIterator,
 };

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -1,6 +1,13 @@
 use {
-    crate::entities::{CandleInterval, candle::Candle, candle_query::CandleQueryBuilder},
+    crate::entities::{
+        CandleInterval,
+        candle::Candle,
+        candle_query::{CandleQueryBuilder, MAX_ITEMS},
+    },
+    dango_types::dex::PairId,
+    futures::future::join_all,
     std::collections::HashMap,
+    strum::IntoEnumIterator,
 };
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -32,11 +39,11 @@ impl CandleCache {
     /// saves it in the cache, returning it.
     pub async fn get_or_save_new_candle(
         &mut self,
-        key: CandleCacheKey,
+        key: &CandleCacheKey,
         clickhouse_client: &clickhouse::Client,
         block_height: Option<u64>,
     ) -> Result<Option<Candle>, crate::error::IndexerError> {
-        let cached_candle = self.candles.get(&key).and_then(|c| c.last());
+        let cached_candle = self.candles.get(key).and_then(|c| c.last());
 
         // If found in cache and the cache block_height is at least block_height,
         match (cached_candle, block_height) {
@@ -58,10 +65,6 @@ impl CandleCache {
             key.quote_denom.clone(),
         );
 
-        // if let Some(block_height) = block_height {
-        //     query_builder = query_builder.after_block_height(block_height);
-        // }
-
         // No candle for this pair and interval
         let Some(fetched_candle) = query_builder.fetch_one(clickhouse_client).await? else {
             return Ok(None);
@@ -72,6 +75,7 @@ impl CandleCache {
             cached_candle.block_height < fetched_candle.block_height
         }) {
             self.add_candle(key.clone(), fetched_candle.clone());
+            self.compact_keep_n_for_key(key, MAX_ITEMS);
         }
 
         // If the fetched candle's block height is less than the provided block height,
@@ -85,8 +89,23 @@ impl CandleCache {
     }
 
     pub fn add_candle(&mut self, key: CandleCacheKey, candle: Candle) {
-        self.candles.entry(key).or_default().push(candle);
+        let candles = self.candles.entry(key).or_default();
+
+        // Check if last candle has same time_start, if so replace it
+        if let Some(last_candle) = candles.last_mut() {
+            if last_candle.time_start == candle.time_start {
+                *last_candle = candle;
+                return;
+            }
+        }
+
+        // Otherwise, add new candle
+        candles.push(candle);
     }
+
+    // pub fn add_candles(&mut self, _key: CandleCacheKey, _candles: &[Candle]) {
+    //     //
+    // }
 
     pub fn get_candles(&self, key: &CandleCacheKey) -> Option<&Vec<Candle>> {
         self.candles.get(key)
@@ -94,6 +113,85 @@ impl CandleCache {
 
     pub fn get_last_candle(&self, key: &CandleCacheKey) -> Option<&Candle> {
         self.candles.get(key).and_then(|candles| candles.last())
+    }
+
+    /// Updates all existing pairs in the cache for a given block height.
+    /// This will fetch the latest candles.
+    pub async fn update_pairs(
+        &mut self,
+        clickhouse_client: &clickhouse::Client,
+        pairs: &[PairId],
+        block_height: u64,
+    ) -> crate::error::Result<()> {
+        // TODO: This is a naive implementation that fetches all pairs and updates them.
+        // Could potentially be optimized by single query to fetch all candles for all pairs.
+
+        for pair in pairs {
+            for interval in CandleInterval::iter() {
+                let key = CandleCacheKey::new(
+                    pair.base_denom.to_string(),
+                    pair.quote_denom.to_string(),
+                    interval,
+                );
+                self.get_or_save_new_candle(&key, clickhouse_client, Some(block_height))
+                    .await
+                    .ok();
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn preload_pairs(
+        &mut self,
+        pairs: &[PairId],
+        clickhouse_client: &clickhouse::Client,
+    ) -> crate::error::Result<()> {
+        // Create all fetch tasks
+        let fetch_tasks = pairs
+            .iter()
+            .flat_map(|pair| {
+                CandleInterval::iter().map(move |interval| {
+                    let key = CandleCacheKey::new(
+                        pair.base_denom.to_string(),
+                        pair.quote_denom.to_string(),
+                        interval,
+                    );
+
+                    async move {
+                        let query_builder = CandleQueryBuilder::new(
+                            key.interval,
+                            key.base_denom.clone(),
+                            key.quote_denom.clone(),
+                        )
+                        .with_limit(MAX_ITEMS);
+
+                        let mut candles = query_builder.fetch_all(clickhouse_client).await?.candles;
+                        candles.reverse(); // Most recent first -> most recent last
+
+                        Ok::<_, crate::error::IndexerError>((key, candles))
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // Execute all fetches in parallel
+        let results = join_all(fetch_tasks).await;
+
+        // Process results
+        for result in results {
+            match result {
+                Ok((key, candles)) => {
+                    *self.candles.entry(key).or_default() = candles;
+                },
+                Err(_err) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!(err = %_err, "Failed to preload candles");
+                },
+            }
+        }
+
+        Ok(())
     }
 
     // Keep only the most recent candle
@@ -137,5 +235,16 @@ impl CandleCache {
                 true
             }
         });
+    }
+
+    // Keep last N candles
+    pub fn compact_keep_n_for_key(&mut self, key: &CandleCacheKey, n: usize) {
+        if let Some(candles) = self.candles.get_mut(key) {
+            if !candles.is_empty() {
+                // Keep only last N candles
+                let start = candles.len().saturating_sub(n);
+                candles.drain(..start);
+            }
+        }
     }
 }

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -1,0 +1,141 @@
+use {
+    crate::entities::{CandleInterval, candle::Candle, candle_query::CandleQueryBuilder},
+    std::collections::HashMap,
+};
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct CandleCacheKey {
+    pub base_denom: String,
+    pub quote_denom: String,
+    pub interval: CandleInterval,
+}
+
+impl CandleCacheKey {
+    pub fn new(base_denom: String, quote_denom: String, interval: CandleInterval) -> Self {
+        Self {
+            base_denom,
+            quote_denom,
+            interval,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CandleCache {
+    candles: HashMap<CandleCacheKey, Vec<Candle>>,
+}
+
+impl CandleCache {
+    /// If the candle is found in the cache and the block height is not greater
+    /// than the last candle's block height, returns the last candle.
+    /// If not found, fetches the latest candle from ClickHouse and
+    /// saves it in the cache, returning it.
+    pub async fn get_or_save_new_candle(
+        &mut self,
+        key: CandleCacheKey,
+        clickhouse_client: &clickhouse::Client,
+        block_height: Option<u64>,
+    ) -> Result<Option<Candle>, crate::error::IndexerError> {
+        let cached_candle = self.candles.get(&key).and_then(|c| c.last());
+
+        // If found in cache and the cache block_height is at least block_height,
+        match (cached_candle, block_height) {
+            (Some(cached_candle), Some(block_height))
+                if cached_candle.block_height >= block_height =>
+            {
+                return Ok(Some(cached_candle.clone()));
+            },
+            (Some(cached_candle), None) => {
+                return Ok(Some(cached_candle.clone()));
+            },
+            _ => {},
+        }
+
+        // Not found in cache, fetch from ClickHouse
+        let query_builder = CandleQueryBuilder::new(
+            key.interval,
+            key.base_denom.clone(),
+            key.quote_denom.clone(),
+        );
+
+        // if let Some(block_height) = block_height {
+        //     query_builder = query_builder.after_block_height(block_height);
+        // }
+
+        // No candle for this pair and interval
+        let Some(fetched_candle) = query_builder.fetch_one(clickhouse_client).await? else {
+            return Ok(None);
+        };
+
+        // Cache the candle only if the fetched candle is newer
+        if cached_candle.map_or(true, |cached_candle| {
+            cached_candle.block_height < fetched_candle.block_height
+        }) {
+            self.add_candle(key.clone(), fetched_candle.clone());
+        }
+
+        // If the fetched candle's block height is less than the provided block height,
+        if let Some(block_height) = block_height {
+            if fetched_candle.block_height < block_height {
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(fetched_candle.clone()))
+    }
+
+    pub fn add_candle(&mut self, key: CandleCacheKey, candle: Candle) {
+        self.candles.entry(key).or_default().push(candle);
+    }
+
+    pub fn get_candles(&self, key: &CandleCacheKey) -> Option<&Vec<Candle>> {
+        self.candles.get(key)
+    }
+
+    pub fn get_last_candle(&self, key: &CandleCacheKey) -> Option<&Candle> {
+        self.candles.get(key).and_then(|candles| candles.last())
+    }
+
+    // Keep only the most recent candle
+    pub fn compact(&mut self) {
+        self.candles.retain(|_key, candles| {
+            if candles.is_empty() {
+                false
+            } else {
+                // Keep only the LAST (most recent) candle
+                if let Some(last_candle) = candles.pop() {
+                    candles.clear();
+                    candles.push(last_candle);
+                }
+                true
+            }
+        });
+    }
+
+    // Keep only the most recent candle
+    pub fn compact_for_key(&mut self, key: &CandleCacheKey) {
+        if let Some(candles) = self.candles.get_mut(key) {
+            if !candles.is_empty() {
+                // Keep only the LAST (most recent) candle
+                if let Some(last_candle) = candles.pop() {
+                    candles.clear();
+                    candles.push(last_candle);
+                }
+            }
+        }
+    }
+
+    // Keep last N candles
+    pub fn compact_keep_n(&mut self, n: usize) {
+        self.candles.retain(|_key, candles| {
+            if candles.is_empty() {
+                false
+            } else {
+                // Keep only last N candles
+                let start = candles.len().saturating_sub(n);
+                candles.drain(..start);
+                true
+            }
+        });
+    }
+}

--- a/indexer/clickhouse/src/context.rs
+++ b/indexer/clickhouse/src/context.rs
@@ -37,6 +37,7 @@ impl Context {
         Self {
             clickhouse_client,
             pubsub: indexer_context.pubsub,
+            candle_cache: Default::default(),
         }
     }
 

--- a/indexer/clickhouse/src/context.rs
+++ b/indexer/clickhouse/src/context.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "testing")]
 use clickhouse::test;
-use {clickhouse::Client, indexer_sql::pubsub::PubSub, std::sync::Arc};
+use {
+    crate::cache::CandleCache, clickhouse::Client, indexer_sql::pubsub::PubSub, std::sync::Arc,
+    tokio::sync::RwLock,
+};
 
 #[derive(Clone)]
 pub struct Context {
@@ -13,6 +16,7 @@ pub struct Context {
     #[allow(dead_code)]
     clickhouse_client: Client,
     pub pubsub: Arc<dyn PubSub + Send + Sync>,
+    pub candle_cache: Arc<RwLock<CandleCache>>,
 }
 
 impl Context {
@@ -61,6 +65,7 @@ impl Context {
             clickhouse_database: database,
             clickhouse_client,
             pubsub: indexer_context.pubsub,
+            candle_cache: Default::default(),
         }
     }
 
@@ -73,6 +78,7 @@ impl Context {
             mock: Some(Arc::new(mock)),
             clickhouse_database: self.clickhouse_database.clone(),
             pubsub: self.pubsub.clone(),
+            candle_cache: Default::default(),
         }
     }
 
@@ -96,6 +102,7 @@ impl Context {
             clickhouse_database: test_database,
             clickhouse_client,
             pubsub: self.pubsub,
+            candle_cache: Default::default(),
         })
     }
 

--- a/indexer/clickhouse/src/context.rs
+++ b/indexer/clickhouse/src/context.rs
@@ -1,6 +1,8 @@
-use crate::httpd::graphql::update_candle_cache;
 #[cfg(feature = "testing")]
 use clickhouse::test;
+
+#[cfg(feature = "async-graphql")]
+use crate::httpd::graphql::update_candle_cache;
 
 use {
     crate::{cache::CandleCache, entities::pair_price::PairPrice, pubsub::PubSub},
@@ -95,6 +97,7 @@ impl Context {
         Ok(())
     }
 
+    #[cfg(feature = "async-graphql")]
     pub async fn start_candle_cache(&self) -> crate::error::Result<()> {
         let self_clone = self.clone();
 

--- a/indexer/clickhouse/src/context.rs
+++ b/indexer/clickhouse/src/context.rs
@@ -1,9 +1,7 @@
-#[cfg(feature = "testing")]
-use clickhouse::test;
-
 #[cfg(feature = "async-graphql")]
 use crate::httpd::graphql::update_candle_cache;
-
+#[cfg(feature = "testing")]
+use clickhouse::test;
 use {
     crate::{cache::CandleCache, entities::pair_price::PairPrice, pubsub::PubSub},
     clickhouse::Client,
@@ -92,9 +90,7 @@ impl Context {
 
         candle_cache
             .preload_pairs(&all_pairs, self.clickhouse_client())
-            .await?;
-
-        Ok(())
+            .await
     }
 
     #[cfg(feature = "async-graphql")]
@@ -106,9 +102,7 @@ impl Context {
             update_candle_cache(self_clone).await;
         });
 
-        self.preload_candle_cache().await?;
-
-        Ok(())
+        self.preload_candle_cache().await
     }
 
     #[cfg(feature = "testing")]

--- a/indexer/clickhouse/src/entities/candle_interval.rs
+++ b/indexer/clickhouse/src/entities/candle_interval.rs
@@ -7,7 +7,7 @@ use {
     strum_macros::{Display, EnumString},
 };
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Display, EnumString, EnumIter)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Display, EnumString, EnumIter)]
 #[cfg_attr(feature = "async-graphql", derive(Enum))]
 #[cfg_attr(feature = "async-graphql", graphql(name = "CandleInterval"))]
 pub enum CandleInterval {

--- a/indexer/clickhouse/src/entities/candle_query.rs
+++ b/indexer/clickhouse/src/entities/candle_query.rs
@@ -60,6 +60,7 @@ impl CandleQueryBuilder {
         self
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn fetch_all(
         &self,
         clickhouse_client: &clickhouse::Client,
@@ -91,6 +92,7 @@ impl CandleQueryBuilder {
         })
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn fetch_one(
         &self,
         clickhouse_client: &clickhouse::Client,
@@ -105,6 +107,7 @@ impl CandleQueryBuilder {
         Ok(cursor_query.fetch_optional().await?)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn get_max_block_height(
         &self,
         clickhouse_client: &clickhouse::Client,

--- a/indexer/clickhouse/src/entities/candle_query.rs
+++ b/indexer/clickhouse/src/entities/candle_query.rs
@@ -8,7 +8,7 @@ use {
     serde::Deserialize,
 };
 
-const MAX_ITEMS: usize = 100;
+pub const MAX_ITEMS: usize = 100;
 
 #[derive(Debug, Clone)]
 pub struct CandleResult {
@@ -60,7 +60,7 @@ impl CandleQueryBuilder {
         self
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn fetch_all(
         &self,
         clickhouse_client: &clickhouse::Client,
@@ -92,7 +92,7 @@ impl CandleQueryBuilder {
         })
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn fetch_one(
         &self,
         clickhouse_client: &clickhouse::Client,
@@ -107,7 +107,7 @@ impl CandleQueryBuilder {
         Ok(cursor_query.fetch_optional().await?)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn get_max_block_height(
         &self,
         clickhouse_client: &clickhouse::Client,

--- a/indexer/clickhouse/src/entities/pair_price.rs
+++ b/indexer/clickhouse/src/entities/pair_price.rs
@@ -95,6 +95,22 @@ impl PairPrice {
         Ok(clickhouse_client.query(query).fetch_all().await?)
     }
 
+    pub async fn all_pairs(clickhouse_client: &clickhouse::Client) -> Result<Vec<PairId>> {
+        let query = "SELECT DISTINCT quote_denom, base_denom FROM pair_prices";
+
+        let pairs: Vec<(String, String)> = clickhouse_client.query(query).fetch_all().await?;
+
+        pairs
+            .into_iter()
+            .map(|(quote_denom, base_denom)| {
+                Ok(PairId {
+                    quote_denom: Denom::from_str(&quote_denom)?,
+                    base_denom: Denom::from_str(&base_denom)?,
+                })
+            })
+            .collect()
+    }
+
     pub async fn cleanup_old_synthetic_data(
         clickhouse_client: &clickhouse::Client,
         current_block: u64,

--- a/indexer/clickhouse/src/entities/pair_price_query.rs
+++ b/indexer/clickhouse/src/entities/pair_price_query.rs
@@ -36,6 +36,7 @@ impl PairPriceQueryBuilder {
         self
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn fetch_all(
         &self,
         clickhouse_client: &clickhouse::Client,
@@ -61,6 +62,7 @@ impl PairPriceQueryBuilder {
         })
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn fetch_one(
         &self,
         clickhouse_client: &clickhouse::Client,

--- a/indexer/clickhouse/src/entities/pair_price_query.rs
+++ b/indexer/clickhouse/src/entities/pair_price_query.rs
@@ -36,7 +36,7 @@ impl PairPriceQueryBuilder {
         self
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn fetch_all(
         &self,
         clickhouse_client: &clickhouse::Client,
@@ -62,7 +62,7 @@ impl PairPriceQueryBuilder {
         })
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn fetch_one(
         &self,
         clickhouse_client: &clickhouse::Client,

--- a/indexer/clickhouse/src/error.rs
+++ b/indexer/clickhouse/src/error.rs
@@ -16,9 +16,6 @@ pub enum IndexerError {
 
     #[error(transparent)]
     GrugMathError(#[from] grug::MathError),
-
-    #[error("rwlock poisoned")]
-    RwLockPoisoned,
 }
 
 impl From<IndexerError> for grug_app::IndexerError {

--- a/indexer/clickhouse/src/error.rs
+++ b/indexer/clickhouse/src/error.rs
@@ -16,6 +16,9 @@ pub enum IndexerError {
 
     #[error(transparent)]
     GrugMathError(#[from] grug::MathError),
+
+    #[error("rwlock poisoned")]
+    RwLockPoisoned,
 }
 
 impl From<IndexerError> for grug_app::IndexerError {

--- a/indexer/clickhouse/src/httpd/graphql.rs
+++ b/indexer/clickhouse/src/httpd/graphql.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "metrics")]
 use indexer_httpd::graphql::extensions::metrics::{MetricsExtension, init_graphql_metrics};
-
 use {
     crate::{
         context::Context,

--- a/indexer/clickhouse/src/httpd/graphql.rs
+++ b/indexer/clickhouse/src/httpd/graphql.rs
@@ -1,12 +1,19 @@
 #[cfg(feature = "metrics")]
 use indexer_httpd::graphql::extensions::metrics::{MetricsExtension, init_graphql_metrics};
+
 use {
-    crate::context::Context,
+    crate::{
+        context::Context,
+        entities::{candle_query::MAX_ITEMS, pair_price::PairPrice},
+    },
     async_graphql::{
         EmptyMutation, EmptySubscription, Schema,
         extensions::{self as AsyncGraphqlExtensions},
     },
+    futures::StreamExt,
     indexer_httpd::graphql::telemetry::SentryExtension,
+    std::time::Duration,
+    tokio::time::sleep,
 };
 
 pub mod query;
@@ -38,4 +45,44 @@ pub fn build_schema(app_ctx: Context) -> AppSchema {
         .limit_complexity(300)
         .limit_depth(20)
         .finish()
+}
+
+/// Must be called to ensure the candle cache is updated
+pub async fn update_candle_cache(app_ctx: Context) {
+    loop {
+        if let Ok(mut subscription) = app_ctx.pubsub.subscribe_block_minted().await {
+            while let Some(block_height) = subscription.next().await {
+                // TODO: get pairs from dex contract
+                let pairs = PairPrice::all_pairs(app_ctx.clickhouse_client())
+                    .await
+                    .unwrap_or_default();
+
+                let mut candle_cache = app_ctx.candle_cache.write().await;
+                if let Err(_err) = candle_cache
+                    .update_pairs(app_ctx.clickhouse_client(), &pairs, block_height)
+                    .await
+                {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!(err = %_err,"Failed to update candle cache");
+                    continue;
+                }
+
+                candle_cache.compact_keep_n(MAX_ITEMS);
+
+                if let Err(_err) = app_ctx
+                    .candle_pubsub
+                    .publish_candles_cached(block_height)
+                    .await
+                {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!(err = %_err, "Failed to publish candles cached");
+                }
+            }
+        }
+
+        #[cfg(feature = "tracing")]
+        tracing::info!("Sleeping before next candle cache update");
+
+        sleep(Duration::from_millis(500)).await;
+    }
 }

--- a/indexer/clickhouse/src/httpd/graphql/query/candle.rs
+++ b/indexer/clickhouse/src/httpd/graphql/query/candle.rs
@@ -42,41 +42,36 @@ impl CandleQuery {
         let app_ctx = ctx.data::<Context>()?;
         let clickhouse_client = app_ctx.clickhouse_client();
 
-        let mut candle_cache = None;
-        let cache_key =
-            cache::CandleCacheKey::new(base_denom.clone(), quote_denom.clone(), interval);
-
-        // If no filters are provided, we can use cache. To avoid first queries to
-        // generate clickhouse queries, we use a write lock on the cache asap.
-        if after.is_none() && earlier_than.is_none() && later_than.is_none() {
-            candle_cache = Some(app_ctx.candle_cache.write().await);
-        }
-
         query_with::<OpaqueCursor<CandleCursor>, _, _, _, _>(
             after,
             None,
             first,
             None,
             |after, _, first, _| async move {
-                if after.is_none() && earlier_than.is_none() && later_than.is_none() {
-                    // We first check the cache for the last candle since this will
-                    // always match except at the start of the httpd process, avoid unnecessary
-                    // write lock.
-                    if let Some(cached_candles) = candle_cache
-                        .as_ref()
-                        .and_then(|c| c.get_candles(&cache_key))
-                    {
-                        let mut connection = Connection::new(false, true);
+                // Can use cache
+                if after.is_none() && first.is_none() {
+                    let candle_cache = app_ctx.candle_cache.read().await;
 
-                        connection.edges.extend(cached_candles.iter().map(|candle| {
-                            Edge::with_additional_fields(
-                                OpaqueCursor(candle.clone().into()),
-                                candle.clone(),
-                                EmptyFields,
-                            )
-                        }));
+                    let cache_key = cache::CandleCacheKey::new(
+                        base_denom.clone(),
+                        quote_denom.clone(),
+                        interval,
+                    );
 
-                        return Ok::<_, async_graphql::Error>(connection);
+                    if candle_cache.date_interval_available(&cache_key, earlier_than, later_than) {
+                        if let Some(cached_candles) = candle_cache.get_candles(&cache_key) {
+                            let mut connection = Connection::new(false, true);
+
+                            connection.edges.extend(cached_candles.iter().map(|candle| {
+                                Edge::with_additional_fields(
+                                    OpaqueCursor(candle.clone().into()),
+                                    candle.clone(),
+                                    EmptyFields,
+                                )
+                            }));
+
+                            return Ok::<_, async_graphql::Error>(connection);
+                        }
                     }
                 }
 

--- a/indexer/clickhouse/src/httpd/graphql/query/candle.rs
+++ b/indexer/clickhouse/src/httpd/graphql/query/candle.rs
@@ -90,15 +90,11 @@ impl CandleQuery {
                     query_builder = query_builder.with_limit(first);
                 }
 
-                if let Some(after) = after.as_ref() {
+                if let Some(after) = after {
                     query_builder = query_builder.with_after(after.time_start);
                 }
 
                 let result = query_builder.fetch_all(clickhouse_client).await?;
-
-                // if after.is_none() && earlier_than.is_none() && later_than.is_none() {
-                //     candle_cache.map(|mut c| c.add_candles(cache_key, &result.candles));
-                // }
 
                 let mut connection =
                     Connection::new(result.has_previous_page, result.has_next_page);

--- a/indexer/clickhouse/src/httpd/graphql/subscription/candle.rs
+++ b/indexer/clickhouse/src/httpd/graphql/subscription/candle.rs
@@ -13,8 +13,7 @@ pub struct CandleSubscription;
 
 #[Subscription]
 impl CandleSubscription {
-    /// Get candles for a given base and quote denom, interval, and later than time.
-    /// If `later_than` is provided, it will be used to filter the candles returned.
+    /// Get candles for a given base and quote denom, interval
     async fn candles<'a>(
         &self,
         ctx: &async_graphql::Context<'a>,

--- a/indexer/clickhouse/src/indexer.rs
+++ b/indexer/clickhouse/src/indexer.rs
@@ -167,8 +167,35 @@ impl Drop for Indexer {
 }
 #[cfg(feature = "metrics")]
 pub fn init_metrics() {
+    use metrics::{describe_counter, describe_gauge};
+
     describe_histogram!(
         "indexer.clickhouse.post_indexing.duration",
         "Post indexing duration in seconds"
+    );
+
+    describe_counter!(
+        "indexer.clickhouse.candles.cache.hits",
+        "Number of candle cache hits"
+    );
+
+    describe_counter!(
+        "indexer.clickhouse.candles.cache.misses",
+        "Number of candle cache misses"
+    );
+
+    describe_histogram!(
+        "indexer.clickhouse.candles.cache.lookup.duration.seconds",
+        "Time spent on cache lookups"
+    );
+
+    describe_gauge!(
+        "indexer.clickhouse.candles.cache.size.entries",
+        "Current number of keys in cache"
+    );
+
+    describe_gauge!(
+        "indexer.clickhouse.candles.cache.size.candles",
+        "Total number of candles in cache"
     );
 }

--- a/indexer/clickhouse/src/lib.rs
+++ b/indexer/clickhouse/src/lib.rs
@@ -7,5 +7,6 @@ pub mod error;
 pub mod httpd;
 pub mod indexer;
 pub mod migrations;
+pub mod pubsub;
 
 pub use indexer::Indexer;

--- a/indexer/clickhouse/src/lib.rs
+++ b/indexer/clickhouse/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod candles;
 pub mod context;
 pub mod entities;

--- a/indexer/clickhouse/src/pubsub.rs
+++ b/indexer/clickhouse/src/pubsub.rs
@@ -1,0 +1,17 @@
+pub mod memory;
+
+pub use memory::MemoryPubSub;
+
+use {crate::error::Result, async_trait::async_trait, std::pin::Pin, tokio_stream::Stream};
+#[async_trait]
+pub trait PubSub {
+    async fn subscribe_candles_cached(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = u64> + Send + '_>>>;
+
+    async fn publish_candles_cached(&self, block_height: u64) -> Result<usize>;
+}
+
+pub enum PubSubType {
+    Memory,
+}

--- a/indexer/clickhouse/src/pubsub.rs
+++ b/indexer/clickhouse/src/pubsub.rs
@@ -1,8 +1,8 @@
 pub mod memory;
 
 pub use memory::MemoryPubSub;
-
 use {crate::error::Result, async_trait::async_trait, std::pin::Pin, tokio_stream::Stream};
+
 #[async_trait]
 pub trait PubSub {
     async fn subscribe_candles_cached(

--- a/indexer/clickhouse/src/pubsub/memory.rs
+++ b/indexer/clickhouse/src/pubsub/memory.rs
@@ -1,0 +1,39 @@
+use {
+    crate::{error::Result, pubsub::PubSub},
+    async_trait::async_trait,
+    std::pin::Pin,
+    tokio::sync::broadcast,
+    tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream},
+};
+
+/// In-memory pubsub implementation.
+pub struct MemoryPubSub {
+    pub sender: broadcast::Sender<u64>,
+}
+
+impl MemoryPubSub {
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+
+        Self { sender }
+    }
+}
+
+#[async_trait]
+impl PubSub for MemoryPubSub {
+    async fn subscribe_candles_cached(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = u64> + Send + '_>>> {
+        let rx = self.sender.subscribe();
+
+        Ok(Box::pin(
+            BroadcastStream::new(rx).filter_map(|res| res.ok()),
+        ))
+    }
+
+    async fn publish_candles_cached(&self, block_height: u64) -> Result<usize> {
+        // NOTE: Discarding the error as it happens if no receivers are connected.
+        // There is no way to know if there are any receivers connected without RACE conditions.
+        Ok(self.sender.send(block_height).unwrap_or_default())
+    }
+}

--- a/indexer/client/src/schemas/schema.graphql
+++ b/indexer/client/src/schemas/schema.graphql
@@ -601,13 +601,9 @@ type Subscription {
 	messages(sinceBlockHeight: Int): [Message!]!
 	events(sinceBlockHeight: Int, filter: [Filter!]): [Event!]!
 	"""
-	Get candles for a given base and quote denom, interval, and later than time.
-	If `limit` is provided, it will be used to limit the number of candles returned.
-	If `limit` is not provided, it will default to MAX_PAST_CANDLES.
-	If `limit` is greater than MAX_PAST_CANDLES, it will be set to MAX_PAST_CANDLES.
-	If `later_than` is provided, it will be used to filter the candles returned.
+	Get candles for a given base and quote denom, interval
 	"""
-	candles(baseDenom: String!, quoteDenom: String!, interval: CandleInterval!, laterThan: DateTime, limit: Int): [Candle!]!
+	candles(baseDenom: String!, quoteDenom: String!, interval: CandleInterval!, laterThan: DateTime @deprecated, limit: Int @deprecated): [Candle!]!
 }
 
 type Transaction {

--- a/indexer/httpd/src/graphql/extensions/metrics.rs
+++ b/indexer/httpd/src/graphql/extensions/metrics.rs
@@ -5,7 +5,7 @@ use {
             Extension, ExtensionContext, ExtensionFactory, NextExecute, NextResolve, ResolveInfo,
         },
     },
-    metrics::{counter, describe_counter, describe_histogram, histogram},
+    metrics::{counter, describe_counter, describe_gauge, describe_histogram, histogram},
     std::{sync::Arc, time::Instant},
 };
 
@@ -131,5 +131,9 @@ pub fn init_graphql_metrics() {
     describe_histogram!(
         "graphql.field.duration",
         "GraphQL field resolution duration in seconds"
+    );
+    describe_gauge!(
+        "graphql.subscriptions.active",
+        "Number of active GraphQL subscriptions"
     );
 }

--- a/indexer/httpd/src/graphql/subscription/block.rs
+++ b/indexer/httpd/src/graphql/subscription/block.rs
@@ -4,6 +4,8 @@ use {
     indexer_sql::entity,
     sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder},
 };
+#[cfg(feature = "metrics")]
+use {grug_httpd::metrics::GaugeGuard, std::sync::Arc};
 
 #[derive(Default)]
 pub struct BlockSubscription;
@@ -21,21 +23,42 @@ impl BlockSubscription {
             .one(&app_ctx.db)
             .await?;
 
-        Ok(once(async { last_block })
-            .chain(app_ctx.pubsub.subscribe_block_minted().await?.then(
-                move |block_height| async move {
-                    entity::blocks::Entity::find()
-                        .filter(entity::blocks::Column::BlockHeight.eq(block_height as i64))
-                        .one(&app_ctx.db)
-                        .await
-                        .inspect_err(|_e| {
-                            #[cfg(feature = "tracing")]
-                            tracing::error!(%_e, "Block error");
-                        })
-                        .ok()
-                        .unwrap_or_default()
-                },
-            ))
-            .filter_map(|block| async { block }))
+        #[cfg(feature = "metrics")]
+        let gauge_guard = Arc::new(GaugeGuard::new(
+            "graphql.subscriptions.active",
+            "block",
+            "subscription",
+        ));
+
+        Ok(once({
+            #[cfg(feature = "metrics")]
+            let _guard = gauge_guard.clone();
+
+            async { last_block }
+        })
+        .chain(
+            app_ctx
+                .pubsub
+                .subscribe_block_minted()
+                .await?
+                .then(move |block_height| {
+                    #[cfg(feature = "metrics")]
+                    let _guard = gauge_guard.clone();
+
+                    async move {
+                        entity::blocks::Entity::find()
+                            .filter(entity::blocks::Column::BlockHeight.eq(block_height as i64))
+                            .one(&app_ctx.db)
+                            .await
+                            .inspect_err(|_e| {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!(%_e, "Block error");
+                            })
+                            .ok()
+                            .unwrap_or_default()
+                    }
+                }),
+        )
+        .filter_map(|block| async { block }))
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add caching for candle subscriptions with GraphQL integration and metrics tracking.
> 
>   - **Caching**:
>     - Introduces `CandleCache` in `cache.rs` to store and manage candle data.
>     - Adds methods to `CandleCache` for adding, retrieving, and updating candles.
>     - Integrates caching with GraphQL queries in `graphql/query/candle.rs` and `graphql/subscription/candle.rs`.
>   - **GraphQL Changes**:
>     - Updates `graphql.rs` to include caching logic in candle queries and subscriptions.
>     - Modifies GraphQL schema in `schema.graphql` to support new caching features.
>   - **Metrics**:
>     - Adds `GaugeGuard` in `metrics.rs` to track active subscriptions.
>     - Introduces metrics for cache hits, misses, and lookup durations in `indexer.rs` and `metrics.rs`.
>   - **Pub-Sub Integration**:
>     - Implements `MemoryPubSub` in `pubsub/memory.rs` for in-memory pub-sub functionality.
>     - Updates `context.rs` to use `MemoryPubSub` for candle cache updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 76edb867f68907658798b4cf5a01dd2297598e63. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->