### PR TITLE
feat(ci): faucet pipeline support testnet environment

### DIFF
--- a/.github/workflows/faucet.yml
+++ b/.github/workflows/faucet.yml
@@ -8,9 +8,17 @@ on:
   workflow_dispatch:
     inputs:
       faucet_version:
-        required: false
+        required: true
         description: "Define faucet version for deployment"
         default: "latest"
+      environment:
+        required: true
+        type: choice
+        description: "Define in what environment deploy"
+        default: "devnet"
+        options:
+          - "devnet"
+          - "testnet"
 
 jobs:
   deploy-faucet:
@@ -43,8 +51,18 @@ jobs:
         run: |
           pipx ensurepath
           ansible-galaxy collection install -r deploy/requirements.yml
+
+      - name: Set target IP
+        id: set_ip
+        run: |
+          if [ "${{ github.event.inputs.environment }}" = "devnet" ]; then
+            echo "SERVER_IP=100.96.253.40" >> $GITHUB_ENV
+          elif [ "${{ github.event.inputs.environment }}" = "testnet" ]; then
+            echo "SERVER_IP=100.107.248.71" >> $GITHUB_ENV
+          fi
+
       - name: Run Ansible playbook
         run: |
           cd deploy
           pipx ensurepath
-          ansible-playbook bots.yml --limit 100.96.253.40 -e '{"dango_networks":["devnet"]}' -e faucet_version=${{ github.event.inputs.faucet_version }}
+          ansible-playbook bots.yml --limit ${{ env.SERVER_IP }} -e '{"dango_networks":["${{ github.event.inputs.environment }}"]}' -e faucet_version=${{ github.event.inputs.faucet_version }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for testnet environment in faucet bot GitHub Actions workflow by setting server IP and updating Ansible playbook command.
> 
>   - **Inputs**:
>     - Adds `environment` input to `.github/workflows/faucet.yml` with options `devnet` and `testnet`.
>     - Makes `faucet_version` input required.
>   - **Environment Setup**:
>     - Sets `SERVER_IP` in `.github/workflows/faucet.yml` based on `environment` input.
>       - `devnet`: `100.96.253.40`
>       - `testnet`: `100.107.248.71`
>   - **Ansible Playbook**:
>     - Updates `ansible-playbook` command in `.github/workflows/faucet.yml` to use `SERVER_IP` and `environment` input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 03fea8b81908d68778f323a2bbd8d01e763f00d4. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->