### PR TITLE
feat(ui): subscription with operationName

### DIFF
--- a/sdk/dango/src/actions/indexer/subscriptions/account.ts
+++ b/sdk/dango/src/actions/indexer/subscriptions/account.ts
@@ -35,7 +35,7 @@ export function accountSubscription<
   const { username, sinceBlockHeight, ...callbacks } = parameters;
 
   const query = /* GraphQL */ `
-    subscription ($username: String, $sinceBlockHeight: Int) {
+    subscription AccountsSubscription ($username: String, $sinceBlockHeight: Int) {
       accounts(username: $username, sinceBlockHeight: $sinceBlockHeight) {
         accountIndex
         address
@@ -46,8 +46,5 @@ export function accountSubscription<
     }
   `;
 
-  return client.subscribe(
-    { query, variables: { username, sinceBlockHeight }, operationName: "accounts" },
-    callbacks,
-  );
+  return client.subscribe({ query, variables: { username, sinceBlockHeight } }, callbacks);
 }

--- a/sdk/dango/src/actions/indexer/subscriptions/block.ts
+++ b/sdk/dango/src/actions/indexer/subscriptions/block.ts
@@ -29,7 +29,7 @@ export function blockSubscription<
   if (!client.subscribe) throw new Error("error: client does not support subscriptions");
 
   const query = /* GraphQL */ `
-    subscription {
+    subscription BlockSubscription {
       block {
         blockHeight
         createdAt
@@ -40,5 +40,5 @@ export function blockSubscription<
     }
   `;
 
-  return client.subscribe({ query, operationName: "block" }, parameters);
+  return client.subscribe({ query }, parameters);
 }

--- a/sdk/dango/src/actions/indexer/subscriptions/candles.ts
+++ b/sdk/dango/src/actions/indexer/subscriptions/candles.ts
@@ -37,7 +37,7 @@ export function candlesSubscription<
   const { baseDenom, quoteDenom, interval, ...callbacks } = parameters;
 
   const query = /* GraphQL */ `
-    subscription (
+    subscription CandlesSubscription (
       $baseDenom: String!
       $quoteDenom: String!
       $interval: CandleInterval!
@@ -64,8 +64,5 @@ export function candlesSubscription<
       }
     }
   `;
-  return client.subscribe(
-    { query, variables: { baseDenom, quoteDenom, interval }, operationName: "candles" },
-    callbacks,
-  );
+  return client.subscribe({ query, variables: { baseDenom, quoteDenom, interval } }, callbacks);
 }

--- a/sdk/dango/src/actions/indexer/subscriptions/transfer.ts
+++ b/sdk/dango/src/actions/indexer/subscriptions/transfer.ts
@@ -34,7 +34,7 @@ export function transferSubscription<
   const { username, sinceBlockHeight, ...callbacks } = parameters;
 
   const query = /* GraphQL */ `
-    subscription ($username: String, $sinceBlockHeight: Int) {
+    subscription TransferSubscription ($username: String, $sinceBlockHeight: Int) {
       transfers(username: $username, sinceBlockHeight: $sinceBlockHeight) {
         id
         txHash
@@ -48,8 +48,5 @@ export function transferSubscription<
     }
   `;
 
-  return client.subscribe(
-    { query, variables: { username, sinceBlockHeight }, operationName: "transfers" },
-    callbacks,
-  );
+  return client.subscribe({ query, variables: { username, sinceBlockHeight } }, callbacks);
 }

--- a/sdk/grug/src/types/transports.ts
+++ b/sdk/grug/src/types/transports.ts
@@ -57,11 +57,7 @@ export type RequestFn<transportSchema extends TransportSchema | undefined = unde
 ) => Promise<_returnType>;
 
 export type SubscribeFn = <T>(
-  {
-    query,
-    operationName,
-    variables,
-  }: { query: string; operationName: string; variables?: Record<string, unknown> },
+  { query, variables }: { query: string; variables?: Record<string, unknown> },
   callback: SubscriptionCallbacks<T>,
 ) => () => void;
 

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -4,7 +4,6 @@ import {
   Badge,
   Cell,
   IconChevronDownFill,
-  IconEmptyStar,
   Table,
   Tabs,
   createContext,
@@ -13,7 +12,7 @@ import {
   useMediaQuery,
 } from "@left-curve/applets-kit";
 import type { OrderId, OrdersByUserResponse, PairId } from "@left-curve/dango/types";
-import { Decimal, formatNumber, formatUnits } from "@left-curve/dango/utils";
+import { Decimal, formatNumber } from "@left-curve/dango/utils";
 import { useAppConfig, useConfig, usePrices, useProTradeState } from "@left-curve/store";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
@@ -218,7 +217,7 @@ const ProTradeOrders: React.FC = () => {
 
     {
       header: m["dex.protrade.spot.ordersTable.type"](),
-      cell: ({ row }) => <Cell.Text text="Limit" />,
+      cell: (_) => <Cell.Text text="Limit" />,
     },
     {
       header: m["dex.protrade.spot.ordersTable.pair"](),
@@ -256,9 +255,14 @@ const ProTradeOrders: React.FC = () => {
       cell: ({ row }) => (
         <Cell.Number
           formatOptions={formatNumberOptions}
-          value={formatUnits(
-            row.original.remaining,
-            coins.byDenom[row.original.baseDenom].decimals,
+          value={formatNumber(
+            Decimal(row.original.remaining)
+              .div(Decimal(10).pow(coins.byDenom[row.original.baseDenom].decimals))
+              .toFixed(),
+            {
+              ...formatNumberOptions,
+              maxSignificantDigits: 10,
+            },
           )}
         />
       ),
@@ -272,7 +276,15 @@ const ProTradeOrders: React.FC = () => {
       cell: ({ row }) => (
         <Cell.Number
           formatOptions={formatNumberOptions}
-          value={formatUnits(row.original.amount, coins.byDenom[row.original.baseDenom].decimals)}
+          value={formatNumber(
+            Decimal(row.original.amount)
+              .div(Decimal(10).pow(coins.byDenom[row.original.baseDenom].decimals))
+              .toFixed(),
+            {
+              ...formatNumberOptions,
+              maxSignificantDigits: 10,
+            },
+          )}
         />
       ),
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add operation names to GraphQL subscriptions and remove `operationName` parameter from `subscribe` calls, with minor UI updates in `ProTrade.tsx`.
> 
>   - **GraphQL Subscriptions**:
>     - Add operation names to GraphQL subscription queries in `account.ts`, `block.ts`, `candles.ts`, and `transfer.ts`.
>     - Remove `operationName` parameter from `client.subscribe` calls in the same files.
>   - **Type Changes**:
>     - Update `SubscribeFn` type in `transports.ts` to remove `operationName` parameter.
>   - **UI Changes**:
>     - Remove unused import `IconEmptyStar` from `ProTrade.tsx`.
>     - Replace `formatUnits` with `formatNumber` for number formatting in `ProTradeOrders` component in `ProTrade.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 146ba6eb954641b7540bf2ef02a15c8a881d55e2. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->