### PR TITLE
Faster clickhouse queries

### DIFF
--- a/dango/testing/tests/indexing/candles.rs
+++ b/dango/testing/tests/indexing/candles.rs
@@ -131,7 +131,7 @@ async fn index_candles_with_real_clickhouse() -> anyhow::Result<()> {
     suite.app.indexer.wait_for_finish()?;
 
     let pair_price_query_builder =
-        PairPriceQueryBuilder::new("dango".to_string(), "bridge/usdc".to_string());
+        PairPriceQueryBuilder::new("dango".to_string(), "bridge/usdc".to_string()).with_limit(1);
 
     let pair_price = pair_price_query_builder
         .fetch_one(clickhouse_context.clickhouse_client())
@@ -154,7 +154,8 @@ async fn index_candles_with_real_clickhouse() -> anyhow::Result<()> {
         CandleInterval::OneMinute,
         "dango".to_string(),
         "bridge/usdc".to_string(),
-    );
+    )
+    .with_limit(1);
 
     let candle_1m = candle_query_builder
         .fetch_one(clickhouse_context.clickhouse_client())
@@ -716,7 +717,7 @@ async fn index_pair_prices_with_small_amounts() -> anyhow::Result<()> {
     suite.app.indexer.wait_for_finish()?;
 
     let pair_price_query_builder =
-        PairPriceQueryBuilder::new("dango".to_string(), "bridge/usdc".to_string());
+        PairPriceQueryBuilder::new("dango".to_string(), "bridge/usdc".to_string()).with_limit(1);
 
     let pair_price = pair_price_query_builder
         .fetch_one(clickhouse_context.clickhouse_client())

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -133,7 +133,8 @@ impl CandleCache {
                             key.interval,
                             key.base_denom.clone(),
                             key.quote_denom.clone(),
-                        );
+                        )
+                        .with_limit(1);
 
                         let candle = query_builder.fetch_one(clickhouse_client).await?;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize Clickhouse queries by adding `with_limit(1)` to limit results in `candles.rs` and `cache.rs`.
> 
>   - **Behavior**:
>     - Add `with_limit(1)` to `PairPriceQueryBuilder` and `CandleQueryBuilder` in `candles.rs` and `cache.rs` to limit query results to 1.
>   - **Tests**:
>     - Update `index_candles_with_real_clickhouse` and `index_pair_prices_with_small_amounts` in `candles.rs` to use `with_limit(1)` for queries.
>   - **Misc**:
>     - Minor refactoring in `cache.rs` to use `with_limit(1)` in `update_pairs()` and `preload_pairs()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 41a2027cf419d8ea7944801e3ff51c5b0687b9f9. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->