### PR TITLE
fix(ui):  chartiq drawing and click away

### DIFF
--- a/ui/portal/web/biome.json
+++ b/ui/portal/web/biome.json
@@ -5,6 +5,7 @@
   "linter": {
     "rules": {
       "a11y": {
+        "noStaticElementInteractions": "off",
         "noSvgWithoutTitle": "off",
         "useKeyWithClickEvents": "off"
       }

--- a/ui/portal/web/chartiq.config.ts
+++ b/ui/portal/web/chartiq.config.ts
@@ -70,14 +70,17 @@ export function createChartIQDataFeed(parameters: CreateChartIQDataFeedParameter
       timeUnit: timeUnit,
     });
 
+    const date = new Date(endDate);
+    date.setMilliseconds(0);
+
     const { nodes } = await queryClient.fetchQuery({
-      queryKey: ["candles", pairSymbol, endDate.toJSON(), candleInterval],
+      queryKey: ["candles", pairSymbol, date.toJSON(), candleInterval],
       queryFn: () =>
         client.queryCandles({
           baseDenom: baseCoin.denom,
           quoteDenom: quoteCoin.denom,
           interval: candleInterval,
-          earlierThan: endDate.toJSON(),
+          earlierThan: date.toJSON(),
         }),
     });
 
@@ -257,14 +260,23 @@ export function createChartIQConfig(params: CreateChartIQConfigParameters) {
       whitespace: 0,
     },
     // @ts-ignore
+    layout: {
+      periodicity: 1,
+      interval: 5,
+      timeUnit: "minute",
+    },
+    // @ts-ignore
     chart: {
+      layout: {
+        periodicity: 1,
+        interval: 1,
+        timeUnit: "minute",
+      },
       yAxis: {
         position: "right",
       },
     },
   };
-
-  config.chartEngineParams;
 
   config.quoteFeeds = [
     {

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -2,26 +2,18 @@ import { useMediaQuery } from "@left-curve/applets-kit";
 import { useEffect, useState } from "react";
 
 import { IconLink, ResizerContainer, Tabs, twMerge } from "@left-curve/applets-kit";
-import { ChartIQ } from "../foundation/ChartIQ";
 
 import { m } from "~/paraglide/messages";
 
 import { mockTrades } from "~/mock";
 import { type OrderBookRow, mockOrderBookData } from "~/mock";
 
-import type { useProTradeState } from "@left-curve/store";
 import type React from "react";
 
-type OrderBookOverviewProps = {
-  state: ReturnType<typeof useProTradeState>;
-};
-
-export const OrderBookOverview: React.FC<OrderBookOverviewProps> = ({ state }) => {
+export const OrderBookOverview: React.FC = () => {
   const [activeTab, setActiveTab] = useState<"order book" | "trades" | "graph">("graph");
 
   const { isLg } = useMediaQuery();
-
-  const { baseCoin, quoteCoin } = state;
 
   useEffect(() => {
     setActiveTab(isLg ? "order book" : "graph");
@@ -41,7 +33,7 @@ export const OrderBookOverview: React.FC<OrderBookOverviewProps> = ({ state }) =
         onTabChange={(tab) => setActiveTab(tab as "order book" | "trades")}
         classNames={{ button: "exposure-xs-italic" }}
       />
-      {activeTab === "graph" && <ChartIQ coins={{ base: baseCoin, quote: quoteCoin }} />}
+      <div id="chartiq-container" className={twMerge({ hidden: activeTab !== "graph" })} />
       {(activeTab === "trades" || activeTab === "order book") && (
         <div className="relative w-full h-full">
           {activeTab === "order book" && <OrderBook />}

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -1,4 +1,19 @@
-import type { TableColumn } from "@left-curve/applets-kit";
+import {
+  createContext,
+  twMerge,
+  useInputs,
+  useMediaQuery,
+  usePortalTarget,
+} from "@left-curve/applets-kit";
+import { useEffect, useMemo, useState } from "react";
+import { useAppConfig, useConfig, usePrices, useProTradeState } from "@left-curve/store";
+import { useNavigate } from "@tanstack/react-router";
+import { useApp } from "~/hooks/useApp";
+
+import { m } from "~/paraglide/messages";
+import { createPortal } from "react-dom";
+import { Decimal, formatNumber } from "@left-curve/dango/utils";
+
 import {
   AddressVisualizer,
   Badge,
@@ -6,20 +21,8 @@ import {
   IconChevronDownFill,
   Table,
   Tabs,
-  createContext,
-  twMerge,
-  useInputs,
-  useMediaQuery,
 } from "@left-curve/applets-kit";
-import type { OrderId, OrdersByUserResponse, PairId } from "@left-curve/dango/types";
-import { Decimal, formatNumber } from "@left-curve/dango/utils";
-import { useAppConfig, useConfig, usePrices, useProTradeState } from "@left-curve/store";
-import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import type { PropsWithChildren } from "react";
-import { useEffect, useState } from "react";
-import { useApp } from "~/hooks/useApp";
-import { m } from "~/paraglide/messages";
 import { ChartIQ } from "../foundation/ChartIQ";
 import { EmptyPlaceholder } from "../foundation/EmptyPlaceholder";
 import { Modals } from "../modals/RootModal";
@@ -27,6 +30,10 @@ import { OrderBookOverview } from "./OrderBookOverview";
 import { SearchToken } from "./SearchToken";
 import { TradeButtons } from "./TradeButtons";
 import { TradeMenu } from "./TradeMenu";
+
+import type { PropsWithChildren } from "react";
+import type { TableColumn } from "@left-curve/applets-kit";
+import type { OrderId, OrdersByUserResponse, PairId } from "@left-curve/dango/types";
 
 const [ProTradeProvider, useProTrade] = createContext<{
   state: ReturnType<typeof useProTradeState>;
@@ -156,8 +163,7 @@ const ProTradeHeader: React.FC = () => {
 };
 
 const ProTradeOverview: React.FC = () => {
-  const { state } = useProTrade();
-  return <OrderBookOverview state={state} />;
+  return <OrderBookOverview />;
 };
 
 const ProTradeChart: React.FC = () => {
@@ -165,18 +171,22 @@ const ProTradeChart: React.FC = () => {
   const { isLg } = useMediaQuery();
   const { baseCoin, quoteCoin } = state;
 
-  if (!isLg) return null;
+  const chartComponent = useMemo(
+    () => <ChartIQ coins={{ base: baseCoin, quote: quoteCoin }} />,
+    [baseCoin, quoteCoin],
+  );
+
+  const mobileContainer = usePortalTarget("#chartiq-container");
 
   return (
-    <div className="shadow-account-card bg-surface-secondary-rice h-full">
-      <ChartIQ coins={{ base: baseCoin, quote: quoteCoin }} />
-    </div>
+    <>{isLg || !mobileContainer ? chartComponent : createPortal(chartComponent, mobileContainer)}</>
   );
 };
 
 const ProTradeMenu: React.FC = () => {
   const { isLg } = useMediaQuery();
   const { state, controllers } = useProTrade();
+
   return (
     <>
       <TradeMenu state={state} controllers={controllers} />

--- a/ui/portal/web/src/components/foundation/ChartIQ.tsx
+++ b/ui/portal/web/src/components/foundation/ChartIQ.tsx
@@ -86,8 +86,6 @@ export const ChartIQ: React.FC<ChartIQProps> = ({ coins }) => {
         { "Up Volume": volumeColor.up, "Down Volume": volumeColor.down },
       );
 
-      stx.setPeriodicity(5, "minute", 0, true);
-
       stx.candleWidthPercent = 0.9;
       stx.chart.yAxis.zoom = -0.0000001;
       stx.chart.maxTicks = 40;

--- a/ui/portal/web/src/components/foundation/ChartIQ.tsx
+++ b/ui/portal/web/src/components/foundation/ChartIQ.tsx
@@ -8,7 +8,7 @@ import "@left-curve/chartiq/js/addOns";
 import { useMediaQuery, useTheme } from "@left-curve/applets-kit";
 import { CIQ } from "@left-curve/chartiq/js/components";
 import { useConfig, usePublicClient } from "@left-curve/store";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { createChartIQConfig, createChartIQDataFeed } from "~/chartiq";
 import { useApp } from "~/hooks/useApp";
 
@@ -19,23 +19,33 @@ import "@left-curve/chartiq/css/stx-chart.css";
 import "@left-curve/chartiq/css/chartiq.css";
 import "@left-curve/chartiq/css/webcomponents.css";
 
-export const ChartIQ = ({ coins }) => {
+import { useQueryClient } from "@tanstack/react-query";
+
+type ChartIQProps = {
+  coins: { base: AnyCoin; quote: AnyCoin };
+};
+
+export const ChartIQ: React.FC<ChartIQProps> = ({ coins }) => {
   const uiContextRef = useRef<CIQ.UI.Context | null>(null);
   const container = useRef<HTMLElement | null>(null);
   const isMounted = useRef(false);
   const { isMd } = useMediaQuery();
 
   const publicClient = usePublicClient();
+  const queryClient = useQueryClient();
   const { subscriptions } = useApp();
   const { coins: allCoins } = useConfig();
 
-  const { current: dataFeed } = useRef(
-    createChartIQDataFeed({
-      client: publicClient,
-      subscriptions,
-      updateChartData: (params) => uiContextRef.current?.stx?.updateChartData(params),
-      coins: allCoins.bySymbol,
-    }),
+  const dataFeed = useMemo(
+    () =>
+      createChartIQDataFeed({
+        client: publicClient,
+        queryClient,
+        subscriptions,
+        updateChartData: (params) => uiContextRef.current?.stx?.updateChartData(params),
+        coins: allCoins.bySymbol,
+      }),
+    [allCoins, queryClient, publicClient],
   );
 
   const { theme } = useTheme();
@@ -144,25 +154,25 @@ export const ChartIQ = ({ coins }) => {
             text=""
             binding="Layout.periodicity"
           />
-          <cq-menu
-            class="nav-dropdown ciq-views alignright-md alignright-sm"
-            config="views"
-            text="Views"
-            icon="views"
-            responsive=""
-            tooltip="Views"
-          />
-          <cq-menu
-            class="nav-dropdown ciq-studies alignright"
-            cq-focus="input"
-            config="studies"
-            text="Studies"
-            icon="studies"
-            responsive=""
-            tooltip="Studies"
-          />
           <div className="ciq-menu-section">
             <div className="ciq-dropdowns">
+              <cq-menu
+                class="nav-dropdown ciq-views alignright-md alignright-sm"
+                config="views"
+                text="Views"
+                icon="views"
+                responsive=""
+                tooltip="Views"
+              />
+              <cq-menu
+                class="nav-dropdown ciq-studies alignright"
+                cq-focus="input"
+                config="studies"
+                text="Studies"
+                icon="studies"
+                responsive=""
+                tooltip="Studies"
+              />
               <cq-menu
                 class="nav-dropdown ciq-preferences alignright"
                 reader="Preferences"
@@ -185,14 +195,6 @@ export const ChartIQ = ({ coins }) => {
                   min-height="300"
                   cq-drawing-edit="none"
                   cq-keystroke-claim=""
-                />
-                <cq-drawing-settings
-                  class="palette-settings"
-                  docked="true"
-                  hide="true"
-                  orientation="horizontal"
-                  min-height="40"
-                  cq-drawing-edit="none"
                 />
               </div>
             </cq-palette-dock>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances ChartIQ integration with query client support and UI updates in ProTrade and OrderBookOverview components.
> 
>   - **ChartIQ Integration**:
>     - Added `queryClient` to `createChartIQDataFeed` in `chartiq.config.ts` for data fetching.
>     - Introduced `createChartIQUIOverride` in `chartiq.config.ts` to customize chart UI components.
>     - Updated `ChartIQ` component in `ChartIQ.tsx` to use `useMemo` for `dataFeed` and handle `queryClient`.
>   - **ProTrade Component**:
>     - Modified `ProTradeChart` in `ProTrade.tsx` to use `createPortal` for rendering `ChartIQ` in mobile view.
>     - Removed `state` prop from `OrderBookOverview` in `ProTrade.tsx`.
>   - **OrderBookOverview Component**:
>     - Removed `ChartIQ` import and usage in `OrderBookOverview.tsx`.
>     - Added `chartiq-container` div for dynamic chart rendering.
>   - **Miscellaneous**:
>     - Disabled `noStaticElementInteractions` rule in `biome.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 4a961d8c3a390826ca4cf75bbe913bee83e31e9a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->