### PR TITLE
feat(ui): show orders in chart

### DIFF
--- a/ui/portal/web/chartiq.config.ts
+++ b/ui/portal/web/chartiq.config.ts
@@ -70,17 +70,16 @@ export function createChartIQDataFeed(parameters: CreateChartIQDataFeedParameter
       timeUnit: timeUnit,
     });
 
-    const date = new Date(endDate);
-    date.setMilliseconds(0);
+    const date = endDate.toJSON();
 
     const { nodes } = await queryClient.fetchQuery({
-      queryKey: ["candles", pairSymbol, date.toJSON(), candleInterval],
+      queryKey: ["candles", pairSymbol, date, candleInterval],
       queryFn: () =>
         client.queryCandles({
           baseDenom: baseCoin.denom,
           quoteDenom: quoteCoin.denom,
           interval: candleInterval,
-          earlierThan: date.toJSON(),
+          earlierThan: date,
         }),
     });
 
@@ -124,16 +123,16 @@ export function createChartIQDataFeed(parameters: CreateChartIQDataFeedParameter
       DT: new Date(candle.timeStart),
       Open: +Decimal(candle.open)
         .times(Decimal(10).pow(baseCoin.decimals - quoteCoin.decimals))
-        .toFixed(),
+        .toFixed(5),
       High: +Decimal(candle.high)
         .times(Decimal(10).pow(baseCoin.decimals - quoteCoin.decimals))
-        .toFixed(),
+        .toFixed(5),
       Low: +Decimal(candle.low)
         .times(Decimal(10).pow(baseCoin.decimals - quoteCoin.decimals))
-        .toFixed(),
+        .toFixed(5),
       Close: +Decimal(candle.close)
         .times(Decimal(10).pow(baseCoin.decimals - quoteCoin.decimals))
-        .toFixed(),
+        .toFixed(5),
     }));
   }
 

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -169,11 +169,11 @@ const ProTradeOverview: React.FC = () => {
 const ProTradeChart: React.FC = () => {
   const { state } = useProTrade();
   const { isLg } = useMediaQuery();
-  const { baseCoin, quoteCoin } = state;
+  const { baseCoin, quoteCoin, orders } = state;
 
   const chartComponent = useMemo(
-    () => <ChartIQ coins={{ base: baseCoin, quote: quoteCoin }} />,
-    [baseCoin, quoteCoin],
+    () => <ChartIQ coins={{ base: baseCoin, quote: quoteCoin }} orders={orders.data} />,
+    [baseCoin, quoteCoin, orders],
   );
 
   const mobileContainer = usePortalTarget("#chartiq-container");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `ChartIQ` to display user orders on the chart in `ProTrade` by drawing horizontal lines and labels for each order.
> 
>   - **Behavior**:
>     - `ChartIQ` component now displays user orders as horizontal lines with labels, using order price and direction.
>     - `ProTradeChart` in `ProTrade.tsx` passes `orders.data` to `ChartIQ`.
>   - **Data Handling**:
>     - `createChartIQDataFeed` in `chartiq.config.ts` uses `endDate.toJSON()` for date formatting.
>     - Decimal precision for `Open`, `High`, `Low`, `Close` values set to 5 decimal places in `chartiq.config.ts`.
>   - **UI Components**:
>     - `ChartIQ` in `ChartIQ.tsx` uses `useEffect` to append draw function for orders.
>     - `ProTradeChart` in `ProTrade.tsx` uses `useMemo` to memoize `ChartIQ` component with orders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ef49613088a32dcd11c0f262e93c34a04ae913f1. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->