### PR TITLE
fix(ui): orders with 0 decimals

### DIFF
--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -149,7 +149,9 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
               variant={action === "sell" ? "primary" : "tertiary"}
               fullWidth
               size="md"
-              isDisabled={amount === "0" || (operation === "limit" && priceAmount === "0")}
+              isDisabled={
+                Decimal(amount).lte(0) || (operation === "limit" && Decimal(priceAmount).lte(0))
+              }
               isLoading={submission.isPending}
               onClick={() => submission.mutateAsync()}
             >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `isDisabled` condition in `SpotTradeMenu` to use `Decimal` for robust zero-checking of `amount` and `priceAmount`.
> 
>   - **Behavior**:
>     - Update `isDisabled` condition for `Button` in `SpotTradeMenu` to use `Decimal` for checking if `amount` or `priceAmount` are <= 0.
>   - **Misc**:
>     - Improves robustness of zero-checking logic in `TradeMenu.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 79c81aaa7e24586fe86718bb6fd0735812a7bc02. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->