### PR TITLE
feat(ui): chartiq format price in y axis

### DIFF
--- a/ui/portal/web/src/components/foundation/ChartIQ.tsx
+++ b/ui/portal/web/src/components/foundation/ChartIQ.tsx
@@ -114,6 +114,14 @@ export const ChartIQ: React.FC<ChartIQProps> = ({ coins, orders }) => {
       { "Up Volume": volumeColor.up, "Down Volume": volumeColor.down },
     );
 
+    stx.formatYAxisPrice = (price, params) => {
+      if (params?.display?.includes("-")) {
+        return formatNumber(price, { ...formatNumberOptions, maxSignificantDigits: 5 });
+      }
+
+      return formatNumber(price, { ...formatNumberOptions, notation: "compact" });
+    };
+
     stx.candleWidthPercent = 0.9;
     stx.chart.yAxis.zoom = -0.0000001;
     stx.chart.maxTicks = 40;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `formatYAxisPrice` method to `ChartIQ` component to format Y-axis price based on display parameter.
> 
>   - **Behavior**:
>     - Adds `formatYAxisPrice` method to `ChartIQ` component in `ChartIQ.tsx`.
>     - Formats price with `maxSignificantDigits: 5` if `params.display` includes '-'.
>     - Otherwise, formats price with `notation: "compact"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 3cb2b5741c64e89d33dbf1b8e720e7de80907ca7. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->