### PR TITLE
Fix psql error

### DIFF
--- a/indexer/sql/src/block_to_index.rs
+++ b/indexer/sql/src/block_to_index.rs
@@ -21,7 +21,7 @@ pub struct BlockToIndex {
     filename: PathBuf,
 }
 
-/// Maximum number of item to insert in a single `insert_many` operation.
+/// Maximum number of items to insert in a single `insert_many` operation.
 /// This to avoid the following psql error:
 /// PgConnection::run(): too many arguments for query
 /// See discussion here:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes PostgreSQL error by chunking data into smaller batches in `BlockToIndex::save()` to limit batch size.
> 
>   - **Behavior**:
>     - Fixes PostgreSQL error by limiting batch size in `BlockToIndex::save()`.
>     - Chunks `transactions`, `messages`, and `events` into batches of `MAX_ROWS_INSERT` (2048) before insertion.
>   - **Imports**:
>     - Adds `itertools::Itertools` for chunking functionality.
>   - **Constants**:
>     - Introduces `MAX_ROWS_INSERT` constant set to 2048 to control batch size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for f998b6cac0ff4daf68ad2b75c1f115a6799c1511. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->