### PR TITLE
dango: pause trading in case an error happens in during cronjob

### DIFF
--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -35,6 +35,11 @@ const HALF: Udec128 = Udec128::new_percent(50);
 /// <https://motokodefi.substack.com/p/uniform-price-call-auctions-a-better>
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
+    // Do nothing if trading is paused.
+    if PAUSED.load(ctx.storage).unwrap_or(false) {
+        return Ok(Response::new());
+    }
+
     _cron_execute(ctx.storage, ctx.api, ctx.querier, ctx.block).inspect_err(|err| {
         #[cfg(feature = "tracing")]
         tracing::error!(%err, "ERROR IN DEX CRONJOB! HALTING TRADING");

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        LIMIT_ORDERS, MAX_ORACLE_STALENESS, PAIRS, RESERVES, VOLUMES, VOLUMES_BY_USER,
+        LIMIT_ORDERS, MAX_ORACLE_STALENESS, PAIRS, PAUSED, RESERVES, VOLUMES, VOLUMES_BY_USER,
         core::{self, PassiveLiquidityPool},
     },
     dango_oracle::OracleQuerier,
@@ -23,6 +23,10 @@ use {
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
     match msg {
+        QueryMsg::Paused {} => {
+            let res = PAUSED.load(ctx.storage)?;
+            res.to_json_value()
+        },
         QueryMsg::Pair {
             base_denom,
             quote_denom,

--- a/dango/dex/src/state.rs
+++ b/dango/dex/src/state.rs
@@ -4,10 +4,12 @@ use {
         dex::{Direction, LimitOrder, MarketOrder, OrderId, PairParams},
     },
     grug::{
-        Addr, CoinPair, Counter, Denom, IndexedMap, Map, MultiIndex, NumberConst, Timestamp,
+        Addr, CoinPair, Counter, Denom, IndexedMap, Item, Map, MultiIndex, NumberConst, Timestamp,
         Udec128_6, Udec128_24, Uint64, UniqueIndex,
     },
 };
+
+pub const PAUSED: Item<bool> = Item::new("paused");
 
 // (base_denom, quote_denom) => params
 pub const PAIRS: Map<(&Denom, &Denom), PairParams> = Map::new("pair");

--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -163,6 +163,14 @@ pub enum ExecuteMsg {
     ForceCancelOrders {},
 }
 
+#[grug::derive(Serde)]
+pub enum ReplyMsg {
+    /// Indicates an error happened during the transfer call in the bank contract.
+    ErrorInTransfer {},
+    /// Indicates an error happened during the fee payment in the taxman contract.
+    ErrorInFeePayment {},
+}
+
 #[grug::derive(Serde, QueryRequest)]
 pub enum QueryMsg {
     /// Query whether trading is paused.

--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -106,6 +106,10 @@ pub struct InstantiateMsg {
 
 #[grug::derive(Serde)]
 pub enum ExecuteMsg {
+    /// Pause or unpause trading.
+    ///
+    /// If paused, orders can't be created or canceled.
+    SetPaused(bool), /* TODO: should we make this more granular, with create and cancel controlled separately? */
     /// Create new, or modify the parametes of existing, trading pairs.
     ///
     /// Can only be called by the chain owner.
@@ -161,6 +165,9 @@ pub enum ExecuteMsg {
 
 #[grug::derive(Serde, QueryRequest)]
 pub enum QueryMsg {
+    /// Query whether trading is paused.
+    #[returns(bool)]
+    Paused {},
     /// Query the parameters of a single trading pair.
     #[returns(PairParams)]
     Pair {


### PR DESCRIPTION
1. set a "paused" boolean to `true`, if
  a. an error happened in `cron_execute`, or 
  b. an error happened during the bank transfer or taxman fee payment
2. if paused is `true`:
  a. refuse to create or cancel orders in `batch_update_orders`
  b. skip the operation in `cron_execute`
3. add an execute function to allow the chain owner to pause/unpause trading
4. add a query function that returns the pause boolean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce a mechanism to pause trading on errors during cron jobs or financial transactions, with new controls for pausing and querying trading status.
> 
>   - **Behavior**:
>     - Introduces a `paused` boolean in `state.rs` to halt trading on errors.
>     - In `cron.rs`, trading is paused if errors occur in `cron_execute` or during bank transfer/taxman fee payment.
>     - In `execute.rs`, order creation/cancellation is blocked if trading is paused.
>     - Adds `SetPaused` to `ExecuteMsg` in `msgs.rs` to allow owner to pause/unpause trading.
>     - Adds `Paused` to `QueryMsg` in `msgs.rs` to query trading status.
>   - **Functions**:
>     - `cron_execute()` and `reply()` in `cron.rs` handle pausing on errors.
>     - `set_paused()` in `execute.rs` manages the paused state.
>   - **State**:
>     - Adds `PAUSED` as a new `Item<bool>` in `state.rs`.
>   - **Messages**:
>     - Adds `ReplyMsg` variants for error handling in `msgs.rs`.
>     - Adds `SetPaused` and `Paused` to `ExecuteMsg` and `QueryMsg` respectively in `msgs.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 8f1b7879f428c54f980c65aac35cc0941a63378d. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->