### PR TITLE
Add operation type

### DIFF
--- a/indexer/httpd/src/graphql/extensions/metrics.rs
+++ b/indexer/httpd/src/graphql/extensions/metrics.rs
@@ -1,9 +1,11 @@
 use {
     async_graphql::{
-        Response, ServerResult, Value,
+        Request, Response, ServerResult, Value,
         extensions::{
-            Extension, ExtensionContext, ExtensionFactory, NextExecute, NextResolve, ResolveInfo,
+            Extension, ExtensionContext, ExtensionFactory, NextExecute, NextPrepareRequest,
+            NextResolve, ResolveInfo,
         },
+        parser::types::{DocumentOperations, OperationType},
     },
     metrics::{counter, describe_counter, describe_gauge, describe_histogram, histogram},
     std::{sync::Arc, time::Instant},
@@ -17,8 +19,41 @@ impl ExtensionFactory for MetricsExtension {
     }
 }
 
+fn pick_operation_type(ops: &DocumentOperations, op_name: Option<&str>) -> Option<OperationType> {
+    match ops {
+        DocumentOperations::Single(def) => Some(def.node.ty), // only one
+        DocumentOperations::Multiple(map) if !map.is_empty() => {
+            if let Some(name) = op_name {
+                if let Some(def) = map.get(name) {
+                    return Some(def.node.ty);
+                }
+            }
+            map.values().next().map(|def| def.node.ty)
+        },
+        _ => None,
+    }
+}
+
 #[async_trait::async_trait]
 impl Extension for MetricsExtension {
+    async fn prepare_request(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        mut request: Request,
+        next: NextPrepareRequest<'_>,
+    ) -> ServerResult<Request> {
+        // clone the Option<String> so we don’t borrow `request` immutably
+        let op_name_owned = request.operation_name.clone();
+
+        if let Ok(doc) = request.parsed_query() {
+            if let Some(op_type) = pick_operation_type(&doc.operations, op_name_owned.as_deref()) {
+                request = request.data(op_type);
+            }
+        }
+
+        next.run(ctx, request).await
+    }
+
     /// Called at the beginning of query execution
     async fn execute(
         &self,
@@ -46,16 +81,25 @@ impl Extension for MetricsExtension {
 
         let operation = operation_name.unwrap_or("anonymous");
 
+        let op_type_str = match ctx.data::<OperationType>() {
+            Ok(OperationType::Query) => "query",
+            Ok(OperationType::Mutation) => "mutation",
+            Ok(OperationType::Subscription) => "subscription",
+            Err(_) => "unknown",
+        };
+
         // Record metrics
         counter!(
             "graphql.requests.total",
-            "operation_name" => operation.to_string()
+            "operation_name" => operation.to_string(),
+            "operation_type" => op_type_str
         )
         .increment(1);
 
         histogram!(
             "graphql.request.duration",
-            "operation_name" => operation.to_string()
+            "operation_name" => operation.to_string(),
+            "operation_type" => op_type_str
         )
         .record(duration);
 
@@ -64,7 +108,8 @@ impl Extension for MetricsExtension {
             counter!(
                 "graphql.requests.errors",
                 "operation_name" => operation.to_string(),
-                "error_count" => res.errors.len().to_string()
+                "error_count" => res.errors.len().to_string(),
+                "operation_type" => op_type_str
             )
             .increment(1);
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds operation type tracking to GraphQL metrics in `MetricsExtension`, enhancing observability and error tracking.
> 
>   - **Behavior**:
>     - Adds `prepare_request` method in `MetricsExtension` to track operation type using `pick_operation_type()`.
>     - Includes operation type in metrics for total requests, request duration, and errors in `execute()`.
>     - Adds warning for anonymous operations in `execute()`.
>   - **Functions**:
>     - Adds `pick_operation_type()` to determine operation type from `DocumentOperations`.
>   - **Metrics**:
>     - Updates `counter!` and `histogram!` calls in `execute()` to include `operation_type`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for bd4dff653bab1860bc5b6198708925ce8ec5a682. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->