### PR TITLE
Fix when file already exists

### DIFF
--- a/indexer/disk-saver/src/error.rs
+++ b/indexer/disk-saver/src/error.rs
@@ -1,4 +1,4 @@
-use {grug_types::StdError, std::path::PathBuf};
+use grug_types::StdError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -13,7 +13,4 @@ pub enum Error {
 
     #[error(transparent)]
     Lzma(#[from] lzma_rs::error::Error),
-
-    #[error("file already exists: {0}")]
-    AlreadyExists(PathBuf),
 }

--- a/indexer/disk-saver/src/persistence.rs
+++ b/indexer/disk-saver/src/persistence.rs
@@ -94,7 +94,8 @@ impl DiskPersistence {
         // NOTE: we might need a `force: true` option in the future but I don't see
         // why we would want to overwrite a block.
         if self.file_path.exists() {
-            return Err(Error::AlreadyExists(self.file_path.clone()));
+            #[cfg(feature = "tracing")]
+            tracing::error!(file_path = %self.file_path.display(), "File already exists, saving anyway");
         }
 
         let serialized = data.to_borsh_vec()?;
@@ -138,7 +139,8 @@ impl DiskPersistence {
         // This shouldn't happen since if compressed file already exists,
         // we should have `self.compressed` to true.
         if compressed_path.exists() {
-            return Err(Error::AlreadyExists(self.file_path.clone()));
+            #[cfg(feature = "tracing")]
+            tracing::error!(file_path = %self.file_path.display(), "Compressed file already exists, saving anyway");
         }
 
         // Compress the file


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `AlreadyExists` error and logs instead of erroring when files exist in `persistence.rs` with `tracing` enabled.
> 
>   - **Behavior**:
>     - Removes `AlreadyExists` error variant from `error.rs`.
>     - In `persistence.rs`, `save()` and `compress()` now log an error instead of returning an error if the file already exists, when `tracing` feature is enabled.
>   - **Misc**:
>     - Removes unused `PathBuf` import from `error.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 826a1392451b167888cc20df83f3c45a83d42109. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->