### PR TITLE
fix(dango): override refund assets instead of add assign

### DIFF
--- a/dango/dex/src/core/market_order.rs
+++ b/dango/dex/src/core/market_order.rs
@@ -139,18 +139,14 @@ where
             // to refund the amount that was not filled.
             match market_order_direction {
                 Direction::Bid => {
-                    filling_outcome.refund_quote.checked_add_assign(
-                        market_order.remaining.checked_sub(
-                            market_order_amount_to_match_in_base.checked_mul(*price)?,
-                        )?,
-                    )?;
+                    filling_outcome.refund_quote = market_order
+                        .remaining
+                        .checked_sub(market_order_amount_to_match_in_base.checked_mul(*price)?)?;
                 },
                 Direction::Ask => {
-                    filling_outcome.refund_base.checked_add_assign(
-                        market_order
-                            .remaining
-                            .checked_sub(market_order_amount_to_match_in_base)?,
-                    )?;
+                    filling_outcome.refund_base = market_order
+                        .remaining
+                        .checked_sub(market_order_amount_to_match_in_base)?;
                 },
             }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change refund logic in `match_and_fill_market_orders` to use direct assignment instead of `checked_add_assign` for refunds.
> 
>   - **Behavior**:
>     - In `match_and_fill_market_orders` in `market_order.rs`, change refund logic for market orders.
>     - Replace `checked_add_assign` with direct assignment for `filling_outcome.refund_quote` and `filling_outcome.refund_base`.
>     - Affects both `Direction::Bid` and `Direction::Ask` cases.
>   - **Tests**:
>     - `panic_case_found_on_testnet` test ensures no panic and correct outcomes count.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 54bb39fe3e4be8aff332d368fb0e0176d54471b3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->