### PR TITLE
Add SequencedSigner trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ version = "0.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "async-trait",
  "bip32",
  "dango-account-factory",
  "dango-auth",
@@ -3689,6 +3690,7 @@ dependencies = [
  "assert-json-diff",
  "assertor",
  "async-graphql",
+ "async-trait",
  "bip32",
  "chrono",
  "clickhouse",
@@ -3752,6 +3754,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-graphql",
+ "async-trait",
  "grug",
  "hyperlane-types",
  "paste",

--- a/dango/cli/src/tx.rs
+++ b/dango/cli/src/tx.rs
@@ -177,7 +177,7 @@ impl TxCmd {
             if let Some(nonce) = self.nonce {
                 signer.with_nonce(nonce)
             } else {
-                signer.query_nonce(&client).await?
+                signer.with_query_nonce(&client).await?
             }
         };
 

--- a/dango/client/Cargo.toml
+++ b/dango/client/Cargo.toml
@@ -12,6 +12,7 @@ version       = { workspace = true }
 [dependencies]
 aes-gcm     = { workspace = true, features = ["std"] }
 anyhow      = { workspace = true }
+async-trait = { workspace = true }
 bip32       = { workspace = true }
 dango-types = { workspace = true }
 grug        = { workspace = true }

--- a/dango/scripts/examples/transfer_ownership.rs
+++ b/dango/scripts/examples/transfer_ownership.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
         CURRENT_OWNER,
         CURRENT_OWNER_PRIVATE_KEY,
     )?
-    .query_nonce(&client)
+    .with_query_nonce(&client)
     .await?;
 
     let mut cfg = client.query_config(None).await?;

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -13,6 +13,7 @@ version       = { workspace = true }
 actix-web               = { workspace = true }
 anyhow                  = { workspace = true }
 async-graphql           = { workspace = true }
+async-trait             = { workspace = true }
 clickhouse              = { workspace = true, features = ["test-util"] }
 dango-genesis           = { workspace = true }
 dango-httpd             = { workspace = true, features = ["metrics"] }

--- a/dango/types/Cargo.toml
+++ b/dango/types/Cargo.toml
@@ -18,6 +18,7 @@ sea-orm = ["dep:sea-orm"]
 [dependencies]
 anyhow          = { workspace = true }
 async-graphql   = { workspace = true, optional = true }
+async-trait     = { workspace = true }
 grug            = { workspace = true }
 hyperlane-types = { workspace = true }
 paste           = { workspace = true }

--- a/dango/types/src/lib.rs
+++ b/dango/types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod gateway;
 pub mod lending;
 pub mod oracle;
 mod querier;
+pub mod signer;
 pub mod taxman;
 pub mod vesting;
 pub mod warp;

--- a/dango/types/src/signer.rs
+++ b/dango/types/src/signer.rs
@@ -1,0 +1,17 @@
+use grug::{QueryClient, Signer};
+
+use crate::auth::Nonce;
+
+#[async_trait::async_trait]
+/// Represent a signer that can query and update its nonce.
+pub trait SequencedSigner: Signer {
+    async fn query_nonce<C>(&self, client: &C) -> anyhow::Result<Nonce>
+    where
+        C: QueryClient,
+        anyhow::Error: From<C::Error>;
+
+    async fn update_nonce<C>(&mut self, client: &C) -> anyhow::Result<()>
+    where
+        C: QueryClient,
+        anyhow::Error: From<C::Error>;
+}

--- a/dango/types/src/signer.rs
+++ b/dango/types/src/signer.rs
@@ -1,9 +1,10 @@
-use grug::{QueryClient, Signer};
+use {
+    crate::auth::Nonce,
+    grug::{QueryClient, Signer},
+};
 
-use crate::auth::Nonce;
-
-#[async_trait::async_trait]
 /// Represent a signer that can query and update its nonce.
+#[async_trait::async_trait]
 pub trait SequencedSigner: Signer {
     async fn query_nonce<C>(&self, client: &C) -> anyhow::Result<Nonce>
     where


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `SequencedSigner` trait for nonce management and refactor existing signers to implement it, adding `async-trait` dependency.
> 
>   - **Trait Addition**:
>     - Add `SequencedSigner` trait in `dango/types/src/signer.rs` for querying and updating nonces.
>   - **Implementations**:
>     - Implement `SequencedSigner` for `SingleSigner<Defined<u32>>` in `dango/client/src/signer.rs`.
>     - Implement `SequencedSigner` for `TestAccount<Defined<Addr>>` in `dango/testing/src/account.rs`.
>   - **Refactoring**:
>     - Rename `query_nonce` to `with_query_nonce` in `dango/cli/src/tx.rs` and `dango/scripts/examples/transfer_ownership.rs`.
>     - Remove `update_nonce` method from `SingleSigner<Defined<u32>>` in `dango/client/src/signer.rs`.
>   - **Dependencies**:
>     - Add `async-trait` to `Cargo.toml` in `dango/client`, `dango/testing`, and `dango/types`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b389e190153ecbcd39acca186cb5f5f6546e1944. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->