### PR TITLE
Add more details for `/up`

### DIFF
--- a/grug/httpd/src/routes/index.rs
+++ b/grug/httpd/src/routes/index.rs
@@ -2,7 +2,8 @@ use {
     crate::context::Context,
     actix_web::{Error, HttpResponse, Responder, error::ErrorInternalServerError, get, web},
     async_graphql::futures_util::TryFutureExt,
-    grug_types::GIT_COMMIT,
+    chrono::{Duration, Utc},
+    grug_types::{BlockInfo, GIT_COMMIT},
 };
 
 #[get("/")]
@@ -10,24 +11,28 @@ pub async fn index() -> impl Responder {
     "OK"
 }
 
-#[derive(serde::Serialize, Default)]
+#[derive(serde::Serialize)]
 struct UpResponse<'a> {
-    block_height: u64,
+    block: BlockInfo,
+    is_running: bool,
     git_commit: &'a str,
 }
 
 #[get("/up")]
 pub async fn up(app_ctx: web::Data<Context>) -> Result<impl Responder, Error> {
     // This ensures that grug is working
-    let block_height = app_ctx
+    let block = app_ctx
         .grug_app
         .last_finalized_block()
         .map_err(ErrorInternalServerError)
-        .await?
-        .height;
+        .await?;
+
+    let is_running =
+        block.timestamp.to_naive_date_time() >= (Utc::now().naive_utc() - Duration::seconds(30));
 
     Ok(HttpResponse::Ok().json(UpResponse {
-        block_height,
+        block,
+        is_running,
         git_commit: GIT_COMMIT,
     }))
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances `/up` endpoint to include `BlockInfo` and `is_running` status based on recent block timestamp.
> 
>   - **Behavior**:
>     - Updates `/up` endpoint in `index.rs` to return `BlockInfo` and `is_running` status.
>     - `is_running` is true if the last block timestamp is within 30 seconds of the current time.
>   - **Data Structures**:
>     - Modifies `UpResponse` struct to include `block: BlockInfo` and `is_running: bool`.
>   - **Imports**:
>     - Adds `chrono::{Duration, Utc}` and `grug_types::BlockInfo` to imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for bf992dc8fd19c8cbe27cc8378062cb58cd3fb7e8. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->