### PR TITLE
feat(dango): verify key association

### DIFF
--- a/dango/account/factory/src/execute.rs
+++ b/dango/account/factory/src/execute.rs
@@ -346,6 +346,15 @@ fn update_key(ctx: MutableCtx, key_hash: Hash256, key: Op<Key>) -> anyhow::Resul
 
     match key {
         Op::Insert(key) => {
+            // Ensure the key isn't already associated with the username.
+            ensure!(
+                !KEYS
+                    .prefix(&username)
+                    .values(ctx.storage, None, None, Order::Ascending)
+                    .any(|v| v.is_ok_and(|k| k == key)),
+                "key is already associated with username `{username}`"
+            );
+
             KEYS.save(ctx.storage, (&username, key_hash), &key)?;
             USERNAMES_BY_KEY.insert(ctx.storage, (key_hash, &username))?;
         },

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -546,6 +546,22 @@ fn update_key() {
             },
         )
         .should_succeed_and_equal(btree_map! { key_hash => pk });
+
+    // It shouldn't be able to add the same key more than once.
+    suite
+        .execute(
+            &mut user,
+            contracts.account_factory,
+            &account_factory::ExecuteMsg::UpdateKey {
+                key: Op::Insert(pk.clone()),
+                key_hash,
+            },
+            Coins::new(),
+        )
+        .should_fail_with_error(format!(
+            "key is already associated with username `{}`",
+            user.username
+        ));
 }
 
 /// A malicious block builder detects a register user transaction, could try to,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add verification in `update_key()` to prevent duplicate key associations with a username in `execute.rs`, with tests in `factory.rs`.
> 
>   - **Behavior**:
>     - In `update_key()` in `execute.rs`, added a check to ensure a key isn't already associated with a username before insertion.
>     - If a duplicate key is detected, an error is raised: "key is already associated with username `{username}`".
>   - **Tests**:
>     - In `factory.rs`, added tests to verify that attempting to add a duplicate key fails with the correct error message.
>     - Tests cover scenarios of adding a key twice and deleting the last key associated with a username.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for fa430189ac484ff12dd5da6a109e460df27bcf7b. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->