### PR TITLE
feat(dango): prevent key duplication

### DIFF
--- a/dango/account/factory/src/execute.rs
+++ b/dango/account/factory/src/execute.rs
@@ -346,6 +346,15 @@ fn update_key(ctx: MutableCtx, key_hash: Hash256, key: Op<Key>) -> anyhow::Resul
 
     match key {
         Op::Insert(key) => {
+            // Ensure the key isn't already associated with the username.
+            ensure!(
+                !KEYS
+                    .prefix(&username)
+                    .values(ctx.storage, None, None, Order::Ascending)
+                    .any(|v| v.is_ok_and(|k| k == key)),
+                "key is already associated with username `{username}`"
+            );
+
             KEYS.save(ctx.storage, (&username, key_hash), &key)?;
             USERNAMES_BY_KEY.insert(ctx.storage, (key_hash, &username))?;
         },

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -524,6 +524,22 @@ fn update_key() {
             key_hash => pk,
         });
 
+    // It shouldn't be able to add the same key more than once.
+    suite
+        .execute(
+            &mut user,
+            contracts.account_factory,
+            &account_factory::ExecuteMsg::UpdateKey {
+                key: Op::Insert(pk),
+                key_hash,
+            },
+            Coins::new(),
+        )
+        .should_fail_with_error(format!(
+            "key is already associated with username `{}`",
+            user.username
+        ));
+
     // Delete the first key should be possible since there is another key.
     suite
         .execute(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent duplicate keys for a username in `update_key()` and add corresponding test.
> 
>   - **Behavior**:
>     - Prevents duplicate keys for a username in `update_key()` in `execute.rs`.
>     - Logs error if duplicate key is attempted.
>   - **Tests**:
>     - Adds test in `factory.rs` to ensure duplicate keys cannot be added for a username.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 85d4b18fd823feb26366e8b3f27cae028ec71281. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->