### PR TITLE
Refactor up

### DIFF
--- a/dango/indexer/httpd/src/server.rs
+++ b/dango/indexer/httpd/src/server.rs
@@ -4,6 +4,7 @@ use {
         HttpResponse,
         web::{self, ServiceConfig},
     },
+    grug_httpd::routes::index::index,
     indexer_httpd::routes,
 };
 
@@ -15,7 +16,7 @@ where
     G: Clone + 'static,
 {
     Box::new(move |cfg: &mut ServiceConfig| {
-        cfg.service(routes::index::index)
+        cfg.service(index)
             .service(routes::index::up)
             .service(routes::index::sentry_raise)
             .service(routes::api::services::api_services())

--- a/grug/httpd/src/routes/index.rs
+++ b/grug/httpd/src/routes/index.rs
@@ -12,10 +12,11 @@ pub async fn index() -> impl Responder {
 }
 
 #[derive(serde::Serialize)]
-struct UpResponse<'a> {
-    block: BlockInfo,
-    is_running: bool,
-    git_commit: &'a str,
+pub struct UpResponse<'a> {
+    pub block: BlockInfo,
+    pub is_running: bool,
+    pub git_commit: &'a str,
+    pub indexed_block_height: Option<u64>,
 }
 
 #[get("/up")]
@@ -34,5 +35,6 @@ pub async fn up(app_ctx: web::Data<Context>) -> Result<impl Responder, Error> {
         block,
         is_running,
         git_commit: GIT_COMMIT,
+        indexed_block_height: None,
     }))
 }

--- a/indexer/httpd/src/server.rs
+++ b/indexer/httpd/src/server.rs
@@ -7,6 +7,7 @@ use {
         middleware::{Compress, Logger},
         web::{self, ServiceConfig},
     },
+    grug_httpd::routes::index::index,
     sentry_actix::Sentry,
     std::fmt::Display,
 };
@@ -143,7 +144,7 @@ where
     G: Clone + 'static,
 {
     Box::new(move |cfg: &mut ServiceConfig| {
-        cfg.service(routes::index::index)
+        cfg.service(index)
             .service(routes::index::up)
             .service(routes::api::services::api_services())
             .service(routes::graphql::graphql_route())

--- a/indexer/testing/tests/api/main.rs
+++ b/indexer/testing/tests/api/main.rs
@@ -1,7 +1,9 @@
 use {
+    assert_json_diff::assert_json_include,
     assertor::*,
     grug_types::{Block, BlockOutcome},
     indexer_testing::{block::create_block, build_app_service, call_api},
+    serde_json::json,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -17,13 +19,13 @@ async fn up_returns_200() -> anyhow::Result<()> {
 
                 let up_response = call_api::<serde_json::Value>(app, "/up").await?;
 
-                assert_that!(
-                    up_response
-                        .get("block_height")
-                        .and_then(|bh| bh.as_u64())
-                        .unwrap_or_default()
-                )
-                .is_equal_to(1);
+                let expected = json!({
+                    "block": { "height": 1 },
+                    "is_running": true,
+                    "indexed_block_height": 1
+                });
+
+                assert_json_include!(actual: up_response, expected: expected);
 
                 Ok::<(), anyhow::Error>(())
             })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `up` endpoint to use shared `UpResponse` struct and update test to verify new response structure.
> 
>   - **Behavior**:
>     - Refactor `up` endpoint in `indexer/httpd/src/routes/index.rs` to use `UpResponse` from `grug_httpd::routes::index`.
>     - Update `up` endpoint logic to check if the server is running and fetch the last finalized block.
>     - Add `indexed_block_height` to `UpResponse`.
>   - **Tests**:
>     - Update `up_returns_200` test in `indexer/testing/tests/api/main.rs` to check for `block`, `is_running`, and `indexed_block_height`.
>   - **Misc**:
>     - Remove redundant `index` function in `indexer/httpd/src/routes/index.rs` and use `grug_httpd::routes::index::index` instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for df5fd60209ff2948707d86e09783350c9be55fea. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->