### PR TITLE
fix(ui): mobile section connect

### DIFF
--- a/ui/portal/web/src/components/landing/Landing.tsx
+++ b/ui/portal/web/src/components/landing/Landing.tsx
@@ -169,7 +169,7 @@ const SectionCommunity: React.FC = () => {
 
   return (
     <section className="section w-full min-h-svh flex items-center justify-center bg-surface-primary-rice bg-[linear-gradient(6.97deg,_#D0CFEB_11.63%,_#F6F6FB_88.19%)] dark:bg-[linear-gradient(6.97deg,_#6E6D77_11.63%,_#373634_88.19%)]">
-      <div className="max-w-[76rem] w-full mx-auto flex flex-col p-4 gap-24 pb-16 lg:pb-4 min-h-[calc(100svh-5svh)] lg:justify-center">
+      <div className="max-w-[76rem] w-full mx-auto flex flex-col p-4 gap-24 pb-16 lg:pb-4 lg:min-h-[calc(100svh-5svh)] lg:justify-center">
         <div className="w-full flex flex-col lg:flex-row items-center lg:justify-between gap-4 lg:flex-1">
           <img
             src="/images/characters/friends.svg"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix mobile layout in `SectionCommunity` by adjusting `min-h` property in `Landing.tsx`.
> 
>   - **UI Fix**:
>     - Adjust `min-h` property in `SectionCommunity` in `Landing.tsx` to `lg:min-h-[calc(100svh-5svh)]` for consistent mobile layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 550cafea537202fb50e33a60cd0bd5f3fd0ff7d8. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->