### PR TITLE
Match market orders ordered by price

### DIFF
--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -33,7 +33,7 @@ use {
 
 const HALF: Udec128 = Udec128::new_percent(50);
 
-type MarketOrders = Vec<(Price, MarketOrder)>;
+type MarketOrders = BTreeMap<(Price, OrderId), MarketOrder>;
 
 /// Match and fill orders using the uniform price auction strategy.
 ///
@@ -95,14 +95,14 @@ pub(crate) fn auction(ctx: MutableCtx) -> anyhow::Result<Response> {
     let mut market_orders = MARKET_ORDERS
         .values(ctx.storage, None, None, IterationOrder::Ascending)
         .try_fold(BTreeMap::new(), |mut acc, res| {
-            let ((pair, direction, price, _), order) = res?;
+            let ((pair, direction, price, order_id), order) = res?;
             let (bids, asks): &mut (MarketOrders, MarketOrders) = acc.entry(pair).or_default();
             match direction {
                 Direction::Bid => {
-                    bids.push((price, order));
+                    bids.insert((price, order_id), order);
                 },
                 Direction::Ask => {
-                    asks.push((price, order));
+                    asks.insert((price, order_id), order);
                 },
             }
 
@@ -597,12 +597,12 @@ fn nested_merged_orders<A, B, C>(
 >
 where
     A: Iterator<Item = StdResult<((Udec128_24, OrderId), LimitOrder)>>,
-    B: Iterator<Item = (Udec128_24, MarketOrder)>,
+    B: Iterator<Item = ((Udec128_24, OrderId), MarketOrder)>,
     C: Iterator<Item = (Udec128_24, PassiveOrder)>,
 {
     // Make the three iterators return the same item type, so they can be merged.
     let limit = limit.map(|res| res.map(|((price, _), order)| (price, Order::Limit(order))));
-    let market = market.map(|(price, order)| Ok((price, Order::Market(order))));
+    let market = market.map(|((price, _), order)| Ok((price, Order::Market(order))));
     let passive = passive.map(|(price, order)| Ok((price, Order::Passive(order))));
 
     // Merge the three iterators.

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -536,16 +536,18 @@ fn clear_orders_of_pair(
     // Find the best bid and ask prices available.
     let best_bid_price = LIMIT_ORDERS
         .prefix((base_denom.clone(), quote_denom.clone()))
+        .append(Direction::Bid)
         .keys(storage, None, None, IterationOrder::Descending)
         .next()
         .transpose()?
-        .map(|(_direction, price, _order_id)| price);
+        .map(|(price, _order_id)| price);
     let best_ask_price = LIMIT_ORDERS
         .prefix((base_denom.clone(), quote_denom.clone()))
+        .append(Direction::Ask)
         .keys(storage, None, None, IterationOrder::Ascending)
         .next()
         .transpose()?
-        .map(|(_direction, price, _order_id)| price);
+        .map(|(price, _order_id)| price);
 
     // Determine the mid price:
     // - if both best bid and ask prices exist, then take the average of them;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `MarketOrders` to `BTreeMap` for price sorting and add test for order sorting in `dex.rs`.
> 
>   - **Behavior**:
>     - Change `MarketOrders` type from `Vec<(Price, MarketOrder)>` to `BTreeMap<(Price, OrderId), MarketOrder>` in `cron.rs`.
>     - Modify `auction()` in `cron.rs` to use `BTreeMap` for sorting market orders by price.
>     - Update `clear_orders_of_pair()` in `cron.rs` to handle `BTreeMap` structure.
>   - **Tests**:
>     - Add `market_orders_are_sorted_by_price_ascending()` in `dex.rs` to verify market orders are sorted by price.
>   - **Misc**:
>     - Adjust `nested_merged_orders()` in `cron.rs` to accommodate `BTreeMap` structure.
>     - Minor changes in `clear_orders_of_pair()` to remove unused variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ca59156e446034c36c6827762c9e7a40cee18175. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->