### PR TITLE
fix: handle left over market orders

### DIFF
--- a/dango/dex/src/core/order_matching.rs
+++ b/dango/dex/src/core/order_matching.rs
@@ -16,6 +16,10 @@ pub struct MatchingOutcome {
     pub bids: Vec<(Udec128_24, Order)>,
     /// The SELL orders that have found a match.
     pub asks: Vec<(Udec128_24, Order)>,
+    /// If a bid was popped out of the iterator but wasn't matched, it's returned here.
+    pub unmatched_bid: Option<(Udec128_24, Order)>,
+    /// If an ask was popped out of the iterator but wasn't matched, it's returned here.
+    pub unmatched_ask: Option<(Udec128_24, Order)>,
 }
 
 /// Given the standing BUY and SELL orders in the book, find range of prices
@@ -89,5 +93,7 @@ where
         volume: bid_volume.min(ask_volume),
         bids,
         asks,
+        unmatched_bid: bid,
+        unmatched_ask: ask,
     })
 }

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -710,6 +710,8 @@ fn refund_unmatched_order(
         },
     }
 
+    // TODO: emit order canceled event
+
     Ok(())
 }
 

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -281,6 +281,8 @@ fn clear_orders_of_pair(
         volume,
         bids,
         asks,
+        unmatched_bid,
+        unmatched_ask,
     } = match_orders(&mut merged_bids, &mut merged_asks)?;
 
     // Any order that isn't visited during `match_limit_orders` is unmatched.
@@ -372,26 +374,22 @@ fn clear_orders_of_pair(
 
     // ------------------- 4. Handle unmatched market orders -------------------
 
+    if let Some((_price, order)) = unmatched_bid {
+        refund_unmatched_order(&base_denom, &quote_denom, Direction::Bid, order, refunds)?;
+    }
+
     for res in unmatched_market_bids {
-        let (_price, bid) = res?;
-        match bid {
-            // Market orders are immediate-or-cancel, so refund the user.
-            Order::Market(order) => {
-                let remaining_quote = order.remaining.checked_mul_dec_floor(order.price)?;
-                refunds.insert(order.user, quote_denom.clone(), remaining_quote)?;
-            },
-            _ => unreachable!("encountered an unmatched bid that isn't a market order: {bid:?}"),
-        }
+        let (_price, order) = res?;
+        refund_unmatched_order(&base_denom, &quote_denom, Direction::Bid, order, refunds)?;
+    }
+
+    if let Some((_price, order)) = unmatched_ask {
+        refund_unmatched_order(&base_denom, &quote_denom, Direction::Ask, order, refunds)?;
     }
 
     for res in unmatched_market_asks {
-        let (_price, ask) = res?;
-        match ask {
-            Order::Market(order) => {
-                refunds.insert(order.user, base_denom.clone(), order.remaining)?;
-            },
-            _ => unreachable!("encountered an unmatched ask that isn't a market order: {ask:?}"),
-        }
+        let (_price, order) = res?;
+        refund_unmatched_order(&base_denom, &quote_denom, Direction::Ask, order, refunds)?;
     }
 
     #[cfg(feature = "tracing")]
@@ -681,6 +679,34 @@ fn fill_passive_order(
         Direction::Ask => {
             inflows.insert((quote_denom.clone(), filled_quote))?;
             outflows.insert((base_denom.clone(), filled_base))?;
+        },
+    }
+
+    Ok(())
+}
+
+fn refund_unmatched_order(
+    base_denom: &Denom,
+    quote_denom: &Denom,
+    direction: Direction,
+    order: Order,
+    refunds: &mut TransferBuilder<DecCoins<6>>,
+) -> StdResult<()> {
+    let Order::Market(order) = order else {
+        // Market orders are immediate-or-cancel, so unmatched market orders are
+        // to be canceled and the user refunded.
+        // Unmatched limit and passive orders remain in the order book, so nothing
+        // to do.
+        return Ok(());
+    };
+
+    match direction {
+        Direction::Bid => {
+            let remaining_in_quote = order.remaining.checked_mul_dec_floor(order.price)?;
+            refunds.insert(order.user, quote_denom.clone(), remaining_in_quote)?;
+        },
+        Direction::Ask => {
+            refunds.insert(order.user, base_denom.clone(), order.remaining)?;
         },
     }
 

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5920,7 +5920,7 @@ fn refund_left_over_market_bid() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Set maker and taker fee rates to 0 for simplicity
-    // TODO: make this configurable in `TestOptions.`
+    // TODO: make this configurable in `TestOptions`
     let mut app_config: AppConfig = suite.query_app_config().unwrap();
     app_config.maker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();
     app_config.taker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5983,7 +5983,8 @@ fn refund_left_over_market_bid() {
     // Block 2: submit two orders:
     // - user 2 submits the limit order that will be matched;
     // - user 3 submits the market order that will be left over.
-    // Make sure the limit order is submitted first, meaning it's more
+    // The limit order has slightly better price, so it has priority order the
+    // market order.
     suite
         .make_block(vec![
             accounts
@@ -6144,7 +6145,8 @@ fn refund_left_over_market_ask() {
     // Block 2: submit two orders:
     // - user 2 submits the limit order that will be matched;
     // - user 3 submits the market order that will be left over.
-    // Make sure the limit order is submitted first, meaning it's more
+    // The limit order has slightly better price, so it has priority order the
+    // market order.
     suite
         .make_block(vec![
             accounts

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5743,7 +5743,7 @@ fn market_orders_are_sorted_by_price_ascending() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Set maker and taker fee rates to 0 for simplicity
-    // TODO: make this configurable in `TestOptions.`
+    // TODO: make this configurable in `TestOptions`
     let mut app_config: AppConfig = suite.query_app_config().unwrap();
     app_config.maker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();
     app_config.taker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -6081,7 +6081,7 @@ fn refund_left_over_market_ask() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Set maker and taker fee rates to 0 for simplicity
-    // TODO: make this configurable in `TestOptions.`
+    // TODO: make this configurable in TestOptions
     let mut app_config: AppConfig = suite.query_app_config().unwrap();
     app_config.maker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();
     app_config.taker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -6067,3 +6067,164 @@ fn refund_left_over_market_bid() {
         usdc::DENOM.clone() => BalanceChange::Unchanged,
     });
 }
+
+/// This is the same as the previous test (`refund_left_over_market_bid`), but
+/// on the different side of the book.
+///
+/// The setup:
+/// - mid price: 100
+/// - resting order book: limit bid, price 100, amount 1
+/// - limit ask, price 99, amount 1
+/// - market ask, price 100, amount 1
+#[test]
+fn refund_left_over_market_ask() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
+
+    // Set maker and taker fee rates to 0 for simplicity
+    // TODO: make this configurable in `TestOptions.`
+    let mut app_config: AppConfig = suite.query_app_config().unwrap();
+    app_config.maker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();
+    app_config.taker_fee_rate = Bounded::new(Udec128::ZERO).unwrap();
+    suite
+        .configure(
+            &mut accounts.owner, // Must be the chain owner
+            None,                // No chain config update
+            Some(app_config),    // App config update
+        )
+        .should_succeed();
+
+    // Block 1: we make it such that a mid price of 100 is recorded.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.dex,
+            &dex::ExecuteMsg::BatchUpdateOrders {
+                creates_market: vec![],
+                creates_limit: vec![
+                    CreateLimitOrderRequest {
+                        base_denom: dango::DENOM.clone(),
+                        quote_denom: usdc::DENOM.clone(),
+                        direction: Direction::Bid,
+                        amount: NonZero::new_unchecked(Uint128::new(2)),
+                        price: NonZero::new_unchecked(Udec128_24::new(100)),
+                    },
+                    CreateLimitOrderRequest {
+                        base_denom: dango::DENOM.clone(),
+                        quote_denom: usdc::DENOM.clone(),
+                        direction: Direction::Ask,
+                        amount: NonZero::new_unchecked(Uint128::new(1)),
+                        price: NonZero::new_unchecked(Udec128_24::new(100)),
+                    },
+                ],
+                cancels: None,
+            },
+            coins! {
+                dango::DENOM.clone() => 1,
+                usdc::DENOM.clone() => 200,
+            },
+        )
+        .should_succeed();
+
+    // Query the mid price to make sure it's accurate.
+    suite
+        .query_wasm_smart(contracts.dex, QueryRestingOrderBookStateRequest {
+            base_denom: dango::DENOM.clone(),
+            quote_denom: usdc::DENOM.clone(),
+        })
+        .should_succeed_and_equal(RestingOrderBookState {
+            best_bid_price: Some(Udec128_24::new(100)),
+            best_ask_price: None,
+            mid_price: Some(Udec128_24::new(100)),
+        });
+
+    suite
+        .balances()
+        .record_many([&accounts.user1, &accounts.user2, &accounts.user3]);
+
+    // Block 2: submit two orders:
+    // - user 2 submits the limit order that will be matched;
+    // - user 3 submits the market order that will be left over.
+    // Make sure the limit order is submitted first, meaning it's more
+    suite
+        .make_block(vec![
+            accounts
+                .user2
+                .sign_transaction(
+                    NonEmpty::new_unchecked(vec![
+                        Message::execute(
+                            contracts.dex,
+                            &dex::ExecuteMsg::BatchUpdateOrders {
+                                creates_market: vec![],
+                                creates_limit: vec![CreateLimitOrderRequest {
+                                    base_denom: dango::DENOM.clone(),
+                                    quote_denom: usdc::DENOM.clone(),
+                                    direction: Direction::Ask,
+                                    amount: NonZero::new_unchecked(Uint128::new(1)),
+                                    price: NonZero::new_unchecked(Udec128_24::new(99)),
+                                }],
+                                cancels: None,
+                            },
+                            coins! {
+                                dango::DENOM.clone() => 1,
+                            },
+                        )
+                        .unwrap(),
+                    ]),
+                    &suite.chain_id,
+                    100_000,
+                )
+                .unwrap(),
+            accounts
+                .user3
+                .sign_transaction(
+                    NonEmpty::new_unchecked(vec![
+                        Message::execute(
+                            contracts.dex,
+                            &dex::ExecuteMsg::BatchUpdateOrders {
+                                creates_market: vec![CreateMarketOrderRequest {
+                                    base_denom: dango::DENOM.clone(),
+                                    quote_denom: usdc::DENOM.clone(),
+                                    direction: Direction::Ask,
+                                    amount: NonZero::new_unchecked(Uint128::new(1)),
+                                    max_slippage: Udec128::ZERO,
+                                }],
+                                creates_limit: vec![],
+                                cancels: None,
+                            },
+                            coins! {
+                                dango::DENOM.clone() => 1,
+                            },
+                        )
+                        .unwrap(),
+                    ]),
+                    &suite.chain_id,
+                    100_000,
+                )
+                .unwrap(),
+        ])
+        .block_outcome
+        .tx_outcomes
+        .into_iter()
+        .for_each(|outcome| {
+            outcome.should_succeed();
+        });
+
+    // Check user 1 and user 2 balances.
+    // The order should match with range 99-100. Since previous block's mid
+    // price was 100, which is within the range, so the orders settle at 100.
+    suite.balances().should_change(&accounts.user1, btree_map! {
+        dango::DENOM.clone() => BalanceChange::Increased(1),
+        usdc::DENOM.clone() => BalanceChange::Unchanged,
+    });
+    suite.balances().should_change(&accounts.user2, btree_map! {
+        dango::DENOM.clone() => BalanceChange::Decreased(1),
+        usdc::DENOM.clone() => BalanceChange::Increased(100),
+    });
+
+    // THE IMPORTANT PART: make sure user 3 has received the refund; or in other
+    // words, his balance should be unchanged.
+    suite.balances().should_change(&accounts.user3, btree_map! {
+        dango::DENOM.clone() => BalanceChange::Unchanged,
+        usdc::DENOM.clone() => BalanceChange::Unchanged,
+    });
+}


### PR DESCRIPTION
A "left over order" is an order that, during the `match_orders` function call, has been popped from the iterator (going into either the `bid` or `ask` variable), but didn't end up being matched. If this order happens to be a market order, we need to cancel the order and refund the user.

Previously, during step "4. Handle unmatched market orders" in `clear_orders_of_pair`, we only go through the order remaining in the iterators. Since the left over order was already popped, it's not properly handled. This PR fixes this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes handling of leftover market orders by ensuring unmatched market orders are refunded in `clear_orders_of_pair()` and adds tests to verify this behavior.
> 
>   - **Behavior**:
>     - Fixes handling of leftover market orders in `clear_orders_of_pair()` by ensuring unmatched market orders are refunded.
>     - Adds `unmatched_bid` and `unmatched_ask` to `MatchingOutcome` in `order_matching.rs` to track unmatched orders.
>   - **Functions**:
>     - Updates `match_orders()` in `order_matching.rs` to return unmatched orders.
>     - Modifies `clear_orders_of_pair()` in `cron.rs` to process unmatched orders using `refund_unmatched_order()`.
>     - Introduces `refund_unmatched_order()` in `cron.rs` to handle refunds for unmatched market orders.
>   - **Tests**:
>     - Adds `refund_left_over_market_bid()` and `refund_left_over_market_ask()` in `dex.rs` to verify refund logic for unmatched market orders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e5e052f02bf7c4bc5df0d38d44ea04beb94be6eb. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->