### PR TITLE
add clickhouse backups and fix candles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ ui/config/project.inlang/*
 networks/**/configs/cometbft/config/addrbook.json
 networks/**/configs/cometbft/config/write-file-atomic-*
 networks/**/data
+networks/**/logs

--- a/dango/cli/src/main.rs
+++ b/dango/cli/src/main.rs
@@ -114,7 +114,10 @@ async fn main() -> anyhow::Result<()> {
 
         tracing::info!("Sentry initialized");
     } else {
-        tracing_subscriber::registry().with(env_filter).init();
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(fmt_layer)
+            .init();
     }
 
     match cli.command {

--- a/deploy/roles/clickhouse/tasks/main.yml
+++ b/deploy/roles/clickhouse/tasks/main.yml
@@ -35,6 +35,15 @@
     - config.xml
     - users.xml
 
+- name: Copy backup script
+  become: true
+  become_user: root
+  template:
+    src: "make_clickhouse_backup.sh"
+    dest: "{{ ansible_env.HOME }}"
+    mode: '0755'
+    owner: '{{ deploy_user }}'
+
 - name: Deploy clickhouse container
   docker_container:
     name: "{{ container_name }}"

--- a/deploy/roles/clickhouse/templates/config.xml
+++ b/deploy/roles/clickhouse/templates/config.xml
@@ -89,4 +89,17 @@
     <asynchronous_metrics>true</asynchronous_metrics>
   </prometheus>
 
+  <storage_configuration>
+    <disks>
+      <backups>
+        <type>local</type>
+        <path>/var/log/clickhouse-server/backups/</path>
+      </backups>
+    </disks>
+  </storage_configuration>
+  <backups>
+    <allowed_disk>backups</allowed_disk>
+    <allowed_path>/var/log/clickhouse-server/backups/</allowed_path>
+  </backups>
+
 </clickhouse>

--- a/deploy/roles/clickhouse/templates/make_clickhouse_backup.sh
+++ b/deploy/roles/clickhouse/templates/make_clickhouse_backup.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+USER="default"
+PASSWORD="{{ clickhouse_password }}"
+
+# Function to backup database if it exists
+backup_db() {
+    local db_name=$1
+    local backup_file="/var/log/clickhouse-server/backups/${db_name}_${TIMESTAMP}.zip"
+
+    echo "Backing up ${db_name}..."
+    if docker exec clickhouse clickhouse-client --user=$USER --password=$PASSWORD --query "EXISTS DATABASE ${db_name}" | grep -q "1"; then
+        docker exec clickhouse clickhouse-client --user=$USER --password=$PASSWORD --query "BACKUP DATABASE ${db_name} TO File('${backup_file}')" && \
+        echo "✓ Backup created: ${backup_file}" || \
+        echo "✗ Failed to backup ${db_name}"
+    else
+        echo "⚠ Database ${db_name} does not exist, skipping"
+    fi
+}
+
+# Backup both databases
+backup_db "testnet_dango_production"
+backup_db "devnet_dango_production"
+
+echo "Backup process completed"

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -156,6 +156,7 @@ impl CandleCache {
             candle.low = last_candle.low.min(candle.low);
             candle.volume_base += last_candle.volume_base;
             candle.volume_quote += last_candle.volume_quote;
+            candle.block_height = last_candle.block_height.max(candle.block_height);
 
             *last_candle = candle;
         } else {

--- a/indexer/clickhouse/src/cache.rs
+++ b/indexer/clickhouse/src/cache.rs
@@ -297,6 +297,9 @@ impl CandleCache {
                                     tracing::warn!(
                                         %candle.block_height,
                                         %highest_block_height,
+                                        base_denom = key.base_denom,
+                                        quote_denom = key.quote_denom,
+                                        %key.interval,
                                         "Candle is older than latest price");
 
                                     // `candle` are built async in clickhouse, and this means they're

--- a/indexer/clickhouse/src/checker.rs
+++ b/indexer/clickhouse/src/checker.rs
@@ -58,7 +58,7 @@ impl Indexer {
             return Ok(true);
         };
 
-        let mut total_candles = 1;
+        let mut _total_candles = 1;
         let mut wrong_candles = 0;
 
         while let Some(candle) = cursor.next().await? {
@@ -75,12 +75,12 @@ impl Indexer {
             }
 
             later_candle = candle;
-            total_candles += 1;
+            _total_candles += 1;
         }
 
         #[cfg(feature = "tracing")]
         tracing::info!(
-            "checked {total_candles} candles for {base_denom}/{quote_denom} at interval {interval:?}, found {wrong_candles} wrong candles"
+            "checked {_total_candles} candles for {base_denom}/{quote_denom} at interval {interval:?}, found {wrong_candles} wrong candles"
         );
 
         Ok(wrong_candles == 0)

--- a/indexer/clickhouse/src/checker.rs
+++ b/indexer/clickhouse/src/checker.rs
@@ -12,13 +12,13 @@ impl Indexer {
     pub async fn check_all(&self) -> Result<bool, IndexerError> {
         let pairs = PairPrice::all_pairs(self.context.clickhouse_client()).await?;
 
+        #[cfg(feature = "tracing")]
+        tracing::info!("Checking {} pairs for candle consistency", pairs.len());
+
         for pair in pairs {
             for interval in CandleInterval::iter() {
                 let base_denom = pair.base_denom.to_string();
                 let quote_denom = pair.quote_denom.to_string();
-
-                #[cfg(feature = "tracing")]
-                tracing::info!("Checking candles for {base_denom}/{quote_denom} at {interval:?}");
 
                 if !self.check(&base_denom, &quote_denom, interval).await? {
                     #[cfg(feature = "tracing")]
@@ -39,14 +39,15 @@ impl Indexer {
         interval: CandleInterval,
     ) -> Result<bool, IndexerError> {
         #[cfg(feature = "tracing")]
-        tracing::info!("Checking candles for {base_denom}/{quote_denom} at {interval:?}");
+        tracing::info!("Checking candles for {base_denom}/{quote_denom} for interval {interval:?}");
 
         let clickhouse_client = self.context.clickhouse_client().clone();
         let query_builder = crate::entities::candle_query::CandleQueryBuilder::new(
             interval,
             base_denom.to_string(),
             quote_denom.to_string(),
-        );
+        )
+        .without_limit();
 
         // will get most recent candle first
         let mut cursor = query_builder.fetch(&clickhouse_client)?;
@@ -58,26 +59,33 @@ impl Indexer {
         };
 
         let mut error = false;
+        let mut counter = 1;
 
         while let Some(candle) = cursor.next().await? {
             if candle.close != later_candle.open {
                 #[cfg(feature = "tracing")]
                 tracing::warn!(
-                    ?candle,
-                    ?later_candle,
-                    candle_close=?candle.close,
-                    later_candle_open=?later_candle.open,
-                    block_height=candle.block_height,
+                    // ?candle,
+                    // ?later_candle,
+                    // candle_close=?candle.close,
+                    // later_candle_open=?later_candle.open,
+                    candle_block_height=candle.block_height,
+                    later_block_height=later_candle.block_height,
+                    candle_time_start=%candle.time_start,
+                    later_time_start=%later_candle.time_start,
                     "Candle close price does not match later candle close"
                 );
                 error = true;
             }
 
             later_candle = candle;
+            counter += 1;
         }
 
         #[cfg(feature = "tracing")]
-        tracing::info!("All candles checked successfully");
+        tracing::info!(
+            "checked {counter} candles for {base_denom}/{quote_denom} at interval {interval:?}"
+        );
 
         Ok(!error)
     }

--- a/indexer/clickhouse/src/checker.rs
+++ b/indexer/clickhouse/src/checker.rs
@@ -21,10 +21,10 @@ impl Indexer {
                 let quote_denom = pair.quote_denom.to_string();
 
                 if !self.check(&base_denom, &quote_denom, interval).await? {
-                    #[cfg(feature = "tracing")]
-                    tracing::info!("candles don't match");
+                    // #[cfg(feature = "tracing")]
+                    // tracing::info!("candles don't match");
 
-                    return Ok(false);
+                    // return Ok(false);
                 }
             }
         }
@@ -58,35 +58,31 @@ impl Indexer {
             return Ok(true);
         };
 
-        let mut error = false;
-        let mut counter = 1;
+        let mut total_candles = 1;
+        let mut wrong_candles = 0;
 
         while let Some(candle) = cursor.next().await? {
             if candle.close != later_candle.open {
-                #[cfg(feature = "tracing")]
-                tracing::warn!(
-                    // ?candle,
-                    // ?later_candle,
-                    // candle_close=?candle.close,
-                    // later_candle_open=?later_candle.open,
-                    candle_block_height=candle.block_height,
-                    later_block_height=later_candle.block_height,
-                    candle_time_start=%candle.time_start,
-                    later_time_start=%later_candle.time_start,
-                    "Candle close price does not match later candle close"
-                );
-                error = true;
+                // #[cfg(feature = "tracing")]
+                // tracing::warn!(
+                //     candle_block_height=candle.block_height,
+                //     later_block_height=later_candle.block_height,
+                //     candle_time_start=%candle.time_start,
+                //     later_time_start=%later_candle.time_start,
+                //     "Candle close price does not match later candle close"
+                // );
+                wrong_candles += 1;
             }
 
             later_candle = candle;
-            counter += 1;
+            total_candles += 1;
         }
 
         #[cfg(feature = "tracing")]
         tracing::info!(
-            "checked {counter} candles for {base_denom}/{quote_denom} at interval {interval:?}"
+            "checked {total_candles} candles for {base_denom}/{quote_denom} at interval {interval:?}, found {wrong_candles} wrong candles"
         );
 
-        Ok(!error)
+        Ok(wrong_candles == 0)
     }
 }

--- a/indexer/clickhouse/src/entities/candle_query.rs
+++ b/indexer/clickhouse/src/entities/candle_query.rs
@@ -25,7 +25,7 @@ pub struct CandleQueryBuilder {
     earlier_than: Option<DateTime<Utc>>,
     later_than: Option<DateTime<Utc>>,
     after: Option<DateTime<Utc>>,
-    limit: usize,
+    limit: Option<usize>,
 }
 
 impl CandleQueryBuilder {
@@ -37,7 +37,7 @@ impl CandleQueryBuilder {
             earlier_than: None,
             later_than: None,
             after: None,
-            limit: MAX_ITEMS,
+            limit: Some(MAX_ITEMS),
         }
     }
 
@@ -47,7 +47,12 @@ impl CandleQueryBuilder {
     }
 
     pub fn with_limit(mut self, limit: usize) -> Self {
-        self.limit = std::cmp::min(limit, MAX_ITEMS);
+        self.limit = Some(std::cmp::min(limit, MAX_ITEMS));
+        self
+    }
+
+    pub fn without_limit(mut self) -> Self {
+        self.limit = None;
         self
     }
 
@@ -80,7 +85,7 @@ impl CandleQueryBuilder {
 
         let mut rows: Vec<Candle> = cursor_query.fetch_all().await?;
 
-        let has_next_page = rows.len() > self.limit - 1;
+        let has_next_page = rows.len() > self.limit.unwrap_or_default() - 1;
         if has_next_page {
             rows.pop();
         }
@@ -197,7 +202,9 @@ impl CandleQueryBuilder {
 
         query.push_str(" GROUP BY quote_denom, base_denom, time_start");
         query.push_str(" ORDER BY time_start DESC");
-        query.push_str(&format!(" LIMIT {}", self.limit + 1));
+        if let Some(limit) = self.limit {
+            query.push_str(&format!(" LIMIT {}", limit + 1));
+        }
 
         (query, params, has_previous_page)
     }

--- a/indexer/clickhouse/src/httpd/graphql/subscription/candle.rs
+++ b/indexer/clickhouse/src/httpd/graphql/subscription/candle.rs
@@ -120,6 +120,7 @@ impl CandleSubscription {
                         cache_max_block_height=?_cache_max_block_height,
                         cache_min_block_height=?_cache_min_block_height,
                         cache_len=?_cache_len,
+                        interval = ?interval,
                         "Skip candle, it has older block_height than received pubsub block_height"
                     );
 

--- a/justfile
+++ b/justfile
@@ -79,3 +79,13 @@ docker-build-builder-images:
 
   # Push the manifest
   docker manifest push ghcr.io/left-curve/left-curve/native-builder:latest
+
+# ------------------------------- Debug --------------------------------
+
+check-candles:
+  INDEXER__CLICKHOUSE__URL="http://localhost:8123" \
+    INDEXER__DATABASE__URL=postgres://postgres@localhost:5432/grug_dev \
+    INDEXER__CLICKHOUSE__DATABASE=testnet_dango_production \
+    INDEXER__CLICKHOUSE__PASSWORD=${CLICKHOUSE_PASSWORD} \
+    RUST_LOG=info \
+    cargo run -p dango-cli indexer --home networks/localdango/configs/dango/ check-candles

--- a/networks/localdango/configs/clickhouse/config.xml
+++ b/networks/localdango/configs/clickhouse/config.xml
@@ -89,4 +89,17 @@
 
     <!-- Format schemas -->
     <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
+
+  <storage_configuration>
+    <disks>
+      <backups>
+        <type>local</type>
+        <path>/var/log/clickhouse-server/backups/</path>
+      </backups>
+    </disks>
+  </storage_configuration>
+  <backups>
+    <allowed_disk>backups</allowed_disk>
+    <allowed_path>/var/log/clickhouse-server/backups/</allowed_path>
+  </backups>
 </clickhouse>

--- a/networks/localdango/docker-compose.yml
+++ b/networks/localdango/docker-compose.yml
@@ -163,8 +163,8 @@ services:
       # - "127.0.0.1:9009:9009" # Inter-server communication (for clusters)
       # - "127.0.0.1:9004:9004" # MySQL compatibility interface
     volumes:
-      - clickhouse_data:/var/lib/clickhouse
-      - clickhouse_logs:/var/log/clickhouse-server
+      - ./data/clickhouse:/var/lib/clickhouse
+      - ./logs/clickhouse:/var/log/clickhouse-server
       - ./configs/clickhouse/config.xml:/etc/clickhouse-server/config.xml:ro
       - ./configs/clickhouse/users.xml:/etc/clickhouse-server/users.xml:ro
     environment:
@@ -219,5 +219,3 @@ volumes:
   dango_data:
   dango_indexer:
   cometbft_data:
-  clickhouse_data:
-  clickhouse_logs:

--- a/networks/localdango/justfile
+++ b/networks/localdango/justfile
@@ -61,6 +61,9 @@ run-dev-db:
 check-dev-db:
   docker compose run --rm db pg_isready -h {{DB_HOST}} -p {{DB_PORT}} -U {{DB_USER}}
 
+restore-clickhouse filename:
+  docker compose exec clickhouse clickhouse-client --query "RESTORE DATABASE testnet_dango_production FROM File('/var/log/clickhouse-server/backups/{{filename}}')"
+
 # Create the development database
 create-dev-db:
   docker compose run --rm db createdb -h {{DB_HOST}} -p {{DB_PORT}} -U {{DB_USER}} {{DB_NAME}}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Clickhouse backup functionality and fix candle handling in the indexer.
> 
>   - **Clickhouse Backups**:
>     - Adds `make_clickhouse_backup.sh` script for backing up Clickhouse databases.
>     - Updates `config.xml` and `docker-compose.yml` to support backup storage at `/var/log/clickhouse-server/backups/`.
>     - Copies backup script in `deploy/roles/clickhouse/tasks/main.yml`.
>   - **Candle Handling Fixes**:
>     - Fixes candle block height handling in `CandleCache::add_candle()` in `cache.rs`.
>     - Updates `check()` in `checker.rs` to log total and wrong candles.
>     - Modifies `CandleQueryBuilder` in `candle_query.rs` to allow optional limits.
>   - **Miscellaneous**:
>     - Adds `check-candles` command to `justfile` for debugging candle consistency.
>     - Adjusts logging in `main.rs` to include `fmt_layer`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for a2a8d53b871719fececc5fef6f7db411933296b9. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->