### PR TITLE
Fix sorted market orders test

### DIFF
--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5861,14 +5861,14 @@ fn market_orders_are_sorted_by_price_ascending() {
                                     base_denom: dango::DENOM.clone(),
                                     quote_denom: usdc::DENOM.clone(),
                                     direction: Direction::Bid,
-                                    amount: NonZero::new_unchecked(Uint128::new(1050000)),
+                                    amount: NonZero::new_unchecked(Uint128::new(1000000)), // amount in base asset
                                     max_slippage: Udec128::new_percent(5),
                                 }],
                                 creates_limit: vec![],
                                 cancels: None,
                             },
                             coins! {
-                                usdc::DENOM.clone() => 1102500, // amount * (best_ask_price * (1 + max_slippage)) = 1050000 * (1 * (1 + 0.05))
+                                usdc::DENOM.clone() => 1050000, // amount * (best_ask_price * (1 + max_slippage)) = 1000000 * (1 * (1 + 0.05))
                             },
                         )
                         .unwrap(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix test in `dex.rs` to correct expected USDC amount for market order with slippage.
> 
>   - **Tests**:
>     - Fix `market_orders_are_sorted_by_price_ascending()` in `dex.rs` by adjusting the expected USDC amount from `1102500` to `1050000` to match the corrected base asset amount and slippage calculation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 37b0d567f1d5434dee9efaf711a8ffb52dc44e63. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->