### PR TITLE
Emit OrderCanceled event for unmatched market orders

### DIFF
--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -13,8 +13,8 @@ use {
         DangoQuerier,
         account_factory::Username,
         dex::{
-            CallbackMsg, Direction, ExecuteMsg, LimitOrder, MarketOrder, Order, OrderFilled,
-            OrderId, OrderTrait, OrdersMatched, PassiveOrder, Paused, Price, ReplyMsg,
+            CallbackMsg, Direction, ExecuteMsg, LimitOrder, MarketOrder, Order, OrderCanceled,
+            OrderFilled, OrderId, OrderTrait, OrdersMatched, PassiveOrder, Paused, Price, ReplyMsg,
             RestingOrderBookState,
         },
         taxman::{self, FeeType},
@@ -375,21 +375,49 @@ fn clear_orders_of_pair(
     // ------------------- 4. Handle unmatched market orders -------------------
 
     if let Some((_price, order)) = unmatched_bid {
-        refund_unmatched_order(&base_denom, &quote_denom, Direction::Bid, order, refunds)?;
+        refund_unmatched_market_order(
+            &base_denom,
+            &quote_denom,
+            Direction::Bid,
+            order,
+            refunds,
+            events,
+        )?;
     }
 
     for res in unmatched_market_bids {
         let (_price, order) = res?;
-        refund_unmatched_order(&base_denom, &quote_denom, Direction::Bid, order, refunds)?;
+        refund_unmatched_market_order(
+            &base_denom,
+            &quote_denom,
+            Direction::Bid,
+            order,
+            refunds,
+            events,
+        )?;
     }
 
     if let Some((_price, order)) = unmatched_ask {
-        refund_unmatched_order(&base_denom, &quote_denom, Direction::Ask, order, refunds)?;
+        refund_unmatched_market_order(
+            &base_denom,
+            &quote_denom,
+            Direction::Ask,
+            order,
+            refunds,
+            events,
+        )?;
     }
 
     for res in unmatched_market_asks {
         let (_price, order) = res?;
-        refund_unmatched_order(&base_denom, &quote_denom, Direction::Ask, order, refunds)?;
+        refund_unmatched_market_order(
+            &base_denom,
+            &quote_denom,
+            Direction::Ask,
+            order,
+            refunds,
+            events,
+        )?;
     }
 
     #[cfg(feature = "tracing")]
@@ -685,12 +713,17 @@ fn fill_passive_order(
     Ok(())
 }
 
-fn refund_unmatched_order(
+/// Add a refund to the `refunds` transfer builder and emit an order canceled event
+/// for an unmatched market order.
+///
+/// If the order is not a market order, then this function is a no-op.
+fn refund_unmatched_market_order(
     base_denom: &Denom,
     quote_denom: &Denom,
     direction: Direction,
     order: Order,
     refunds: &mut TransferBuilder<DecCoins<6>>,
+    events: &mut EventBuilder,
 ) -> StdResult<()> {
     let Order::Market(order) = order else {
         // Market orders are immediate-or-cancel, so unmatched market orders are
@@ -700,17 +733,26 @@ fn refund_unmatched_order(
         return Ok(());
     };
 
-    match direction {
+    let refund = match direction {
         Direction::Bid => {
             let remaining_in_quote = order.remaining.checked_mul_dec_floor(order.price)?;
             refunds.insert(order.user, quote_denom.clone(), remaining_in_quote)?;
+            (quote_denom.clone(), remaining_in_quote).into()
         },
         Direction::Ask => {
             refunds.insert(order.user, base_denom.clone(), order.remaining)?;
+            (base_denom.clone(), order.remaining).into()
         },
-    }
+    };
 
-    // TODO: emit order canceled event
+    // Emit order canceled event
+    events.push(OrderCanceled {
+        user: order.user,
+        id: order.id,
+        kind: order.kind(),
+        remaining: order.remaining,
+        refund,
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Emit `OrderCanceled` event for unmatched market orders by introducing `refund_unmatched_market_order()` in `cron.rs`.
> 
>   - **Behavior**:
>     - Emit `OrderCanceled` event for unmatched market orders in `clear_orders_of_pair()`.
>     - Introduce `refund_unmatched_market_order()` to handle refunds and event emission.
>   - **Functions**:
>     - Replace `refund_unmatched_order()` with `refund_unmatched_market_order()` in `clear_orders_of_pair()`.
>     - `refund_unmatched_market_order()` emits `OrderCanceled` event and processes refunds for market orders.
>   - **Misc**:
>     - Update imports in `cron.rs` to include `OrderCanceled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 92044f2f1d69b7738936fc826808e5bc8c923cd4. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->