### PR TITLE
Fix zero output tests

### DIFF
--- a/dango/dex/src/core/order_matching.rs
+++ b/dango/dex/src/core/order_matching.rs
@@ -93,7 +93,15 @@ where
         volume: bid_volume.min(ask_volume),
         bids,
         asks,
-        unmatched_bid: bid,
-        unmatched_ask: ask,
+        unmatched_bid: if bid_is_new {
+            bid
+        } else {
+            None
+        },
+        unmatched_ask: if ask_is_new {
+            ask
+        } else {
+            None
+        },
     })
 }

--- a/dango/dex/src/core/order_matching.rs
+++ b/dango/dex/src/core/order_matching.rs
@@ -93,15 +93,7 @@ where
         volume: bid_volume.min(ask_volume),
         bids,
         asks,
-        unmatched_bid: if bid_is_new {
-            bid
-        } else {
-            None
-        },
-        unmatched_ask: if ask_is_new {
-            ask
-        } else {
-            None
-        },
+        unmatched_bid: bid.take_if(|_| bid_is_new),
+        unmatched_ask: ask.take_if(|_| ask_is_new),
     })
 }

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5505,37 +5505,6 @@ fn market_order_clearing(
     CreateLimitOrderRequest {
         base_denom: eth::DENOM.clone(),
         quote_denom: usdc::DENOM.clone(),
-        direction: Direction::Ask,
-        amount: NonZero::new_unchecked(Uint128::new(9307)),
-        price: NonZero::new_unchecked(Udec128_24::new(1000000)),
-    },
-    coins! {
-        eth::DENOM.clone() => 9307,
-    },
-    CreateMarketOrderRequest {
-        base_denom: eth::DENOM.clone(),
-        quote_denom: usdc::DENOM.clone(),
-        direction: Direction::Bid,
-        amount: NonZero::new_unchecked(Uint128::new(500000)),
-        max_slippage: Udec128::new_percent(8),
-    },
-    coins! {
-        usdc::DENOM.clone() => 500000,
-    },
-    btree_map! {
-        eth::DENOM.clone() => BalanceChange::Decreased(9307),
-        usdc::DENOM.clone() => BalanceChange::Increased(498750),
-    },
-    btree_map! {
-        eth::DENOM.clone() => BalanceChange::Unchanged,
-        usdc::DENOM.clone() => BalanceChange::Decreased(500000),
-    }
-    ; "limit ask matched with market bid market size limiting factor market order gets refunded"
-)]
-#[test_case(
-    CreateLimitOrderRequest {
-        base_denom: eth::DENOM.clone(),
-        quote_denom: usdc::DENOM.clone(),
         direction: Direction::Bid,
         amount: NonZero::new_unchecked(Uint128::new(500000)),
         price: NonZero::new_unchecked(Udec128_24::new_bps(1)),

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -5561,7 +5561,7 @@ fn market_order_clearing(
         eth::DENOM.clone() => BalanceChange::Decreased(9999),
         usdc::DENOM.clone() => BalanceChange::Unchanged,
     }
-    ; "limit bid matched with market ask market size limiting factor market order gets refunded"
+    ; "limit bid matched with market ask market size limiting factor market order does not get refunded"
 )]
 #[test_case(
     CreateLimitOrderRequest {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of unmatched market orders in `match_orders` and update related tests in `dex.rs`.
> 
>   - **Behavior**:
>     - Modify `match_orders` in `order_matching.rs` to set `unmatched_bid` and `unmatched_ask` to `None` if the bid or ask is not new, respectively.
>     - Remove test case for "limit ask matched with market bid market size limiting factor market order gets refunded" in `dex.rs`.
>   - **Tests**:
>     - Remove test case in `dex.rs` that expected market orders to be refunded when not fully matched.
>     - Update test case description in `dex.rs` to reflect that market orders do not get refunded when not fully matched.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for bd03f4e72b5c1a61c3ccaf80e8b5dbbba0c69ba4. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->