### PR TITLE
Add query_status to QueryClientExt

### DIFF
--- a/grug/types/src/client/query.rs
+++ b/grug/types/src/client/query.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         Addr, Binary, Code, Coins, Config, ContractInfo, Denom, Hash256, JsonDeExt, Query,
-        QueryRequest, QueryResponse, StdError, TxOutcome, UnsignedTx,
+        QueryRequest, QueryResponse, QueryStatusResponse, StdError, TxOutcome, UnsignedTx,
     },
     async_trait::async_trait,
     grug_math::Uint128,
@@ -32,6 +32,12 @@ pub trait QueryClient: Send + Sync {
 
 #[async_trait]
 pub trait QueryClientExt: QueryClient {
+    async fn query_status(&self, height: Option<u64>) -> Result<QueryStatusResponse, Self::Error> {
+        self.query_app(Query::status(), height)
+            .await
+            .map(|res| res.as_status())
+    }
+
     async fn query_config(&self, height: Option<u64>) -> Result<Config, Self::Error> {
         self.query_app(Query::config(), height)
             .await


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `query_status` method to `QueryClientExt` in `query.rs` for querying application status at a specific block height.
> 
>   - **Functionality**:
>     - Adds `query_status` method to `QueryClientExt` in `query.rs` to query application status at a specific block height.
>     - Uses `query_app` with `Query::status()` and maps the result to `QueryStatusResponse`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 1f259ba300ca2ffc29b77cd0edbd41d87003beea. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->