### PR TITLE
feat(ui): chartiq lazy loading

### DIFF
--- a/ui/portal/web/public/global.css
+++ b/ui/portal/web/public/global.css
@@ -188,119 +188,119 @@ body {
 }
 
 .fp-overflow {
-width: 100%;
+  width: 100%;
 }
 
 /* ChartIQ */
-cq-drawing-palette cq-separator {
+#chartiq cq-drawing-palette cq-separator {
   opacity: .4;
   border-color: var(--color-secondary-700);
 }
 
-cq-drawing-palette .tool-group .drawing-tools-group cq-separator {
+#chartiq cq-drawing-palette .tool-group .drawing-tools-group cq-separator {
   margin: 5px 4px;
 }
 
-cq-drawing-palette cq-scroll {
+#chartiq cq-drawing-palette cq-scroll {
   scrollbar-width: none;
   scrollbar-color: initial;
   max-width: 65px;
   margin: 0 auto;
 }
 
-cq-drawing-palette cq-scroll::-webkit-scrollbar {
+#chartiq cq-drawing-palette cq-scroll::-webkit-scrollbar {
   width: 0;
   height: 0;
 }
 
-cq-drawing-palette cq-scroll:hover {
+#chartiq cq-drawing-palette cq-scroll:hover {
   scrollbar-width: thin;
   scrollbar-color: var(--color-secondary-gray) var(--color-surface-primary-rice);
 }
 
 
-.ciq-day .ciq-nav,
-.ciq-day .chartContainer,
-.ciq-day cq-chart-title,
-.ciq-night .ciq-nav,
-.ciq-night .chartContainer,
-.ciq-night cq-chart-title {
+#chartiq .ciq-day .ciq-nav,
+#chartiq .ciq-day .chartContainer,
+#chartiq .ciq-day cq-chart-title,
+#chartiq .ciq-night .ciq-nav,
+#chartiq .ciq-night .chartContainer,
+#chartiq .ciq-night cq-chart-title {
   color: var(--color-tertiary-500) !important;
   background: var(--color-surface-secondary-rice) !important;
   border: none;
 }
 
-cq-palette-dock [orientation="vertical"] {
+#chartiq cq-palette-dock [orientation="vertical"] {
   border-right: var(--color-secondary-gray) 1px solid;
 }
 
-cq-separator {
+#chartiq cq-separator {
   border-color: var(--color-secondary-gray);
 }
 
-.palette-container {
+#chartiq .palette-container {
   background: var(--color-surface-secondary-rice);
   border: none;
 }
 
-.ciq-day cq-menu .menu-clickable:not(cq-help),
-.ciq-night cq-menu .menu-clickable:not(cq-help) {
+#chartiq .ciq-day cq-menu .menu-clickable:not(cq-help),
+#chartiq .ciq-night cq-menu .menu-clickable:not(cq-help) {
   color: var(--color-tertiary-500);
 }
 
-.stx-subholder {
+#chartiq .stx-subholder {
   border: none;
 }
 
-.ciq-chart {
+#chartiq .ciq-chart {
   box-shadow: none;
 }
 
-cq-drawing-palette .tool-group .drawing-tools-group {
+#chartiq cq-drawing-palette .tool-group .drawing-tools-group {
   margin: 0;
 }
 
-.ciq-day .ciq-chart:first-of-type,
-.ciq-day cq-dropdown .content,
-.ciq-night .ciq-chart:first-of-type,
-.ciq-night cq-dropdown .content,
-cq-drawing-palette .ciq-tool:before,
-cq-drawing-palette .ciq-mini-widget:before {
+#chartiq .ciq-day .ciq-chart:first-of-type,
+#chartiq .ciq-day cq-dropdown .content,
+#chartiq .ciq-night .ciq-chart:first-of-type,
+#chartiq .ciq-night cq-dropdown .content,
+#chartiq cq-drawing-palette .ciq-tool:before,
+#chartiq cq-drawing-palette .ciq-mini-widget:before {
   background: var(--color-surface-secondary-rice);
 }
 
-.ciq-night cq-drawing-palette .ciq-tool:before,
-.ciq-night cq-drawing-palette .ciq-mini-widget:before,
-.ciq-night .ciq-select:hover,
-.ciq-day cq-drawing-palette .ciq-tool:before,
-.ciq-day cq-drawing-palette .ciq-mini-widget:before,
-.ciq-day .ciq-select:hover {
+#chartiq .ciq-night cq-drawing-palette .ciq-tool:before,
+#chartiq .ciq-night cq-drawing-palette .ciq-mini-widget:before,
+#chartiq .ciq-night .ciq-select:hover,
+#chartiq .ciq-day cq-drawing-palette .ciq-tool:before,
+#chartiq .ciq-day cq-drawing-palette .ciq-mini-widget:before,
+#chartiq .ciq-day .ciq-select:hover {
   background: var(--color-surface-tertiary-rice);
   border: transparent;
   color: var(--color-primary-900);
 }
 
-cq-heading {
+#chartiq cq-heading {
   @apply exposure-xs-italic;
   text-transform: capitalize;
   color: var(--color-secondary-700);
 }
 
-cq-dropdown .content>.item.ciq-active .ciq-switch,
-cq-dropdown .content>.item.ciq-active:hover .ciq-switch,
-.ciq-active .ciq-radio span:after,
-.ciq-radio.ciq-active span:after,
-.ciq-active>.ciq-switch,
-.ciq-switch:checked,
-.ciq-active>.ciq-switch:hover,
-html:not([ciq-last-interaction="touch"]) .ciq-context-menu div.ciq-switch-item.ciq-active:hover .ciq-switch,
+#chartiq cq-dropdown .content>.item.ciq-active .ciq-switch,
+#chartiq cq-dropdown .content>.item.ciq-active:hover .ciq-switch,
+#chartiq .ciq-active .ciq-radio span:after,
+#chartiq .ciq-radio.ciq-active span:after,
+#chartiq .ciq-active>.ciq-switch,
+#chartiq .ciq-switch:checked,
+#chartiq .ciq-active>.ciq-switch:hover,
+html:not([ciq-last-interaction="touch"]) #chartiq .ciq-context-menu div.ciq-switch-item.ciq-active:hover .ciq-switch,
 .ciq-context-menu div.ciq-switch-item.ciq-active .ciq-switch {
   /* biome-ignore lint/correctness/noUnknownFunction: theme() is required for dynamic Tailwind color */
   background: theme("colors.red-bean.500");
 }
 
-.ciq-active .ciq-radio span:after,
-.ciq-radio.ciq-active span:after {
+#chartiq .ciq-active .ciq-radio span:after,
+#chartiq .ciq-radio.ciq-active span:after {
   bottom: initial;
   top: 50%;
   left: 50%;
@@ -308,23 +308,23 @@ html:not([ciq-last-interaction="touch"]) .ciq-context-menu div.ciq-switch-item.c
 }
 
 
-cq-drawing-palette.list .mini-widget-group .ciq-mini-widget[cq-view="list"] .icon,
-cq-drawing-palette.grid .mini-widget-group .ciq-mini-widget[cq-view="grid"] .icon,
-cq-drawing-palette .ciq-mini-widget.active .icon,
-cq-drawing-palette .ciq-mini-widget .active .icon,
-cq-drawing-palette .ciq-mini-widget:active .icon,
-cq-drawing-palette .ciq-mini-widget .active+.icon,
-cq-drawing-palette .ciq-tool.active .icon,
-cq-drawing-palette .ciq-tool:active .icon {
+#chartiq cq-drawing-palette.list .mini-widget-group .ciq-mini-widget[cq-view="list"] .icon,
+#chartiq cq-drawing-palette.grid .mini-widget-group .ciq-mini-widget[cq-view="grid"] .icon,
+#chartiq cq-drawing-palette .ciq-mini-widget.active .icon,
+#chartiq cq-drawing-palette .ciq-mini-widget .active .icon,
+#chartiq cq-drawing-palette .ciq-mini-widget:active .icon,
+#chartiq cq-drawing-palette .ciq-mini-widget .active+.icon,
+#chartiq cq-drawing-palette .ciq-tool.active .icon,
+#chartiq cq-drawing-palette .ciq-tool:active .icon {
   filter: var(--chartiq-filter);
 }
 
-cq-drawing-palette .ciq-tool label,
-cq-drawing-palette .ciq-tool span[label],
-cq-drawing-palette .ciq-mini-widget label,
-cq-drawing-palette .ciq-mini-widget span[label],
-[cq-tooltip],
-*>[cq-tooltip] {
+#chartiq cq-drawing-palette .ciq-tool label,
+#chartiq cq-drawing-palette .ciq-tool span[label],
+#chartiq cq-drawing-palette .ciq-mini-widget label,
+#chartiq cq-drawing-palette .ciq-mini-widget span[label],
+#chartiq [cq-tooltip],
+#chartiq *>[cq-tooltip] {
   background: var(--color-surface-quaternary-rice);
   color: var(--color-foreground-primary-rice);
   border-radius: 8px;
@@ -333,60 +333,60 @@ cq-drawing-palette .ciq-mini-widget span[label],
   font-size: 10px;
 }
 
-:host(cq-dropdown.ciq-night) .item.separator-item hr,
-.ciq-night cq-dropdown .item.separator-item hr,
-:host(cq-dropdown.ciq-day) .item.separator-item hr,
-.ciq-day cq-dropdown .item.separator-item hr,
-cq-dialog.ciq-night hr,
-cq-dialog.ciq-day hr {
+:host(cq-dropdown.ciq-night) #chartiq .item.separator-item hr,
+#chartiq .ciq-night cq-dropdown .item.separator-item hr,
+:host(cq-dropdown.ciq-day) #chartiq .item.separator-item hr,
+#chartiq .ciq-day cq-dropdown .item.separator-item hr,
+#chartiq cq-dialog.ciq-night hr,
+#chartiq cq-dialog.ciq-day hr {
   border-bottom-color: var(--color-border-secondary-rice);
 }
 
-cq-dropdown .content>.item:not(:is(.separator-item, .heading-item, .template-item, .ciq-btn)):hover>*,
-cq-drawing-palette,
-cq-menu.nav-dropdown:before,
-.ciq-nav cq-toggle:before,
-cq-views .item:hover,
-cq-study-legend.shaded .item:hover,
-html:not([ciq-last-interaction="touch"]) cq-studies .item:hover {
+#chartiq cq-dropdown .content>.item:not(:is(.separator-item, .heading-item, .template-item, .ciq-btn)):hover>*,
+#chartiq cq-drawing-palette,
+#chartiq cq-menu.nav-dropdown:before,
+#chartiq .ciq-nav cq-toggle:before,
+#chartiq cq-views .item:hover,
+#chartiq cq-study-legend.shaded .item:hover,
+html:not([ciq-last-interaction="touch"]) #chartiq cq-studies .item:hover {
   background: var(--color-surface-tertiary-rice) !important
 }
 
-cq-drawing-palette {
+#chartiq cq-drawing-palette {
   outline: none;
 }
 
-:host(cq-toggle.active),
-cq-toggle.active {
+:host(cq-toggle.active) #chartiq,
+#chartiq cq-toggle.active {
   border-bottom: 3px solid var(--color-primary-rice)
 }
 
-.stx_current_hr_up,
-.stx_candle_up {
+#chartiq .stx_current_hr_up,
+#chartiq .stx_candle_up {
   background-color: var(--color-status-success);
 }
 
-.stx_current_hr_down,
-.stx_candle_down {
+#chartiq .stx_current_hr_down,
+#chartiq .stx_candle_down {
   background-color: var(--color-status-fail);
 }
 
-.cq-down,
-.stx_candle_down {
+#chartiq .cq-down,
+#chartiq .stx_candle_down {
   color: var(--color-status-fail);
 }
 
-.cq-up,
-.stx_candle_up {
+#chartiq .cq-up,
+#chartiq .stx_candle_up {
   color: var(--color-status-success);
 }
 
-.ciq-chart-area,
-cq-side-panel {
+#chartiq .ciq-chart-area,
+#chartiq cq-side-panel {
   bottom: 0;
 }
 
-.cq-dialogs {
+#chartiq .cq-dialogs {
   z-index: 99999999;
   position: fixed;
   top: 50%;
@@ -396,17 +396,17 @@ cq-side-panel {
   color: var(--color-primary-900);
 }
 
-html:not([ciq-last-interaction="touch"]) .ciq-night .ciq-context-menu div:hover {
+html:not([ciq-last-interaction="touch"]) #chartiq .ciq-night .ciq-context-menu div:hover {
   background: var(--color-surface-tertiary-rice);
 
 }
 
-cq-dialog.ciq-night[cq-drawing-context],
-cq-dialog.ciq-night[cq-study-context],
-cq-dialog.ciq-night[cq-yaxis-context],
-cq-dialog.ciq-day[cq-drawing-context],
-cq-dialog.ciq-day[cq-study-context],
-cq-dialog.ciq-day[cq-yaxis-context] {
+#chartiq cq-dialog.ciq-night[cq-drawing-context],
+#chartiq cq-dialog.ciq-night[cq-study-context],
+#chartiq cq-dialog.ciq-night[cq-yaxis-context],
+#chartiq cq-dialog.ciq-day[cq-drawing-context],
+#chartiq cq-dialog.ciq-day[cq-study-context],
+#chartiq cq-dialog.ciq-day[cq-yaxis-context] {
   box-shadow: var(--shadow-card);
 }
 
@@ -415,34 +415,34 @@ cq-dialog.ciq-day[cq-yaxis-context] {
 .ciq-night cq-dropdown .content,
 cq-dropdown.ciq-night .content,
 :host(cq-dropdown.ciq-day) .content,
-.ciq-day cq-dropdown .content,
-cq-dropdown.ciq-day .content {
+#chartiq .ciq-day cq-dropdown .content,
+#chartiq cq-dropdown.ciq-day .content {
   /* biome-ignore lint/correctness/noUnknownFunction: theme() is required for dynamic Tailwind boxShadow */
   box-shadow: theme("boxShadow.account-card");
   @apply diatype-xs-medium;
 }
 
-html:not([ciq-last-interaction="touch"]) cq-palette-dock .ciq-select:hover {
+html:not([ciq-last-interaction="touch"]) #chartiq cq-palette-dock .ciq-select:hover {
   color: var(--color-secondary-700);
 }
 
-.ciq-select {
+#chartiq .ciq-select {
   background: var(--color-surface-secondary-rice);
   border-radius: 8px;
   border: 1px solid var(--color-surface-tertiary-rice) !important;
 }
 
-cq-menu .ciq-screen-reader {
+#chartiq cq-menu .ciq-screen-reader {
   @apply diatype-xs-medium;
 }
 
-.chartContainer {
+#chartiq .chartContainer {
   @apply diatype-xs-medium;
   font-size: 10px;
 }
 
-cq-dialog.ciq-night,
-cq-dialog.ciq-day {
+#chartiq cq-dialog.ciq-night,
+#chartiq cq-dialog.ciq-day {
   /* biome-ignore lint/correctness/noUnknownFunction: theme() is required for dynamic Tailwind boxShadow */
   box-shadow: theme("boxShadow.account-card");
   margin-top: 0;
@@ -453,24 +453,24 @@ cq-dialog.ciq-day {
 }
 
 
-cq-chart-title cq-symbol {
+#chartiq cq-chart-title cq-symbol {
   @apply h3-heavy;
 }
 
-cq-dialog.ciq-night input:hover,
-cq-dialog.ciq-day input:hover {
+#chartiq cq-dialog.ciq-night input:hover,
+#chartiq cq-dialog.ciq-day input:hover {
   background: var(--color-surface-tertiary-rice);
 }
 
-.ciq-night .ciq-btn,
-.ciq-night .ciq-btn-negative,
-.ciq-night .annotationCancel,
-.ciq-night .annotationSave,
-.ciq-day .ciq-btn,
-.ciq-day .ciq-btn-negative,
-.ciq-day .annotationCancel,
-.ciq-day .annotationSave,
-cq-study-legend .item.ciq-btn {
+#chartiq .ciq-night .ciq-btn,
+#chartiq .ciq-night .ciq-btn-negative,
+#chartiq .ciq-night .annotationCancel,
+#chartiq .ciq-night .annotationSave,
+#chartiq .ciq-day .ciq-btn,
+#chartiq .ciq-day .ciq-btn-negative,
+#chartiq .ciq-day .annotationCancel,
+#chartiq .ciq-day .annotationSave,
+#chartiq cq-study-legend .item.ciq-btn {
   display: inline-flex;
   justify-content: center;
   align-items: center;
@@ -489,29 +489,29 @@ cq-study-legend .item.ciq-btn {
   @apply exposure-xs-italic;
 }
 
-cq-study-legend.shaded [section-dynamic] {
+#chartiq cq-study-legend.shaded [section-dynamic] {
   background: var(--color-surface-secondary-rice);
 }
 
-.ciq-dialog-cntrls {
+#chartiq .ciq-dialog-cntrls {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-cq-clickable {
+#chartiq cq-clickable {
   margin: 8px auto 0;
 }
 
-.ciq-night .ciq-btn:hover,
-.ciq-night .ciq-btn-negative:hover,
-.ciq-night .annotationCancel:hover,
-.ciq-night .annotationSave:hover,
-.ciq-day .ciq-btn:hover,
-.ciq-day .ciq-btn-negative:hover,
-.ciq-day .annotationCancel:hover,
-.ciq-day .annotationSave:hover,
-cq-study-legend.shaded cq-clickable.clickable-item.item.ciq-btn:hover {
+#chartiq .ciq-night .ciq-btn:hover,
+#chartiq .ciq-night .ciq-btn-negative:hover,
+#chartiq .ciq-night .annotationCancel:hover,
+#chartiq .ciq-night .annotationSave:hover,
+#chartiq .ciq-day .ciq-btn:hover,
+#chartiq .ciq-day .ciq-btn-negative:hover,
+#chartiq .ciq-day .annotationCancel:hover,
+#chartiq .ciq-day .annotationSave:hover,
+#chartiq cq-study-legend.shaded cq-clickable.clickable-item.item.ciq-btn:hover {
   /* biome-ignore lint/correctness/noUnknownFunction: theme() is required for dynamic Tailwind colors */
   background: theme("colors.red-bean.600") !important;
   color: var(--color-surface-primary-rice) !important;
@@ -521,7 +521,7 @@ cq-study-legend.shaded cq-clickable.clickable-item.item.ciq-btn:hover {
 }
 
 
-cq-heading.dropdown input {
+#chartiq cq-heading.dropdown input {
   border: 0px solid transparent;
   padding-left: 8px;
   outline: none;
@@ -533,12 +533,12 @@ cq-heading.dropdown input {
   font-style: normal;
 }
 
-cq-study-legend.shaded cq-clickable.clickable-item.item.ciq-btn {
+#chartiq cq-study-legend.shaded cq-clickable.clickable-item.item.ciq-btn {
   display: flex;
   margin: 6px auto 0;
 }
 
-cq-dropdown[config="studies"] .content {
+#chartiq cq-dropdown[config="studies"] .content {
   padding-top: 16px;
 }
 

--- a/ui/portal/web/src/components/landing/Landing.tsx
+++ b/ui/portal/web/src/components/landing/Landing.tsx
@@ -223,7 +223,7 @@ const SectionCommunity: React.FC = () => {
           <p>© 2024-{format(new Date(), "yy")} Left Curve Software</p>
           <div className="flex gap-10 lg:gap-4 diatype-m-medium">
             <a
-              href="/documents/Dango%20-%20Terms%20of%20use.pdf"
+              href="/documents/Dango%20-%20Terms%20of%20Use.pdf"
               target="_blank"
               rel="noopener noreferrer"
               className="hover:underline text-tertiary-500"

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
@@ -1,0 +1,82 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+
+import { useConfig } from "@left-curve/store";
+import { useNavigate } from "@tanstack/react-router";
+
+import { ProTrade } from "~/components/dex/ProTrade";
+
+import type { PairId } from "@left-curve/dango/types";
+
+export const Route = createLazyFileRoute("/(app)/_app/trade/$pairSymbols")({
+  component: ProTradeApplet,
+});
+
+function ProTradeApplet() {
+  const navigate = useNavigate();
+  const { coins } = useConfig();
+  const { pairSymbols } = Route.useParams();
+  const { action = "buy", order_type = "market" } = Route.useSearch();
+
+  const onChangePairId = ({ baseDenom, quoteDenom }: PairId) => {
+    const baseSymbol = coins.byDenom[baseDenom]?.symbol;
+    const quoteSymbol = coins.byDenom[quoteDenom]?.symbol;
+
+    navigate({
+      to: "/trade/$pairSymbols",
+      params: { pairSymbols: `${baseSymbol}-${quoteSymbol}` },
+      replace: false,
+    });
+  };
+
+  const onChangeAction = (action: "buy" | "sell") => {
+    navigate({
+      to: "/trade/$pairSymbols",
+      params: { pairSymbols },
+      replace: false,
+      search: { order_type, action },
+    });
+  };
+
+  const onChangeOrderType = (order_type: "limit" | "market") => {
+    navigate({
+      to: "/trade/$pairSymbols",
+      params: { pairSymbols },
+      replace: false,
+      search: { order_type, action },
+    });
+  };
+
+  const [baseSymbol, quoteSymbol] = pairSymbols.split("-");
+
+  const pairId = {
+    baseDenom: coins.bySymbol[baseSymbol]?.denom,
+    quoteDenom: coins.bySymbol[quoteSymbol]?.denom,
+  };
+
+  return (
+    <div className="flex w-full min-h-screen lg:min-h-[calc(100vh-76px)] relative overflow-visible">
+      <ProTrade
+        pairId={pairId}
+        onChangePairId={onChangePairId}
+        action={action}
+        onChangeAction={onChangeAction}
+        orderType={order_type}
+        onChangeOrderType={onChangeOrderType}
+      >
+        <div className="flex flex-col flex-1">
+          <div className="flex flex-col xl:flex-row flex-1">
+            <div className="flex flex-col flex-1">
+              <ProTrade.Header />
+              <ProTrade.Chart />
+            </div>
+            <ProTrade.OrderBook />
+          </div>
+          <ProTrade.Orders />
+        </div>
+        <div className="hidden lg:flex pt-4 w-full lg:w-[331px] xl:[width:clamp(279px,20vw,330px)] lg:bg-surface-secondary-rice shadow-account-card z-20 max-h-[calc(100vh-76px)] md:sticky top-[76px]">
+          <ProTrade.TradeMenu />
+        </div>
+      </ProTrade>
+    </div>
+  );
+}

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
@@ -3,13 +3,6 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { z } from "zod";
 import { m } from "~/paraglide/messages";
 
-import { useConfig } from "@left-curve/store";
-import { useNavigate } from "@tanstack/react-router";
-
-import { ProTrade } from "~/components/dex/ProTrade";
-
-import type { PairId } from "@left-curve/dango/types";
-
 export const Route = createFileRoute("/(app)/_app/trade/$pairSymbols")({
   head: () => ({
     meta: [{ title: `Dango | ${m["applets.0.title"]()}` }],
@@ -33,76 +26,4 @@ export const Route = createFileRoute("/(app)/_app/trade/$pairSymbols")({
     order_type: z.enum(["limit", "market"]).default("market"),
     action: z.enum(["buy", "sell"]).default("buy"),
   }),
-  component: ProTradeApplet,
-  wrapInSuspense: true,
 });
-
-function ProTradeApplet() {
-  const navigate = useNavigate();
-  const { coins } = useConfig();
-  const { pairSymbols } = Route.useParams();
-  const { action = "buy", order_type = "market" } = Route.useSearch();
-
-  const onChangePairId = ({ baseDenom, quoteDenom }: PairId) => {
-    const baseSymbol = coins.byDenom[baseDenom]?.symbol;
-    const quoteSymbol = coins.byDenom[quoteDenom]?.symbol;
-
-    navigate({
-      to: "/trade/$pairSymbols",
-      params: { pairSymbols: `${baseSymbol}-${quoteSymbol}` },
-      replace: false,
-    });
-  };
-
-  const onChangeAction = (action: "buy" | "sell") => {
-    navigate({
-      to: "/trade/$pairSymbols",
-      params: { pairSymbols },
-      replace: false,
-      search: { order_type, action },
-    });
-  };
-
-  const onChangeOrderType = (order_type: "limit" | "market") => {
-    navigate({
-      to: "/trade/$pairSymbols",
-      params: { pairSymbols },
-      replace: false,
-      search: { order_type, action },
-    });
-  };
-
-  const [baseSymbol, quoteSymbol] = pairSymbols.split("-");
-
-  const pairId = {
-    baseDenom: coins.bySymbol[baseSymbol]?.denom,
-    quoteDenom: coins.bySymbol[quoteSymbol]?.denom,
-  };
-
-  return (
-    <div className="flex w-full min-h-screen lg:min-h-[calc(100vh-76px)] relative overflow-visible">
-      <ProTrade
-        pairId={pairId}
-        onChangePairId={onChangePairId}
-        action={action}
-        onChangeAction={onChangeAction}
-        orderType={order_type}
-        onChangeOrderType={onChangeOrderType}
-      >
-        <div className="flex flex-col flex-1">
-          <div className="flex flex-col xl:flex-row flex-1">
-            <div className="flex flex-col flex-1">
-              <ProTrade.Header />
-              <ProTrade.Chart />
-            </div>
-            <ProTrade.OrderBook />
-          </div>
-          <ProTrade.Orders />
-        </div>
-        <div className="hidden lg:flex pt-4 w-full lg:w-[331px] xl:[width:clamp(279px,20vw,330px)] lg:bg-surface-secondary-rice shadow-account-card z-20 max-h-[calc(100vh-76px)] md:sticky top-[76px]">
-          <ProTrade.TradeMenu />
-        </div>
-      </ProTrade>
-    </div>
-  );
-}

--- a/ui/portal/web/src/pages/__root.tsx
+++ b/ui/portal/web/src/pages/__root.tsx
@@ -48,7 +48,12 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       })();
     }, []);
 
-    if (!isReady) return <Spinner />;
+    if (!isReady)
+      return (
+        <div className="flex h-screen w-screen items-center justify-center">
+          <Spinner size="md" color="pink" />
+        </div>
+      );
 
     return (
       <>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce lazy loading for ChartIQ in ProTrade page and scope CSS styles under #chartiq.
> 
>   - **Lazy Loading**:
>     - `ChartIQ` component in `ProTrade.tsx` is now lazy-loaded using `React.lazy` and `Suspense`.
>     - New file `_app.trade.$pairSymbols.lazy.tsx` created for lazy-loaded route.
>   - **CSS Changes**:
>     - Styles in `global.css` scoped under `#chartiq` to apply only to ChartIQ component.
>   - **Route Changes**:
>     - `_app.trade.$pairSymbols.tsx` replaced with `_app.trade.$pairSymbols.lazy.tsx` for lazy loading.
>   - **Misc**:
>     - Fixes typo in `Landing.tsx` for terms of use link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c3828fa7c20989a30bac09cbdb367d5685861d82. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->