### PR TITLE
Fix indexer tests after clearing price algorithm change

### DIFF
--- a/dango/testing/tests/indexing/candles.rs
+++ b/dango/testing/tests/indexing/candles.rs
@@ -288,11 +288,11 @@ async fn index_candles_with_real_clickhouse_and_one_second_interval() -> anyhow:
             .collect::<Vec<_>>()
     )
     .is_equal_to(vec![
-        &Udec128_6::from_str("687.5").unwrap(),
-        &Udec128_6::from_str("1375").unwrap(),
-        &Udec128_6::from_str("1375").unwrap(),
-        &Udec128_6::from_str("1375").unwrap(),
-        &Udec128_6::from_str("1375").unwrap(),
+        &Udec128_6::from_str("625").unwrap(),
+        &Udec128_6::from_str("1250").unwrap(),
+        &Udec128_6::from_str("1250").unwrap(),
+        &Udec128_6::from_str("1250").unwrap(),
+        &Udec128_6::from_str("1250").unwrap(),
         &Udec128_6::from_str("687.5").unwrap(),
     ]);
 
@@ -312,11 +312,20 @@ async fn index_candles_with_real_clickhouse_and_one_second_interval() -> anyhow:
         &Udec128_6::from_str("25").unwrap(),
     ]);
 
-    for candle in candle_1s.candles.into_iter() {
-        assert_that!(candle.open).is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
-        assert_that!(candle.high).is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
-        assert_that!(candle.low).is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
-        assert_that!(candle.close).is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1s.candles[5].open)
+        .is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1s.candles[5].high)
+        .is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1s.candles[5].low)
+        .is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
+    assert_that!(candle_1s.candles[5].close)
+        .is_equal_to::<Udec128_24>(Udec128_24::from_str("27.5").unwrap());
+
+    for candle in candle_1s.candles.into_iter().rev().skip(1) {
+        assert_that!(candle.open).is_equal_to::<Udec128_24>(Udec128_24::from_str("25").unwrap());
+        assert_that!(candle.high).is_equal_to::<Udec128_24>(Udec128_24::from_str("25").unwrap());
+        assert_that!(candle.low).is_equal_to::<Udec128_24>(Udec128_24::from_str("25").unwrap());
+        assert_that!(candle.close).is_equal_to::<Udec128_24>(Udec128_24::from_str("25").unwrap());
     }
 
     Ok(())

--- a/dango/testing/tests/indexing/candles.rs
+++ b/dango/testing/tests/indexing/candles.rs
@@ -213,9 +213,9 @@ async fn index_candles_with_real_clickhouse_and_one_minute_interval() -> anyhow:
             .naive_utc(),
     );
 
-    assert_that!(candle_1m.candles[0].open).is_equal_to(pair_prices[0].clone().close_price);
-    assert_that!(candle_1m.candles[0].high).is_equal_to(pair_prices[0].clone().close_price);
-    assert_that!(candle_1m.candles[0].low).is_equal_to(pair_prices[0].clone().close_price);
+    assert_that!(candle_1m.candles[0].open).is_equal_to(pair_prices[0].clone().open_price);
+    assert_that!(candle_1m.candles[0].high).is_equal_to(pair_prices[0].clone().highest_price);
+    assert_that!(candle_1m.candles[0].low).is_equal_to(pair_prices[0].clone().lowest_price);
     assert_that!(candle_1m.candles[0].close).is_equal_to(pair_prices[0].clone().close_price);
     assert_that!(candle_1m.candles[0].volume_base).is_equal_to(
         pair_prices[0]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `candles.rs` test assertions to align with new price algorithm changes.
> 
>   - **Test Updates**:
>     - Update assertions in `index_candles_with_real_clickhouse_and_one_minute_interval()` to use `open_price`, `highest_price`, and `lowest_price` instead of `close_price` for `open`, `high`, and `low`.
>     - Modify expected volume values in `index_candles_with_real_clickhouse_and_one_second_interval()` to reflect new algorithm outputs.
>     - Adjust order amounts and expected outcomes in `index_candles_with_both_market_and_limit_orders_one_minute_interval()` to match new clearing price logic.
>   - **Behavior**:
>     - Tests now reflect changes in price calculation logic, ensuring correct behavior under new algorithm.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for d1e58a643f80fb4124e4a413b06094124bf58ece. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->