### PR TITLE
fix(ui): chartiq styles

### DIFF
--- a/ui/portal/web/public/global.css
+++ b/ui/portal/web/public/global.css
@@ -204,8 +204,12 @@ body {
 #chartiq cq-drawing-palette cq-scroll {
   scrollbar-width: none;
   scrollbar-color: initial;
-  max-width: 65px;
-  margin: 0 auto;
+}
+
+#chartiq cq-drawing-palette cq-scroll .drawing-tools-group.lines,
+#chartiq cq-drawing-palette cq-scroll .drawing-tools-group.markings,
+#chartiq cq-drawing-palette cq-scroll .drawing-tools-group.text {
+  margin: 0 3px;
 }
 
 #chartiq cq-drawing-palette cq-scroll::-webkit-scrollbar {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `max-width` and adjust margins for `#chartiq cq-drawing-palette cq-scroll` in `global.css`.
> 
>   - **CSS Changes**:
>     - Removed `max-width: 65px` from `#chartiq cq-drawing-palette cq-scroll` in `global.css`.
>     - Adjusted margin to `0 3px` for `.drawing-tools-group.lines`, `.drawing-tools-group.markings`, and `.drawing-tools-group.text` under `#chartiq cq-drawing-palette cq-scroll`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 51df0de99e78c99f282463ee4af2e848eb4f11a5. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->