### PR TITLE
feat(ui): auto save storage tv

### DIFF
--- a/ui/config/messages/en.json
+++ b/ui/config/messages/en.json
@@ -598,6 +598,16 @@
       },
       "time": { "hours": "h", "minutes": "m", "seconds": "s" }
     },
+    "chartEngines": [
+      {
+        "declarations": ["input chart"],
+        "selectors": ["chart"],
+        "match": {
+          "chart=tradingview": "TradingView",
+          "chart=chartiq": "ChartIQ"
+        }
+      }
+    ],
     "languages": [
       {
         "declarations": ["input language"],

--- a/ui/portal/web/src/components/dex/TradingView.tsx
+++ b/ui/portal/web/src/components/dex/TradingView.tsx
@@ -43,6 +43,9 @@ export const TradingView: React.FC<TradingViewProps> = ({ coins, orders }) => {
 
   useEffect(() => {
     const toolbar_bg = theme === "dark" ? "#363432" : "#FFF9F0";
+    const toTimestamp = Math.floor(Date.now() / 1000);
+    const fromTimestamp = toTimestamp - 3600 * 4;
+
     const widget = new TV.widget({
       container: "tv_chart_container",
       autosize: true,
@@ -54,6 +57,10 @@ export const TradingView: React.FC<TradingViewProps> = ({ coins, orders }) => {
       theme,
       auto_save_delay: 1,
       datafeed: dataFeed,
+      timeframe: {
+        from: fromTimestamp,
+        to: toTimestamp,
+      },
       loading_screen: {
         backgroundColor: "transparent",
         foregroundColor: "rgb(249 169 178)",

--- a/ui/portal/web/src/components/settings/DisplaySection.tsx
+++ b/ui/portal/web/src/components/settings/DisplaySection.tsx
@@ -16,7 +16,7 @@ import {
 import { m } from "~/paraglide/messages";
 import { getLocale, locales, setLocale } from "~/paraglide/runtime";
 
-import { capitalize, type FormatNumberOptions } from "@left-curve/dango/utils";
+import type { FormatNumberOptions } from "@left-curve/dango/utils";
 import type { PropsWithChildren } from "react";
 import type React from "react";
 
@@ -64,7 +64,7 @@ const ChartEngineSection: React.FC = () => {
       >
         {["tradingview", "chartiq"].map((chart) => (
           <Select.Item key={chart} value={chart}>
-            {capitalize(chart)}
+            {m["settings.chartEngines"]({ chart })}
           </Select.Item>
         ))}
       </Select>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds auto-save functionality to TradingView charts and updates chart engine selection in settings UI.
> 
>   - **Behavior**:
>     - Adds auto-save functionality to `TradingView` in `TradingView.tsx` with a delay of 1 second.
>     - Saves chart state using `useStorage` hook with key `tv.{pairSymbol}`.
>     - Disables `header_saveload` feature in TradingView widget.
>   - **UI Components**:
>     - Updates `ChartEngineSection` in `DisplaySection.tsx` to use `m["settings.chartEngines"]` for chart engine names.
>   - **Localization**:
>     - Adds `chartEngines` to `en.json` for chart engine localization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c87398b8c6b91e55c6b975e1c10209d84258c322. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->