### PR TITLE
dex: limit the number of passive orders

### DIFF
--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -288,24 +288,20 @@ impl PassiveLiquidityPool for PairParams {
             );
         };
 
-        let output_amount = match self.pool_type {
-            PassiveLiquidity::Xyk { .. } => xyk::swap_exact_amount_in(
+        let output_amount = match &self.pool_type {
+            PassiveLiquidity::Xyk(_) => xyk::swap_exact_amount_in(
                 reserve.amount_of(&input.denom)?,
                 reserve.amount_of(&output_denom)?,
                 input.amount,
                 self.swap_fee_rate,
             )?,
-            PassiveLiquidity::Geometric {
-                ratio,
-                order_spacing,
-            } => geometric::swap_exact_amount_in(
+            PassiveLiquidity::Geometric(params) => geometric::swap_exact_amount_in(
                 oracle_querier,
                 base_denom,
                 quote_denom,
                 &input,
                 &reserve,
-                ratio,
-                order_spacing,
+                params.clone(),
                 self.swap_fee_rate,
             )?,
         };
@@ -342,24 +338,20 @@ impl PassiveLiquidityPool for PairParams {
         let input_reserve = reserve.amount_of(&input_denom)?;
         let output_reserve = reserve.amount_of(&output.denom)?;
 
-        let input_amount = match self.pool_type {
-            PassiveLiquidity::Xyk { .. } => xyk::swap_exact_amount_out(
+        let input_amount = match &self.pool_type {
+            PassiveLiquidity::Xyk(_) => xyk::swap_exact_amount_out(
                 input_reserve,
                 output_reserve,
                 output.amount,
                 self.swap_fee_rate,
             )?,
-            PassiveLiquidity::Geometric {
-                ratio,
-                order_spacing,
-            } => geometric::swap_exact_amount_out(
+            PassiveLiquidity::Geometric(params) => geometric::swap_exact_amount_out(
                 oracle_querier,
                 base_denom,
                 quote_denom,
                 &output,
                 &reserve,
-                ratio,
-                order_spacing,
+                params.clone(),
                 self.swap_fee_rate,
             )?,
         };
@@ -393,27 +385,16 @@ impl PassiveLiquidityPool for PairParams {
         let quote_reserve = reserve.amount_of(&quote_denom)?;
 
         match self.pool_type {
-            PassiveLiquidity::Xyk {
-                order_spacing,
-                reserve_ratio,
-            } => xyk::reflect_curve(
-                base_reserve,
-                quote_reserve,
-                order_spacing,
-                reserve_ratio,
-                self.swap_fee_rate,
-            ),
-            PassiveLiquidity::Geometric {
-                ratio,
-                order_spacing,
-            } => geometric::reflect_curve(
+            PassiveLiquidity::Xyk(params) => {
+                xyk::reflect_curve(base_reserve, quote_reserve, params, self.swap_fee_rate)
+            },
+            PassiveLiquidity::Geometric(params) => geometric::reflect_curve(
                 oracle_querier,
                 &base_denom,
                 &quote_denom,
                 base_reserve,
                 quote_reserve,
-                ratio,
-                order_spacing,
+                params,
                 self.swap_fee_rate,
             ),
         }
@@ -440,6 +421,7 @@ mod tests {
         super::*,
         dango_types::{
             constants::{eth, usdc},
+            dex::{Geometric, Xyk},
             oracle::PrecisionedPrice,
         },
         grug::{Bounded, Coins, Inner, Timestamp, coin_pair, coins, hash_map},
@@ -448,10 +430,11 @@ mod tests {
     };
 
     #[test_case(
-        PassiveLiquidity::Xyk {
-            order_spacing: Udec128::ONE,
+        PassiveLiquidity::Xyk(Xyk {
+            spacing: Udec128::ONE,
             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-        },
+            limit: 10,
+        }),
         Udec128::new_permille(5),
         coins! {
             eth::DENOM.clone() => 10000000,
@@ -485,10 +468,11 @@ mod tests {
         "xyk pool balance 1:200 tick size 1 0.5% fee"
     )]
     #[test_case(
-        PassiveLiquidity::Xyk {
-            order_spacing: Udec128::ONE,
+        PassiveLiquidity::Xyk(Xyk {
+            spacing: Udec128::ONE,
             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-        },
+            limit: 10,
+        }),
         Udec128::new_percent(1),
         coins! {
             eth::DENOM.clone() => 10000000,
@@ -522,10 +506,11 @@ mod tests {
         "xyk pool balance 1:200 tick size 1 one percent fee"
     )]
     #[test_case(
-        PassiveLiquidity::Xyk {
-            order_spacing: Udec128::new_percent(1),
+        PassiveLiquidity::Xyk(Xyk {
+            spacing: Udec128::new_percent(1),
             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-        },
+            limit: 10,
+        }),
         Udec128::new_permille(5),
         coins! {
             eth::DENOM.clone() => 10000000,
@@ -559,10 +544,11 @@ mod tests {
         "xyk pool balance 1:1 0.5% fee"
     )]
     #[test_case(
-        PassiveLiquidity::Xyk {
-            order_spacing: Udec128::new_percent(1),
+        PassiveLiquidity::Xyk(Xyk {
+            spacing: Udec128::new_percent(1),
             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-        },
+            limit: 10,
+        }),
         Udec128::new_percent(1),
         coins! {
             eth::DENOM.clone() => 10000000,
@@ -596,10 +582,11 @@ mod tests {
         "xyk pool balance 1:1 one percent fee"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(70)).unwrap(),
-            order_spacing: Udec128::new_percent(1),
-        },
+            spacing: Udec128::new_percent(1),
+            limit: 10,
+        }),
         Udec128::new_percent(1),
         coins! {
             eth::DENOM.clone() => 10000000,
@@ -698,10 +685,11 @@ mod tests {
     #[test]
     fn geometric_pool_iterator_stops_at_zero_price() {
         let pair = PairParams {
-            pool_type: PassiveLiquidity::Geometric {
+            pool_type: PassiveLiquidity::Geometric(Geometric {
                 ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-                order_spacing: Udec128::new_percent(50),
-            },
+                spacing: Udec128::new_percent(50),
+                limit: 10,
+            }),
             swap_fee_rate: Bounded::new(Udec128::new_percent(1)).unwrap(),
             lp_denom: Denom::new_unchecked(vec!["lp".to_string()]),
         };
@@ -751,15 +739,16 @@ mod tests {
         }
 
         // Check that ask iterator keeps going after bid iterator is exhausted
-        let asks_collected = asks.take(10).collect::<Vec<_>>();
+        let asks_collected = asks.collect::<Vec<_>>();
         assert_eq!(asks_collected.len(), 10);
     }
 
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -788,10 +777,11 @@ mod tests {
         "geometric pool 1:1 price swap in base denom amount matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -820,10 +810,11 @@ mod tests {
         "geometric pool 1:1 price swap in quote denom amount matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -852,10 +843,11 @@ mod tests {
         "geometric pool 2:1 price swap in quote denom amount partiallymatches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -884,10 +876,11 @@ mod tests {
         "geometric pool 2:1 price swap in quote denom amount fully matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -916,10 +909,11 @@ mod tests {
         "geometric pool 2:1 price swap in quote denom amount matches first and part of second order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -948,10 +942,11 @@ mod tests {
         "geometric pool 2:1 price swap in base denom amount partially matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -980,10 +975,11 @@ mod tests {
         "geometric pool 2:1 price swap in base denom amount almost fully matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1044,10 +1040,11 @@ mod tests {
     }
 
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1076,10 +1073,11 @@ mod tests {
         "geometric pool 1:1 price swap out quote denom amount matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1108,10 +1106,11 @@ mod tests {
         "geometric pool 1:1 price swap out base denom amount matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1140,10 +1139,11 @@ mod tests {
         "geometric pool 1:1 price swap out quote denom amount matches first order part of second order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1172,10 +1172,11 @@ mod tests {
         "geometric pool 1:1 price swap out base denom amount matches first order part of second order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1204,10 +1205,11 @@ mod tests {
         "geometric pool 2:1 price swap out quote denom amount partially matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1236,10 +1238,11 @@ mod tests {
         "geometric pool 2:1 price swap out quote denom amount matches first and part of second order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1268,10 +1271,11 @@ mod tests {
         "geometric pool 2:1 price swap out base denom amount matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,
@@ -1300,10 +1304,11 @@ mod tests {
         "geometric pool 2:1 price swap out base denom amount partially matches first order"
     )]
     #[test_case(
-        PassiveLiquidity::Geometric {
+        PassiveLiquidity::Geometric(Geometric {
             ratio: Bounded::new(Udec128::new_percent(50)).unwrap(),
-            order_spacing: Udec128::new_percent(50),
-        },
+            spacing: Udec128::new_percent(50),
+            limit: 10,
+        }),
         coin_pair! {
             eth::DENOM.clone() => 10000000,
             usdc::DENOM.clone() => 10000000,

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -1,10 +1,9 @@
 use {
     anyhow::ensure,
-    dango_types::dex::PassiveOrder,
+    dango_types::dex::{PassiveOrder, Xyk},
     grug::{
         Bounded, CoinPair, Exponentiate, IsZero, MathResult, MultiplyFraction, MultiplyRatio,
         Number, NumberConst, Udec128, Udec128_24, Uint64, Uint128, ZeroExclusiveOneExclusive,
-        ZeroInclusiveOneExclusive,
     },
     std::{cmp, iter},
 };
@@ -98,8 +97,7 @@ pub fn swap_exact_amount_out(
 pub fn reflect_curve(
     mut base_reserve: Uint128,
     mut quote_reserve: Uint128,
-    order_spacing: Udec128,
-    reserve_ratio: Bounded<Udec128, ZeroInclusiveOneExclusive>,
+    params: Xyk,
     swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
 ) -> anyhow::Result<(
     Box<dyn Iterator<Item = (Udec128_24, PassiveOrder)>>,
@@ -107,7 +105,7 @@ pub fn reflect_curve(
 )> {
     // Withhold the funds corresponding to the reserve requirement.
     // These funds will not be used to place orders.
-    let one_sub_reserve_ratio = Udec128::ONE - *reserve_ratio;
+    let one_sub_reserve_ratio = Udec128::ONE - *params.reserve_ratio;
     base_reserve.checked_mul_dec_floor_assign(one_sub_reserve_ratio)?;
     quote_reserve.checked_mul_dec_floor_assign(one_sub_reserve_ratio)?;
 
@@ -163,7 +161,7 @@ pub fn reflect_curve(
             id += Uint64::ONE;
             prev_size = size;
             prev_size_quote = size_quote;
-            maybe_price = price.checked_sub(order_spacing).ok();
+            maybe_price = price.checked_sub(params.spacing).ok();
 
             Some((price, PassiveOrder {
                 id,
@@ -172,6 +170,7 @@ pub fn reflect_curve(
                 remaining: amount.checked_into_dec().ok()?,
             }))
         })
+        .take(params.limit)
     };
 
     // Construct the ask order iterator.
@@ -207,7 +206,7 @@ pub fn reflect_curve(
             // Update the iterator state.
             id -= Uint64::ONE;
             prev_size = size;
-            maybe_price = price.checked_add(order_spacing).ok();
+            maybe_price = price.checked_add(params.spacing).ok();
 
             Some((price, PassiveOrder {
                 id,
@@ -216,6 +215,7 @@ pub fn reflect_curve(
                 remaining: amount.checked_into_dec().ok()?,
             }))
         })
+        .take(params.limit)
     };
 
     Ok((Box::new(bids), Box::new(asks)))
@@ -256,8 +256,11 @@ mod tests {
         let (mut bids, mut asks) = reflect_curve(
             base_reserve,
             quote_reserve,
-            Udec128::ONE,
-            Bounded::new_unchecked(Udec128::ZERO),
+            Xyk {
+                spacing: Udec128::ONE,
+                reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
+                limit: 30,
+            },
             Bounded::new_unchecked(Udec128::new_bps(30)),
         )
         .unwrap();

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -875,7 +875,7 @@ mod tests {
         dango_types::{
             config::{AppAddresses, AppConfig},
             constants::{dango, usdc},
-            dex::{PairParams, PassiveLiquidity},
+            dex::{Geometric, PairParams, PassiveLiquidity},
             oracle::PriceSource,
         },
         grug::{Bounded, MockContext, MockQuerier, Timestamp, Uint128},
@@ -1095,10 +1095,11 @@ mod tests {
                 (&dango::DENOM, &usdc::DENOM),
                 &PairParams {
                     lp_denom: Denom::from_str("dex/pool/dango/usdc").unwrap(),
-                    pool_type: PassiveLiquidity::Geometric {
-                        order_spacing: Udec128::ZERO,
+                    pool_type: PassiveLiquidity::Geometric(Geometric {
+                        spacing: Udec128::ZERO,
                         ratio: Bounded::new_unchecked(Udec128::ONE),
-                    },
+                        limit: 10,
+                    }),
                     swap_fee_rate: Bounded::new_unchecked(Udec128::ZERO),
                 },
             )

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -458,7 +458,7 @@ mod tests {
         crate::RESTING_ORDER_BOOK,
         dango_types::{
             constants::{dango, usdc},
-            dex::{Direction, PairParams, PassiveLiquidity, RestingOrderBookState},
+            dex::{Direction, PairParams, PassiveLiquidity, RestingOrderBookState, Xyk},
         },
         grug::{Addr, Bounded, MockContext, NumberConst, Udec128, Udec128_24},
         std::str::FromStr,
@@ -614,10 +614,11 @@ mod tests {
                 (&dango::DENOM, &usdc::DENOM),
                 &PairParams {
                     lp_denom: Denom::from_str("lp").unwrap(),
-                    pool_type: PassiveLiquidity::Xyk {
-                        order_spacing: Udec128::ONE,
+                    pool_type: PassiveLiquidity::Xyk(Xyk {
+                        spacing: Udec128::ONE,
                         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                    },
+                        limit: 10,
+                    }),
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                 },
             )

--- a/dango/testing/src/genesis.rs
+++ b/dango/testing/src/genesis.rs
@@ -16,7 +16,7 @@ use {
         constants::{
             PYTH_PRICE_SOURCES, atom, bch, bnb, btc, dango, doge, eth, ltc, sol, usdc, xrp,
         },
-        dex::{PairParams, PairUpdate, PassiveLiquidity},
+        dex::{PairParams, PairUpdate, PassiveLiquidity, Xyk},
         gateway::{Remote, WithdrawalFee},
         lending::InterestRateModel,
         taxman,
@@ -340,10 +340,11 @@ impl Preset for DexOption {
                     quote_denom: usdc::DENOM.clone(),
                     params: PairParams {
                         lp_denom: Denom::from_str("dex/pool/dango/usdc").unwrap(),
-                        pool_type: PassiveLiquidity::Xyk {
-                            order_spacing: Udec128::ONE,
+                        pool_type: PassiveLiquidity::Xyk(Xyk {
+                            spacing: Udec128::ONE,
                             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                        },
+                            limit: 30,
+                        }),
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },
                 },
@@ -352,10 +353,11 @@ impl Preset for DexOption {
                     quote_denom: usdc::DENOM.clone(),
                     params: PairParams {
                         lp_denom: Denom::from_str("dex/pool/btc/usdc").unwrap(),
-                        pool_type: PassiveLiquidity::Xyk {
-                            order_spacing: Udec128::ONE,
+                        pool_type: PassiveLiquidity::Xyk(Xyk {
+                            spacing: Udec128::ONE,
                             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                        },
+                            limit: 30,
+                        }),
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },
                 },
@@ -364,10 +366,11 @@ impl Preset for DexOption {
                     quote_denom: usdc::DENOM.clone(),
                     params: PairParams {
                         lp_denom: Denom::from_str("dex/pool/eth/usdc").unwrap(),
-                        pool_type: PassiveLiquidity::Xyk {
-                            order_spacing: Udec128::ONE,
+                        pool_type: PassiveLiquidity::Xyk(Xyk {
+                            spacing: Udec128::ONE,
                             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                        },
+                            limit: 30,
+                        }),
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },
                 },
@@ -376,10 +379,11 @@ impl Preset for DexOption {
                     quote_denom: usdc::DENOM.clone(),
                     params: PairParams {
                         lp_denom: Denom::from_str("dex/pool/sol/usdc").unwrap(),
-                        pool_type: PassiveLiquidity::Xyk {
-                            order_spacing: Udec128::ONE,
+                        pool_type: PassiveLiquidity::Xyk(Xyk {
+                            spacing: Udec128::ONE,
                             reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                        },
+                            limit: 30,
+                        }),
                         swap_fee_rate: Bounded::new_unchecked(Udec128::new_bps(30)),
                     },
                 },

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -8,9 +8,9 @@ use {
         constants::{atom, dango, eth, usdc, xrp},
         dex::{
             self, CancelOrderRequest, CreateLimitOrderRequest, CreateMarketOrderRequest, Direction,
-            OrderId, OrderResponse, PairId, PairParams, PairUpdate, PassiveLiquidity,
+            Geometric, OrderId, OrderResponse, PairId, PairParams, PairUpdate, PassiveLiquidity,
             QueryOrdersByPairRequest, QueryOrdersRequest, QueryReserveRequest,
-            QueryRestingOrderBookStateRequest, RestingOrderBookState,
+            QueryRestingOrderBookStateRequest, RestingOrderBookState, Xyk,
         },
         gateway::Remote,
         oracle::{self, PrecisionlessPrice, PriceSource},
@@ -1174,10 +1174,11 @@ fn only_owner_can_create_passive_pool() {
                 quote_denom: usdc::DENOM.clone(),
                 params: PairParams {
                     lp_denom: lp_denom.clone(),
-                    pool_type: PassiveLiquidity::Xyk {
-                        order_spacing: Udec128::new_bps(1),
+                    pool_type: PassiveLiquidity::Xyk(Xyk {
+                        spacing: Udec128::new_bps(1),
                         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                    },
+                        limit: 30,
+                    }),
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
             }])),
@@ -1195,10 +1196,11 @@ fn only_owner_can_create_passive_pool() {
                 quote_denom: usdc::DENOM.clone(),
                 params: PairParams {
                     lp_denom: lp_denom.clone(),
-                    pool_type: PassiveLiquidity::Xyk {
-                        order_spacing: Udec128::new_bps(1),
+                    pool_type: PassiveLiquidity::Xyk(Xyk {
+                        spacing: Udec128::new_bps(1),
                         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                    },
+                        limit: 30,
+                    }),
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
             }])),
@@ -1213,10 +1215,11 @@ fn only_owner_can_create_passive_pool() {
         usdc::DENOM.clone() => 100,
     },
     Udec128::new_permille(5),
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 30,
+    }),
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
@@ -1230,10 +1233,11 @@ fn only_owner_can_create_passive_pool() {
         usdc::DENOM.clone() => 50,
     },
     Udec128::new_permille(5),
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 30,
+    }),
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
@@ -1247,10 +1251,11 @@ fn only_owner_can_create_passive_pool() {
         usdc::DENOM.clone() => 50,
     },
     Udec128::new_permille(5),
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 30,
+    }),
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
         (usdc::DENOM.clone(), Udec128::new(1)),
@@ -1264,10 +1269,11 @@ fn only_owner_can_create_passive_pool() {
         usdc::DENOM.clone() => 100,
     },
     Udec128::new_permille(5),
-    PassiveLiquidity::Geometric {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Geometric(Geometric {
+        spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-    },
+        limit: 30,
+    }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
         (usdc::DENOM.clone(), Udec128::new(1_000_000)),
@@ -1281,10 +1287,11 @@ fn only_owner_can_create_passive_pool() {
         usdc::DENOM.clone() => 50,
     },
     Udec128::new_permille(5),
-    PassiveLiquidity::Geometric {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Geometric(Geometric {
+        spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-    },
+        limit: 30,
+    }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
         (usdc::DENOM.clone(), Udec128::new(1_000_000)),
@@ -1298,10 +1305,11 @@ fn only_owner_can_create_passive_pool() {
         usdc::DENOM.clone() => 50,
     },
     Udec128::new_permille(5),
-    PassiveLiquidity::Geometric {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Geometric(Geometric {
+        spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-    },
+        limit: 30,
+    }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
         (usdc::DENOM.clone(), Udec128::new(1_000_000)),
@@ -1315,10 +1323,11 @@ fn only_owner_can_create_passive_pool() {
         usdc::DENOM.clone() => 100,
     },
     Udec128::new_permille(5),
-    PassiveLiquidity::Geometric {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Geometric(Geometric {
+        spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-    },
+        limit: 30,
+    }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
         (usdc::DENOM.clone(), Udec128::new(1_000_000)),
@@ -1474,10 +1483,11 @@ fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
                         params: PairParams {
                             lp_denom: pair_params.lp_denom.clone(),
                             swap_fee_rate: pair_params.swap_fee_rate,
-                            pool_type: PassiveLiquidity::Geometric {
-                                order_spacing: Udec128::ONE,
+                            pool_type: PassiveLiquidity::Geometric(Geometric {
+                                spacing: Udec128::ONE,
                                 ratio: Bounded::new_unchecked(Udec128::ONE),
-                            },
+                                limit: 30,
+                            }),
                         },
                     }])),
                     Coins::new(),
@@ -2412,10 +2422,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                         params: PairParams {
                             lp_denom: pair_params.lp_denom.clone(),
                             swap_fee_rate: pair_params.swap_fee_rate,
-                            pool_type: PassiveLiquidity::Geometric {
-                                order_spacing: Udec128::ONE,
+                            pool_type: PassiveLiquidity::Geometric(Geometric {
+                                spacing: Udec128::ONE,
                                 ratio: Bounded::new_unchecked(Udec128::ONE),
-                            },
+                                limit: 30,
+                            }),
                         },
                     }])),
                     Coins::new(),
@@ -2466,10 +2477,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
 }
 
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_percent(1),
     coins! {
         eth::DENOM.clone() => 10000000,
@@ -2513,10 +2525,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
     "xyk pool balance 1:200 tick size 1 one percent fee no matching orders"
 )]
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_permille(5),
     coins! {
         eth::DENOM.clone() => 10000000,
@@ -2558,10 +2571,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
     "xyk pool balance 1:200 tick size 1 no fee user bid order exactly matches passive order"
 )]
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_percent(1),
     coins! {
         eth::DENOM.clone() => 10000000,
@@ -2603,10 +2617,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
     "xyk pool balance 1:200 tick size 1 one percent fee user bid order partially fills passive order"
 )]
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_percent(1),
     coins! {
         eth::DENOM.clone() => 10000000,
@@ -2650,10 +2665,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
     "xyk pool balance 1:200 tick size 1 one percent fee user bid order fully fills passive order with amount remaining after"
 )]
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_permille(5),
     coins! {
         eth::DENOM.clone() => 10000000,
@@ -2695,10 +2711,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
     "xyk pool balance 1:200 tick size 1 no fee user ask order exactly matches passive order"
 )]
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_permille(5),
     coins! {
         eth::DENOM.clone() => 10000000,
@@ -2740,10 +2757,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
     "xyk pool balance 1:200 tick size 1 no fee user ask order partially fills passive order"
 )]
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_permille(5),
     coins! {
         eth::DENOM.clone() => 10000000,
@@ -2787,10 +2805,11 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
     "xyk pool balance 1:200 tick size 1 no fee user ask order fully fills passive order with amount remaining after"
 )]
 #[test_case(
-    PassiveLiquidity::Xyk {
-        order_spacing: Udec128::ONE,
+    PassiveLiquidity::Xyk(Xyk {
+        spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-    },
+        limit: 10,
+    }),
     Udec128::new_percent(1),
     coins! {
         eth::DENOM.clone() => 10000000,

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -1177,7 +1177,7 @@ fn only_owner_can_create_passive_pool() {
                     pool_type: PassiveLiquidity::Xyk(Xyk {
                         spacing: Udec128::new_bps(1),
                         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                        limit: 30,
+                        limit: 10,
                     }),
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
@@ -1199,7 +1199,7 @@ fn only_owner_can_create_passive_pool() {
                     pool_type: PassiveLiquidity::Xyk(Xyk {
                         spacing: Udec128::new_bps(1),
                         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-                        limit: 30,
+                        limit: 10,
                     }),
                     swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                 },
@@ -1218,7 +1218,7 @@ fn only_owner_can_create_passive_pool() {
     PassiveLiquidity::Xyk(Xyk {
         spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-        limit: 30,
+        limit: 10,
     }),
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
@@ -1236,7 +1236,7 @@ fn only_owner_can_create_passive_pool() {
     PassiveLiquidity::Xyk(Xyk {
         spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-        limit: 30,
+        limit: 10,
     }),
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
@@ -1254,7 +1254,7 @@ fn only_owner_can_create_passive_pool() {
     PassiveLiquidity::Xyk(Xyk {
         spacing: Udec128::ONE,
         reserve_ratio: Bounded::new_unchecked(Udec128::ZERO),
-        limit: 30,
+        limit: 10,
     }),
     vec![
         (dango::DENOM.clone(), Udec128::new(1)),
@@ -1272,7 +1272,7 @@ fn only_owner_can_create_passive_pool() {
     PassiveLiquidity::Geometric(Geometric {
         spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-        limit: 30,
+        limit: 10,
     }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
@@ -1290,7 +1290,7 @@ fn only_owner_can_create_passive_pool() {
     PassiveLiquidity::Geometric(Geometric {
         spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-        limit: 30,
+        limit: 10,
     }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
@@ -1308,7 +1308,7 @@ fn only_owner_can_create_passive_pool() {
     PassiveLiquidity::Geometric(Geometric {
         spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-        limit: 30,
+        limit: 10,
     }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
@@ -1326,7 +1326,7 @@ fn only_owner_can_create_passive_pool() {
     PassiveLiquidity::Geometric(Geometric {
         spacing: Udec128::ONE,
         ratio: Bounded::new_unchecked(Udec128::new_percent(50)),
-        limit: 30,
+        limit: 10,
     }),
     vec![
         (dango::DENOM.clone(), Udec128::new(2_000_000)),
@@ -1486,7 +1486,7 @@ fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
                             pool_type: PassiveLiquidity::Geometric(Geometric {
                                 spacing: Udec128::ONE,
                                 ratio: Bounded::new_unchecked(Udec128::ONE),
-                                limit: 30,
+                                limit: 10,
                             }),
                         },
                     }])),
@@ -2425,7 +2425,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                             pool_type: PassiveLiquidity::Geometric(Geometric {
                                 spacing: Udec128::ONE,
                                 ratio: Bounded::new_unchecked(Udec128::ONE),
-                                limit: 30,
+                                limit: 10,
                             }),
                         },
                     }])),

--- a/dango/testing/tests/dex_proptests.rs
+++ b/dango/testing/tests/dex_proptests.rs
@@ -8,7 +8,7 @@ use {
         constants::{dango, eth, sol, usdc},
         dex::{
             self, CreateLimitOrderRequest, CreateMarketOrderRequest, Direction, PairId, PairParams,
-            PairUpdate, PassiveLiquidity, SwapRoute,
+            PairUpdate, PassiveLiquidity, SwapRoute, Xyk,
         },
         gateway::Remote,
     },
@@ -793,10 +793,11 @@ fn test_dex_actions(
                                 pair.base_denom, pair.quote_denom
                             ))
                             .unwrap(),
-                            pool_type: PassiveLiquidity::Xyk {
-                                order_spacing: Udec128::new_bps(1000),
+                            pool_type: PassiveLiquidity::Xyk(Xyk {
+                                spacing: Udec128::new_bps(1000),
                                 reserve_ratio: Bounded::new_unchecked(Udec128::new_percent(1)),
-                            },
+                                limit: 30,
+                            }),
                             swap_fee_rate: Bounded::new_unchecked(Udec128::new_permille(5)),
                         },
                     })

--- a/dango/types/src/dex/pair.rs
+++ b/dango/types/src/dex/pair.rs
@@ -19,37 +19,41 @@ pub struct PairParams {
 
 #[grug::derive(Serde, Borsh)]
 pub enum PassiveLiquidity {
-    Xyk {
-        /// The order spacing for the passive liquidity pool.
-        ///
-        /// This is the price difference between two consecutive orders when
-        /// the passive liquidity is reflected onto the orderbook.
-        order_spacing: Udec128,
-        /// The portion of reserve that the pool will keep on hand and not use
-        /// to place orders.
-        ///
-        /// This prevents an edge case where a trader makes an extremely large
-        /// trade, reducing one side of the pool's liquidity to zero. This would
-        /// cause any subsequent liquidity provision to fail with a "division by
-        /// zero" error.
-        reserve_ratio: Bounded<Udec128, ZeroInclusiveOneExclusive>,
-    },
-    /// Places liquidity around the oracle price in a geometric progression,
-    /// such that the liquidity assigned to each price point is a fixed ratio of
-    /// the liquidity remaining to be assigned. Leading to a geometric
-    /// progression of order sizes. Where the first order has size `1 - ratio`,
-    /// the second order has size `(1 - ratio) * ratio`, the third order has size
-    /// `(1 - ratio) * ratio^2`, and so on.
-    Geometric {
-        /// The order spacing for the passive liquidity pool.
-        ///
-        /// This is the price difference between two consecutive orders when
-        /// the passive liquidity is reflected onto the orderbook.
-        order_spacing: Udec128,
-        /// The amount of the remaining liquidity to be assigned to each
-        /// consecutive order.
-        ratio: Bounded<Udec128, ZeroExclusiveOneInclusive>,
-    },
+    Xyk(Xyk),
+    Geometric(Geometric),
+}
+
+#[grug::derive(Serde, Borsh)]
+pub struct Xyk {
+    /// How far apart each order is placed.
+    pub spacing: Udec128,
+    /// The portion of reserve that the pool will keep on hand and not use
+    /// to place orders.
+    ///
+    /// This prevents an edge case where a trader makes an extremely large
+    /// trade, reducing one side of the pool's liquidity to zero. This would
+    /// cause any subsequent liquidity provision to fail with a "division by
+    /// zero" error.
+    pub reserve_ratio: Bounded<Udec128, ZeroInclusiveOneExclusive>,
+    /// Maximum number of orders to place on each side of the book.
+    pub limit: usize,
+}
+
+/// Places liquidity around the oracle price in a geometric progression,
+/// such that the liquidity assigned to each price point is a fixed ratio of
+/// the liquidity remaining to be assigned. Leading to a geometric
+/// progression of order sizes. Where the first order has size `1 - ratio`,
+/// the second order has size `(1 - ratio) * ratio`, the third order has size
+/// `(1 - ratio) * ratio^2`, and so on.
+#[grug::derive(Serde, Borsh)]
+pub struct Geometric {
+    /// How far apart each order is placed.
+    pub spacing: Udec128,
+    /// The amount of the remaining liquidity to be assigned to each
+    /// consecutive order.
+    pub ratio: Bounded<Udec128, ZeroExclusiveOneInclusive>,
+    /// Maximum number of orders to place on each side of the book.
+    pub limit: usize,
 }
 
 /// Updates to a trading pair's parameters.

--- a/deploy/roles/cometbft/templates/devnet/config/genesis.json
+++ b/deploy/roles/cometbft/templates/devnet/config/genesis.json
@@ -308,8 +308,9 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -322,8 +323,9 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -336,8 +338,9 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -350,8 +353,9 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"

--- a/deploy/roles/cometbft/templates/testnet/config/genesis.json
+++ b/deploy/roles/cometbft/templates/testnet/config/genesis.json
@@ -308,8 +308,9 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -322,8 +323,9 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -336,8 +338,9 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -350,8 +353,9 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"

--- a/deploy/roles/full-app/templates/devnet/config/cometbft/genesis.json
+++ b/deploy/roles/full-app/templates/devnet/config/cometbft/genesis.json
@@ -308,8 +308,9 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -322,8 +323,9 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -336,8 +338,9 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -350,8 +353,9 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"

--- a/networks/localdango/configs/cometbft/config/genesis.json
+++ b/networks/localdango/configs/cometbft/config/genesis.json
@@ -308,8 +308,9 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -322,8 +323,9 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -336,8 +338,9 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"
@@ -350,8 +353,9 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "pool_type": {
                     "xyk": {
-                      "order_spacing": "1",
-                      "reserve_ratio": "0"
+                      "limit": 30,
+                      "reserve_ratio": "0",
+                      "spacing": "1"
                     }
                   },
                   "swap_fee_rate": "0.003"


### PR DESCRIPTION
Add a maximum number of orders the passive pool (xyk or geometric) can place in the book.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce a limit on the number of passive orders in DEX by adding a `limit` parameter to `Xyk` and `Geometric` structs and updating related configurations and tests.
> 
>   - **Behavior**:
>     - Add `limit` parameter to `Xyk` and `Geometric` structs in `pair.rs` to cap passive orders.
>     - Modify `reflect_curve()` in `geometric.rs` and `xyk.rs` to use `limit` to restrict order count.
>   - **Configuration**:
>     - Update `genesis.json` files in `devnet`, `testnet`, `full-app`, and `localdango` to include `limit` in DEX configurations.
>   - **Tests**:
>     - Update tests in `dex_proptests.rs` and `dex.rs` to reflect changes in order limits.
>   - **Misc**:
>     - Refactor `PassiveLiquidity` enum to use `Xyk` and `Geometric` structs for better parameter management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 2c9b3213a1ad195e5c8069ab2d0e92f98c22b38c. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->