### PR TITLE
feat(ui): convert slider

### DIFF
--- a/ui/applets/convert/src/components/Convert.tsx
+++ b/ui/applets/convert/src/components/Convert.tsx
@@ -16,6 +16,7 @@ import {
   IconArrowDown,
   Input,
   Modals,
+  Range,
   Skeleton,
   type useApp,
 } from "@left-curve/applets-kit";
@@ -237,7 +238,7 @@ const ConvertForm: React.FC = () => {
         label={isReverse ? m["dex.convert.youGet"]() : m["dex.convert.youSwap"]()}
         classNames={{
           base: "z-20",
-          inputWrapper: "pl-0 py-3 flex-col h-auto gap-[6px]",
+          inputWrapper: "pl-0 py-3 flex-col h-auto gap-[6px] hover:bg-surface-secondary-rice",
           inputParent: "h-[34px] h3-bold",
           input: "!h3-bold",
         }}
@@ -251,36 +252,75 @@ const ConvertForm: React.FC = () => {
           </div>
         }
         insideBottomComponent={
-          <div className="flex items-center justify-between gap-2 w-full h-[22px] text-tertiary-500 diatype-sm-regular pl-4">
-            <div className="flex items-center gap-2">
-              <p>
-                {baseBalance} {base.symbol}
-              </p>
-              {isReverse ? null : (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="xs"
-                  className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
-                  onClick={() => {
-                    setActiveInput("base");
-                    setValue("base", baseBalance);
-                  }}
-                >
-                  {m["common.max"]()}
-                </Button>
-              )}
+          <div className="flex flex-col w-full gap-2 pl-4">
+            <div className="flex items-center justify-between gap-2 w-full h-[22px] text-tertiary-500 diatype-sm-regular">
+              <div className="flex items-center gap-2">
+                <p>
+                  {baseBalance} {base.symbol}
+                </p>
+              </div>
+              <div>
+                {simulation.isPending && activeInput !== "base" ? (
+                  <Skeleton className="w-14 h-4" />
+                ) : (
+                  getPrice(baseAmount, base.denom, {
+                    format: true,
+                    formatOptions: formatNumberOptions,
+                  })
+                )}
+              </div>
             </div>
-            <div>
-              {simulation.isPending && activeInput !== "base" ? (
-                <Skeleton className="w-14 h-4" />
-              ) : (
-                getPrice(baseAmount, base.denom, {
-                  format: true,
-                  formatOptions: formatNumberOptions,
-                })
-              )}
-            </div>
+            {isReverse ? null : (
+              <div className="flex flex-col gap-4">
+                <Range
+                  minValue={0}
+                  maxValue={Number(baseBalance)}
+                  step={0.1}
+                  value={Number(baseAmount)}
+                  onChange={(value) => setValue("base", String(value))}
+                  classNames={{ inputWrapper: "px-0" }}
+                  showPercentage
+                />
+                <div className="w-full flex gap-4 justify-end">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
+                    onClick={() => {
+                      setActiveInput("base");
+                      setValue("base", String(Number(baseBalance) * 0.25));
+                    }}
+                  >
+                    25%
+                  </Button>{" "}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
+                    onClick={() => {
+                      setActiveInput("base");
+                      setValue("base", String(Number(baseBalance) * 0.5));
+                    }}
+                  >
+                    50%
+                  </Button>{" "}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
+                    onClick={() => {
+                      setActiveInput("base");
+                      setValue("base", baseBalance);
+                    }}
+                  >
+                    {m["common.max"]()}
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         }
       />
@@ -314,7 +354,7 @@ const ConvertForm: React.FC = () => {
         })}
         classNames={{
           base: "z-20",
-          inputWrapper: "pl-0 py-3 flex-col h-auto gap-[6px]",
+          inputWrapper: "pl-0 py-3 flex-col h-auto gap-[6px] hover:bg-surface-secondary-rice",
           inputParent: "h-[34px] h3-bold",
           input: "!h3-bold",
         }}
@@ -333,36 +373,75 @@ const ConvertForm: React.FC = () => {
           )
         }
         insideBottomComponent={
-          <div className="flex items-center justify-between gap-2 w-full h-[22px] text-tertiary-500 diatype-sm-regular pl-4">
-            <div className="flex items-center gap-2">
+          <div className="flex flex-col w-full gap-2 pl-4">
+            <div className="flex items-center justify-between gap-2 w-full h-[22px] text-tertiary-500 diatype-sm-regular">
+              <div className="flex items-center gap-2">
               <p>
                 {quoteBalance} {quote.symbol}
               </p>
-              {isReverse ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="xs"
-                  className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
-                  onClick={() => {
-                    setActiveInput("quote");
-                    setValue("quote", quoteBalance);
-                  }}
-                >
-                  {m["common.max"]()}
-                </Button>
-              ) : null}
+              </div>
+              <div>
+                {simulation.isPending && activeInput !== "quote" ? (
+                  <Skeleton className="w-14 h-4" />
+                ) : (
+                  getPrice(quoteAmount, quote.denom, {
+                    format: true,
+                    formatOptions: formatNumberOptions,
+                  })
+                )}
+              </div>
             </div>
-            <div>
-              {simulation.isPending && activeInput !== "quote" ? (
-                <Skeleton className="w-14 h-4" />
-              ) : (
-                getPrice(quoteAmount, quote.denom, {
-                  format: true,
-                  formatOptions: formatNumberOptions,
-                })
-              )}
-            </div>
+            {isReverse ? (
+              <div className="flex flex-col gap-4">
+                <Range
+                  minValue={0}
+                  maxValue={Number(quoteBalance)}
+                  step={0.1}
+                  value={Number(quoteAmount)}
+                  onChange={(value) => setValue("quote", String(value))}
+                  classNames={{ inputWrapper: "px-0" }}
+                  showPercentage
+                />
+                <div className="w-full flex gap-4 justify-end">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
+                    onClick={() => {
+                      setActiveInput("quote");
+                      setValue("quote", String(Number(quoteBalance) * 0.25));
+                    }}
+                  >
+                    25%
+                  </Button>{" "}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
+                    onClick={() => {
+                      setActiveInput("quote");
+                      setValue("quote", String(Number(quoteBalance) * 0.5));
+                    }}
+                  >
+                    50%
+                  </Button>{" "}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    className="bg-red-bean-50 text-red-bean-500 hover:bg-red-bean-100 focus:[box-shadow:0px_0px_0px_3px_#F575893D] py-[2px] px-[6px]"
+                    onClick={() => {
+                      setActiveInput("quote");
+                      setValue("quote", quoteBalance);
+                    }}
+                  >
+                    {m["common.max"]()}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
           </div>
         }
       />

--- a/ui/applets/kit/src/components/Range.tsx
+++ b/ui/applets/kit/src/components/Range.tsx
@@ -34,9 +34,11 @@ export type RangeProps = {
   label?: string | ReactNode;
   isDisabled?: boolean;
   showSteps?: boolean | StepObject[];
+  showPercentage?: boolean;
   classNames?: {
     base?: string;
     input?: string;
+    inputWrapper?: string;
   };
   withInput?: boolean;
   inputEndContent?: ReactNode;
@@ -55,6 +57,7 @@ export const Range: React.FC<RangeProps> = ({
   classNames,
   withInput = false,
   inputEndContent,
+  showPercentage = false,
 }) => {
   const [value, setValue] = useControlledState(controlledValue, onChange, () => {
     const initial = defaultValue !== undefined ? defaultValue : minValue;
@@ -198,7 +201,13 @@ export const Range: React.FC<RangeProps> = ({
       {label && <div className="text-tertiary-500 exposure-xs-italic">{label}</div>}
 
       <div className="flex items-center gap-3">
-        <div className="flex flex-col flex-1 px-[10px]">
+        <div
+          className={twMerge(
+            "flex flex-col flex-1",
+            { "mt-4": showPercentage },
+            classNames?.inputWrapper,
+          )}
+        >
           <div
             ref={sliderRef}
             className={twMerge(
@@ -215,6 +224,7 @@ export const Range: React.FC<RangeProps> = ({
               )}
               style={{ width: `${currentPercentage}%` }}
             />
+
             <div
               className={twMerge(
                 "absolute top-1/2 w-4 h-4 rounded-full shadow-md focus:outline-none focus:border-red-bean-600",
@@ -223,7 +233,7 @@ export const Range: React.FC<RangeProps> = ({
                   : "bg-white border-2 border-red-bean-500 cursor-grab active:cursor-grabbing",
               )}
               style={{
-                left: `calc(${currentPercentage}% - 10px)`,
+                left: `calc(${currentPercentage}% - ${currentPercentage < 2 ? "0px" : "16px"})`,
                 transform: "translateY(-50%)",
               }}
               tabIndex={isDisabled ? -1 : 0}
@@ -242,7 +252,13 @@ export const Range: React.FC<RangeProps> = ({
                 if (!isDisabled) setIsDragging(true);
               }}
               onKeyDown={handleThumbKeyDown}
-            />
+            >
+              {showPercentage && (
+                <p className="absolute -top-5 text-tertiary-500 exposure-xs-italic select-none">
+                  {currentPercentage.toFixed(0)}%
+                </p>
+              )}
+            </div>
           </div>
           {showSteps && stepsToDisplay.length > 0 && (
             <div className="flex justify-between mt-2 px-1">

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -176,7 +176,7 @@
         "title": "Block not found",
         "description": "We couldn’t find the block you were looking for. If it’s a valid block, it may not have been generated yet, so please try again later. If the issue persists, please contact us for further assistance."
       },
-      "cronsOutcomes": "Crons Outcomes",
+      "cronsOutcomes": "Cron Outcomes",
       "details": {
         "blockDetails": "Block {height}",
         "blockHash": "Block Hash",

--- a/ui/portal/web/src/components/explorer/BlockExplorer.tsx
+++ b/ui/portal/web/src/components/explorer/BlockExplorer.tsx
@@ -260,7 +260,7 @@ const BlockDetails: React.FC = () => {
   const { transactions, createdAt, blockHeight, hash } = data.searchBlock;
 
   return (
-    <div className="flex flex-col rounded-md p-4 bg-surface-secondary-rice shadow-account-card text-secondary-700 relative overflow-hidden diatype-sm-medium">
+    <div className="flex flex-col rounded-xl p-4 bg-surface-secondary-rice shadow-account-card text-secondary-700 relative overflow-hidden diatype-sm-medium">
       <div className="overflow-y-auto scrollbar-none w-full gap-4 flex flex-col">
         <h1 className="h4-bold text-primary-900">
           {m["explorer.block.details.blockDetails"]({ height: `#${blockHeight}` })}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `Convert` component with a `Range` slider for percentage selection and fix a typo in messages.
> 
>   - **UI Enhancements**:
>     - Integrate `Range` slider in `ConvertForm` in `Convert.tsx` for base and quote inputs, allowing users to select percentages (25%, 50%, max).
>     - Add hover effect to `inputWrapper` in `Convert.tsx` and `BlockExplorer.tsx`.
>   - **Component Updates**:
>     - Add `showPercentage` prop to `Range` in `Range.tsx` to display percentage above the slider thumb.
>     - Adjust slider thumb position calculation in `Range.tsx`.
>   - **Miscellaneous**:
>     - Fix typo in `en.json` by changing "Crons Outcomes" to "Cron Outcomes".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 2b98bbe12a4be6a96a41384dfd48268f77fcffea. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->