### PR TITLE
Dex/metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "dango-oracle",
  "dango-types",
  "grug",
+ "metrics",
  "test-case",
  "tracing",
 ]

--- a/dango/cli/Cargo.toml
+++ b/dango/cli/Cargo.toml
@@ -21,7 +21,7 @@ colored                     = { workspace = true }
 colored_json                = { workspace = true }
 config-parser               = { workspace = true }
 dango-client                = { workspace = true }
-dango-genesis               = { workspace = true }
+dango-genesis               = { workspace = true, features = ["metrics"] }
 dango-httpd                 = { workspace = true, features = ["metrics"] }
 dango-indexer-clickhouse    = { workspace = true, features = ["async-graphql", "metrics", "tracing"] }
 dango-indexer-sql           = { workspace = true, features = ["async-graphql", "metrics", "tracing"] }

--- a/dango/dex/Cargo.toml
+++ b/dango/dex/Cargo.toml
@@ -13,6 +13,7 @@ version       = { workspace = true }
 # If enabled, Wasm exports won't be created. This allows this contract to be
 # imported into other contracts as a library.
 library = []
+metrics = ["dep:metrics"]
 tracing = ["dep:tracing"]
 
 [dependencies]
@@ -21,6 +22,7 @@ dango-account-factory = { workspace = true, features = ["library"] }
 dango-oracle          = { workspace = true, features = ["library"] }
 dango-types           = { workspace = true }
 grug                  = { workspace = true }
+metrics               = { workspace = true, optional = true }
 tracing               = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -420,7 +420,7 @@ fn clear_orders_of_pair(
     let mut outflows = DecCoins::new();
 
     #[cfg(feature = "metrics")]
-    let mut metric_volume: HashMap<(&Denom, &Denom, &Denom), grug::Uint128> = HashMap::new();
+    let mut metric_volume = HashMap::new();
 
     #[cfg(feature = "metrics")]
     {

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -421,13 +421,15 @@ fn clear_orders_of_pair(
 
     #[cfg(feature = "metrics")]
     let mut metric_volume: HashMap<(&Denom, &Denom, &Denom), grug::Uint128> = HashMap::new();
+
     #[cfg(feature = "metrics")]
     {
-        metrics::counter!(crate::metrics::TOTAL_TRADES_LABEL)
-            .increment(filling_outcomes.len() as u64);
-        metrics::histogram!(crate::metrics::TRADE_PER_BLOCK_LABEL)
+        metrics::counter!(crate::metrics::LABEL_TRADES).increment(filling_outcomes.len() as u64);
+
+        metrics::histogram!(crate::metrics::LABEL_TRADES_PER_BLOCK)
             .record(filling_outcomes.len() as f64);
     }
+
     // Handle order filling outcomes for the user placed orders.
     for FillingOutcome {
         order,
@@ -480,8 +482,11 @@ fn clear_orders_of_pair(
                                 order.id,
                             ),
                         )?;
+
                         #[cfg(feature = "metrics")]
-                        metrics::counter!(crate::metrics::TOTAL_FILLED_ORDERS_LABEL).increment(1);
+                        {
+                            metrics::counter!(crate::metrics::LABEL_ORDERS_FILLED).increment(1);
+                        }
                     } else {
                         ORDERS.save(
                             storage,
@@ -507,8 +512,11 @@ fn clear_orders_of_pair(
                             order.id,
                         ),
                     )?;
+
                     #[cfg(feature = "metrics")]
-                    metrics::counter!(crate::metrics::TOTAL_FILLED_ORDERS_LABEL).increment(1);
+                    {
+                        metrics::counter!(crate::metrics::LABEL_ORDERS_FILLED).increment(1);
+                    }
                 },
             }
         } else {
@@ -566,7 +574,7 @@ fn clear_orders_of_pair(
                 .checked_add_assign(filled_quote.into_int_floor())?;
 
             metrics::histogram!(
-                crate::metrics::VOLUME_PER_TRADE_LABEL,
+                crate::metrics::LABEL_VOLUME_PER_TRADE,
                 "base_denom" => base_denom.to_string(),
                 "quote_denom" => quote_denom.to_string(),
                 "token" => base_denom.to_string(),
@@ -574,7 +582,7 @@ fn clear_orders_of_pair(
             .record(filled_base.into_inner() as f64);
 
             metrics::histogram!(
-                crate::metrics::VOLUME_PER_TRADE_LABEL,
+                crate::metrics::LABEL_VOLUME_PER_TRADE,
                 "base_denom" => base_denom.to_string(),
                 "quote_denom" => quote_denom.to_string(),
                 "token" => quote_denom.to_string(),
@@ -587,7 +595,7 @@ fn clear_orders_of_pair(
     {
         for ((bd, qd, token), amount) in metric_volume {
             metrics::histogram!(
-                crate::metrics::VOLUME_PER_BLOCK_LABEL,
+                crate::metrics::LABEL_VOLUME_PER_BLOCK,
                 "base_denom" => bd.to_string(),
                 "quote_denom" => qd.to_string(),
                 "token" => token.to_string(),

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -25,6 +25,11 @@ use {
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
+    #[cfg(feature = "metrics")]
+    {
+        crate::metrics::init_metrics();
+    }
+
     PAUSED.save(ctx.storage, &false)?;
     batch_update_pairs(ctx, msg.pairs)
 }

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -25,11 +25,6 @@ use {
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
-    #[cfg(feature = "metrics")]
-    {
-        crate::metrics::init_metrics();
-    }
-
     PAUSED.save(ctx.storage, &false)?;
     batch_update_pairs(ctx, msg.pairs)
 }

--- a/dango/dex/src/execute/order_cancellation.rs
+++ b/dango/dex/src/execute/order_cancellation.rs
@@ -103,12 +103,13 @@ fn cancel_order(
             order.remaining,
             &pair.bucket_sizes,
         )?;
+
         #[cfg(feature = "metrics")]
         {
-            // We can skip the check for TimeInForce::ImmediateOrCancel, because
-            // the order will be proceed in the next auction. and always canceled.
+            // We can skip the check for `TimeInForce::ImmediateOrCancel`, because
+            // the order will be proceed in the next auction and always canceled.
             if order.amount > order.remaining.into_int_floor() {
-                metrics::counter!(crate::metrics::TOTAL_FILLED_ORDERS_LABEL).increment(1);
+                metrics::counter!(crate::metrics::LABEL_ORDERS_FILLED).increment(1);
             }
         }
     }

--- a/dango/dex/src/execute/order_cancellation.rs
+++ b/dango/dex/src/execute/order_cancellation.rs
@@ -103,6 +103,14 @@ fn cancel_order(
             order.remaining,
             &pair.bucket_sizes,
         )?;
+        #[cfg(feature = "metrics")]
+        {
+            // We can skip the check for TimeInForce::ImmediateOrCancel, because
+            // the order will be proceed in the next auction. and always canceled.
+            if order.amount > order.remaining.into_int_floor() {
+                metrics::counter!(crate::metrics::TOTAL_FILLED_ORDERS_LABEL).increment(1);
+            }
+        }
     }
 
     // Compute the amount of tokens to be sent back to the user.

--- a/dango/dex/src/lib.rs
+++ b/dango/dex/src/lib.rs
@@ -5,6 +5,9 @@ pub mod liquidity_depth;
 mod query;
 mod state;
 
+#[cfg(feature = "metrics")]
+pub mod metrics;
+
 pub use {cron::*, execute::*, query::*, state::*};
 
 /// If an oracle price is older than this, it is not used for the logics in this contract.

--- a/dango/dex/src/lib.rs
+++ b/dango/dex/src/lib.rs
@@ -2,11 +2,10 @@ pub mod core;
 mod cron;
 mod execute;
 pub mod liquidity_depth;
-mod query;
-mod state;
-
 #[cfg(feature = "metrics")]
 pub mod metrics;
+mod query;
+mod state;
 
 pub use {cron::*, execute::*, query::*, state::*};
 

--- a/dango/dex/src/lib.rs
+++ b/dango/dex/src/lib.rs
@@ -2,7 +2,6 @@ pub mod core;
 mod cron;
 mod execute;
 pub mod liquidity_depth;
-mod metrics;
 mod query;
 mod state;
 

--- a/dango/dex/src/lib.rs
+++ b/dango/dex/src/lib.rs
@@ -2,6 +2,7 @@ pub mod core;
 mod cron;
 mod execute;
 pub mod liquidity_depth;
+mod metrics;
 mod query;
 mod state;
 

--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -4,9 +4,13 @@ use {
 };
 
 pub const LABEL_TRADES: &str = "dango.contract.dex.trades";
+
 pub const LABEL_ORDERS_FILLED: &str = "dango.contract.dex.orders_filled";
+
 pub const LABEL_TRADES_PER_BLOCK: &str = "dango.contract.dex.trades_per_block";
+
 pub const LABEL_VOLUME_PER_TRADE: &str = "dango.contract.dex.volume_per_trade";
+
 pub const LABEL_VOLUME_PER_BLOCK: &str = "dango.contract.dex.volume_per_block";
 
 pub fn init_metrics() {

--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -3,7 +3,7 @@ use {
     std::sync::Once,
 };
 
-const ONCE_METRICS_INITIALIZED: Once = Once::new();
+static ONCE_METRICS_INITIALIZED: Once = Once::new();
 
 pub const TOTAL_TRADES_LABEL: &str = "dango.contract.dex.total_trades";
 pub const VOLUME_PER_TRADE_LABEL: &str = "dango.contract.dex.volume_per_trade";

--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -1,6 +1,0 @@
-#[macro_export]
-macro_rules! metric {
-    ( $($stmt:stmt)* ) => {
-        $( #[cfg(feature = "metrics")] $stmt)*
-    };
-}

--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! metric {
+    ( $($stmt:stmt)* ) => {
+        $( #[cfg(feature = "metrics")] $stmt)*
+    };
+}

--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -3,23 +3,24 @@ use {
     std::sync::Once,
 };
 
-static ONCE_METRICS_INITIALIZED: Once = Once::new();
-
-pub const TOTAL_TRADES_LABEL: &str = "dango.contract.dex.total_trades";
-pub const TOTAL_FILLED_ORDERS_LABEL: &str = "dango.contract.dex.total_filled_orders";
-pub const TRADE_PER_BLOCK_LABEL: &str = "dango.contract.dex.trade_per_block";
-pub const VOLUME_PER_TRADE_LABEL: &str = "dango.contract.dex.volume_per_trade";
-pub const VOLUME_PER_BLOCK_LABEL: &str = "dango.contract.dex.volume_per_block";
+pub const LABEL_TRADES: &str = "dango.contract.dex.trades";
+pub const LABEL_ORDERS_FILLED: &str = "dango.contract.dex.orders_filled";
+pub const LABEL_TRADES_PER_BLOCK: &str = "dango.contract.dex.trades_per_block";
+pub const LABEL_VOLUME_PER_TRADE: &str = "dango.contract.dex.volume_per_trade";
+pub const LABEL_VOLUME_PER_BLOCK: &str = "dango.contract.dex.volume_per_block";
 
 pub fn init_metrics() {
-    ONCE_METRICS_INITIALIZED.call_once(|| {
-        describe_counter!(TOTAL_TRADES_LABEL, "Cumulative total trades");
-        describe_counter!(
-            TOTAL_FILLED_ORDERS_LABEL,
-            "Cumulative total filled unique orders"
-        );
-        describe_histogram!(TRADE_PER_BLOCK_LABEL, "Trade per block");
-        describe_histogram!(VOLUME_PER_TRADE_LABEL, "Volume per trade");
-        describe_histogram!(VOLUME_PER_BLOCK_LABEL, "Volume per block");
+    static ONCE: Once = Once::new();
+
+    ONCE.call_once(|| {
+        describe_counter!(LABEL_TRADES, "Number of trades executed");
+
+        describe_counter!(LABEL_ORDERS_FILLED, "Number of unique orders filled");
+
+        describe_histogram!(LABEL_TRADES_PER_BLOCK, "Number of trades in a block");
+
+        describe_histogram!(LABEL_VOLUME_PER_TRADE, "Volume per trade");
+
+        describe_histogram!(LABEL_VOLUME_PER_BLOCK, "Volume per block");
     });
 }

--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -1,0 +1,18 @@
+use {
+    metrics::{describe_counter, describe_histogram},
+    std::sync::Once,
+};
+
+const ONCE_METRICS_INITIALIZED: Once = Once::new();
+
+pub const TOTAL_TRADES_LABEL: &str = "dango.contract.dex.total_trades";
+pub const VOLUME_PER_TRADE_LABEL: &str = "dango.contract.dex.volume_per_trade";
+pub const VOLUME_PER_BLOCK_LABEL: &str = "dango.contract.dex.volume_per_block";
+
+pub(crate) fn init_metrics() {
+    ONCE_METRICS_INITIALIZED.call_once(|| {
+        describe_counter!(TOTAL_TRADES_LABEL, "Total trades");
+        describe_histogram!(VOLUME_PER_TRADE_LABEL, "Volume per trade");
+        describe_histogram!(VOLUME_PER_BLOCK_LABEL, "Volume per block");
+    });
+}

--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -6,12 +6,19 @@ use {
 static ONCE_METRICS_INITIALIZED: Once = Once::new();
 
 pub const TOTAL_TRADES_LABEL: &str = "dango.contract.dex.total_trades";
+pub const TOTAL_FILLED_ORDERS_LABEL: &str = "dango.contract.dex.total_filled_orders";
+pub const TRADE_PER_BLOCK_LABEL: &str = "dango.contract.dex.trade_per_block";
 pub const VOLUME_PER_TRADE_LABEL: &str = "dango.contract.dex.volume_per_trade";
 pub const VOLUME_PER_BLOCK_LABEL: &str = "dango.contract.dex.volume_per_block";
 
-pub(crate) fn init_metrics() {
+pub fn init_metrics() {
     ONCE_METRICS_INITIALIZED.call_once(|| {
-        describe_counter!(TOTAL_TRADES_LABEL, "Total trades");
+        describe_counter!(TOTAL_TRADES_LABEL, "Cumulative total trades");
+        describe_counter!(
+            TOTAL_FILLED_ORDERS_LABEL,
+            "Cumulative total filled unique orders"
+        );
+        describe_histogram!(TRADE_PER_BLOCK_LABEL, "Trade per block");
         describe_histogram!(VOLUME_PER_TRADE_LABEL, "Volume per trade");
         describe_histogram!(VOLUME_PER_BLOCK_LABEL, "Volume per block");
     });

--- a/dango/genesis/Cargo.toml
+++ b/dango/genesis/Cargo.toml
@@ -9,6 +9,9 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
+[features]
+metrics = ["dango-dex/metrics"]
+
 [dependencies]
 anyhow                = { workspace = true }
 dango-account-factory = { workspace = true, features = ["library"] }

--- a/dango/genesis/src/codes.rs
+++ b/dango/genesis/src/codes.rs
@@ -62,6 +62,8 @@ impl GenesisCodes for RustVm {
             .with_reply(Box::new(dango_dex::reply))
             .build();
 
+        #[cfg(feature = "metrics")]
+        dango_dex::metrics::init_metrics();
         let gateway = ContractBuilder::new(Box::new(dango_gateway::instantiate))
             .with_execute(Box::new(dango_gateway::execute))
             .with_query(Box::new(dango_gateway::query))

--- a/dango/genesis/src/codes.rs
+++ b/dango/genesis/src/codes.rs
@@ -62,8 +62,6 @@ impl GenesisCodes for RustVm {
             .with_reply(Box::new(dango_dex::reply))
             .build();
 
-        #[cfg(feature = "metrics")]
-        dango_dex::metrics::init_metrics();
         let gateway = ContractBuilder::new(Box::new(dango_gateway::instantiate))
             .with_execute(Box::new(dango_gateway::execute))
             .with_query(Box::new(dango_gateway::query))
@@ -112,6 +110,12 @@ impl GenesisCodes for RustVm {
             .with_execute(Box::new(dango_warp::execute))
             .with_query(Box::new(dango_warp::query))
             .build();
+
+        #[cfg(feature = "metrics")]
+        {
+            dango_dex::metrics::init_metrics();
+            // TODO: add other contracts that emit metrics
+        }
 
         Codes {
             account_factory,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Integrate metrics tracking for trades, orders filled, and volume in the Dango DEX module, with conditional compilation using a 'metrics' feature flag.
> 
>   - **Metrics Integration**:
>     - Add `metrics` dependency to `Cargo.lock`, `dango/cli/Cargo.toml`, `dango/dex/Cargo.toml`, and `dango/genesis/Cargo.toml`.
>     - Introduce `metrics.rs` in `dango/dex` to define and initialize metrics labels and counters.
>     - Update `dango/dex/src/cron.rs` and `dango/dex/src/execute/order_cancellation.rs` to record metrics for trades, orders filled, and volume per trade/block.
>   - **Feature Flags**:
>     - Add `metrics` feature flag to `dango-genesis` and `dango-dex` to conditionally compile metrics-related code.
>   - **Code Changes**:
>     - Modify `clear_orders_of_pair()` in `cron.rs` to track metrics for trades and volumes.
>     - Update `cancel_order()` in `order_cancellation.rs` to increment order filled counter.
>     - Initialize metrics in `genesis/src/codes.rs` if the `metrics` feature is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for cdcb43aacf8655a3ccfe7795d705824e84e271d3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->