### PR TITLE
feat: purge old volume data

### DIFF
--- a/dango/dex/src/lib.rs
+++ b/dango/dex/src/lib.rs
@@ -10,6 +10,9 @@ pub use {cron::*, execute::*, query::*, state::*};
 /// If an oracle price is older than this, it is not used for the logics in this contract.
 pub const MAX_ORACLE_STALENESS: grug::Duration = grug::Duration::from_seconds(5);
 
+/// Maximum age of volume data to store.
+pub const MAX_VOLUME_AGE: grug::Duration = grug::Duration::from_weeks(3);
+
 /// The minimum amount of LP tokens that can exist for a pool with liquidity.
 /// This are minted to and permanently locked in the DEX contract itself upon
 /// the first liquidity provision.

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -4,6 +4,7 @@ use {
         RESTING_ORDER_BOOK, VOLUMES, VOLUMES_BY_USER,
         core::{self, PassiveLiquidityPool},
     },
+    anyhow::ensure,
     dango_oracle::OracleQuerier,
     dango_types::{
         DangoQuerier,
@@ -438,9 +439,9 @@ fn query_volume(
 ) -> anyhow::Result<Udec128_6> {
     // Validate that the since timestamp is not more than MAX_VOLUME_AGE ago.
     if let Some(since) = since {
-        anyhow::ensure!(
+        ensure!(
             ctx.block.timestamp.saturating_sub(MAX_VOLUME_AGE) <= since,
-            "cannot query volume since timestamp that is more than MAX_VOLUME_AGE ago"
+            "the `since` timestamp can't be more than `MAX_VOLUME_AGE` ago"
         );
     }
 
@@ -477,9 +478,9 @@ fn query_volume_by_user(
 ) -> anyhow::Result<Udec128_6> {
     // Validate that the since timestamp is not more than MAX_VOLUME_AGE ago.
     if let Some(since) = since {
-        anyhow::ensure!(
+        ensure!(
             ctx.block.timestamp.saturating_sub(MAX_VOLUME_AGE) <= since,
-            "cannot query volume since timestamp that is more than MAX_VOLUME_AGE ago"
+            "the `since` timestamp can't be more than `MAX_VOLUME_AGE` ago"
         );
     }
 

--- a/dango/dex/src/state.rs
+++ b/dango/dex/src/state.rs
@@ -30,10 +30,10 @@ pub const ORDERS: IndexedMap<OrderKey, Order, OrderIndex> = IndexedMap::new("ord
 /// Stores the liquidity depths for each bucket size. The value is a tuple of (base, quote) depths.
 pub const DEPTHS: Map<DepthKey, (Udec128_6, Udec128_6)> = Map::new("depth");
 
-/// Stores the total trading volume in USD for each account address and timestamp.
+/// Stores the total (cumulative) trading volume in USD for each account address and timestamp.
 pub const VOLUMES: Map<(&Addr, Timestamp), Udec128_6> = Map::new("volume");
 
-/// Stores the total trading volume in USD for each username and timestamp.
+/// Stores the total (cumulative) trading volume in USD for each username and timestamp.
 pub const VOLUMES_BY_USER: Map<(&Username, Timestamp), Udec128_6> = Map::new("volume_by_user");
 
 /// Storage key for orders.

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -3094,6 +3094,7 @@ fn submit_standard_order(
         Direction::Bid => Coins::one(usdc::DENOM.clone(), 100_000_000).unwrap(),
         Direction::Ask => Coins::one(dango::DENOM.clone(), 100_000_000).unwrap(),
     };
+
     suite
         .execute(
             user,
@@ -3553,9 +3554,7 @@ fn volume_tracking_works() {
             user: user1_addr_1.address(),
             since: Some(timestamp_after_second_trade),
         })
-        .should_fail_with_error(
-            "cannot query volume since timestamp that is more than MAX_VOLUME_AGE ago",
-        );
+        .should_fail_with_error("the `since` timestamp can't be more than `MAX_VOLUME_AGE` ago");
 
     // Query the volume for user2 address 1 since timestamp after second trade,
     // should fail as time is more than MAX_VOLUME_AGE ago.
@@ -3564,9 +3563,7 @@ fn volume_tracking_works() {
             user: user2_addr_1.address(),
             since: Some(timestamp_after_second_trade),
         })
-        .should_fail_with_error(
-            "cannot query volume since timestamp that is more than MAX_VOLUME_AGE ago",
-        );
+        .should_fail_with_error("the `since` timestamp can't be more than `MAX_VOLUME_AGE` ago");
 
     // Query the volume for username user1 since timestamp after second trade,
     // should fail as time is more than MAX_VOLUME_AGE ago.
@@ -3575,9 +3572,7 @@ fn volume_tracking_works() {
             user: user1_addr_1.username.clone(),
             since: Some(timestamp_after_second_trade),
         })
-        .should_fail_with_error(
-            "cannot query volume since timestamp that is more than MAX_VOLUME_AGE ago",
-        );
+        .should_fail_with_error("the `since` timestamp can't be more than `MAX_VOLUME_AGE` ago");
 
     // Query the volume for username user2 since timestamp after second trade,
     // should fail as time is more than MAX_VOLUME_AGE ago.
@@ -3586,9 +3581,7 @@ fn volume_tracking_works() {
             user: user2_addr_1.username.clone(),
             since: Some(timestamp_after_second_trade),
         })
-        .should_fail_with_error(
-            "cannot query volume since timestamp that is more than MAX_VOLUME_AGE ago",
-        );
+        .should_fail_with_error("the `since` timestamp can't be more than `MAX_VOLUME_AGE` ago");
 }
 
 #[test]

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -3437,31 +3437,31 @@ fn volume_tracking_works() {
     let timestamp_after_fourth_trade_minus_max_volume_age =
         timestamp_after_fourth_trade.saturating_sub(MAX_VOLUME_AGE);
 
-    // Ensure the oldest data was removed. The first two entries for address 1 and 2 should be
-    // replaced with one entry at the timestamp of MAX_VOLUME_AGE ago.
-    let storage = suite.contract_storage(contracts.dex);
-    let volumes = VOLUMES
-        .range(&storage, None, None, Order::Ascending)
-        .collect::<StdResult<BTreeMap<_, _>>>()
-        .unwrap();
-    assert_eq!(volumes, btree_map! {
-        (user1_addr_1.address(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(200),
-        (user1_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
-        (user1_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
-        (user2_addr_1.address(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(200),
-        (user2_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
-        (user2_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
-    });
-    let volumes_by_user = VOLUMES_BY_USER
-        .range(&storage, None, None, Order::Ascending)
-        .collect::<StdResult<BTreeMap<_, _>>>()
-        .unwrap();
-    assert_eq!(volumes_by_user, btree_map! {
-        (user1_addr_1.username.clone(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(300),
-        (user1_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
-        (user2_addr_1.username.clone(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(300),
-        (user2_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
-    });
+    // // Ensure the oldest data was removed. The first two entries for address 1 and 2 should be
+    // // replaced with one entry at the timestamp of MAX_VOLUME_AGE ago.
+    // let storage = suite.contract_storage(contracts.dex);
+    // let volumes = VOLUMES
+    //     .range(&storage, None, None, Order::Ascending)
+    //     .collect::<StdResult<BTreeMap<_, _>>>()
+    //     .unwrap();
+    // assert_eq!(volumes, btree_map! {
+    //     (user1_addr_1.address(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(200),
+    //     (user1_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
+    //     (user1_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
+    //     (user2_addr_1.address(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(200),
+    //     (user2_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
+    //     (user2_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
+    // });
+    // let volumes_by_user = VOLUMES_BY_USER
+    //     .range(&storage, None, None, Order::Ascending)
+    //     .collect::<StdResult<BTreeMap<_, _>>>()
+    //     .unwrap();
+    // assert_eq!(volumes_by_user, btree_map! {
+    //     (user1_addr_1.username.clone(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(300),
+    //     (user1_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
+    //     (user2_addr_1.username.clone(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(300),
+    //     (user2_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
+    // });
 
     // Query the volume for username user1, should be 400
     suite

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -3409,6 +3409,7 @@ fn volume_tracking_works() {
         (user2_addr_1.address(), timestamp_after_second_trade) => Udec128_6::new(200),
         (user2_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
     });
+
     let volumes_by_user = VOLUMES_BY_USER
         .range(&storage, None, None, Order::Ascending)
         .collect::<StdResult<BTreeMap<_, _>>>()
@@ -3437,31 +3438,34 @@ fn volume_tracking_works() {
     let timestamp_after_fourth_trade_minus_max_volume_age =
         timestamp_after_fourth_trade.saturating_sub(MAX_VOLUME_AGE);
 
-    // // Ensure the oldest data was removed. The first two entries for address 1 and 2 should be
-    // // replaced with one entry at the timestamp of MAX_VOLUME_AGE ago.
-    // let storage = suite.contract_storage(contracts.dex);
-    // let volumes = VOLUMES
-    //     .range(&storage, None, None, Order::Ascending)
-    //     .collect::<StdResult<BTreeMap<_, _>>>()
-    //     .unwrap();
-    // assert_eq!(volumes, btree_map! {
-    //     (user1_addr_1.address(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(200),
-    //     (user1_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
-    //     (user1_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
-    //     (user2_addr_1.address(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(200),
-    //     (user2_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
-    //     (user2_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
-    // });
-    // let volumes_by_user = VOLUMES_BY_USER
-    //     .range(&storage, None, None, Order::Ascending)
-    //     .collect::<StdResult<BTreeMap<_, _>>>()
-    //     .unwrap();
-    // assert_eq!(volumes_by_user, btree_map! {
-    //     (user1_addr_1.username.clone(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(300),
-    //     (user1_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
-    //     (user2_addr_1.username.clone(), timestamp_after_fourth_trade_minus_max_volume_age) => Udec128_6::new(300),
-    //     (user2_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
-    // });
+    // Ensure the oldest data was removed. The first two entries for address 1 and 2 should be
+    // replaced with one entry at the timestamp of MAX_VOLUME_AGE ago.
+    let storage = suite.contract_storage(contracts.dex);
+    let volumes = VOLUMES
+        .range(&storage, None, None, Order::Ascending)
+        .collect::<StdResult<BTreeMap<_, _>>>()
+        .unwrap();
+    assert_eq!(volumes, btree_map! {
+        // `user1_addr_1` has three trades: 1st, 2nd, 4th. Among which, 1st and 2nd
+        // are older than the cutoff. 2nd is kept, 1st is deleted.
+        (user1_addr_1.address(), timestamp_after_second_trade) => Udec128_6::new(200),
+        (user1_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
+        (user1_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
+        (user2_addr_1.address(), timestamp_after_second_trade) => Udec128_6::new(200),
+        (user2_addr_1.address(), timestamp_after_fourth_trade) => Udec128_6::new(300),
+        (user2_addr_2.address(), timestamp_after_third_trade) => Udec128_6::new(100),
+    });
+
+    let volumes_by_user = VOLUMES_BY_USER
+        .range(&storage, None, None, Order::Ascending)
+        .collect::<StdResult<BTreeMap<_, _>>>()
+        .unwrap();
+    assert_eq!(volumes_by_user, btree_map! {
+        (user1_addr_1.username.clone(), timestamp_after_third_trade) => Udec128_6::new(300),
+        (user1_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
+        (user2_addr_1.username.clone(), timestamp_after_third_trade) => Udec128_6::new(300),
+        (user2_addr_1.username.clone(), timestamp_after_fourth_trade) => Udec128_6::new(400),
+    });
 
     // Query the volume for username user1, should be 400
     suite

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -625,6 +625,7 @@ where
         QuerierWrapper::new(self)
     }
 
+    /// Return a `Storage` object representing the storage of a given contract.
     pub fn contract_storage(&self, address: Addr) -> StorageProvider
     where
         <DB as grug_app::Db>::Error: std::fmt::Debug,

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -5,7 +5,7 @@ use {
     },
     grug_app::{
         App, AppError, Db, Indexer, NaiveProposalPreparer, NullIndexer, ProposalPreparer,
-        UpgradeHandler, Vm,
+        StorageProvider, UpgradeHandler, Vm,
     },
     grug_db_memory::MemDb,
     grug_math::Uint128,
@@ -623,6 +623,14 @@ where
     /// Return a `QuerierWrapper` object.
     pub fn querier(&self) -> QuerierWrapper<'_> {
         QuerierWrapper::new(self)
+    }
+
+    pub fn contract_storage(&self, address: Addr) -> StorageProvider
+    where
+        <DB as grug_app::Db>::Error: std::fmt::Debug,
+    {
+        let storage = self.app.db.state_storage(None).unwrap();
+        StorageProvider::new(Box::new(storage), &[grug_app::CONTRACT_NAMESPACE, &address])
     }
 }
 

--- a/grug/types/src/time.rs
+++ b/grug/types/src/time.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 use {
     crate::Inner,
     borsh::{BorshDeserialize, BorshSerialize},
-    grug_math::{Dec, Int, IsZero, NumberConst, Uint128},
+    grug_math::{Dec, Int, IsZero, MathResult, Number, NumberConst, Uint128},
     serde::{Deserialize, Serialize},
     std::ops::{Add, Mul, Sub},
 };
@@ -208,6 +208,40 @@ where
 
     fn mul(self, rhs: U) -> Self::Output {
         Self(self.0 * Dec::<u128, 9>::new(rhs.into().into_inner()))
+    }
+}
+
+impl Number for Duration {
+    fn checked_add(self, other: Self) -> MathResult<Self> {
+        self.0.checked_add(other.0).map(Self)
+    }
+
+    fn checked_sub(self, other: Self) -> MathResult<Self> {
+        self.0.checked_sub(other.0).map(Self)
+    }
+
+    fn checked_mul(self, other: Self) -> MathResult<Self> {
+        self.0.checked_mul(other.0).map(Self)
+    }
+
+    fn checked_div(self, other: Self) -> MathResult<Self> {
+        self.0.checked_div(other.0).map(Self)
+    }
+
+    fn checked_rem(self, other: Self) -> MathResult<Self> {
+        self.0.checked_rem(other.0).map(Self)
+    }
+
+    fn saturating_add(self, other: Self) -> Self {
+        Self(self.0.saturating_add(other.0))
+    }
+
+    fn saturating_sub(self, other: Self) -> Self {
+        Self(self.0.saturating_sub(other.0))
+    }
+
+    fn saturating_mul(self, other: Self) -> Self {
+        Self(self.0.saturating_mul(other.0))
     }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR adds functionality to purge old volume data based on a maximum age, updates related queries, and includes tests to verify the changes.
> 
>   - **Behavior**:
>     - Introduces `MAX_VOLUME_AGE` constant in `lib.rs` to define the maximum age of volume data.
>     - Implements `purge_old_volume_data()` in `cron.rs` to remove volume data older than `MAX_VOLUME_AGE`, retaining the most recent entry.
>     - Updates `auction()` in `cron.rs` to call `purge_old_volume_data()` for `VOLUMES` and `VOLUMES_BY_USER`.
>     - Modifies `query_volume()` and `query_volume_by_user()` in `query.rs` to validate `since` timestamp is not older than `MAX_VOLUME_AGE`.
>   - **Tests**:
>     - Adds tests in `dex.rs` to verify volume data purging and querying behavior.
>     - Refactors test setup with `submit_standard_order()` helper function in `dex.rs`.
>   - **Misc**:
>     - Adds `contract_storage()` method to `TestSuite` in `suite.rs` for accessing contract storage.
>     - Implements `Number` trait for `Duration` in `time.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ca7996c50db79b4797d215e22bf72bb55917a063. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->