### PR TITLE
dex: replace `Udec128_24` with alias `Price`

### DIFF
--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -2,10 +2,10 @@ use {
     super::{geometric, xyk},
     anyhow::{bail, ensure},
     dango_oracle::OracleQuerier,
-    dango_types::dex::{PairParams, PassiveLiquidity},
+    dango_types::dex::{PairParams, PassiveLiquidity, Price},
     grug::{
         Coin, CoinPair, Denom, IsZero, MultiplyFraction, NextNumber, Number, NumberConst,
-        PrevNumber, Sign, Udec128, Udec128_24, Uint128,
+        PrevNumber, Sign, Udec128, Uint128,
     },
     std::ops::Sub,
 };
@@ -133,8 +133,8 @@ pub trait PassiveLiquidityPool {
         quote_denom: Denom,
         reserve: &CoinPair,
     ) -> anyhow::Result<(
-        Box<dyn Iterator<Item = (Udec128_24, Uint128)>>, // bids: price => amount in base asset
-        Box<dyn Iterator<Item = (Udec128_24, Uint128)>>, // asks: price => amount in base asset
+        Box<dyn Iterator<Item = (Price, Uint128)>>, // bids: price => amount in base asset
+        Box<dyn Iterator<Item = (Price, Uint128)>>, // asks: price => amount in base asset
     )>;
 }
 
@@ -377,8 +377,8 @@ impl PassiveLiquidityPool for PairParams {
         quote_denom: Denom,
         reserve: &CoinPair,
     ) -> anyhow::Result<(
-        Box<dyn Iterator<Item = (Udec128_24, Uint128)>>,
-        Box<dyn Iterator<Item = (Udec128_24, Uint128)>>,
+        Box<dyn Iterator<Item = (Price, Uint128)>>,
+        Box<dyn Iterator<Item = (Price, Uint128)>>,
     )> {
         let base_reserve = reserve.amount_of(&base_denom)?;
         let quote_reserve = reserve.amount_of(&quote_denom)?;

--- a/dango/dex/src/core/order_filling.rs
+++ b/dango/dex/src/core/order_filling.rs
@@ -1,6 +1,6 @@
 use {
-    dango_types::dex::Order,
-    grug::{IsZero, Number, NumberConst, StdResult, Udec128, Udec128_6, Udec128_24},
+    dango_types::dex::{Order, Price},
+    grug::{IsZero, Number, NumberConst, StdResult, Udec128, Udec128_6},
 };
 
 #[derive(Debug)]
@@ -20,14 +20,14 @@ pub struct FillingOutcome {
     /// Fee charged in quote asset.
     pub fee_quote: Udec128_6,
     /// The price at which the order was filled.
-    pub clearing_price: Udec128_24,
+    pub clearing_price: Price,
 }
 
 /// Clear the orders given a clearing price and volume.
 pub fn fill_orders(
-    bids: Vec<(Udec128_24, Order)>,
-    asks: Vec<(Udec128_24, Order)>,
-    clearing_price: Udec128_24,
+    bids: Vec<(Price, Order)>,
+    asks: Vec<(Price, Order)>,
+    clearing_price: Price,
     volume: Udec128_6,
     current_block_height: u64,
     maker_fee_rate: Udec128,
@@ -58,8 +58,8 @@ pub fn fill_orders(
 
 /// Fill the BUY orders given a clearing price and volume.
 fn fill_bids(
-    bids: Vec<(Udec128_24, Order)>,
-    clearing_price: Udec128_24,
+    bids: Vec<(Price, Order)>,
+    clearing_price: Price,
     mut volume: Udec128_6,
     current_block_height: u64,
     maker_fee_rate: Udec128,
@@ -120,8 +120,8 @@ fn fill_bids(
 
 /// Fill the SELL orders given a clearing price and volume.
 fn fill_asks(
-    asks: Vec<(Udec128_24, Order)>,
-    clearing_price: Udec128_24,
+    asks: Vec<(Price, Order)>,
+    clearing_price: Price,
     mut volume: Udec128_6,
     current_block_height: u64,
     maker_fee_rate: Udec128,

--- a/dango/dex/src/core/order_matching.rs
+++ b/dango/dex/src/core/order_matching.rs
@@ -1,6 +1,6 @@
 use {
-    dango_types::dex::Order,
-    grug::{Number, NumberConst, StdResult, Udec128_6, Udec128_24},
+    dango_types::dex::{Order, Price},
+    grug::{Number, NumberConst, StdResult, Udec128_6},
 };
 
 pub struct MatchingOutcome {
@@ -9,13 +9,13 @@ pub struct MatchingOutcome {
     ///
     /// All prices in this range achieve the same volume. It's up to the caller
     /// to decide which price to use: the lowest, the highest, or the midpoint.
-    pub range: Option<(Udec128_24, Udec128_24)>,
+    pub range: Option<(Price, Price)>,
     /// The amount of trading volume, measured as the amount of the base asset.
     pub volume: Udec128_6,
     /// The BUY orders that have found a match.
-    pub bids: Vec<(Udec128_24, Order)>,
+    pub bids: Vec<(Price, Order)>,
     /// The SELL orders that have found a match.
-    pub asks: Vec<(Udec128_24, Order)>,
+    pub asks: Vec<(Price, Order)>,
 }
 
 /// Given the standing BUY and SELL orders in the book, find range of prices
@@ -31,8 +31,8 @@ pub struct MatchingOutcome {
 ///   follows the price-time priority.
 pub fn match_orders<B, A>(bid_iter: &mut B, ask_iter: &mut A) -> StdResult<MatchingOutcome>
 where
-    B: Iterator<Item = StdResult<(Udec128_24, Order)>>,
-    A: Iterator<Item = StdResult<(Udec128_24, Order)>>,
+    B: Iterator<Item = StdResult<(Price, Order)>>,
+    A: Iterator<Item = StdResult<(Price, Order)>>,
 {
     let mut bid = bid_iter.next().transpose()?;
     let mut bids = Vec::new();

--- a/dango/dex/src/core/xyk.rs
+++ b/dango/dex/src/core/xyk.rs
@@ -1,9 +1,9 @@
 use {
     anyhow::ensure,
-    dango_types::dex::Xyk,
+    dango_types::dex::{Price, Xyk},
     grug::{
         Bounded, CoinPair, Exponentiate, IsZero, MathResult, MultiplyFraction, MultiplyRatio,
-        Number, NumberConst, Udec128, Udec128_24, Uint128, ZeroExclusiveOneExclusive,
+        Number, NumberConst, Udec128, Uint128, ZeroExclusiveOneExclusive,
     },
     std::{cmp, iter},
 };
@@ -17,7 +17,7 @@ pub fn add_initial_liquidity(deposit: &CoinPair) -> MathResult<Uint128> {
 pub fn add_subsequent_liquidity(
     reserve: &mut CoinPair,
     deposit: CoinPair,
-) -> anyhow::Result<Udec128_24> {
+) -> anyhow::Result<Price> {
     let invariant_before = normalized_invariant(reserve)?;
 
     // Add the used funds to the pool reserves.
@@ -25,12 +25,12 @@ pub fn add_subsequent_liquidity(
 
     // Compute the proportional increase in the invariant.
     let invariant_after = normalized_invariant(reserve)?;
-    let invariant_ratio = Udec128_24::checked_from_ratio(invariant_after, invariant_before)?;
+    let invariant_ratio = Price::checked_from_ratio(invariant_after, invariant_before)?;
 
     // Compute the mint ratio from the invariant ratio based on the curve type.
     // This ensures that an unbalances provision will be equivalent to a swap
     // followed by a balancedliquidity provision.
-    Ok(invariant_ratio.checked_sub(Udec128_24::ONE)?)
+    Ok(invariant_ratio.checked_sub(Price::ONE)?)
 }
 
 /// Note: this function does not concern the liquidity fee.
@@ -100,8 +100,8 @@ pub fn reflect_curve(
     params: Xyk,
     swap_fee_rate: Bounded<Udec128, ZeroExclusiveOneExclusive>,
 ) -> anyhow::Result<(
-    Box<dyn Iterator<Item = (Udec128_24, Uint128)>>,
-    Box<dyn Iterator<Item = (Udec128_24, Uint128)>>,
+    Box<dyn Iterator<Item = (Price, Uint128)>>,
+    Box<dyn Iterator<Item = (Price, Uint128)>>,
 )> {
     // Withhold the funds corresponding to the reserve requirement.
     // These funds will not be used to place orders.
@@ -110,7 +110,7 @@ pub fn reflect_curve(
     quote_reserve.checked_mul_dec_floor_assign(one_sub_reserve_ratio)?;
 
     // Compute the marginal price. We will place orders above and below this price.
-    let marginal_price = Udec128_24::checked_from_ratio(quote_reserve, base_reserve)?;
+    let marginal_price = Price::checked_from_ratio(quote_reserve, base_reserve)?;
 
     // Construct the bid order iterator.
     // Start from the marginal price minus the swap fee rate.
@@ -220,7 +220,7 @@ pub fn normalized_invariant(reserve: &CoinPair) -> MathResult<Uint128> {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, grug::Udec128_24};
+    use super::*;
 
     #[test]
     fn marginal_price_is_non_zero_with_low_price_and_high_precision_token() {
@@ -235,7 +235,7 @@ mod tests {
         // $1B worth of quote asset at 1 USD per whole token with 6 decimals precision
         let quote_reserve = Uint128::new(1_000_000_000 * 10u128.pow(6));
 
-        let marginal_price = Udec128_24::checked_from_ratio(quote_reserve, base_reserve).unwrap();
+        let marginal_price = Price::checked_from_ratio(quote_reserve, base_reserve).unwrap();
         println!("marginal_price: {marginal_price}");
         assert!(marginal_price.is_non_zero());
 

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -12,7 +12,7 @@ use {
         account_factory::Username,
         dex::{
             CallbackMsg, Direction, ExecuteMsg, Order, OrderCanceled, OrderFilled, OrdersMatched,
-            Paused, ReplyMsg, RestingOrderBookState, TimeInForce,
+            Paused, Price, ReplyMsg, RestingOrderBookState, TimeInForce,
         },
         taxman::{self, FeeType},
     },
@@ -20,7 +20,7 @@ use {
         Addr, Bound, Coins, DecCoins, Denom, EventBuilder, Inner, IsZero, Map, Message,
         MultiplyFraction, MutableCtx, NonZero, Number, NumberConst, Order as IterationOrder,
         PrimaryKey, Response, StdError, StdResult, Storage, SubMessage, SubMsgResult, SudoCtx,
-        Timestamp, TransferBuilder, Udec128, Udec128_6, Udec128_24,
+        Timestamp, TransferBuilder, Udec128, Udec128_6,
     },
     std::collections::{BTreeMap, BTreeSet, HashMap, hash_map::Entry},
 };
@@ -185,7 +185,7 @@ fn clear_orders_of_pair(
     taker_fee_rate: Udec128,
     base_denom: Denom,
     quote_denom: Denom,
-    bucket_sizes: &BTreeSet<NonZero<Udec128_24>>,
+    bucket_sizes: &BTreeSet<NonZero<Price>>,
     events: &mut EventBuilder,
     refunds: &mut TransferBuilder<DecCoins<6>>,
     fees: &mut DecCoins<6>,

--- a/dango/dex/src/execute.rs
+++ b/dango/dex/src/execute.rs
@@ -445,11 +445,11 @@ mod tests {
         dango_types::{
             constants::{dango, usdc},
             dex::{
-                AmountOption, PairParams, PassiveLiquidity, PriceOption, RestingOrderBookState,
-                TimeInForce, Xyk,
+                AmountOption, PairParams, PassiveLiquidity, Price, PriceOption,
+                RestingOrderBookState, TimeInForce, Xyk,
             },
         },
-        grug::{Addr, Bounded, MockContext, MockQuerier, NumberConst, Udec128, Udec128_24},
+        grug::{Addr, Bounded, MockContext, MockQuerier, NumberConst, Udec128},
         std::{collections::BTreeSet, str::FromStr},
         test_case::test_case,
     };
@@ -462,7 +462,7 @@ mod tests {
             creates: vec![CreateOrderRequest {
                 base_denom: dango::DENOM.clone(),
                 quote_denom: usdc::DENOM.clone(),
-                price: PriceOption::Limit(NonZero::new_unchecked(Udec128_24::new(2))),
+                price: PriceOption::Limit(NonZero::new_unchecked(Price::new(2))),
                 amount: AmountOption::Bid {
                     quote: NonZero::new_unchecked(Uint128::new(200)),
                 },
@@ -480,7 +480,7 @@ mod tests {
             creates: vec![CreateOrderRequest {
                 base_denom: dango::DENOM.clone(),
                 quote_denom: usdc::DENOM.clone(),
-                price: PriceOption::Limit(NonZero::new_unchecked(Udec128_24::new(2))),
+                price: PriceOption::Limit(NonZero::new_unchecked(Price::new(2))),
                 amount: AmountOption::Ask {
                     base: NonZero::new_unchecked(Uint128::new(100)),
                 },
@@ -494,9 +494,9 @@ mod tests {
     )]
     #[test_case(
         Some(RestingOrderBookState {
-            best_bid_price: Some(Udec128_24::new(100)),
-            best_ask_price: Some(Udec128_24::new(100)),
-            mid_price: Some(Udec128_24::new(100)),
+            best_bid_price: Some(Price::new(100)),
+            best_ask_price: Some(Price::new(100)),
+            mid_price: Some(Price::new(100)),
         }),
         ExecuteMsg::BatchUpdateOrders {
             creates: vec![CreateOrderRequest {
@@ -518,9 +518,9 @@ mod tests {
     )]
     #[test_case(
         Some(RestingOrderBookState {
-            best_bid_price: Some(Udec128_24::new(100)),
-            best_ask_price: Some(Udec128_24::new(100)),
-            mid_price: Some(Udec128_24::new(100)),
+            best_bid_price: Some(Price::new(100)),
+            best_ask_price: Some(Price::new(100)),
+            mid_price: Some(Price::new(100)),
         }),
         ExecuteMsg::BatchUpdateOrders {
             creates: vec![CreateOrderRequest {
@@ -542,9 +542,9 @@ mod tests {
     )]
     #[test_case(
         Some(RestingOrderBookState {
-            best_bid_price: Some(Udec128_24::new(100)),
-            best_ask_price: Some(Udec128_24::new(100)),
-            mid_price: Some(Udec128_24::new(100)),
+            best_bid_price: Some(Price::new(100)),
+            best_ask_price: Some(Price::new(100)),
+            mid_price: Some(Price::new(100)),
         }),
         ExecuteMsg::BatchUpdateOrders {
             creates: vec![
@@ -575,7 +575,7 @@ mod tests {
                 CreateOrderRequest {
                     base_denom: dango::DENOM.clone(),
                     quote_denom: usdc::DENOM.clone(),
-                    price: PriceOption::Limit(NonZero::new_unchecked(Udec128_24::new(2))),
+                    price: PriceOption::Limit(NonZero::new_unchecked(Price::new(2))),
                     amount: AmountOption::Bid {
                         quote: NonZero::new_unchecked(Uint128::new(200)),
                     },
@@ -584,7 +584,7 @@ mod tests {
                 CreateOrderRequest {
                     base_denom: dango::DENOM.clone(),
                     quote_denom: usdc::DENOM.clone(),
-                    price: PriceOption::Limit(NonZero::new_unchecked(Udec128_24::new(2))),
+                    price: PriceOption::Limit(NonZero::new_unchecked(Price::new(2))),
                     amount: AmountOption::Ask {
                         base: NonZero::new_unchecked(Uint128::new(100)),
                     },

--- a/dango/dex/src/execute/order_creation.rs
+++ b/dango/dex/src/execute/order_creation.rs
@@ -5,11 +5,10 @@ use {
     },
     anyhow::{anyhow, ensure},
     dango_types::dex::{
-        AmountOption, CreateOrderRequest, Direction, Order, OrderCreated, PriceOption, TimeInForce,
+        AmountOption, CreateOrderRequest, Direction, Order, OrderCreated, Price, PriceOption,
+        TimeInForce,
     },
-    grug::{
-        Addr, Coin, Coins, EventBuilder, MultiplyFraction, Number, NumberConst, Storage, Udec128_24,
-    },
+    grug::{Addr, Coin, Coins, EventBuilder, MultiplyFraction, Number, NumberConst, Storage},
 };
 
 pub(super) fn create_order(
@@ -47,7 +46,7 @@ pub(super) fn create_order(
                             order.quote_denom
                         )
                     })?;
-                let one_add_max_slippage = Udec128_24::ONE.saturating_add(*max_slippage);
+                let one_add_max_slippage = Price::ONE.saturating_add(*max_slippage);
                 best_ask_price.saturating_mul(one_add_max_slippage)
             },
             Direction::Ask => {
@@ -61,7 +60,7 @@ pub(super) fn create_order(
                             order.quote_denom
                         )
                     })?;
-                let one_sub_max_slippage = Udec128_24::ONE.saturating_sub(*max_slippage);
+                let one_sub_max_slippage = Price::ONE.saturating_sub(*max_slippage);
                 best_bid_price.saturating_mul(one_sub_max_slippage)
             },
         },

--- a/dango/dex/src/liquidity_depth.rs
+++ b/dango/dex/src/liquidity_depth.rs
@@ -1,20 +1,13 @@
 use {
     crate::DEPTHS,
-    dango_types::dex::Direction,
-    grug::{
-        Decimal, Denom, IsZero, MathResult, NonZero, Number, StdResult, Storage, Udec128_6,
-        Udec128_24,
-    },
+    dango_types::dex::{Direction, Price},
+    grug::{Decimal, Denom, IsZero, MathResult, NonZero, Number, StdResult, Storage, Udec128_6},
     std::collections::BTreeSet,
 };
 
 /// For bids, return the bucket that is immediately smaller than the price.
 /// For asks, return the bucket that is immediately larger than the price.
-pub fn get_bucket(
-    bucket_size: Udec128_24,
-    direction: Direction,
-    price: Udec128_24,
-) -> MathResult<Udec128_24> {
+pub fn get_bucket(bucket_size: Price, direction: Direction, price: Price) -> MathResult<Price> {
     // This is the bucket immediately smaller than the price.
     let lower = price
         .checked_div(bucket_size)?
@@ -45,9 +38,9 @@ pub fn increase_liquidity_depths(
     base_denom: &Denom,
     quote_denom: &Denom,
     direction: Direction,
-    price: Udec128_24,
+    price: Price,
     amount_base: Udec128_6,
-    bucket_sizes: &BTreeSet<NonZero<Udec128_24>>,
+    bucket_sizes: &BTreeSet<NonZero<Price>>,
 ) -> StdResult<()> {
     let amount_quote = amount_base.checked_mul(price)?;
 
@@ -81,9 +74,9 @@ pub fn decrease_liquidity_depths(
     base_denom: &Denom,
     quote_denom: &Denom,
     direction: Direction,
-    price: Udec128_24,
+    price: Price,
     amount_base: Udec128_6,
-    bucket_sizes: &BTreeSet<NonZero<Udec128_24>>,
+    bucket_sizes: &BTreeSet<NonZero<Price>>,
 ) -> StdResult<()> {
     let amount_quote = amount_base.checked_mul(price)?;
 

--- a/dango/dex/src/query.rs
+++ b/dango/dex/src/query.rs
@@ -11,15 +11,15 @@ use {
         account_factory::Username,
         dex::{
             Direction, LiquidityDepth, LiquidityDepthResponse, OrderId, OrderResponse,
-            OrdersByPairResponse, OrdersByUserResponse, PairId, PairParams, PairUpdate, QueryMsg,
-            ReflectCurveResponse, ReservesResponse, RestingOrderBookState,
+            OrdersByPairResponse, OrdersByUserResponse, PairId, PairParams, PairUpdate, Price,
+            QueryMsg, ReflectCurveResponse, ReservesResponse, RestingOrderBookState,
             RestingOrderBookStatesResponse, SwapRoute,
         },
     },
     grug::{
         Addr, Bound, Coin, CoinPair, DEFAULT_PAGE_LIMIT, Denom, ImmutableCtx, Inner, Json,
         JsonSerExt, NonZero, Number, NumberConst, Order as IterationOrder, QuerierExt, StdResult,
-        Timestamp, Udec128_6, Udec128_24, Uint128,
+        Timestamp, Udec128_6, Uint128,
     },
     std::collections::BTreeMap,
 };
@@ -153,7 +153,7 @@ fn query_liquidity_depth(
     ctx: ImmutableCtx,
     base_denom: Denom,
     quote_denom: Denom,
-    bucket_size: Udec128_24,
+    bucket_size: Price,
     limit: usize,
 ) -> anyhow::Result<LiquidityDepthResponse> {
     // load the pair params

--- a/dango/dex/src/state.rs
+++ b/dango/dex/src/state.rs
@@ -1,11 +1,11 @@
 use {
     dango_types::{
         account_factory::Username,
-        dex::{Direction, Order, OrderId, PairParams, RestingOrderBookState, TimeInForce},
+        dex::{Direction, Order, OrderId, PairParams, Price, RestingOrderBookState, TimeInForce},
     },
     grug::{
         Addr, CoinPair, Counter, Denom, IndexedMap, Item, Map, MultiIndex, NumberConst, Timestamp,
-        Udec128_6, Udec128_24, Uint64, UniqueIndex,
+        Udec128_6, Uint64, UniqueIndex,
     },
 };
 
@@ -41,14 +41,14 @@ pub const VOLUMES_BY_USER: Map<(&Username, Timestamp), Udec128_6> = Map::new("vo
 /// ```plain
 /// ((base_denom, quote_denom), direction, price, order_id)
 /// ```
-pub type OrderKey = ((Denom, Denom), Direction, Udec128_24, OrderId);
+pub type OrderKey = ((Denom, Denom), Direction, Price, OrderId);
 
 /// Storage key for liquidity depths.
 ///
 /// ```plain
 /// ((base_denom, quote_denom), bucket_size, direction, bucket)
 /// ```
-pub type DepthKey<'a> = ((&'a Denom, &'a Denom), Udec128_24, Direction, Udec128_24);
+pub type DepthKey<'a> = ((&'a Denom, &'a Denom), Price, Direction, Price);
 
 #[grug::index_list(OrderKey, Order)]
 pub struct OrderIndex<'a> {

--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -20,8 +20,8 @@ use {
     grug::{
         Addr, Addressable, BalanceChange, Bounded, Coin, CoinPair, Coins, Denom, Fraction, Inner,
         MaxLength, Message, MultiplyFraction, NonEmpty, NonZero, Number, NumberConst, Order,
-        QuerierExt, ResultExt, Signer, StdError, StdResult, Timestamp, Udec128, Udec128_6,
-        Udec128_24, Uint128, UniqueVec, btree_map, coin_pair, coins,
+        QuerierExt, ResultExt, Signer, StdError, StdResult, Timestamp, Udec128, Udec128_6, Uint128,
+        UniqueVec, btree_map, coin_pair, coins,
     },
     grug_app::NaiveProposalPreparer,
     hyperlane_types::constants::ethereum,
@@ -53,7 +53,7 @@ fn cannot_submit_order_with_zero_amount() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::ZERO), // incorrect!
                 )],
                 cancels: None,
@@ -95,7 +95,7 @@ fn cannot_submit_orders_in_non_existing_pairs() {
                     atom::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100)),
                 )],
                 cancels: None,
@@ -392,7 +392,7 @@ fn dex_works(
         .into_iter()
         .zip(accounts.users_mut())
         .map(|((direction, price, amount_base), signer)| {
-            let price = Udec128_24::new(price);
+            let price = Price::new(price);
             let amount_base = Uint128::new(amount_base);
 
             let (amount, funds) = match direction {
@@ -463,7 +463,7 @@ fn dex_works(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     None,
@@ -475,7 +475,7 @@ fn dex_works(
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
             direction: Direction::Bid,
-            price: Udec128_24::new(1),
+            price: Price::new(1),
             amount: Uint128::new(100),
             remaining: Udec128_6::new(100),
         },
@@ -487,7 +487,7 @@ fn dex_works(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     Some(CancelOrderRequest::Some(BTreeSet::from([OrderId::new(!1)]))),
@@ -502,14 +502,14 @@ fn dex_works(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
         CreateOrderRequest::new_limit(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
     ],
@@ -522,7 +522,7 @@ fn dex_works(
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
             direction: Direction::Bid,
-            price: Udec128_24::new(1),
+            price: Price::new(1),
             amount: Uint128::new(100),
             remaining: Udec128_6::new(100),
         },
@@ -535,14 +535,14 @@ fn dex_works(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
         CreateOrderRequest::new_limit(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
     ],
@@ -558,14 +558,14 @@ fn dex_works(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
         CreateOrderRequest::new_limit(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
     ],
@@ -581,14 +581,14 @@ fn dex_works(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
         CreateOrderRequest::new_limit(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
             Direction::Bid,
-            NonZero::new_unchecked(Udec128_24::new(1)),
+            NonZero::new_unchecked(Price::new(1)),
             NonZero::new_unchecked(Uint128::new(100)),
         ),
     ],
@@ -667,7 +667,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     coins! { usdc::DENOM.clone() => 100 },
@@ -676,7 +676,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     Coins::new(),
@@ -687,7 +687,7 @@ fn submit_and_cancel_orders(
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
             direction: Direction::Bid,
-            price: Udec128_24::new(1),
+            price: Price::new(1),
             amount: Uint128::new(100),
             remaining: Udec128_6::new(100),
         },
@@ -699,7 +699,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     coins! { usdc::DENOM.clone() => 100 },
@@ -708,7 +708,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(50)),
     )],
     Coins::new(),
@@ -719,7 +719,7 @@ fn submit_and_cancel_orders(
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
             direction: Direction::Bid,
-            price: Udec128_24::new(1),
+            price: Price::new(1),
             amount: Uint128::new(50),
             remaining: Udec128_6::new(50),
         },
@@ -731,7 +731,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     coins! { usdc::DENOM.clone() => 100 },
@@ -740,7 +740,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(200)),
     )],
     coins! { usdc::DENOM.clone() => 100 },
@@ -751,7 +751,7 @@ fn submit_and_cancel_orders(
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
             direction: Direction::Bid,
-            price: Udec128_24::new(1),
+            price: Price::new(1),
             amount: Uint128::new(200),
             remaining: Udec128_6::new(200),
         },
@@ -763,7 +763,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     coins! { usdc::DENOM.clone() => 100 },
@@ -772,7 +772,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(200)),
     )],
     Coins::new(),
@@ -783,7 +783,7 @@ fn submit_and_cancel_orders(
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
             direction: Direction::Bid,
-            price: Udec128_24::new(1),
+            price: Price::new(1),
             amount: Uint128::new(200),
             remaining: Udec128_6::new(200),
         },
@@ -796,7 +796,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(100)),
     )],
     coins! { usdc::DENOM.clone() => 100 },
@@ -805,7 +805,7 @@ fn submit_and_cancel_orders(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new(1)),
+        NonZero::new_unchecked(Price::new(1)),
         NonZero::new_unchecked(Uint128::new(150)),
     )],
     coins! { usdc::DENOM.clone() => 100 },
@@ -816,7 +816,7 @@ fn submit_and_cancel_orders(
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
             direction: Direction::Bid,
-            price: Udec128_24::new(1),
+            price: Price::new(1),
             amount: Uint128::new(150),
             remaining: Udec128_6::new(150),
         },
@@ -903,7 +903,7 @@ fn submit_and_cancel_order_in_same_block() {
                 dango::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Bid,
-                NonZero::new_unchecked(Udec128_24::new(1)),
+                NonZero::new_unchecked(Price::new(1)),
                 NonZero::new_unchecked(Uint128::new(100)),
             )],
             cancels: None,
@@ -1086,7 +1086,7 @@ fn query_orders_by_pair(
     let txs = orders_to_submit
         .into_iter()
         .map(|((base_denom, quote_denom), direction, price, amount)| {
-            let price = Udec128_24::new(price);
+            let price = Price::new(price);
             let amount_base = Uint128::new(amount);
 
             let (amount, funds) = match direction {
@@ -2507,7 +2507,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Bid,
-                NonZero::new_unchecked(Udec128_24::new_percent(20100)),
+                NonZero::new_unchecked(Price::new_percent(20100)),
                 NonZero::new_unchecked(Uint128::from(49751 * 201)),
             ),
         ],
@@ -2560,7 +2560,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Bid,
-                NonZero::new_unchecked(Udec128_24::new_percent(20100)),
+                NonZero::new_unchecked(Price::new_percent(20100)),
                 NonZero::new_unchecked(Uint128::from(49751 * 201)),
             ),
         ],
@@ -2606,7 +2606,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Bid,
-                NonZero::new_unchecked(Udec128_24::new_percent(20200)),
+                NonZero::new_unchecked(Price::new_percent(20200)),
                 NonZero::new_unchecked(Uint128::from(47783 * 202)),
             ),
         ],
@@ -2652,7 +2652,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Bid,
-                NonZero::new_unchecked(Udec128_24::new_percent(20300)),
+                NonZero::new_unchecked(Price::new_percent(20300)),
                 NonZero::new_unchecked(Uint128::from(157784 * 203)),
             ),
         ],
@@ -2700,7 +2700,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Ask,
-                NonZero::new_unchecked(Udec128_24::new_percent(19900)),
+                NonZero::new_unchecked(Price::new_percent(19900)),
                 NonZero::new_unchecked(Uint128::from(50251)),
             ),
         ],
@@ -2746,7 +2746,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Ask,
-                NonZero::new_unchecked(Udec128_24::new_percent(19900)),
+                NonZero::new_unchecked(Price::new_percent(19900)),
                 NonZero::new_unchecked(Uint128::from(30000)),
             ),
         ],
@@ -2792,7 +2792,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Ask,
-                NonZero::new_unchecked(Udec128_24::new_percent(19900)),
+                NonZero::new_unchecked(Price::new_percent(19900)),
                 NonZero::new_unchecked(Uint128::from(60251)),
             ),
         ],
@@ -2840,7 +2840,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Ask,
-                NonZero::new_unchecked(Udec128_24::new_percent(19800)),
+                NonZero::new_unchecked(Price::new_percent(19800)),
                 NonZero::new_unchecked(Uint128::from(162284)),
             ),
         ],
@@ -2849,7 +2849,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 eth::DENOM.clone(),
                 usdc::DENOM.clone(),
                 Direction::Bid,
-                NonZero::new_unchecked(Udec128_24::new_percent(20200)),
+                NonZero::new_unchecked(Price::new_percent(20200)),
                 NonZero::new_unchecked(Uint128::from(157784 * 202)),
             ),
         ],
@@ -3104,7 +3104,7 @@ fn submit_standard_order(
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     direction,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 )],
                 cancels: None,
@@ -3651,21 +3651,21 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::new(1)),
+                        NonZero::new_unchecked(Price::new(1)),
                         NonZero::new_unchecked(Uint128::new(100_000_000)),
                     ),
                     CreateOrderRequest::new_limit(
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::from_str("1.01").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("1.01").unwrap()),
                         NonZero::new_unchecked(Uint128::new(101_000_000)),
                     ),
                     CreateOrderRequest::new_limit(
                         eth::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::from_str("852.485845").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("852.485845").unwrap()),
                         NonZero::new_unchecked(Uint128::new(100_000_000)), // ceil(117304 * 852.485845)
                     ),
                 ],
@@ -3686,14 +3686,14 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Ask,
-                        NonZero::new_unchecked(Udec128_24::new(1)),
+                        NonZero::new_unchecked(Price::new(1)),
                         NonZero::new_unchecked(Uint128::new(200_000_000)),
                     ),
                     CreateOrderRequest::new_limit(
                         eth::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Ask,
-                        NonZero::new_unchecked(Udec128_24::from_str("852.485845").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("852.485845").unwrap()),
                         NonZero::new_unchecked(Uint128::new(117304)),
                     ),
                 ],
@@ -3766,28 +3766,28 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::new(1)),
+                        NonZero::new_unchecked(Price::new(1)),
                         NonZero::new_unchecked(Uint128::new(100_000_000)),
                     ),
                     CreateOrderRequest::new_limit(
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::from_str("1.01").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("1.01").unwrap()),
                         NonZero::new_unchecked(Uint128::new(101_000_000)),
                     ),
                     CreateOrderRequest::new_limit(
                         eth::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::from_str("852.485845").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("852.485845").unwrap()),
                         NonZero::new_unchecked(Uint128::new(100_000_000)), // ceil(117304 * 852.485845)
                     ),
                     CreateOrderRequest::new_limit(
                         eth::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::from_str("937.7344336").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("937.7344336").unwrap()),
                         NonZero::new_unchecked(Uint128::new(110_000_000)), // ceil(117304 * 937.7344336)
                     ),
                 ],
@@ -3810,7 +3810,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Ask,
-                        NonZero::new_unchecked(Udec128_24::new(1)),
+                        NonZero::new_unchecked(Price::new(1)),
                         NonZero::new_unchecked(Uint128::new(300_000_000)),
                     ),
                     CreateOrderRequest::new_limit(
@@ -3818,10 +3818,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                         usdc::DENOM.clone(),
                         Direction::Ask,
                         NonZero::new_unchecked(
-                            Udec128_24::from_str("85248.71")
-                                .unwrap()
-                                .checked_inv()
-                                .unwrap(),
+                            Price::from_str("85248.71").unwrap().checked_inv().unwrap(),
                         ),
                         NonZero::new_unchecked(Uint128::new(117304 * 2)),
                     ),
@@ -3907,7 +3904,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -3959,7 +3956,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4011,7 +4008,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4060,7 +4057,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(2)),
+                    NonZero::new_unchecked(Price::new(2)),
                     NonZero::new_unchecked(Uint128::new(200_000_000)), // 100_000_000 * 2
                 ),
             ],
@@ -4109,7 +4106,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4158,7 +4155,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(2)),
+                    NonZero::new_unchecked(Price::new(2)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4207,7 +4204,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(150_000_000)),
                 ),
             ],
@@ -4258,7 +4255,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(2)),
+                    NonZero::new_unchecked(Price::new(2)),
                     NonZero::new_unchecked(Uint128::new(150_000_000)),
                 ),
             ],
@@ -4309,7 +4306,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(150_000_000)),
                 ),
             ],
@@ -4360,7 +4357,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(2)),
+                    NonZero::new_unchecked(Price::new(2)),
                     NonZero::new_unchecked(Uint128::new(300_000_000)), // 150_000_000 * 2
                 ),
             ],
@@ -4411,7 +4408,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4460,7 +4457,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4474,7 +4471,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new_percent(105)),
+                    NonZero::new_unchecked(Price::new_percent(105)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4529,7 +4526,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4543,7 +4540,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new_percent(50)),
+                    NonZero::new_unchecked(Price::new_percent(50)),
                     NonZero::new_unchecked(Uint128::new(50_000_000)), // 100_000_000 * 0.5
                 ),
             ],
@@ -4598,7 +4595,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4668,7 +4665,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4738,7 +4735,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4787,7 +4784,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(2)),
+                    NonZero::new_unchecked(Price::new(2)),
                     NonZero::new_unchecked(Uint128::new(50_000_000)),
                 ),
             ],
@@ -4836,7 +4833,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4885,7 +4882,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(2)),
+                    NonZero::new_unchecked(Price::new(2)),
                     NonZero::new_unchecked(Uint128::new(200_000_000)), // 100_000_000 * 2
                 ),
             ],
@@ -4934,7 +4931,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -4984,7 +4981,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -5034,7 +5031,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -5090,7 +5087,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -5146,7 +5143,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -5220,7 +5217,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100_000_000)),
                 ),
             ],
@@ -5294,7 +5291,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(110_000_000)),
                 ),
             ],
@@ -5368,7 +5365,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(110_000_000)),
                 ),
             ],
@@ -5597,7 +5594,7 @@ fn market_order_clearing(
         eth::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new_bps(1)),
+        NonZero::new_unchecked(Price::new_bps(1)),
         NonZero::new_unchecked(Uint128::new(50)), // 500000 * 0.0001
     ),
     coins! {
@@ -5628,7 +5625,7 @@ fn market_order_clearing(
         eth::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new_bps(1)),
+        NonZero::new_unchecked(Price::new_bps(1)),
         NonZero::new_unchecked(Uint128::new(1)), // ceil(9999 * 0.0001)
     ),
     coins! {
@@ -5739,7 +5736,7 @@ fn cron_execute_gracefully_handles_oracle_price_failure() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Ask,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(1000000)),
                 )],
                 cancels: None,
@@ -5760,7 +5757,7 @@ fn cron_execute_gracefully_handles_oracle_price_failure() {
                     dango::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(1000000)),
                 )],
                 cancels: None,
@@ -5865,7 +5862,7 @@ fn market_orders_are_sorted_by_price_ascending() {
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Ask,
-                        NonZero::new_unchecked(Udec128_24::new(1)),
+                        NonZero::new_unchecked(Price::new(1)),
                         NonZero::new_unchecked(Uint128::new(1000000)),
                     )],
                     cancels: None,
@@ -5998,14 +5995,14 @@ fn refund_left_over_market_bid() {
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Ask,
-                        NonZero::new_unchecked(Udec128_24::new(100)),
+                        NonZero::new_unchecked(Price::new(100)),
                         NonZero::new_unchecked(Uint128::new(2)),
                     ),
                     CreateOrderRequest::new_limit(
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::new(100)),
+                        NonZero::new_unchecked(Price::new(100)),
                         NonZero::new_unchecked(Uint128::new(100)),
                     ),
                 ],
@@ -6026,8 +6023,8 @@ fn refund_left_over_market_bid() {
         })
         .should_succeed_and_equal(RestingOrderBookState {
             best_bid_price: None,
-            best_ask_price: Some(Udec128_24::new(100)),
-            mid_price: Some(Udec128_24::new(100)),
+            best_ask_price: Some(Price::new(100)),
+            mid_price: Some(Price::new(100)),
         });
 
     suite
@@ -6052,7 +6049,7 @@ fn refund_left_over_market_bid() {
                                     dango::DENOM.clone(),
                                     usdc::DENOM.clone(),
                                     Direction::Bid,
-                                    NonZero::new_unchecked(Udec128_24::new(101)),
+                                    NonZero::new_unchecked(Price::new(101)),
                                     NonZero::new_unchecked(Uint128::new(101)),
                                 )],
                                 cancels: None,
@@ -6160,14 +6157,14 @@ fn refund_left_over_market_ask() {
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::new(100)),
+                        NonZero::new_unchecked(Price::new(100)),
                         NonZero::new_unchecked(Uint128::new(200)),
                     ),
                     CreateOrderRequest::new_limit(
                         dango::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Ask,
-                        NonZero::new_unchecked(Udec128_24::new(100)),
+                        NonZero::new_unchecked(Price::new(100)),
                         NonZero::new_unchecked(Uint128::new(1)),
                     ),
                 ],
@@ -6187,9 +6184,9 @@ fn refund_left_over_market_ask() {
             quote_denom: usdc::DENOM.clone(),
         })
         .should_succeed_and_equal(RestingOrderBookState {
-            best_bid_price: Some(Udec128_24::new(100)),
+            best_bid_price: Some(Price::new(100)),
             best_ask_price: None,
-            mid_price: Some(Udec128_24::new(100)),
+            mid_price: Some(Price::new(100)),
         });
 
     suite
@@ -6214,7 +6211,7 @@ fn refund_left_over_market_ask() {
                                     dango::DENOM.clone(),
                                     usdc::DENOM.clone(),
                                     Direction::Ask,
-                                    NonZero::new_unchecked(Udec128_24::new(99)),
+                                    NonZero::new_unchecked(Price::new(99)),
                                     NonZero::new_unchecked(Uint128::new(1)),
                                 )],
                                 cancels: None,
@@ -6299,7 +6296,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
                                 dango::DENOM.clone(),
                                 usdc::DENOM.clone(),
                                 Direction::Ask,
-                                NonZero::new_unchecked(Udec128_24::new(100)),
+                                NonZero::new_unchecked(Price::new(100)),
                                 NonZero::new_unchecked(Uint128::new(1000000)),
                             )],
                             cancels: None,
@@ -6325,7 +6322,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
                                 dango::DENOM.clone(),
                                 usdc::DENOM.clone(),
                                 Direction::Bid,
-                                NonZero::new_unchecked(Udec128_24::new(99)),
+                                NonZero::new_unchecked(Price::new(99)),
                                 NonZero::new_unchecked(Uint128::new(1000000 * 99)),
                             )],
                             cancels: None,
@@ -6357,9 +6354,9 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
             quote_denom: usdc::DENOM.clone(),
         })
         .should_succeed_and_equal(RestingOrderBookState {
-            best_bid_price: Some(Udec128_24::new(99)),
-            best_ask_price: Some(Udec128_24::new(100)),
-            mid_price: Some(Udec128_24::new_permille(99500)),
+            best_bid_price: Some(Price::new(99)),
+            best_ask_price: Some(Price::new(100)),
+            mid_price: Some(Price::new_permille(99500)),
         });
 }
 
@@ -6375,7 +6372,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     dex::LiquidityDepthResponse {
         bid_depth: None,
         ask_depth: Some(vec![
-            (Udec128_24::new(52), dex::LiquidityDepth {
+            (Price::new(52), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(52),
             }),
@@ -6396,7 +6393,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     dex::LiquidityDepthResponse {
         bid_depth: None,
         ask_depth: Some(vec![
-            (Udec128_24::new(60), dex::LiquidityDepth {
+            (Price::new(60), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(52),
             }),
@@ -6416,7 +6413,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     None,
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(48), dex::LiquidityDepth {
+            (Price::new(48), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(48),
             }),
@@ -6437,7 +6434,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     None,
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(40), dex::LiquidityDepth {
+            (Price::new(40), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(48),
             }),
@@ -6477,13 +6474,13 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     None,
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(40), dex::LiquidityDepth {
+            (Price::new(40), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(55),
                 depth_quote: Udec128_6::new(2365),
             }),
         ]),
         ask_depth: Some(vec![
-            (Udec128_24::new(60), dex::LiquidityDepth {
+            (Price::new(60), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(55),
                 depth_quote: Udec128_6::new(3135),
             }),
@@ -6522,85 +6519,85 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     None,
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(49), dex::LiquidityDepth {
+            (Price::new(49), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(49),
             }),
-            (Udec128_24::new(48), dex::LiquidityDepth {
+            (Price::new(48), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(2),
                 depth_quote: Udec128_6::new(2 * 48),
             }),
-            (Udec128_24::new(47), dex::LiquidityDepth {
+            (Price::new(47), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3),
                 depth_quote: Udec128_6::new(3 * 47),
             }),
-            (Udec128_24::new(46), dex::LiquidityDepth {
+            (Price::new(46), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(4),
                 depth_quote: Udec128_6::new(4 * 46),
             }),
-            (Udec128_24::new(45), dex::LiquidityDepth {
+            (Price::new(45), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5),
                 depth_quote: Udec128_6::new(5 * 45),
             }),
-            (Udec128_24::new(44), dex::LiquidityDepth {
+            (Price::new(44), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(6),
                 depth_quote: Udec128_6::new(6 * 44),
             }),
-            (Udec128_24::new(43), dex::LiquidityDepth {
+            (Price::new(43), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7),
                 depth_quote: Udec128_6::new(7 * 43),
             }),
-            (Udec128_24::new(42), dex::LiquidityDepth {
+            (Price::new(42), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(8),
                 depth_quote: Udec128_6::new(8 * 42),
             }),
-            (Udec128_24::new(41), dex::LiquidityDepth {
+            (Price::new(41), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9),
                 depth_quote: Udec128_6::new(9 * 41),
             }),
-            (Udec128_24::new(40), dex::LiquidityDepth {
+            (Price::new(40), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(10),
                 depth_quote: Udec128_6::new(10 * 40),
             }),
         ]),
         ask_depth: Some(vec![
-            (Udec128_24::new(51), dex::LiquidityDepth {
+            (Price::new(51), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(51),
             }),
-            (Udec128_24::new(52), dex::LiquidityDepth {
+            (Price::new(52), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(2),
                 depth_quote: Udec128_6::new(2 * 52),
             }),
-            (Udec128_24::new(53), dex::LiquidityDepth {
+            (Price::new(53), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3),
                 depth_quote: Udec128_6::new(3 * 53),
             }),
-            (Udec128_24::new(54), dex::LiquidityDepth {
+            (Price::new(54), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(4),
                 depth_quote: Udec128_6::new(4 * 54),
             }),
-            (Udec128_24::new(55), dex::LiquidityDepth {
+            (Price::new(55), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5),
                 depth_quote: Udec128_6::new(5 * 55),
             }),
-            (Udec128_24::new(56), dex::LiquidityDepth {
+            (Price::new(56), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(6),
                 depth_quote: Udec128_6::new(6 * 56),
             }),
-            (Udec128_24::new(57), dex::LiquidityDepth {
+            (Price::new(57), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7),
                 depth_quote: Udec128_6::new(7 * 57),
             }),
-            (Udec128_24::new(58), dex::LiquidityDepth {
+            (Price::new(58), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(8),
                 depth_quote: Udec128_6::new(8 * 58),
             }),
-            (Udec128_24::new(59), dex::LiquidityDepth {
+            (Price::new(59), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9),
                 depth_quote: Udec128_6::new(9 * 59),
             }),
-            (Udec128_24::new(60), dex::LiquidityDepth {
+            (Price::new(60), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(10),
                 depth_quote: Udec128_6::new(10 * 60),
             }),
@@ -6639,29 +6636,29 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     Some(3),
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(49), dex::LiquidityDepth {
+            (Price::new(49), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(49),
             }),
-            (Udec128_24::new(48), dex::LiquidityDepth {
+            (Price::new(48), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(2),
                 depth_quote: Udec128_6::new(2 * 48),
             }),
-            (Udec128_24::new(47), dex::LiquidityDepth {
+            (Price::new(47), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3),
                 depth_quote: Udec128_6::new(3 * 47),
             }),
         ]),
         ask_depth: Some(vec![
-            (Udec128_24::new(51), dex::LiquidityDepth {
+            (Price::new(51), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1),
                 depth_quote: Udec128_6::new(51),
             }),
-            (Udec128_24::new(52), dex::LiquidityDepth {
+            (Price::new(52), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(2),
                 depth_quote: Udec128_6::new(2 * 52),
             }),
-            (Udec128_24::new(53), dex::LiquidityDepth {
+            (Price::new(53), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3),
                 depth_quote: Udec128_6::new(3 * 53),
             }),
@@ -6700,45 +6697,45 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     None,
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(490), dex::LiquidityDepth {
+            (Price::new(490), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(495 + 2 * 490),
             }),
-            (Udec128_24::new(480), dex::LiquidityDepth {
+            (Price::new(480), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3 + 4),
                 depth_quote: Udec128_6::new(3 * 485 + 4 * 480),
             }),
-            (Udec128_24::new(470), dex::LiquidityDepth {
+            (Price::new(470), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5 + 6),
                 depth_quote: Udec128_6::new(5 * 475 + 6 * 470),
             }),
-            (Udec128_24::new(460), dex::LiquidityDepth {
+            (Price::new(460), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7 + 8),
                 depth_quote: Udec128_6::new(7 * 465 + 8 * 460),
             }),
-            (Udec128_24::new(450), dex::LiquidityDepth {
+            (Price::new(450), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 455 + 10 * 450),
             }),
         ]),
         ask_depth: Some(vec![
-            (Udec128_24::new(510), dex::LiquidityDepth {
+            (Price::new(510), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(505 + 2 * 510),
             }),
-            (Udec128_24::new(520), dex::LiquidityDepth {
+            (Price::new(520), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3 + 4),
                 depth_quote: Udec128_6::new(3 * 515 + 4 * 520),
             }),
-            (Udec128_24::new(530), dex::LiquidityDepth {
+            (Price::new(530), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5 + 6),
                 depth_quote: Udec128_6::new(5 * 525 + 6 * 530),
             }),
-            (Udec128_24::new(540), dex::LiquidityDepth {
+            (Price::new(540), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7 + 8),
                 depth_quote: Udec128_6::new(7 * 535 + 8 * 540),
             }),
-            (Udec128_24::new(550), dex::LiquidityDepth {
+            (Price::new(550), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 545 + 10 * 550),
             }),
@@ -6777,45 +6774,45 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     None,
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(490), dex::LiquidityDepth {
+            (Price::new(490), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(495 + 2 * 490),
             }),
-            (Udec128_24::new(480), dex::LiquidityDepth {
+            (Price::new(480), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3 + 4),
                 depth_quote: Udec128_6::new(3 * 485 + 4 * 480),
             }),
-            (Udec128_24::new(470), dex::LiquidityDepth {
+            (Price::new(470), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5 + 6),
                 depth_quote: Udec128_6::new(5 * 475 + 6 * 470),
             }),
-            (Udec128_24::new(460), dex::LiquidityDepth {
+            (Price::new(460), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7 + 8),
                 depth_quote: Udec128_6::new(7 * 465 + 8 * 460),
             }),
-            (Udec128_24::new(450), dex::LiquidityDepth {
+            (Price::new(450), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 455 + 10 * 450),
             }),
         ]),
         ask_depth: Some(vec![
-            (Udec128_24::new(510), dex::LiquidityDepth {
+            (Price::new(510), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(505 + 2 * 510),
             }),
-            (Udec128_24::new(520), dex::LiquidityDepth {
+            (Price::new(520), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3 + 4),
                 depth_quote: Udec128_6::new(3 * 515 + 4 * 520),
             }),
-            (Udec128_24::new(530), dex::LiquidityDepth {
+            (Price::new(530), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5 + 6),
                 depth_quote: Udec128_6::new(5 * 525 + 6 * 530),
             }),
-            (Udec128_24::new(540), dex::LiquidityDepth {
+            (Price::new(540), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7 + 8),
                 depth_quote: Udec128_6::new(7 * 535 + 8 * 540),
             }),
-            (Udec128_24::new(550), dex::LiquidityDepth {
+            (Price::new(550), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 545 + 10 * 550),
             }),
@@ -6861,45 +6858,45 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     None,
     dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(490), dex::LiquidityDepth {
+            (Price::new(490), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(495 + 2 * 490),
             }),
-            (Udec128_24::new(480), dex::LiquidityDepth {
+            (Price::new(480), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3 + 4),
                 depth_quote: Udec128_6::new(3 * 485 + 4 * 480),
             }),
-            (Udec128_24::new(470), dex::LiquidityDepth {
+            (Price::new(470), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5 + 6),
                 depth_quote: Udec128_6::new(5 * 475 + 6 * 470),
             }),
-            (Udec128_24::new(460), dex::LiquidityDepth {
+            (Price::new(460), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7 + 8),
                 depth_quote: Udec128_6::new(7 * 465 + 8 * 460),
             }),
-            (Udec128_24::new(450), dex::LiquidityDepth {
+            (Price::new(450), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 455 + 10 * 450),
             }),
         ]),
         ask_depth: Some(vec![
-            (Udec128_24::new(510), dex::LiquidityDepth {
+            (Price::new(510), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(505 + 2 * 510),
             }),
-            (Udec128_24::new(520), dex::LiquidityDepth {
+            (Price::new(520), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3 + 4),
                 depth_quote: Udec128_6::new(3 * 515 + 4 * 520),
             }),
-            (Udec128_24::new(530), dex::LiquidityDepth {
+            (Price::new(530), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5 + 6),
                 depth_quote: Udec128_6::new(5 * 525 + 6 * 530),
             }),
-            (Udec128_24::new(540), dex::LiquidityDepth {
+            (Price::new(540), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7 + 8),
                 depth_quote: Udec128_6::new(7 * 535 + 8 * 540),
             }),
-            (Udec128_24::new(550), dex::LiquidityDepth {
+            (Price::new(550), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 545 + 10 * 550),
             }),
@@ -6907,45 +6904,45 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     },
     Some(    dex::LiquidityDepthResponse {
         bid_depth: Some(vec![
-            (Udec128_24::new(490), dex::LiquidityDepth {
+            (Price::new(490), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(495 + 2 * 490),
             }),
-            (Udec128_24::new(480), dex::LiquidityDepth {
+            (Price::new(480), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3 + 4),
                 depth_quote: Udec128_6::new(3 * 485 + 4 * 480),
             }),
-            (Udec128_24::new(470), dex::LiquidityDepth {
+            (Price::new(470), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(6),
                 depth_quote: Udec128_6::new(6 * 470),
             }),
-            (Udec128_24::new(460), dex::LiquidityDepth {
+            (Price::new(460), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7),
                 depth_quote: Udec128_6::new(7 * 465),
             }),
-            (Udec128_24::new(450), dex::LiquidityDepth {
+            (Price::new(450), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 455 + 10 * 450),
             }),
         ]),
         ask_depth: Some(vec![
-            (Udec128_24::new(510), dex::LiquidityDepth {
+            (Price::new(510), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(1 + 2),
                 depth_quote: Udec128_6::new(505 + 2 * 510),
             }),
-            (Udec128_24::new(520), dex::LiquidityDepth {
+            (Price::new(520), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(3),
                 depth_quote: Udec128_6::new(3 * 515),
             }),
-            (Udec128_24::new(530), dex::LiquidityDepth {
+            (Price::new(530), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(5 + 6),
                 depth_quote: Udec128_6::new(5 * 525 + 6 * 530),
             }),
-            (Udec128_24::new(540), dex::LiquidityDepth {
+            (Price::new(540), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(7 + 8),
                 depth_quote: Udec128_6::new(7 * 535 + 8 * 540),
             }),
-            (Udec128_24::new(550), dex::LiquidityDepth {
+            (Price::new(550), dex::LiquidityDepth {
                 depth_base: Udec128_6::new(9 + 10),
                 depth_quote: Udec128_6::new(9 * 545 + 10 * 550),
             }),
@@ -6956,7 +6953,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
 fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancellation(
     limit_orders: Vec<(Direction, Price, Uint128)>, // direction, price, amount
     cancels: Option<CancelOrderRequest>,
-    bucket_size: Udec128_24,
+    bucket_size: Price,
     limit: Option<u32>,
     expected_liquidity_depth_after_clearing: dex::LiquidityDepthResponse,
     expected_liquidity_depth_after_cancellation: Option<dex::LiquidityDepthResponse>,
@@ -7123,14 +7120,14 @@ fn decrease_liquidity_depths_minimal_failing_test() {
                         eth::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::from_str("852.485845").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("852.485845").unwrap()),
                         NonZero::new_unchecked(Uint128::new(100_000_000)), // ceil(117304 * 852.485845)
                     ),
                     CreateOrderRequest::new_limit(
                         eth::DENOM.clone(),
                         usdc::DENOM.clone(),
                         Direction::Bid,
-                        NonZero::new_unchecked(Udec128_24::from_str("937.7344336").unwrap()),
+                        NonZero::new_unchecked(Price::from_str("937.7344336").unwrap()),
                         NonZero::new_unchecked(Uint128::new(110_000_000)), // ceil(117304 * 937.7344336)
                     ),
                 ],
@@ -7153,10 +7150,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
                     usdc::DENOM.clone(),
                     Direction::Ask,
                     NonZero::new_unchecked(
-                        Udec128_24::from_str("85248.71")
-                            .unwrap()
-                            .checked_inv()
-                            .unwrap(),
+                        Price::from_str("85248.71").unwrap().checked_inv().unwrap(),
                     ),
                     NonZero::new_unchecked(Uint128::new(117304 * 2)),
                 )],
@@ -7184,7 +7178,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(100)), // ceil(199 * 0.5)
     ),
     coins! { usdc::DENOM.clone() => 100 },
@@ -7197,7 +7191,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(99)), // ceil(198 * 0.5)
     ),
     coins! { usdc::DENOM.clone() => 100 },
@@ -7210,7 +7204,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Ask,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(200)),
     ),
     coins! { dango::DENOM.clone() => 200 },
@@ -7223,7 +7217,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Ask,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(198)),
     ),
     coins! { dango::DENOM.clone() => 198 },
@@ -7305,7 +7299,7 @@ fn limit_order_minimum_order_size(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Ask,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(200)),
     ),
     CreateOrderRequest::new_market(
@@ -7326,7 +7320,7 @@ fn limit_order_minimum_order_size(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Ask,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(200)),
     ),
     CreateOrderRequest::new_market(
@@ -7358,7 +7352,7 @@ fn limit_order_minimum_order_size(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Ask,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(200)),
     ),
     CreateOrderRequest::new_market(
@@ -7379,7 +7373,7 @@ fn limit_order_minimum_order_size(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(100)), // 200 * 0.5
     ),
     CreateOrderRequest::new_market(
@@ -7407,7 +7401,7 @@ fn limit_order_minimum_order_size(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(100)), // 200 * 0.5
     ),
     CreateOrderRequest::new_market(
@@ -7428,7 +7422,7 @@ fn limit_order_minimum_order_size(
         dango::DENOM.clone(),
         usdc::DENOM.clone(),
         Direction::Bid,
-        NonZero::new_unchecked(Udec128_24::new_percent(50)),
+        NonZero::new_unchecked(Price::new_percent(50)),
         NonZero::new_unchecked(Uint128::new(100)), // 200 * 0.5
     ),
     CreateOrderRequest::new_market(
@@ -7537,7 +7531,7 @@ fn orders_cannot_be_created_for_non_existing_pair() {
                     dango::DENOM.clone(),
                     eth::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(1)),
+                    NonZero::new_unchecked(Price::new(1)),
                     NonZero::new_unchecked(Uint128::new(100)),
                 )],
                 cancels: None,
@@ -7599,7 +7593,7 @@ fn create_and_cancel_order_with_remainder() {
                     eth::DENOM.clone(),
                     usdc::DENOM.clone(),
                     Direction::Bid,
-                    NonZero::new_unchecked(Udec128_24::new(100)),
+                    NonZero::new_unchecked(Price::new(100)),
                     NonZero::new_unchecked(Uint128::new(150)),
                 )],
                 cancels: None,

--- a/dango/testing/tests/dex_handle_error.rs
+++ b/dango/testing/tests/dex_handle_error.rs
@@ -4,14 +4,14 @@ use {
     dango_types::{
         constants::{dango, usdc},
         dex::{
-            self, CreateOrderRequest, Direction, OrderId, OrdersByPairResponse,
+            self, CreateOrderRequest, Direction, OrderId, OrdersByPairResponse, Price,
             QueryOrdersByPairRequest, QueryPausedRequest,
         },
     },
     grug::{
         Addr, Addressable, ContractBuilder, ContractWrapper, Empty, HashExt, Message, NonEmpty,
-        NonZero, QuerierExt, Response, ResultExt, Signer, StdResult, SudoCtx, Udec128_6,
-        Udec128_24, Uint128, btree_map, coins,
+        NonZero, QuerierExt, Response, ResultExt, Signer, StdResult, SudoCtx, Udec128_6, Uint128,
+        btree_map, coins,
     },
     test_case::test_case,
 };
@@ -121,14 +121,14 @@ fn handling_error_in_auction(f: fn(&Contracts) -> (Addr, ContractWrapper)) {
                                 dango::DENOM.clone(),
                                 usdc::DENOM.clone(),
                                 Direction::Bid,
-                                NonZero::new_unchecked(Udec128_24::new(100)),
+                                NonZero::new_unchecked(Price::new(100)),
                                 NonZero::new_unchecked(Uint128::new(300)), // 100 * 3
                             ),
                             CreateOrderRequest::new_limit(
                                 dango::DENOM.clone(),
                                 usdc::DENOM.clone(),
                                 Direction::Ask,
-                                NonZero::new_unchecked(Udec128_24::new(100)),
+                                NonZero::new_unchecked(Price::new(100)),
                                 NonZero::new_unchecked(Uint128::new(3)),
                             ),
                         ],
@@ -169,14 +169,14 @@ fn handling_error_in_auction(f: fn(&Contracts) -> (Addr, ContractWrapper)) {
             OrderId::new(!1) => OrdersByPairResponse {
                 user: accounts.owner.address(),
                 direction: Direction::Bid,
-                price: Udec128_24::new(100),
+                price: Price::new(100),
                 amount: Uint128::new(3),
                 remaining: Udec128_6::new(3),
             },
             OrderId::new(2) => OrdersByPairResponse {
                 user: accounts.owner.address(),
                 direction: Direction::Ask,
-                price: Udec128_24::new(100),
+                price: Price::new(100),
                 amount: Uint128::new(3),
                 remaining: Udec128_6::new(3),
             },

--- a/dango/testing/tests/dex_proptests.rs
+++ b/dango/testing/tests/dex_proptests.rs
@@ -10,15 +10,15 @@ use {
         },
         dex::{
             self, CreateOrderRequest, Direction, PairId, PairParams, PairUpdate, PassiveLiquidity,
-            SwapRoute, Xyk,
+            Price, SwapRoute, Xyk,
         },
         gateway::Remote,
     },
     grug::{
         Addressable, Bounded, Coin, Coins, Dec128_24, Denom, Inner, IsZero, MaxLength, Message,
         MultiplyFraction, NonEmpty, NonZero, Number, NumberConst, QuerierExt, ResultExt, Signed,
-        Signer, Udec128, Udec128_24, Uint128, UniqueVec, ZeroInclusiveOneExclusive, btree_map,
-        btree_set, coins,
+        Signer, Udec128, Uint128, UniqueVec, ZeroInclusiveOneExclusive, btree_map, btree_set,
+        coins,
     },
     grug_app::NaiveProposalPreparer,
     hyperlane_types::constants::{ethereum, solana},
@@ -182,7 +182,7 @@ pub enum DexAction {
         quote_denom: Denom,
         direction: Direction,
         amount: Uint128,
-        price: Udec128_24,
+        price: Price,
     },
     CreateMarketOrder {
         base_denom: Denom,
@@ -303,7 +303,7 @@ impl DexAction {
                         }
                         let best_ask_price = resting_order_book.best_ask_price.unwrap();
 
-                        let one_add_max_slippage = Udec128_24::ONE.saturating_add(*max_slippage);
+                        let one_add_max_slippage = Price::ONE.saturating_add(*max_slippage);
                         let price = best_ask_price.saturating_mul(one_add_max_slippage);
 
                         Coin {
@@ -511,7 +511,7 @@ fn amount() -> impl Strategy<Value = Uint128> {
 }
 
 /// Proptest strategy for generating a price as [-3, 3] permille from 1.0
-fn price() -> impl Strategy<Value = Udec128_24> {
+fn price() -> impl Strategy<Value = Price> {
     (-3i128..3i128).prop_map(|price_diff| {
         (Dec128_24::ONE - Dec128_24::new_permille(price_diff))
             .checked_into_unsigned()
@@ -520,9 +520,9 @@ fn price() -> impl Strategy<Value = Udec128_24> {
 }
 
 // Proptest strategy for generating an arbitrary price between 0.00000000000000001 and 10000000000
-// fn price() -> impl Strategy<Value = Udec128_24> {
+// fn price() -> impl Strategy<Value = Price> {
 //     (10_000_000u128..10_000_000_000_000_000_000_000_000_000_000_000u128)
-//         .prop_map(|raw_price| Udec128_24::raw(Uint128::new(raw_price)))
+//         .prop_map(|raw_price| Price::raw(Uint128::new(raw_price)))
 // }
 
 /// Proptest strategy for generating a SwapRoute
@@ -827,7 +827,7 @@ fn test_dex_actions(
             .should_succeed();
     }
 
-    let bucket_sizes: BTreeSet<NonZero<Udec128_24>> = btree_set! {
+    let bucket_sizes: BTreeSet<NonZero<Price>> = btree_set! {
         NonZero::new_unchecked(ONE_HUNDREDTH),
         NonZero::new_unchecked(ONE_TENTH),
         NonZero::new_unchecked(ONE),

--- a/dango/types/src/dex/events.rs
+++ b/dango/types/src/dex/events.rs
@@ -1,6 +1,6 @@
 use {
-    crate::dex::{Direction, OrderId, PairId, TimeInForce},
-    grug::{Addr, Coin, DecCoin, Denom, Udec128_6, Udec128_24, Uint128},
+    crate::dex::{Direction, OrderId, PairId, Price, TimeInForce},
+    grug::{Addr, Coin, DecCoin, Denom, Udec128_6, Uint128},
 };
 
 #[grug::derive(Serde)]
@@ -12,7 +12,7 @@ pub struct OrderCreated {
     pub base_denom: Denom,
     pub quote_denom: Denom,
     pub direction: Direction,
-    pub price: Udec128_24,
+    pub price: Price,
     pub amount: Uint128,
     pub deposit: Coin,
 }
@@ -33,7 +33,7 @@ pub struct OrderCanceled {
     /// The direction of the order.
     pub direction: Direction,
     /// The order's limit price, measured in quote asset per base asset.
-    pub price: Udec128_24,
+    pub price: Price,
     /// The order's total size, measured in the _base asset_.
     pub amount: Uint128,
 }
@@ -45,7 +45,7 @@ pub struct OrderCanceled {
 pub struct OrdersMatched {
     pub base_denom: Denom,
     pub quote_denom: Denom,
-    pub clearing_price: Udec128_24,
+    pub clearing_price: Price,
     /// Amount matched denominated in the base asset.
     pub volume: Udec128_6,
 }
@@ -66,7 +66,7 @@ pub struct OrderFilled {
     pub fee_base: Udec128_6,
     pub fee_quote: Udec128_6,
     /// The price at which the order was executed.
-    pub clearing_price: Udec128_24,
+    pub clearing_price: Price,
     /// Whether the order was _completed_ filled and cleared from the book.
     pub cleared: bool,
 }

--- a/dango/types/src/dex/msgs.rs
+++ b/dango/types/src/dex/msgs.rs
@@ -1,11 +1,13 @@
 use {
     crate::{
         account_factory::Username,
-        dex::{Direction, OrderId, PairParams, PairUpdate, RestingOrderBookState, TimeInForce},
+        dex::{
+            Direction, OrderId, PairParams, PairUpdate, Price, RestingOrderBookState, TimeInForce,
+        },
     },
     grug::{
         Addr, Bounded, Coin, CoinPair, Denom, MaxLength, NonZero, Timestamp, Udec128, Udec128_6,
-        Udec128_24, Uint128, UniqueVec, ZeroInclusiveOneExclusive,
+        Uint128, UniqueVec, ZeroInclusiveOneExclusive,
     },
     std::collections::{BTreeMap, BTreeSet},
 };
@@ -42,7 +44,7 @@ impl CreateOrderRequest {
         base_denom: Denom,
         quote_denom: Denom,
         direction: Direction,
-        price: NonZero<Udec128_24>,
+        price: NonZero<Price>,
         amount: NonZero<Uint128>, // Quote asset amount for bids; base asset amount for asks.
     ) -> Self {
         Self {
@@ -83,7 +85,7 @@ impl CreateOrderRequest {
 #[grug::derive(Serde)]
 pub enum PriceOption {
     /// The order is to have the specified limit price.
-    Limit(NonZero<Udec128_24>),
+    Limit(NonZero<Price>),
     /// The order's limit price is to be determined by the best available price
     /// in the resting order book and the specified maximum slippage.
     ///
@@ -337,7 +339,7 @@ pub enum QueryMsg {
     LiquidityDepth {
         base_denom: Denom,
         quote_denom: Denom,
-        bucket_size: Udec128_24,
+        bucket_size: Price,
         limit: Option<u32>,
     },
 }
@@ -372,7 +374,7 @@ pub struct OrderResponse {
     pub base_denom: Denom,
     pub quote_denom: Denom,
     pub direction: Direction,
-    pub price: Udec128_24,
+    pub price: Price,
     pub amount: Uint128,
     pub remaining: Udec128_6,
 }
@@ -382,7 +384,7 @@ pub struct OrderResponse {
 pub struct OrdersByPairResponse {
     pub user: Addr,
     pub direction: Direction,
-    pub price: Udec128_24,
+    pub price: Price,
     pub amount: Uint128,
     pub remaining: Udec128_6,
 }
@@ -393,7 +395,7 @@ pub struct OrdersByUserResponse {
     pub base_denom: Denom,
     pub quote_denom: Denom,
     pub direction: Direction,
-    pub price: Udec128_24,
+    pub price: Price,
     pub amount: Uint128,
     pub remaining: Udec128_6,
 }
@@ -401,8 +403,8 @@ pub struct OrdersByUserResponse {
 /// Response type of the `QueryMsg::ReflectCurve` query.
 #[grug::derive(Serde)]
 pub struct ReflectCurveResponse {
-    pub bids: BTreeMap<Udec128_24, Uint128>, // price => amount in base asset
-    pub asks: BTreeMap<Udec128_24, Uint128>, // price => amount in base asset
+    pub bids: BTreeMap<Price, Uint128>, // price => amount in base asset
+    pub asks: BTreeMap<Price, Uint128>, // price => amount in base asset
 }
 
 /// Response type of the `QueryMsg::LiquidityDepth` query.
@@ -415,6 +417,6 @@ pub struct LiquidityDepth {
 /// Response type of the `QueryMsg::LiquidityDepth` query.
 #[grug::derive(Serde)]
 pub struct LiquidityDepthResponse {
-    pub bid_depth: Option<Vec<(Udec128_24, LiquidityDepth)>>,
-    pub ask_depth: Option<Vec<(Udec128_24, LiquidityDepth)>>,
+    pub bid_depth: Option<Vec<(Price, LiquidityDepth)>>,
+    pub ask_depth: Option<Vec<(Price, LiquidityDepth)>>,
 }

--- a/dango/types/src/dex/order.rs
+++ b/dango/types/src/dex/order.rs
@@ -1,6 +1,6 @@
 use {
-    crate::dex::{Direction, TimeInForce},
-    grug::{Addr, MathResult, Number, NumberConst, Udec128_6, Udec128_24, Uint64, Uint128},
+    crate::dex::{Direction, Price, TimeInForce},
+    grug::{Addr, MathResult, Number, NumberConst, Udec128_6, Uint64, Uint128},
 };
 
 /// Numerical identifier of an order (limit or market).
@@ -68,7 +68,7 @@ pub struct Order {
     /// The order's time-in-force.
     pub time_in_force: TimeInForce,
     /// The order's limit price, measured in quote asset per base asset.
-    pub price: Udec128_24,
+    pub price: Price,
     /// The order's total size, measured in the _base asset_.
     pub amount: Uint128,
     /// Portion of the order that remains unfilled, measured in the _base asset_.

--- a/dango/types/src/dex/pair.rs
+++ b/dango/types/src/dex/pair.rs
@@ -1,6 +1,7 @@
 use {
+    crate::dex::Price,
     grug::{
-        Bounded, Denom, NonZero, Udec128, Udec128_24, Uint128, ZeroExclusiveOneExclusive,
+        Bounded, Denom, NonZero, Udec128, Uint128, ZeroExclusiveOneExclusive,
         ZeroExclusiveOneInclusive, ZeroInclusiveOneExclusive,
     },
     std::collections::BTreeSet,
@@ -14,7 +15,7 @@ pub struct PairParams {
     /// Specifies the pool type (e.g. Xyk or Geometric).
     pub pool_type: PassiveLiquidity,
     /// Price buckets for the liquidity depth chart.
-    pub bucket_sizes: BTreeSet<NonZero<Udec128_24>>,
+    pub bucket_sizes: BTreeSet<NonZero<Price>>,
     /// Fee rate for instant swaps in the passive liquidity pool.
     /// For the xyk pool, this also sets the spread of the orders when the
     /// passive liquidity is reflected onto the orderbook.

--- a/dango/types/src/dex/price.rs
+++ b/dango/types/src/dex/price.rs
@@ -32,7 +32,7 @@ use grug::Udec128_24;
 /// Suppose ETH is trading at 4000 USDC (or in other words, 4e-15 in base units),
 /// this corresponds to 3.4e+14 / 4e-15 = 8.5e+28 wei or 8.5e+10 ETH, way beyond
 /// the biggest order size we reasonable expect. So, 128-bit is sufficient.
-pub type Price = Udec128_24; // TODO: use this alias throughout the types and dex contract crates.
+pub type Price = Udec128_24;
 
 /// The state of resting order book.
 ///


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor codebase to replace `Udec128_24` with `Price` alias for improved readability and maintainability across multiple modules and tests.
> 
>   - **Refactor**:
>     - Replace `Udec128_24` with alias `Price` across multiple files for better readability.
>     - Affects functions like `add_subsequent_liquidity()`, `bid_exact_amount_in()`, `ask_exact_amount_in()`, `bid_exact_amount_out()`, `ask_exact_amount_out()`, `oracle_value()` in `geometric.rs`.
>     - Update `PassiveLiquidityPool` trait and `PairParams` struct in `liquidity_pool.rs`.
>     - Modify `Order`, `OrderCreated`, `OrderCanceled`, `OrdersMatched`, `OrderFilled` structs in `events.rs`.
>     - Adjust `CreateOrderRequest`, `PriceOption`, `AmountOption` in `msgs.rs`.
>     - Update `Order` struct in `order.rs` and `PairParams` in `pair.rs`.
>     - Change `RestingOrderBookState` struct in `price.rs`.
>   - **Tests**:
>     - Update tests in `dex.rs`, `dex_handle_error.rs`, `dex_proptests.rs` to use `Price` alias.
>     - Ensure all test cases reflect the new type alias for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 8becfff3d803ec33b02dcc5b9466bf3d7bfe74e4. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->