### PR TITLE
feat(ui): tradingview and chartiq as optional dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,9 +487,6 @@ importers:
       '@left-curve/applets-kit':
         specifier: workspace:^
         version: link:../../applets/kit
-      '@left-curve/chartiq':
-        specifier: ^9.9.0
-        version: 9.9.0
       '@left-curve/dango':
         specifier: workspace:^
         version: link:../../../sdk/dango
@@ -499,9 +496,6 @@ importers:
       '@left-curve/store':
         specifier: workspace:^
         version: link:../../store
-      '@left-curve/tradingview':
-        specifier: ^29.4.0
-        version: 29.4.0
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -553,6 +547,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 18.3.1(react@18.3.1)
+      react-error-boundary:
+        specifier: ^6.0.0
+        version: 6.0.0(react@18.3.1)
       react-hook-form:
         specifier: 'catalog:'
         version: 7.53.0(react@18.3.1)
@@ -565,6 +562,13 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 3.24.1
+    optionalDependencies:
+      '@left-curve/chartiq':
+        specifier: ^9.9.0
+        version: 9.9.0
+      '@left-curve/tradingview':
+        specifier: ^29.4.0
+        version: 29.4.0
     devDependencies:
       '@left-curve/config':
         specifier: workspace:^
@@ -7511,6 +7515,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-error-boundary@6.0.0:
+    resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
+    peerDependencies:
+      react: '>=16.13.1'
+
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
@@ -11465,9 +11474,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@left-curve/chartiq@9.9.0': {}
+  '@left-curve/chartiq@9.9.0':
+    optional: true
 
-  '@left-curve/tradingview@29.4.0': {}
+  '@left-curve/tradingview@29.4.0':
+    optional: true
 
   '@lix-js/sdk@0.4.1':
     dependencies:
@@ -16589,6 +16600,11 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-error-boundary@6.0.0(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.25.7
+      react: 18.3.1
 
   react-fast-compare@3.2.2: {}
 

--- a/ui/portal/web/package.json
+++ b/ui/portal/web/package.json
@@ -11,11 +11,9 @@
     "@fullpage/react-fullpage": "^0.1.45",
     "@left-curve/applets-convert": "workspace:^",
     "@left-curve/applets-kit": "workspace:^",
-    "@left-curve/chartiq": "^9.9.0",
     "@left-curve/dango": "workspace:^",
     "@left-curve/foundation": "workspace:^",
     "@left-curve/store": "workspace:^",
-    "@left-curve/tradingview": "^29.4.0",
     "@monaco-editor/react": "^4.7.0",
     "@sentry/react": "^9.10.1",
     "@sentry/webpack-plugin": "^3.2.4",
@@ -33,10 +31,15 @@
     "graphql-ws": "^6.0.4",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-error-boundary": "^6.0.0",
     "react-hook-form": "catalog:",
     "react-hot-toast": "catalog:",
     "react-modal-sheet": "^4.0.1",
     "zod": "catalog:"
+  },
+  "optionalDependencies": {
+    "@left-curve/tradingview": "^29.4.0",
+    "@left-curve/chartiq": "^9.9.0"
   },
   "devDependencies": {
     "@left-curve/config": "workspace:^",

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -24,6 +24,7 @@ import { OrderBookOverview } from "./OrderBookOverview";
 import { SearchToken } from "./SearchToken";
 import { TradeButtons } from "./TradeButtons";
 import { TradeMenu } from "./TradeMenu";
+import { ErrorBoundary } from "react-error-boundary";
 
 import type { PropsWithChildren } from "react";
 import type { TableColumn } from "@left-curve/applets-kit";
@@ -180,7 +181,9 @@ const ProTradeChart: React.FC = () => {
   const Chart = (
     <Suspense fallback={<Spinner color="pink" size="md" />}>
       <div className="flex w-full h-full lg:min-h-[52vh]" id="chart-container">
-        <ChartComponent coins={{ base: baseCoin, quote: quoteCoin }} orders={ordersByPair} />
+        <ErrorBoundary fallback={<div className="p-4">Chart Engine</div>}>
+          <ChartComponent coins={{ base: baseCoin, quote: quoteCoin }} orders={ordersByPair} />
+        </ErrorBoundary>
       </div>
     </Suspense>
   );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `tradingview` and `chartiq` optional dependencies and add error boundary to `ProTradeChart` in `ProTrade.tsx`.
> 
>   - **Dependencies**:
>     - Move `@left-curve/tradingview` and `@left-curve/chartiq` from `dependencies` to `optionalDependencies` in `package.json`.
>   - **Error Handling**:
>     - Wrap `ChartComponent` in `ProTradeChart` in `ProTrade.tsx` with `ErrorBoundary` to handle errors gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 9b235be765dea7529174044305db4cacc64d3b21. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->