### PR TITLE
refactor(ui): format number

### DIFF
--- a/sdk/dango/src/utils/dex.ts
+++ b/sdk/dango/src/utils/dex.ts
@@ -37,7 +37,6 @@ export function calculatePrice(
 ) {
   return formatNumber(parseUnits(price, decimals.base - decimals.quote), {
     ...options,
-    minSignificantDigits: 8,
-    maxSignificantDigits: 8,
-  }).slice(0, 7);
+    minimumTotalDigits: 8,
+  });
 }

--- a/sdk/dango/src/utils/formatters.ts
+++ b/sdk/dango/src/utils/formatters.ts
@@ -1,43 +1,11 @@
 import { Decimal } from "@left-curve/sdk/utils";
 
-export type CurrencyFormatterOptions = {
-  currency: string;
-  language: string;
-  maxFractionDigits?: number;
-  minFractionDigits?: number;
-};
-
-/**
- * Format a currency with the given options.
- * @param amount The amount to format.
- * @param options The formatting options.
- * @param options.currency The currency code. Ex: "USD".
- * @param options.language The language to use. Ex: "en-US".
- * @param options.maxFractionDigits The maximum number of fraction digits.
- * @param options.minFractionDigits The minimum number of fraction digits.
- * @returns The formatted currency.
- */
-export function formatCurrency(amount: number | bigint, options: CurrencyFormatterOptions) {
-  const { currency, language, minFractionDigits = 2, maxFractionDigits = 2 } = options;
-  return new Intl.NumberFormat(language, {
-    currency,
-    style: "currency",
-    notation: "compact",
-    minimumFractionDigits: minFractionDigits,
-    maximumFractionDigits: maxFractionDigits,
-    currencyDisplay: "narrowSymbol",
-  }).format(amount);
-}
-
 export type FormatNumberOptions = {
   language: string;
   currency?: string;
-  style?: "decimal" | "percent" | "currency";
-  notation?: "standard" | "scientific" | "engineering" | "compact";
-  maxFractionDigits?: number;
-  minFractionDigits?: number;
-  maxSignificantDigits?: number;
-  minSignificantDigits?: number;
+  style?: "decimal" | "currency";
+  minimumTotalDigits?: number;
+  maximumTotalDigits?: number;
   mask: keyof typeof formatNumberMask;
 };
 
@@ -81,47 +49,65 @@ const formatNumberMask = {
  * @param options The formatting options.
  * @param options.currency The currency code. Ex: "USD".
  * @param options.language The language to use. Ex: "en-US".
- * @param options.maxFractionDigits The maximum number of fraction digits.
- * @param options.minFractionDigits The minimum number of fraction digits.
+ * @param options.maximumTotalDigits The maximum number of total digits.
+ * @param options.minimumTotalDigits The minimum number of total digits.
+ * @param options.mask The mask to use. Ex: 1 for "1,234.00", 2 for "1.234,00", 3 for "1234,00", 4 for "1 234,00".
  * @returns The formatted number.
  */
-export function formatNumber(_amount_: number | bigint | string, options: FormatNumberOptions) {
-  const {
-    language,
-    currency,
-    maxFractionDigits = 2,
-    minFractionDigits = 2,
-    maxSignificantDigits = 3,
-    minSignificantDigits = 1,
-    notation = "standard",
-    mask = 1,
-  } = options;
-  const amount = typeof _amount_ === "string" ? Number(_amount_) : _amount_;
+export function formatNumber(_amount_: number | string, options: FormatNumberOptions) {
+  const { language, currency, maximumTotalDigits = 20, minimumTotalDigits = 0, mask = 1 } = options;
+
+  const amount = Decimal(_amount_);
 
   const currencyOptions = currency
     ? ({
         currency,
         currencyDisplay: "narrowSymbol",
-        notation: "compact",
         style: "currency",
       } as const)
-    : {};
+    : ({
+        style: "decimal",
+      } as const);
 
-  return new Intl.NumberFormat(language, {
-    notation,
-    // @ts-ignore: For some reason roundingMode is not in the type definition but it is supported.
-    roundingMode: "floor",
-    minimumFractionDigits: minFractionDigits,
-    maximumFractionDigits: maxFractionDigits,
-    maximumSignificantDigits: maxSignificantDigits,
-    minimumSignificantDigits: minSignificantDigits,
-    useGrouping: formatNumberMask[mask].useGrouping,
+  const intlOptions: Intl.NumberFormatOptions = {
     ...currencyOptions,
-  })
-    .formatToParts(amount)
+    useGrouping: formatNumberMask[mask].useGrouping,
+  };
+
+  const absAmount = amount.abs();
+
+  const integerPart = absAmount.round(0, 0);
+  const integerDigits = integerPart.isZero() ? 1 : integerPart.toFixed(0).length;
+
+  const threshold = Decimal(1).div(Decimal(10).pow(maximumTotalDigits - 1));
+
+  if (absAmount.gt(0) && absAmount.lt(threshold)) {
+    const thresholdFormatter = new Intl.NumberFormat(language, {
+      maximumFractionDigits: maximumTotalDigits - 1,
+    });
+    return `< ${thresholdFormatter.format(threshold.toNumber())}`;
+  }
+
+  if (integerDigits > maximumTotalDigits) {
+    intlOptions.notation = "compact";
+    intlOptions.maximumFractionDigits = maximumTotalDigits;
+  } else {
+    intlOptions.maximumFractionDigits = maximumTotalDigits - integerDigits;
+  }
+
+  if (minimumTotalDigits > integerDigits) {
+    intlOptions.minimumFractionDigits = minimumTotalDigits;
+  } else {
+    intlOptions.minimumFractionDigits = minimumTotalDigits - integerDigits;
+  }
+
+  return new Intl.NumberFormat(language, intlOptions)
+    .formatToParts(amount.toNumber())
     .map((part) => {
       const partType =
-        formatNumberMask[mask].format[part.type as keyof (typeof formatNumberMask)[3]["format"]];
+        formatNumberMask[mask].format[
+          part.type as keyof (typeof formatNumberMask)[keyof typeof formatNumberMask]["format"]
+        ];
       return partType || part.value;
     })
     .join("");
@@ -133,10 +119,8 @@ export function formatNumber(_amount_: number | bigint | string, options: Format
  * @param decimals The number of decimals to divide the number by.
  * @returns The formatted number.
  */
-export function formatUnits(value: bigint | number | string, decimals: number): string {
-  return Decimal(typeof value === "bigint" ? value.toString() : value)
-    .div(Decimal(10).pow(decimals))
-    .toFixed();
+export function formatUnits(value: number | string, decimals: number): string {
+  return Decimal(value.toString()).div(Decimal(10).pow(decimals)).toFixed();
 }
 
 /**

--- a/sdk/dango/src/utils/index.ts
+++ b/sdk/dango/src/utils/index.ts
@@ -14,8 +14,6 @@ export {
 } from "./typedData.js";
 
 export {
-  type CurrencyFormatterOptions,
-  formatCurrency,
   type FormatNumberOptions,
   formatNumber,
   formatUnits,

--- a/sdk/grug/src/utils/decimal.ts
+++ b/sdk/grug/src/utils/decimal.ts
@@ -29,6 +29,10 @@ class Decimal {
     return new Decimal(value);
   }
 
+  round(dp: number, rm: number): Decimal {
+    return new Decimal(this.inner.round(dp, rm as Big.RoundingMode));
+  }
+
   plus(num: string | number | Decimal): Decimal {
     const other = Decimal.from(num);
     const result = this.inner.plus(other.inner);

--- a/ui/applets/convert/src/applet.tsx
+++ b/ui/applets/convert/src/applet.tsx
@@ -272,7 +272,7 @@ const ConvertForm: React.FC = () => {
             <div className="flex items-center justify-between gap-2 w-full h-[22px] text-tertiary-500 diatype-sm-regular">
               <div className="flex items-center gap-2">
                 <p>
-                  {baseBalance} {base.symbol}
+                  {formatNumber(baseBalance, formatNumberOptions)} {base.symbol}
                 </p>
               </div>
               <div>
@@ -281,7 +281,7 @@ const ConvertForm: React.FC = () => {
                 ) : (
                   getPrice(baseAmount, base.denom, {
                     format: true,
-                    formatOptions: formatNumberOptions,
+                    formatOptions: { ...formatNumberOptions, maximumTotalDigits: 6 },
                   })
                 )}
               </div>
@@ -350,7 +350,7 @@ const ConvertForm: React.FC = () => {
             <div className="flex items-center justify-between gap-2 w-full h-[22px] text-tertiary-500 diatype-sm-regular">
               <div className="flex items-center gap-2">
                 <p>
-                  {quoteBalance} {quote.symbol}
+                  {formatNumber(quoteBalance, formatNumberOptions)} {quote.symbol}
                 </p>
               </div>
               <div>
@@ -359,7 +359,7 @@ const ConvertForm: React.FC = () => {
                 ) : (
                   getPrice(quoteAmount, quote.denom, {
                     format: true,
-                    formatOptions: formatNumberOptions,
+                    formatOptions: { ...formatNumberOptions, maximumTotalDigits: 6 },
                   })
                 )}
               </div>
@@ -419,9 +419,9 @@ const ConvertDetails: React.FC = () => {
         ) : (
           <p className="text-secondary-700 diatype-sm-medium">
             1 {inputCoin.symbol} ≈{" "}
-            {formatNumber(Number(outputAmount) / Number(inputAmount), {
+            {formatNumber(Decimal(outputAmount).div(inputAmount).toFixed(), {
               ...formatNumberOptions,
-              maxFractionDigits: outputCoin.decimals,
+              maximumTotalDigits: 10,
             })}{" "}
             {outputCoin.symbol}
           </p>

--- a/ui/foundation/react/providers/AppProvider.tsx
+++ b/ui/foundation/react/providers/AppProvider.tsx
@@ -55,7 +55,7 @@ export const AppProvider: React.FC<PropsWithChildren<AppProviderProps>> = ({
 
   // App settings
   const [settings, setSettings] = useStorage<AppState["settings"]>("app.settings", {
-    version: 1.5,
+    version: 1.6,
     initialValue: {
       chart: "tradingview",
       showWelcome: true,
@@ -66,10 +66,8 @@ export const AppProvider: React.FC<PropsWithChildren<AppProviderProps>> = ({
       timeZone: "local",
       formatNumberOptions: {
         mask: 1,
+        maximumTotalDigits: 8,
         language: "en-US",
-        maxFractionDigits: 4,
-        minFractionDigits: 0,
-        notation: "standard",
       },
     },
     sync: true,
@@ -86,6 +84,14 @@ export const AppProvider: React.FC<PropsWithChildren<AppProviderProps>> = ({
         state.timeFormat = "hh:mm a";
         state.dateFormat = "MM/dd/yyyy";
         state.timeZone = "local";
+        return state;
+      },
+      1.5: (state: AppState["settings"]) => {
+        state.formatNumberOptions = {
+          mask: state.formatNumberOptions.mask,
+          maximumTotalDigits: 8,
+          language: state.formatNumberOptions.language,
+        };
         return state;
       },
     },

--- a/ui/portal/web/src/components/account/AccountCreation.tsx
+++ b/ui/portal/web/src/components/account/AccountCreation.tsx
@@ -255,9 +255,7 @@ export const Deposit: React.FC = () => {
             <p>{m["common.available"]()}</p>
             <p className="flex gap-1">
               <span>{coinInfo.symbol}</span>
-              <span>
-                {formatNumber(humanBalance, { ...formatNumberOptions, maxSignificantDigits: 6 })}
-              </span>
+              <span>{formatNumber(humanBalance, formatNumberOptions)}</span>
             </p>
           </div>
         }

--- a/ui/portal/web/src/components/activities/OrderFilled.tsx
+++ b/ui/portal/web/src/components/activities/OrderFilled.tsx
@@ -68,13 +68,7 @@ export const ActivityOrderFilled = forwardRef<ActivityRef, ActivityOrderFilledPr
 
     const limitPrice = null;
 
-    const width = cleared
-      ? null
-      : formatNumber(remaining, {
-          ...formatNumberOptions,
-          minSignificantDigits: 8,
-          maxSignificantDigits: 8,
-        }).slice(0, 7);
+    const width = cleared ? null : formatNumber(remaining, formatNumberOptions);
 
     const filled =
       direction === Direction.Buy

--- a/ui/portal/web/src/components/activities/Transfer.tsx
+++ b/ui/portal/web/src/components/activities/Transfer.tsx
@@ -88,10 +88,7 @@ export const ActivityTransfer = forwardRef<ActivityRef, ActivityTransferProps>(
                       />
                     )}
                   </span>
-                  {`${isSent ? "−" : "+"}${formatNumber(formatUnits(amount, coin.decimals), {
-                    ...formatNumberOptions,
-                    maxSignificantDigits: 4,
-                  })}  ${coin.symbol}`}
+                  {`${isSent ? "−" : "+"}${formatNumber(formatUnits(amount, coin.decimals), formatNumberOptions)}  ${coin.symbol}`}
                 </p>
               );
             })}

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -68,11 +68,8 @@ const OrderRow: React.FC<OrderBookRowProps> = (props) => {
 
   const formattedSize = formatNumber(size, {
     ...formatNumberOptions,
-    maxSignificantDigits: 5,
-    minSignificantDigits: 5,
+    minimumTotalDigits: 8,
   });
-
-  const isAmountTooSmall = Decimal(size).lt(0.00001);
 
   const depthBarClass =
     type === "bid"
@@ -93,21 +90,9 @@ const OrderRow: React.FC<OrderBookRowProps> = (props) => {
             : "text-status-fail order-2 lg:order-none text-end lg:text-left",
         )}
       >
-        {formatNumber(price, {
-          ...formatNumberOptions,
-          maxSignificantDigits: 8,
-        })}
+        {formatNumber(price, formatNumberOptions)}
       </div>
-      <div className="z-10 justify-center text-center hidden lg:flex gap-1">
-        {isAmountTooSmall ? (
-          <>
-            <span>{"<"}</span>
-            {"0.00001"}
-          </>
-        ) : (
-          formattedSize
-        )}
-      </div>
+      <div className="z-10 justify-end text-end hidden lg:flex gap-1">{formattedSize}</div>
       <div
         className={twMerge(
           "z-10",
@@ -116,8 +101,7 @@ const OrderRow: React.FC<OrderBookRowProps> = (props) => {
       >
         {formatNumber(total, {
           ...formatNumberOptions,
-          minSignificantDigits: 8,
-          maxSignificantDigits: 8,
+          minimumTotalDigits: 8,
         })}
       </div>
     </div>
@@ -172,7 +156,7 @@ const OrderBook: React.FC<OrderBookOverviewProps> = ({ state }) => {
         <p className="order-2 lg:order-none text-end lg:text-start">
           {m["dex.protrade.history.price"]()}
         </p>
-        <p className="text-center hidden lg:block">
+        <p className="text-end hidden lg:block">
           {m["dex.protrade.history.size"]({ symbol: bucketSizeSymbol })}
         </p>
         <p className="lg:text-end order-1 lg:order-none">
@@ -197,10 +181,7 @@ const OrderBook: React.FC<OrderBookOverviewProps> = ({ state }) => {
               Decimal(previousPrice).lte(currentPrice) ? "text-status-fail" : "text-status-success",
             )}
           >
-            {formatNumber(currentPrice || "0", {
-              ...formatNumberOptions,
-              maxSignificantDigits: 8,
-            })}
+            {formatNumber(currentPrice || "0", formatNumberOptions)}
           </p>
           <span className="bg-surface-tertiary-rice w-[calc(100%+2rem)] absolute -left-4 top-0 h-full z-10" />
         </div>
@@ -236,11 +217,10 @@ const LiveTrades: React.FC<OrderBookOverviewProps> = ({ state }) => {
 
           const formattedSize = formatNumber(size, {
             ...formatNumberOptions,
-            maxSignificantDigits: 5,
-            minSignificantDigits: 5,
+            maximumTotalDigits: 5,
+            minimumTotalDigits: 5,
           });
 
-          const isAmountTooSmall = Decimal(size).lt(0.00001);
           return (
             <div
               key={`${trade.addr}-${trade.createdAt}-${index}`}
@@ -259,19 +239,10 @@ const LiveTrades: React.FC<OrderBookOverviewProps> = ({ state }) => {
                   Decimal(trade.clearingPrice)
                     .times(Decimal(10).pow(baseCoin.decimals - quoteCoin.decimals))
                     .toFixed(),
-                  { ...formatNumberOptions, maxSignificantDigits: 8 },
-                ).slice(0, 10)}
-              </p>
-              <p className="text-center z-10 flex gap-1 justify-center">
-                {isAmountTooSmall ? (
-                  <>
-                    <span>{"<"}</span>
-                    {"0.00001"}
-                  </>
-                ) : (
-                  formattedSize
+                  { ...formatNumberOptions, minimumTotalDigits: 8 },
                 )}
               </p>
+              <p className="text-center z-10 flex gap-1 justify-center">{formattedSize}</p>
 
               <div className="flex flex-nowrap whitespace-nowrap gap-1 items-center justify-end z-10">
                 <p>{formatDate(trade.createdAt, timeFormat.replace("mm", "mm:ss"))}</p>

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -133,7 +133,7 @@ const ProTradeHeader: React.FC = () => {
                     : "text-status-success",
                 )}
               >
-                {formatNumber(currentPrice, { ...formatNumberOptions, maxSignificantDigits: 6 })}
+                {formatNumber(currentPrice, formatNumberOptions)}
               </p>
             </div>
             <div className="items-center flex gap-1 flex-row lg:flex-col min-w-[4rem] lg:items-start">
@@ -304,7 +304,7 @@ const ProTradeOpenOrders: React.FC = () => {
         }),
       cell: ({ row }) => (
         <Cell.Number
-          formatOptions={{ ...formatNumberOptions, maxSignificantDigits: 10 }}
+          formatOptions={formatNumberOptions}
           value={Decimal(row.original.remaining)
             .div(Decimal(10).pow(coins.byDenom[row.original.baseDenom].decimals))
             .toFixed()}
@@ -319,7 +319,7 @@ const ProTradeOpenOrders: React.FC = () => {
         }),
       cell: ({ row }) => (
         <Cell.Number
-          formatOptions={{ ...formatNumberOptions, maxSignificantDigits: 10 }}
+          formatOptions={formatNumberOptions}
           value={Decimal(row.original.amount)
             .div(Decimal(10).pow(coins.byDenom[row.original.baseDenom].decimals))
             .toFixed()}
@@ -339,7 +339,7 @@ const ProTradeOpenOrders: React.FC = () => {
                 ),
               )
               .toFixed(),
-            { ...formatNumberOptions, maxSignificantDigits: 10 },
+            formatNumberOptions,
           )}
         />
       ),
@@ -448,7 +448,7 @@ const ProTradeOrdersHistory: React.FC = () => {
       cell: ({ row }) => {
         return (
           <Cell.Number
-            formatOptions={{ ...formatNumberOptions, maxSignificantDigits: 10 }}
+            formatOptions={formatNumberOptions}
             value={calculateTradeSize(
               row.original,
               coins.byDenom[row.original.baseDenom].decimals,
@@ -470,7 +470,7 @@ const ProTradeOrdersHistory: React.FC = () => {
                 ),
               )
               .toFixed(),
-            { ...formatNumberOptions, maxSignificantDigits: 10 },
+            formatNumberOptions,
           )}
         />
       ),

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -78,11 +78,7 @@ const SpotTradeMenu: React.FC<TradeMenuProps> = ({ state, controllers }) => {
             {m["dex.protrade.spot.availableToTrade"]()}
           </p>
           <p className="diatype-xs-medium text-secondary-700">
-            {formatNumber(availableCoin.amount, {
-              ...formatNumberOptions,
-              maxSignificantDigits: 10,
-            })}{" "}
-            {availableCoin.symbol}
+            {formatNumber(availableCoin.amount, formatNumberOptions)} {availableCoin.symbol}
           </p>
         </div>
         {operation === "limit" ? (

--- a/ui/portal/web/src/components/earn/PoolLiquidity.tsx
+++ b/ui/portal/web/src/components/earn/PoolLiquidity.tsx
@@ -131,7 +131,7 @@ const PoolLiquidityUserLiquidity: React.FC = () => {
   const { coins, userHasLiquidity, userLiquidity } = state;
   const { base, quote } = coins;
 
-  const { getPrice } = usePrices({ defaultFormatOptions: formatNumberOptions });
+  const { getPrice } = usePrices();
 
   if (userLiquidity.isLoading)
     return <Skeleton className="h-[9rem] rounded-xl shadow-account-card flex-1" />;
@@ -228,7 +228,7 @@ const PoolLiquidityDeposit: React.FC = () => {
               <div className="w-full flex justify-between pl-4 h-[22px]">
                 <div className="flex gap-1 items-center justify-center diatype-sm-regular text-tertiary-500">
                   <span>
-                    {base.balance} {base.symbol}
+                    {formatNumber(base.balance, formatNumberOptions)} {base.symbol}
                   </span>
                   <Button
                     type="button"
@@ -274,7 +274,7 @@ const PoolLiquidityDeposit: React.FC = () => {
               <div className="w-full flex justify-between pl-4 h-[22px]">
                 <div className="flex gap-1 items-center justify-center diatype-sm-regular text-tertiary-500">
                   <span>
-                    {quote.balance} {quote.symbol}
+                    {formatNumber(quote.balance, formatNumberOptions)} {quote.symbol}
                   </span>
                   <Button
                     type="button"

--- a/ui/portal/web/src/components/foundation/AssetCard.tsx
+++ b/ui/portal/web/src/components/foundation/AssetCard.tsx
@@ -43,7 +43,7 @@ export const AssetCard: React.FC<Props> = ({ coin }) => {
           <p className="text-primary-900 diatype-m-bold">{price}</p>
           <p>
             {coinInfo.type === "lp"
-              ? formatNumber(humanAmount, { ...formatNumberOptions, notation: "compact" })
+              ? formatNumber(humanAmount, { ...formatNumberOptions, maximumTotalDigits: 4 })
               : formatNumber(humanAmount, formatNumberOptions)}
           </p>
         </div>

--- a/ui/portal/web/src/components/foundation/ChartIQ.tsx
+++ b/ui/portal/web/src/components/foundation/ChartIQ.tsx
@@ -115,10 +115,10 @@ export const ChartIQ: React.FC<ChartIQProps> = ({ coins, orders }) => {
 
     stx.formatYAxisPrice = (price, params) => {
       if (params?.display?.includes("-")) {
-        return formatNumber(price, { ...formatNumberOptions, maxSignificantDigits: 5 });
+        return formatNumber(price, formatNumberOptions);
       }
 
-      return formatNumber(price, { ...formatNumberOptions, notation: "compact" });
+      return formatNumber(price, { ...formatNumberOptions, maximumTotalDigits: 3 });
     };
 
     stx.candleWidthPercent = 0.9;
@@ -172,7 +172,7 @@ export const ChartIQ: React.FC<ChartIQProps> = ({ coins, orders }) => {
         });
         stx.createYAxisLabel(
           stx.chart.panel,
-          formatNumber(price, { ...formatNumberOptions, maxSignificantDigits: 5 }),
+          formatNumber(price, formatNumberOptions),
           stx.pixelFromTransformedValue(price),
           color,
           "white",

--- a/ui/portal/web/src/pages/(app)/_app.transfer.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.transfer.lazy.tsx
@@ -184,13 +184,7 @@ function TransferApplet() {
                   insideBottomComponent={
                     <div className="w-full flex justify-between pl-4 h-[22px]">
                       <div className="flex gap-1 items-center justify-center diatype-sm-regular text-tertiary-500">
-                        <span>
-                          {formatNumber(humanAmount, {
-                            ...formatNumberOptions,
-                            notation: "compact",
-                            maxFractionDigits: selectedCoin.decimals / 3,
-                          })}
-                        </span>
+                        <span>{formatNumber(humanAmount, formatNumberOptions)}</span>
                         <Button
                           type="button"
                           isDisabled={isPending}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor number formatting logic to use total digits options, updating `formatNumber` and its usage across components and utilities.
> 
>   - **Behavior**:
>     - Refactor `formatNumber` in `formatters.ts` to use `minimumTotalDigits` and `maximumTotalDigits` instead of significant digits.
>     - Update `calculatePrice` in `dex.ts` to use `minimumTotalDigits`.
>     - Remove `formatCurrency` and `CurrencyFormatterOptions` from `formatters.ts`.
>   - **Components**:
>     - Update `ConvertForm`, `ConvertDetails`, and `ConvertContainer` in `applet.tsx` to use new `formatNumber` options.
>     - Modify `OrderRow` in `OrderBookOverview.tsx` to use `minimumTotalDigits`.
>     - Adjust `ProTradeOpenOrders` and `ProTradeOrdersHistory` in `ProTrade.tsx` to use new `formatNumber` options.
>     - Update `PoolLiquidityUserLiquidity` and `PoolLiquidityDeposit` in `PoolLiquidity.tsx` to use new `formatNumber` options.
>     - Change `AssetCard` in `AssetCard.tsx` to use `maximumTotalDigits`.
>     - Modify `ChartIQ` in `ChartIQ.tsx` to use `maximumTotalDigits` for formatting.
>     - Update `TransferApplet` in `_app.transfer.lazy.tsx` to use new `formatNumber` options.
>   - **Misc**:
>     - Update `Decimal` class in `decimal.ts` to include `round()` method.
>     - Increment `version` in `AppProvider.tsx` to 1.6 and update `formatNumberOptions` in settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ff2dbd5b66c44ec9812a558ab4abc9df111866ad. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->