### PR TITLE
feat(hyperlane): MockValidatorSet random Nonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,6 +5577,7 @@ dependencies = [
  "hyperlane-types",
  "identity",
  "k256",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -382,7 +382,7 @@ where
     // Create the mock validator sets.
     // TODO: For now, we always use the preset mock. It may not match the ones
     // in the genesis state. We should generate this based on the `genesis_opt`.
-    let validator_sets = MockValidatorSets::new_preset();
+    let validator_sets = MockValidatorSets::new_preset(false);
 
     for op in (test_opt.bridge_ops)(&accounts) {
         match op.remote {

--- a/dango/testing/tests/gateway.rs
+++ b/dango/testing/tests/gateway.rs
@@ -321,7 +321,7 @@ fn native_denom() {
 
     // Register the validator set for the remote domain.
     {
-        let validator_set = MockValidatorSet::new_preset(remote_domain);
+        let validator_set = MockValidatorSet::new_preset(remote_domain, false);
 
         suite
             .execute(

--- a/hyperlane/testing/Cargo.toml
+++ b/hyperlane/testing/Cargo.toml
@@ -16,3 +16,4 @@ hex-literal     = { workspace = true }
 hyperlane-types = { workspace = true }
 identity        = { workspace = true }
 k256            = { workspace = true }
+rand            = { workspace = true }

--- a/hyperlane/testing/src/mock_validator_set.rs
+++ b/hyperlane/testing/src/mock_validator_set.rs
@@ -50,7 +50,8 @@ impl Nonce {
         }
     }
 
-    pub fn increment(&mut self) -> u32 {
+    /// Get the next nonce.
+    pub fn next(&mut self) -> u32 {
         match self {
             Self::Random => rand::thread_rng().gen(),
             Self::Sequential(nonce) => {
@@ -182,8 +183,8 @@ impl MockValidatorSet {
             // syntax look cleaner.
             let (merkle_tree, nonce) = &mut *guard;
 
-            // Increment the nonce.
-            let next_nonce = nonce.increment();
+            // Get the next nonce.
+            let next_nonce = nonce.next();
 
             // Compose the Hyperlane message and encode it to raw bytes.
             let raw_message = mailbox::Message {

--- a/hyperlane/testing/src/mock_validator_set.rs
+++ b/hyperlane/testing/src/mock_validator_set.rs
@@ -10,19 +10,20 @@ use {
         multisig_hash,
     },
     k256::ecdsa::SigningKey,
+    rand::Rng,
     std::collections::{BTreeSet, HashMap},
 };
 
 pub struct MockValidatorSets(HashMap<Domain, MockValidatorSet>);
 
 impl MockValidatorSets {
-    pub fn new_preset() -> Self {
+    pub fn new_preset(random_nonce: bool) -> Self {
         Self(hash_map! {
-            arbitrum::DOMAIN => MockValidatorSet::new_preset(arbitrum::DOMAIN),
-            base::DOMAIN     => MockValidatorSet::new_preset(base::DOMAIN),
-            ethereum::DOMAIN => MockValidatorSet::new_preset(ethereum::DOMAIN),
-            optimism::DOMAIN => MockValidatorSet::new_preset(optimism::DOMAIN),
-            solana::DOMAIN   => MockValidatorSet::new_preset(solana::DOMAIN),
+            arbitrum::DOMAIN => MockValidatorSet::new_preset(arbitrum::DOMAIN, random_nonce),
+            base::DOMAIN     => MockValidatorSet::new_preset(base::DOMAIN, random_nonce),
+            ethereum::DOMAIN => MockValidatorSet::new_preset(ethereum::DOMAIN, random_nonce),
+            optimism::DOMAIN => MockValidatorSet::new_preset(optimism::DOMAIN, random_nonce),
+            solana::DOMAIN   => MockValidatorSet::new_preset(solana::DOMAIN, random_nonce),
         })
     }
 
@@ -35,19 +36,48 @@ impl MockValidatorSets {
     }
 }
 
+pub enum Nonce {
+    Random,
+    Sequential(u32),
+}
+
+impl Nonce {
+    pub fn new(random_nonce: bool) -> Self {
+        if random_nonce {
+            Self::Random
+        } else {
+            Self::Sequential(0)
+        }
+    }
+
+    pub fn increment(&mut self) -> u32 {
+        match self {
+            Self::Random => rand::thread_rng().gen(),
+            Self::Sequential(nonce) => {
+                *nonce += 1;
+                *nonce
+            },
+        }
+    }
+}
 /// A mock up Hyperlane validator set for testing purpose.
 #[derive(Clone)]
 pub struct MockValidatorSet {
     domain: Domain,
     validators: Vec<k256::ecdsa::SigningKey>,
     merkle_tree_address: Addr32,
-    merkle_tree_and_nonce: Shared<(IncrementalMerkleTree, u32)>,
+    merkle_tree_and_nonce: Shared<(IncrementalMerkleTree, Nonce)>,
 }
 
 impl MockValidatorSet {
     /// Create new a mock validator set of a domain with the given validators
     /// signing keys.
-    pub fn new<I>(domain: Domain, merkle_tree_address: Addr32, signing_keys: I) -> Self
+    pub fn new<I>(
+        domain: Domain,
+        merkle_tree_address: Addr32,
+        signing_keys: I,
+        random_nonce: bool,
+    ) -> Self
     where
         I: IntoIterator<Item = eth_utils::SigningKey>,
     {
@@ -62,16 +92,20 @@ impl MockValidatorSet {
             domain,
             validators,
             merkle_tree_address,
-            merkle_tree_and_nonce: Shared::new((IncrementalMerkleTree::default(), 0)),
+            merkle_tree_and_nonce: Shared::new((
+                IncrementalMerkleTree::default(),
+                Nonce::new(random_nonce),
+            )),
         }
     }
 
     /// Create a new mock validator set of a domain with a preset validator set.
-    pub fn new_preset(domain: Domain) -> Self {
+    pub fn new_preset(domain: Domain, random_nonce: bool) -> Self {
         Self::new(
             domain,
             MOCK_HYPERLANE_REMOTE_MERKLE_TREE,
             MOCK_HYPERLANE_VALIDATOR_SIGNING_KEYS,
+            random_nonce,
         )
     }
 
@@ -149,12 +183,12 @@ impl MockValidatorSet {
             let (merkle_tree, nonce) = &mut *guard;
 
             // Increment the nonce.
-            *nonce += 1;
+            let next_nonce = nonce.increment();
 
             // Compose the Hyperlane message and encode it to raw bytes.
             let raw_message = mailbox::Message {
                 version: MAILBOX_VERSION,
-                nonce: *nonce,
+                nonce: next_nonce,
                 origin_domain: self.domain,
                 sender,
                 destination_domain,

--- a/hyperlane/testing/src/mock_validator_set.rs
+++ b/hyperlane/testing/src/mock_validator_set.rs
@@ -51,7 +51,7 @@ impl Nonce {
     }
 
     /// Get the next nonce.
-    pub fn next(&mut self) -> u32 {
+    pub fn next_nonce(&mut self) -> u32 {
         match self {
             Self::Random => rand::thread_rng().gen(),
             Self::Sequential(nonce) => {
@@ -184,7 +184,7 @@ impl MockValidatorSet {
             let (merkle_tree, nonce) = &mut *guard;
 
             // Get the next nonce.
-            let next_nonce = nonce.next();
+            let next_nonce = nonce.next_nonce();
 
             // Compose the Hyperlane message and encode it to raw bytes.
             let raw_message = mailbox::Message {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add random nonce support to `MockValidatorSet` in Hyperlane testing framework, updating setup and tests accordingly.
> 
>   - **Behavior**:
>     - `MockValidatorSet` now supports random nonces via a new `Nonce` enum in `mock_validator_set.rs`.
>     - `MockValidatorSets::new_preset()` and `MockValidatorSet::new_preset()` updated to accept a `random_nonce` boolean parameter.
>     - `Nonce::next_nonce()` generates a random nonce if `Nonce::Random` is used.
>   - **Dependencies**:
>     - Added `rand` crate to `Cargo.toml` and `Cargo.lock` for random number generation.
>   - **Tests**:
>     - Updated `setup_test()` and `native_denom()` in `gateway.rs` to use `MockValidatorSet::new_preset()` with `random_nonce` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for ebb90f2c9d1e02ae464c655cce517c92e4b8ac18. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->