### PR TITLE
dex: add more duration metrics

### DIFF
--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -13,19 +13,21 @@ pub const LABEL_VOLUME_PER_TRADE: &str = "dango.contract.dex.volume_per_trade";
 
 pub const LABEL_VOLUME_PER_BLOCK: &str = "dango.contract.dex.volume_per_block";
 
-pub const LABEL_DURATION_AUCTION: &str = "dango.contract.dex.duration.auction";
+pub const LABEL_DURATION_AUCTION: &str = "dango.contract.dex.auction.duration";
 
-pub const LABEL_DURATION_REFLECT_CURVE: &str = "dango.contract.dex.duration.reflect_curve";
+pub const LABEL_DURATION_REFLECT_CURVE: &str = "dango.contract.dex.reflect_curve.duration";
 
-pub const LABEL_DURATION_ORDER_MATCHING: &str = "dango.contract.dex.duration.order_matching";
+pub const LABEL_DURATION_ORDER_MATCHING: &str = "dango.contract.dex.order_matching.duration";
 
-pub const LABEL_DURATION_ORDER_FILLING: &str = "dango.contract.dex.duration.order_filling";
+pub const LABEL_DURATION_ORDER_FILLING: &str = "dango.contract.dex.order_filling.duration";
 
-pub const LABEL_DURATION_HANDLE_FILLED: &str = "dango.contract.dex.duration.handle_filled";
+pub const LABEL_DURATION_HANDLE_FILLED: &str = "dango.contract.dex.handle_filled.duration";
 
-pub const LABEL_DURATION_CANCEL_IOC: &str = "dango.contract.dex.duration.cancel_ioc";
+pub const LABEL_DURATION_CANCEL_IOC: &str = "dango.contract.dex.cancel_ioc.duration";
 
-pub const LABEL_DURATION_UPDATE_REST_STATE: &str = "dango.contract.dex.duration.update_rest_state";
+pub const LABEL_DURATION_UPDATE_REST_STATE: &str = "dango.contract.dex.update_rest_state.duration";
+
+pub const LABEL_DURATION_STORE_VOLUME: &str = "dango.contract.dex.store_volume.duration";
 
 pub fn init_metrics() {
     static ONCE: Once = Once::new();
@@ -64,7 +66,7 @@ pub fn init_metrics() {
         );
 
         describe_histogram!(
-            LABEL_DURATION_HANDLE_FILLED,
+            LABEL_DURATION_CANCEL_IOC,
             "Time spent on canceling IOC orders"
         );
 
@@ -72,5 +74,7 @@ pub fn init_metrics() {
             LABEL_DURATION_UPDATE_REST_STATE,
             "Time spent on updating the resting order book state"
         );
+
+        describe_histogram!(LABEL_DURATION_STORE_VOLUME, "Time spent on storing volume");
     });
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add new duration metrics for various auction stages in DEX, enhancing performance monitoring.
> 
>   - **Metrics**:
>     - Add new duration metrics in `cron.rs` for various auction stages: `LABEL_DURATION_REFLECT_CURVE`, `LABEL_DURATION_ORDER_MATCHING`, `LABEL_DURATION_ORDER_FILLING`, `LABEL_DURATION_HANDLE_FILLED`, `LABEL_DURATION_CANCEL_IOC`, `LABEL_DURATION_UPDATE_REST_STATE`, and `LABEL_DURATION_STORE_VOLUME`.
>     - Record these metrics at appropriate points in `clear_orders_of_pair()` and `auction()` functions.
>   - **Metrics Initialization**:
>     - Update `init_metrics()` in `metrics.rs` to describe new duration metrics.
>   - **Renames**:
>     - Rename `LABEL_AUCTION_DURATION` to `LABEL_DURATION_AUCTION` in `metrics.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 8883d9d14a4f2dbabe806fdaa4864a34347b7c47. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->