### PR TITLE
ci: improve workflow jobs naming

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -228,7 +228,7 @@ jobs:
           # when needing to try on all runner types
           # - [self-hosted, Linux]
           # - [self-hosted, macOS]
-    name: Build ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}
+    name: Build backend for ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}
     runs-on: ${{ matrix.runner }}
     needs: [backend-test]
     permissions:
@@ -407,7 +407,7 @@ jobs:
           # NOTE: building arm on `self-hosted` is very very slow
           - arch: arm64
             runner: ubuntu-24.04-arm
-    name: Build ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}
+    name: Build frontend for ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}
     runs-on: ${{ matrix.runner }}
     env:
       GITHUB_USER: ${{ github.actor }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames workflow job names in `rust.yml` for backend and frontend builds for clarity.
> 
>   - **Workflow Jobs Naming**:
>     - Renames job `Build ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}` to `Build backend for ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}` in `backend-build`.
>     - Renames job `Build ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}` to `Build frontend for ${{ matrix.arch }} on ${{ join(matrix.runner, ', ') }}` in `frontend-build`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b73603f8a3af54e5432c65a4f4117edfe1e0811f. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->