### PR TITLE
force test to use 4 threads

### DIFF
--- a/pyth/client/tests/client.rs
+++ b/pyth/client/tests/client.rs
@@ -55,7 +55,7 @@ async fn test_lazer_stream() {
 // - Wait for a few seconds to allow the client to reconnect.
 // - Ensure the client has reconnected multiple times;
 // - Ensure there are some data in the stream.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn reconnection() {
     setup_tracing_subscriber(Level::DEBUG);
 
@@ -131,9 +131,6 @@ async fn reconnection() {
             assert!(data.is_some(), "Expected some data from the stream")
         }
     }
-
-    // Assert there is at lest one message in the stream.
-    // assert!(stream.try_next().await.is_some());
 }
 
 #[derive(Clone)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `reconnection` test in `client.rs` to use 4 threads.
> 
>   - **Tests**:
>     - Modify `reconnection` test in `client.rs` to use 4 threads by adding `worker_threads = 4` to `#[tokio::test]` attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for d538c11c782faab8ef15101331610016cf15fad1. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->