### PR TITLE
use `RustVm` instead of `HybridVm` in dango-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,7 @@ dependencies = [
  "grug-httpd",
  "grug-types",
  "grug-vm-hybrid",
+ "grug-vm-rust",
  "hex",
  "home",
  "indexer-hooked",

--- a/dango/cli/Cargo.toml
+++ b/dango/cli/Cargo.toml
@@ -12,6 +12,8 @@ version       = { workspace = true }
 [features]
 default = []
 testing = ["pyth-client", "pyth-types", "tokio-stream"]
+# Enable wasm smart contracts by using the `HybridVm`. If disabled, the `RustVm` is used.
+wasm = ["dango-genesis", "grug-vm-hybrid"]
 
 [dependencies]
 anyhow                      = { workspace = true }
@@ -21,7 +23,7 @@ colored                     = { workspace = true }
 colored_json                = { workspace = true }
 config-parser               = { workspace = true }
 dango-client                = { workspace = true }
-dango-genesis               = { workspace = true, features = ["metrics"] }
+dango-genesis               = { workspace = true, features = ["metrics"], optional = true }
 dango-httpd                 = { workspace = true, features = ["metrics"] }
 dango-indexer-clickhouse    = { workspace = true, features = ["async-graphql", "metrics", "tracing"] }
 dango-indexer-sql           = { workspace = true, features = ["async-graphql", "metrics", "tracing"] }
@@ -35,7 +37,8 @@ grug-client                 = { workspace = true }
 grug-db-disk-lite           = { workspace = true }
 grug-httpd                  = { workspace = true }
 grug-types                  = { workspace = true }
-grug-vm-hybrid              = { workspace = true }
+grug-vm-hybrid              = { workspace = true, optional = true }
+grug-vm-rust                = { workspace = true }
 hex                         = { workspace = true }
 home                        = { workspace = true }
 indexer-hooked              = { workspace = true, features = ["metrics", "tracing"] }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch `dango-cli` to use `RustVm` by default, with `HybridVm` used only when `wasm` feature is enabled.
> 
>   - **Behavior**:
>     - Default VM changed to `RustVm` in `start.rs` when `wasm` feature is not enabled.
>     - `HybridVm` used only when `wasm` feature is enabled.
>   - **Configuration**:
>     - Added `grug-vm-rust` to dependencies in `Cargo.toml`.
>     - Made `grug-vm-hybrid` optional in `Cargo.toml`.
>     - Added `wasm` feature in `Cargo.toml` to toggle between `RustVm` and `HybridVm`.
>   - **Code Changes**:
>     - Conditional imports and VM initialization in `start.rs` based on `wasm` feature.
>     - Updated `setup_indexer_stack` and `run_with_indexer` functions to be generic over VM type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for d3c8a770d21ba0815f5650d60fea0058aa1170f5. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->