### PR TITLE
fix(ui): setting migrations

### DIFF
--- a/ui/foundation/react/providers/AppProvider.tsx
+++ b/ui/foundation/react/providers/AppProvider.tsx
@@ -87,6 +87,11 @@ export const AppProvider: React.FC<PropsWithChildren<AppProviderProps>> = ({
         return state;
       },
       1.5: (state: AppState["settings"]) => {
+        state.showWelcome = Object.hasOwn(state, "showWelcome") ? state.showWelcome : true;
+        state.chart = state.chart || "tradingview";
+        state.timeFormat = state.timeFormat || "hh:mm a";
+        state.dateFormat = state.dateFormat || "MM/dd/yyyy";
+        state.timeZone = state.timeZone || "local";
         state.formatNumberOptions = {
           mask: state.formatNumberOptions.mask,
           maximumTotalDigits: 8,

--- a/ui/portal/web/src/components/dex/OrderBookOverview.tsx
+++ b/ui/portal/web/src/components/dex/OrderBookOverview.tsx
@@ -169,7 +169,7 @@ const OrderBook: React.FC<OrderBookOverviewProps> = ({ state }) => {
       </div>
       <div className="flex gap-2 lg:flex-col items-start justify-center w-full tabular-nums lining-nums">
         <div className="asks-container flex flex-1 flex-col w-full gap-1">
-          {asks.records.map((ask) => (
+          {[...asks.records].reverse().map((ask) => (
             <OrderRow key={`ask-${ask.price}`} type="ask" {...ask} max={asks.total} />
           ))}
         </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set default app settings, reverse ask records order, and add direction-based sorting in liquidity depth mapping.
> 
>   - **AppProvider.tsx**:
>     - Set default values for `showWelcome`, `chart`, `timeFormat`, `dateFormat`, and `timeZone` in settings migration 1.5.
>   - **OrderBookOverview.tsx**:
>     - Reverse order of `asks.records` in `OrderBook` component.
>   - **useLiquidityDepthState.ts**:
>     - Add `direction` parameter to `liquidityDepthMapper` for sorting records based on `Direction.Buy` or `Direction.Sell`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 66fe62805932383156d463dd9f9392c4f00a9f4e. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->