### PR TITLE
add iteration order to DB iterator metric

### DIFF
--- a/grug/types/src/db.rs
+++ b/grug/types/src/db.rs
@@ -62,6 +62,15 @@ pub enum Order {
     Descending = 2,
 }
 
+impl Order {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Order::Ascending => "ascending",
+            Order::Descending => "descending",
+        }
+    }
+}
+
 // We need to convert Order into a primitive type such as `i32` so that it can
 // be passed over FFI.
 impl From<Order> for i32 {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add iteration order to database iterator metrics in `cron.rs` and update `Order` enum in `db.rs` to support this.
> 
>   - **Metrics**:
>     - Add `iteration_order` parameter to `with_metrics` in `cron.rs` to track iteration order in metrics.
>     - Update `MetricsIter` in `cron.rs` to include `iteration_order`.
>     - Add `as_str()` method to `Order` enum in `db.rs` to convert order to string for metrics.
>   - **Behavior**:
>     - Update calls to `with_metrics` in `clear_orders_of_pair` in `cron.rs` to include `IterationOrder`.
>     - Modify `MetricsIterExt` trait in `cron.rs` to accept `iteration_order`.
>   - **Misc**:
>     - Minor refactoring in `cron.rs` to support new metrics functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 489cce327731603ba18f42607db39be842179d7e. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->