### PR TITLE
fix(ui): account menu styles

### DIFF
--- a/ui/foundation/react/index.ts
+++ b/ui/foundation/react/index.ts
@@ -47,7 +47,7 @@ export {
   type CreateContextReturn,
 } from "./utils/context.js";
 
-export { formatDate } from "./utils/dates.js";
+export { formatDate, formatActivityTimestamp } from "./utils/dates.js";
 export { twMerge } from "./utils/twMerge.js";
 export { mergeRefs } from "./utils/mergeRefs.js";
 export { forwardRefPolymorphic } from "./utils/polymorph.js";

--- a/ui/foundation/react/utils/dates.ts
+++ b/ui/foundation/react/utils/dates.ts
@@ -1,4 +1,10 @@
-import { format } from "date-fns";
+import {
+  differenceInDays,
+  differenceInHours,
+  differenceInMinutes,
+  format,
+  isToday,
+} from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 
 import type { DateArg, FormatOptions } from "date-fns";
@@ -24,3 +30,29 @@ export function formatDate(
 
   return format(date, mask, formatOptions);
 }
+
+export const formatActivityTimestamp = (timestamp: Date, mask: string): string => {
+  const now = new Date();
+  if (isToday(timestamp)) {
+    const minutesDifference = differenceInMinutes(now, timestamp);
+    if (minutesDifference < 1) {
+      return "1m";
+    }
+
+    if (minutesDifference < 60) {
+      return `${minutesDifference}m`;
+    }
+
+    const hoursDifference = differenceInHours(now, timestamp);
+    if (hoursDifference < 24) {
+      return `${hoursDifference}h`;
+    }
+  }
+
+  const daysDifference = differenceInDays(now, timestamp);
+  if (daysDifference === 1) {
+    return "1d";
+  }
+
+  return formatDate(timestamp, mask);
+};

--- a/ui/portal/web/src/components/activities/Activity.tsx
+++ b/ui/portal/web/src/components/activities/Activity.tsx
@@ -10,38 +10,10 @@ import {
 } from "react";
 import { useActivities } from "@left-curve/store";
 
-import { differenceInDays, differenceInHours, differenceInMinutes, isToday } from "date-fns";
-
-import { formatDate, IconClose, useApp } from "@left-curve/applets-kit";
+import { formatActivityTimestamp, IconClose, useApp } from "@left-curve/applets-kit";
 
 import type React from "react";
 import type { Activities, ActivityRecord } from "@left-curve/store";
-
-const formatActivityTimestamp = (timestamp: Date, mask: string): string => {
-  const now = new Date();
-  if (isToday(timestamp)) {
-    const minutesDifference = differenceInMinutes(now, timestamp);
-    if (minutesDifference < 1) {
-      return "1m";
-    }
-
-    if (minutesDifference < 60) {
-      return `${minutesDifference}m`;
-    }
-
-    const hoursDifference = differenceInHours(now, timestamp);
-    if (hoursDifference < 24) {
-      return `${hoursDifference}h`;
-    }
-  }
-
-  const daysDifference = differenceInDays(now, timestamp);
-  if (daysDifference === 1) {
-    return "1d";
-  }
-
-  return formatDate(timestamp, mask);
-};
 
 const activities: Record<
   keyof Activities,

--- a/ui/portal/web/src/components/activities/NewAccount.tsx
+++ b/ui/portal/web/src/components/activities/NewAccount.tsx
@@ -23,11 +23,11 @@ export const ActivityNewAccount = forwardRef<ActivityRef, ActivityAccountProps>(
 
     return (
       <div className="flex items-start gap-2 max-w-full overflow-hidden">
-        <div className="flex justify-center items-center bg-surface-primary-gray w-7 h-7 rounded-sm">
+        <div className="flex justify-center items-center bg-surface-primary-gray min-w-7 min-h-7 rounded-sm">
           <IconNewAccount className="text-brand-green h-4 w-4" />
         </div>
         <div className="flex flex-col max-w-[calc(100%)] overflow-hidden">
-          <div className="flex justify-center items-center gap-2 diatype-m-medium text-ink-secondary-700 capitalize">
+          <div className="flex justify-start items-center gap-2 diatype-m-medium text-ink-secondary-700 capitalize">
             <p>{m["activities.activity.account.title"]()}</p>
             <Badge className="capitalize" text={accountType} />
           </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `formatActivityTimestamp` to a utility function and adjust styles in `NewAccount.tsx`.
> 
>   - **Refactoring**:
>     - Extract `formatActivityTimestamp` to `utils/dates.ts` from `Activity.tsx`.
>     - Update `index.ts` to export `formatActivityTimestamp`.
>   - **UI Styles**:
>     - Adjust `NewAccount.tsx` styles: change `w-7 h-7` to `min-w-7 min-h-7` and `justify-center` to `justify-start`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b8858ef6f54a8bf5ecd502789292b01fdb9db89b. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->