### PR TITLE
dex: `match_orders` function to take ownership of the iterators

### DIFF
--- a/dango/dex/src/core/order_matching.rs
+++ b/dango/dex/src/core/order_matching.rs
@@ -29,7 +29,7 @@ pub struct MatchingOutcome {
 ///   for orders the same price, the oldest one first.
 /// - `ask_iter`: An iterator over the SELL orders in the book that similarly
 ///   follows the price-time priority.
-pub fn match_orders<B, A>(bid_iter: &mut B, ask_iter: &mut A) -> StdResult<MatchingOutcome>
+pub fn match_orders<B, A>(mut bid_iter: B, mut ask_iter: A) -> StdResult<MatchingOutcome>
 where
     B: Iterator<Item = StdResult<Order>>,
     A: Iterator<Item = StdResult<Order>>,

--- a/dango/dex/src/cron.rs
+++ b/dango/dex/src/cron.rs
@@ -345,12 +345,12 @@ fn clear_orders_of_pair(
     //
     // Iterate BUY orders from the highest price to the lowest.
     // Iterate SELL orders from the lowest price to the highest.
-    let mut bid_iter = ORDERS
+    let bid_iter = ORDERS
         .prefix((base_denom.clone(), quote_denom.clone()))
         .append(Direction::Bid)
         .values(storage, None, None, IterationOrder::Descending)
         .with_metrics(&base_denom, &quote_denom, IterationOrder::Descending);
-    let mut ask_iter = ORDERS
+    let ask_iter = ORDERS
         .prefix((base_denom.clone(), quote_denom.clone()))
         .append(Direction::Ask)
         .values(storage, None, None, IterationOrder::Ascending)
@@ -362,13 +362,7 @@ fn clear_orders_of_pair(
         volume,
         bids,
         asks,
-    } = match_orders(&mut bid_iter, &mut ask_iter)?;
-
-    // Drop the iterators, which hold immutable references to the storage,
-    // so that we can write to storage later.
-    // The Rust compiler isn't smart enough to do this on its own.
-    drop(bid_iter);
-    drop(ask_iter);
+    } = match_orders(bid_iter, ask_iter)?;
 
     #[cfg(feature = "tracing")]
     {


### PR DESCRIPTION
This isn't a vulnerability nor affects performance in any way. Just make the code a little more concise.

We don't use the `bid_iter`/`ask_iter` iterators anywhere else other than in the `match_orders` function, so we can just give the function their ownership, instead of just giving references and having to `drop` them manually later.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `match_orders` now takes ownership of iterators, simplifying code by removing manual `drop` in `cron.rs`.
> 
>   - **Function Signature Change**:
>     - `match_orders` in `order_matching.rs` now takes ownership of `bid_iter` and `ask_iter` instead of mutable references.
>   - **Code Simplification**:
>     - Removed manual `drop` of `bid_iter` and `ask_iter` in `clear_orders_of_pair` in `cron.rs`.
>     - Updated calls to `match_orders` in `cron.rs` to pass iterators by value instead of reference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for a3638d23721c5d45c17a5eb9fea0c399268e9b6f. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->