### PR TITLE
fix pyth version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7595,9 +7595,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "8.0.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c9f6a5834d47ee4c400eaaaf971cb4f8fe5304e746216ed9282809f9ce8815"
+checksum = "44bda75272a21bc3250bed6e950c4b1342cc2841e6e0d7f65632a8966c96e7d7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7622,9 +7622,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d91dc5606c70529bf14769034738bc8773d359b4313be3c44449dd3b442096d"
+checksum = "409449853d2d574fbc24788fc334f1f6d65fbd2d98136ce5619ef30042af7269"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,8 @@ proc-macro2                 = "1"
 prometheus                  = "0.13"
 proptest                    = "1"
 prost                       = "0.13"
-pyth-lazer-client           = "8"
-pyth-lazer-protocol         = "0.15"
+pyth-lazer-client           = "8.2.0"
+pyth-lazer-protocol         = "0.16.0"
 quote                       = "1"
 rand                        = "0.8" # can't use 0.9 because RustCrypto libraries still depend on 0.8
 reqwest                     = { version = "0.12", features = ["stream"] }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `pyth-lazer-client` to `8.2.0` and `pyth-lazer-protocol` to `0.16.0` in `Cargo.lock` and `Cargo.toml`.
> 
>   - **Dependencies**:
>     - Update `pyth-lazer-client` version from `8.0.1` to `8.2.0` in `Cargo.lock` and `Cargo.toml`.
>     - Update `pyth-lazer-protocol` version from `0.15.1` to `0.16.0` in `Cargo.lock` and `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 34cb7a965bb3b400978918accd9d78cbdf452997. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->