### PR TITLE
fix count metrics

### DIFF
--- a/pyth/types/src/metrics.rs
+++ b/pyth/types/src/metrics.rs
@@ -7,5 +7,8 @@ pub const PYTH_UPTIME: &str = "pyth.lazer.uptime";
 /// Number of reconnection attempts made to Pyth Lazer.
 pub const PYTH_RECONNECTION_ATTEMPTS: &str = "pyth.lazer.reconnection_attempts";
 
-/// Number of data messages received from Pyth Lazer.
-pub const PYTH_DATA_RECEIVED: &str = "pyth.lazer.data_received";
+/// Number of messages received from Pyth Lazer.
+pub const PYTH_MESSAGES_RECEIVED: &str = "pyth.lazer.messages_received";
+
+/// Number of times data was read from Pyth Lazer.
+pub const PYTH_DATA_READ: &str = "pyth.lazer.data_read";

--- a/pyth/types/src/metrics.rs
+++ b/pyth/types/src/metrics.rs
@@ -11,4 +11,4 @@ pub const PYTH_RECONNECTION_ATTEMPTS: &str = "pyth.lazer.reconnection_attempts";
 pub const PYTH_MESSAGES_RECEIVED: &str = "pyth.lazer.messages_received";
 
 /// Number of times data was read from Pyth Lazer.
-pub const PYTH_DATA_READ: &str = "pyth.lazer.data_read";
+pub const PYTH_DATA_READ: &str = "pyth.lazer.data_read.count";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix and update metrics in Pyth client by replacing a histogram with a counter and renaming metrics for clarity.
> 
>   - **Metrics Update**:
>     - In `client.rs`, replace `PYTH_DATA_RECEIVED` histogram with `PYTH_DATA_READ` counter to track data read events.
>     - Add `PYTH_MESSAGES_RECEIVED` histogram to record the number of messages received.
>     - Update `init_metrics()` in `client.rs` to describe new metrics.
>   - **Renames**:
>     - Rename `PYTH_DATA_RECEIVED` to `PYTH_MESSAGES_RECEIVED` in `metrics.rs`.
>     - Add `PYTH_DATA_READ` constant in `metrics.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for b1897586d4538da9fe47820cf042e0ad41591407. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->