### PR TITLE
refractor(infra): Genesis use Gemoetric instead Xyk

### DIFF
--- a/deploy/roles/full-app/templates/config/cometbft/genesis.json
+++ b/deploy/roles/full-app/templates/config/cometbft/genesis.json
@@ -309,13 +309,13 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               },
@@ -333,13 +333,13 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               },
@@ -357,13 +357,13 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               },
@@ -379,13 +379,13 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               }

--- a/justfile
+++ b/justfile
@@ -61,9 +61,7 @@ book:
 update-genesis:
   cargo run -p dango-scripts --example build_genesis -- \
     networks/localdango/configs/cometbft/config/genesis.json \
-    deploy/roles/cometbft/templates/devnet/config/genesis.json \
-    deploy/roles/cometbft/templates/testnet/config/genesis.json \
-    deploy/roles/full-app/templates/devnet/config/cometbft/genesis.json
+    deploy/roles/full-app/templates/config/cometbft/genesis.json
 
 # Update wasm artifacts used in tests
 update-testdata:

--- a/networks/localdango/configs/cometbft/config/genesis.json
+++ b/networks/localdango/configs/cometbft/config/genesis.json
@@ -309,13 +309,13 @@
                   "lp_denom": "dex/pool/dango/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               },
@@ -333,13 +333,13 @@
                   "lp_denom": "dex/pool/btc/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               },
@@ -357,13 +357,13 @@
                   "lp_denom": "dex/pool/eth/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               },
@@ -379,13 +379,13 @@
                   "lp_denom": "dex/pool/sol/usdc",
                   "min_order_size": "0",
                   "pool_type": {
-                    "xyk": {
-                      "limit": 30,
-                      "reserve_ratio": "0",
-                      "spacing": "1"
+                    "geometric": {
+                      "limit": 1,
+                      "ratio": "1",
+                      "spacing": "0.0001"
                     }
                   },
-                  "swap_fee_rate": "0.003"
+                  "swap_fee_rate": "0.0001"
                 },
                 "quote_denom": "bridge/usdc"
               }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch DEX liquidity pool type from `xyk` to `geometric` and adjust swap fee rate in genesis configuration.
> 
>   - **Behavior**:
>     - Change liquidity pool type from `xyk` to `geometric` in `build_genesis.rs` and `genesis.json` files.
>     - Adjust swap fee rate from `0.003` to `0.0001` in `genesis.json` files.
>   - **Configuration**:
>     - Update `build_genesis.rs` to use `Geometric` pool type with specific parameters for `dango`, `btc`, `eth`, and `sol` pairs.
>     - Modify `genesis.json` in `deploy/roles/full-app/templates/config/cometbft/` and `networks/localdango/configs/cometbft/config/` to reflect new pool type and fee rate.
>   - **Misc**:
>     - Update `justfile` to remove redundant paths in `update-genesis` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 68b7ab9b0c54d76383b405ca26f0fccf61352990. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->