### PR TITLE
fix: localdango CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -590,7 +590,7 @@ jobs:
           COMETBFT_TAG: v0.38.17
         run: |
           cd networks/localdango
-          docker compose down -v
+          docker compose --profile dango down -v
           docker compose --profile dango up -d --wait || {
             echo "Services failed to become healthy"
             docker compose ps
@@ -601,4 +601,4 @@ jobs:
         if: always()
         run: |
           cd networks/localdango
-          docker compose down -v || true
+          docker compose --profile dango down -v || true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `localdango` CI job in `rust.yml` to use `docker compose --profile dango` for service management.
> 
>   - **CI Workflow**:
>     - In `.github/workflows/rust.yml`, update `localdango` job to use `docker compose --profile dango` for both `down` and `up` commands.
>     - Ensures only `dango` profile services are managed during CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 8551ad76242555b90077e31f107d4d757d74c530. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->