### PR TITLE
Audit - Issue 6: Disallow minting of zero LP-tokens

### DIFF
--- a/dango/testing/tests/dex.rs
+++ b/dango/testing/tests/dex.rs
@@ -7618,23 +7618,3 @@ fn create_and_cancel_order_with_remainder() {
         usdc::DENOM.clone() => BalanceChange::Unchanged,
     });
 }
-
-#[test]
-fn cannot_mint_zero_lp_tokens() {
-    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
-
-    // Provide liquidity with zero amount of one side
-    suite
-        .execute(
-            &mut accounts.user1,
-            contracts.dex,
-            &dex::ExecuteMsg::ProvideLiquidity {
-                base_denom: dango::DENOM.clone(),
-                quote_denom: usdc::DENOM.clone(),
-            },
-            coins! {
-                dango::DENOM.clone() => 100_000,
-            },
-        )
-        .should_fail_with_error("lp mint amount must be non-zero");
-}

--- a/dango/testing/tests/dex_audit.rs
+++ b/dango/testing/tests/dex_audit.rs
@@ -211,3 +211,23 @@ fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
             },
         });
 }
+
+#[test]
+fn issue_6_cannot_mint_zero_lp_tokens() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
+
+    // Provide liquidity with zero amount of one side
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.dex,
+            &dex::ExecuteMsg::ProvideLiquidity {
+                base_denom: dango::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+            },
+            coins! {
+                dango::DENOM.clone() => 100_000,
+            },
+        )
+        .should_fail_with_error("lp mint amount must be non-zero");
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes vulnerability in `provide_liquidity()` to prevent minting zero LP tokens, with a new test case added.
> 
>   - **Behavior**:
>     - In `provide_liquidity()` in `execute.rs`, added check to ensure `lp_mint_amount` is non-zero to prevent zero LP token minting.
>     - Logs error "lp mint amount must be non-zero" if zero LP tokens would be minted.
>   - **Tests**:
>     - Added test `issue_6_cannot_mint_zero_lp_tokens()` in `dex_audit.rs` to verify that providing liquidity with zero amount of one side fails with the correct error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 10c097ca8f3dc0b65b1cfb554e4881a7d2e894ce. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->