### PR TITLE
Increase dex bot liquidity

### DIFF
--- a/deploy/group_vars/all/main.yml
+++ b/deploy/group_vars/all/main.yml
@@ -17,7 +17,7 @@ dango:
     minter_username: "user9"
     minter_address: "0x6f95c4f169f38f598dd571084daa5c799c5743de"
     minter_private_key: "c0d853951557d3bdec5add2ca8e03983fea2f50c6db0a45977990fb7b0c569b3"
-    mint_amount: 1000000
+    mint_amount: 1000000000
     liquidity_amount: 1000000000
 ports:
   dango_port: 8080

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -202,8 +202,8 @@ services:
       # Mandatory else fails with `file not found: /root/.dango-dex/config.json`
       app_settings__sleep__min: 1s
       app_settings__sleep__max: 2s
-      app_settings__size_percent__min: 0.5
-      app_settings__size_percent__max: 3.0
+      app_settings__size_percent__min: 0.0005
+      app_settings__size_percent__max: 0.003
       app_settings__price_percent__min: 0.05
       app_settings__price_percent__max: 0.2
       app_settings__order_number__min: 1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase dex bot liquidity by adjusting mint and liquidity amounts in `main.yml` and size percent settings in `docker-compose.yml`.
> 
>   - **Liquidity Increase**:
>     - In `main.yml`, `mint_amount` and `liquidity_amount` increased from `1000000` to `1000000000`.
>   - **Dex Bot Configuration**:
>     - In `docker-compose.yml`, `app_settings__size_percent__min` changed from `0.5` to `0.0005` and `app_settings__size_percent__max` from `3.0` to `0.003`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 2ea77adc0e1fca16539f6b8b7420b67453dc6088. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->