### PR TITLE
Issue 401 - fix: ceil input amount in geometric pool swap_exact_amount_out

### DIFF
--- a/dango/dex/src/core/geometric.rs
+++ b/dango/dex/src/core/geometric.rs
@@ -175,7 +175,7 @@ fn bid_exact_amount_out(
         input_amount.checked_add_assign(matched_amount_in_quote)?;
 
         if remaining_bid.is_zero() || matched_amount_in_quote.is_zero() {
-            return Ok(input_amount.into_int());
+            return Ok(input_amount.into_int_ceil());
         }
     }
 
@@ -201,7 +201,7 @@ fn ask_exact_amount_out(
             || remaining_ask.is_zero()
             || matched_amount_in_quote.is_zero()
         {
-            return Ok(input_amount.into_int());
+            return Ok(input_amount.into_int_ceil());
         }
     }
 

--- a/dango/dex/src/core/liquidity_pool.rs
+++ b/dango/dex/src/core/liquidity_pool.rs
@@ -1135,10 +1135,10 @@ mod tests {
         },
         Udec128::new_percent(1),
         Coin::new(eth::DENOM.clone(), 4950495).unwrap(),
-        Coin::new(usdc::DENOM.clone(), 4999999).unwrap(),
+        Coin::new(usdc::DENOM.clone(), 5000000).unwrap(),
         coin_pair! {
             eth::DENOM.clone() => 10000000 - 4950495,
-            usdc::DENOM.clone() => 10000000 + 4999999,
+            usdc::DENOM.clone() => 10000000 + 5000000,
         };
         "geometric pool 1:1 price swap out base denom amount matches first order"
     )]
@@ -1166,10 +1166,10 @@ mod tests {
         },
         Udec128::new_percent(1),
         Coin::new(usdc::DENOM.clone(), 4_950_495 + 100_000).unwrap(),
-        Coin::new(eth::DENOM.clone(), 5_153_556).unwrap(),
+        Coin::new(eth::DENOM.clone(), 5_153_557).unwrap(),
         coin_pair! {
             usdc::DENOM.clone() => 10000000 - 4_950_495 - 100_000,
-            eth::DENOM.clone() => 10000000 + 5_153_556,
+            eth::DENOM.clone() => 10000000 + 5_153_557,
         };
         "geometric pool 1:1 price swap out quote denom amount matches first order part of second order"
     )]
@@ -1259,10 +1259,10 @@ mod tests {
         },
         Udec128::new_percent(1),
         Coin::new(usdc::DENOM.clone(), 5_000_000 + 100_000).unwrap(),
-        Coin::new(eth::DENOM.clone(), 2_525_252 + 67_568).unwrap(),
+        Coin::new(eth::DENOM.clone(), 2_525_252 + 67_569).unwrap(),
         coin_pair! {
             usdc::DENOM.clone() => 10000000 - 5_000_000 - 100_000,
-            eth::DENOM.clone() => 10000000 + 2_525_252 + 67_568,
+            eth::DENOM.clone() => 10000000 + 2_525_252 + 67_569,
         };
         "geometric pool 2:1 price swap out quote denom amount matches first and part of second order"
     )]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ceil input amounts in `swap_exact_amount_out` for geometric pools, updating related test cases.
> 
>   - **Behavior**:
>     - Change `input_amount.into_int()` to `input_amount.into_int_ceil()` in `bid_exact_amount_out()` and `ask_exact_amount_out()` in `geometric.rs` to ensure input amounts are ceiled.
>   - **Tests**:
>     - Update expected values in test cases in `liquidity_pool.rs` to reflect ceiled input amounts for geometric pool swaps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 1bf632bd8b2d0d25b987cf56b625acc2049844e5. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->