### PR TITLE
pyth: fix cargo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7609,9 +7609,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-client"
-version = "8.2.0"
+version = "8.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bda75272a21bc3250bed6e950c4b1342cc2841e6e0d7f65632a8966c96e7d7"
+checksum = "9a1c5d0599485cb55333dc8f4de88edc50681a67b49a53a4ab2288768e7ca850"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7636,9 +7636,9 @@ dependencies = [
 
 [[package]]
 name = "pyth-lazer-protocol"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409449853d2d574fbc24788fc334f1f6d65fbd2d98136ce5619ef30042af7269"
+checksum = "9f8609c264c03a18a07a2c0c57a4b38b6e7b141a4e3d41161e7ab5a455157ae8"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,8 +152,8 @@ proc-macro2                 = "1"
 prometheus                  = "0.13"
 proptest                    = "1"
 prost                       = "0.13"
-pyth-lazer-client           = "8.2.0"
-pyth-lazer-protocol         = "0.16.0"
+pyth-lazer-client           = "=8.4.1"
+pyth-lazer-protocol         = "=0.18.1"
 quote                       = "1"
 rand                        = "0.8" # can't use 0.9 because RustCrypto libraries still depend on 0.8
 reqwest                     = { version = "0.12", features = ["stream"] }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `pyth-lazer-client` to `8.4.1` and `pyth-lazer-protocol` to `0.18.1` in `Cargo.lock` and `Cargo.toml`.
> 
>   - **Dependencies**:
>     - Update `pyth-lazer-client` version from `8.2.0` to `8.4.1` in `Cargo.lock` and `Cargo.toml`.
>     - Update `pyth-lazer-protocol` version from `0.16.0` to `0.18.1` in `Cargo.lock` and `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for d3b13e33c8b9eae5ff9f149bd02fb3c046bd7ed8. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->