### PR TITLE
Add different tags for localdango

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -785,7 +785,8 @@ jobs:
       - name: Ensure localdango works
         if: env.BACKEND_CHANGED == 'true'
         env:
-          DANGO_TAG: ${{ env.GIT_COMMIT }}
+          DANGO_TAG: ${{ env.DEPLOY_BACKEND_IMAGE_TAG }}
+          FRONTEND_TAG: ${{ env.DEPLOY_FRONTEND_IMAGE_TAG }}
           POSTGRES_PORT: 0
           CLICKHOUSE_PORT: 0
           DANGO_PORT: 0

--- a/deploy/roles/full-app/tasks/github_main_deployments.yml
+++ b/deploy/roles/full-app/tasks/github_main_deployments.yml
@@ -72,6 +72,4 @@
     | **Dango GraphiQL** | [https://api-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}/graphiql](https://api-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}/graphiql) |
     | **Faucet bot** | [https://faucet-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}/mint](https://faucet-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}/mint) |
     | **Deployment name** | `{{ deployment_name }}` |
-    | **Docker backend tag** | `{{ dango_image_tag }}` |
-    | **Docker frontend tag** | `{{ frontend_image_tag }}` |
     EOF

--- a/deploy/roles/full-app/tasks/github_pr_deployments.yml
+++ b/deploy/roles/full-app/tasks/github_pr_deployments.yml
@@ -92,6 +92,4 @@
     | **CometBFT ABCI** | [http://{{ tailscale_ip }}:{{ cometbft_abci_port }}](http://{{ tailscale_ip }}:{{ cometbft_abci_port }}) |
     | **CometBFT Metrics** | [http://{{ tailscale_ip }}:{{ cometbft_metrics_port }}/metrics](http://{{ tailscale_ip }}:{{ cometbft_metrics_port }}/metrics) |
     | **Deployment name** | `{{ deployment_name }}` |
-    | **Docker backend tag** | `{{ dango_image_tag }}` |
-    | **Docker frontend tag** | `{{ frontend_image_tag }}` |
     EOF

--- a/networks/localdango/docker-compose.yml
+++ b/networks/localdango/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       retries: 3
 
   frontend:
-    image: ghcr.io/left-curve/left-curve/dango-frontend:${DANGO_TAG:-latest}
+    image: ghcr.io/left-curve/left-curve/dango-frontend:${FRONTEND_TAG:-latest}
     labels:
       <<: *common-labels
     ports:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update localdango deployment to use specific backend and frontend image tags and adjust deployment summaries.
> 
>   - **Environment Variables**:
>     - In `.github/workflows/rust.yml`, `DANGO_TAG` changed to `DEPLOY_BACKEND_IMAGE_TAG` and `FRONTEND_TAG` to `DEPLOY_FRONTEND_IMAGE_TAG`.
>   - **Deployment Configurations**:
>     - Removed Docker backend and frontend tag lines from `github_main_deployments.yml` and `github_pr_deployments.yml`.
>   - **Docker Compose**:
>     - In `docker-compose.yml`, `frontend` service image tag changed from `${DANGO_TAG}` to `${FRONTEND_TAG}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e2773ca27dfe6019c7e6f370c889529aff8a87d1. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->