### PR TITLE
feat: Add perps positions to margin account query_health

### DIFF
--- a/dango/perps/src/query.rs
+++ b/dango/perps/src/query.rs
@@ -184,6 +184,7 @@ fn query_perps_positions_for_user(
             entry_funding_index: perps_position.entry_funding_index,
             realized_pnl: perps_position.realized_pnl,
             size: perps_position.size,
+            current_fill_price: fill_price,
         });
     }
 
@@ -251,6 +252,7 @@ fn query_perps_positions(
             entry_funding_index: perps_position.entry_funding_index,
             realized_pnl: perps_position.realized_pnl,
             size: perps_position.size,
+            current_fill_price: fill_price,
         };
 
         result

--- a/dango/types/src/account/margin.rs
+++ b/dango/types/src/account/margin.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         auth::Nonce,
         dex::{OrderId, OrdersByUserResponse},
+        perps::{PerpsPositionResponse, PerpsVaultState},
     },
     grug::{Bounded, Coins, Denom, Udec128, Udec256, Uint128, ZeroExclusiveOneInclusive},
     std::collections::{BTreeMap, BTreeSet},
@@ -16,6 +17,8 @@ pub struct HealthData {
     pub scaled_debts: BTreeMap<Denom, Udec256>,
     pub collateral_balances: BTreeMap<Denom, Uint128>,
     pub limit_orders: BTreeMap<OrderId, OrdersByUserResponse>,
+    pub perps_positions: BTreeMap<Denom, PerpsPositionResponse>,
+    pub perps_vault_state: PerpsVaultState,
 }
 
 /// Output for computing a margin account's health.
@@ -38,6 +41,10 @@ pub struct HealthResponse {
     pub limit_order_collaterals: Coins,
     /// The coins that would be returned if the account's limit orders were to be filled.
     pub limit_order_outputs: Coins,
+    /// The total value of the margin account's debt from perps positions.
+    pub perps_debts: Udec128,
+    /// The total value of the margin account's collateral from perps positions.
+    pub perps_collaterals: Udec128,
 }
 
 #[grug::derive(Serde)]

--- a/dango/types/src/perps/perps_position.rs
+++ b/dango/types/src/perps/perps_position.rs
@@ -81,4 +81,6 @@ pub struct PerpsPositionResponse {
     pub realized_pnl: Pnl,
     /// The unrealized pnl of the position, if the whole position was closed now.
     pub unrealized_pnl: Pnl,
+    /// The current fill price if the whole position was closed now.
+    pub current_fill_price: Dec128,
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add perps positions to margin account health computation, updating `query_health`, `compute_health`, and tests.
> 
>   - **Behavior**:
>     - `query_health` in `core.rs` now queries perps positions and vault state.
>     - `compute_health` in `core.rs` includes perps positions in debt and collateral calculations.
>     - `PerpsPositionResponse` in `perps_position.rs` now includes `current_fill_price`.
>   - **Tests**:
>     - Added tests in `perps.rs` to verify perps positions are correctly included in health calculations.
>     - Tests ensure correct debt and collateral values for perps positions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 39b7b5774ad29002c50215ec3b2ef039973b0c6a. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->