### PR TITLE
test dex performance [DO NOT MERGE]

### DIFF
--- a/deploy/group_vars/all/main.yml
+++ b/deploy/group_vars/all/main.yml
@@ -25,6 +25,17 @@ dango:
     minter_private_key: "c0d853951557d3bdec5add2ca8e03983fea2f50c6db0a45977990fb7b0c569b3"
     mint_amount: 1000000000
     liquidity_amount: 1000000000
+
+    app_settings__sleep__min: 0s
+    app_settings__sleep__max: 0s
+    app_settings__size_percent__min: 0.005
+    app_settings__size_percent__max: 0.03
+    app_settings__price_percent__min: 0.05
+    app_settings__price_percent__max: 0.2
+    app_settings__order_number__min: 100
+    app_settings__order_number__max: 100
+    app_settings__order_type: market
+
 ports:
   dango_port: 8080
   dango_frontend_port: 8081
@@ -55,7 +66,6 @@ traefik:
       graphiql_port: 8056
       cometbft_p2p_port: 36656
       cometbft_rpc_port: 36657
-
 # in summary cometbft needs to expose:
 # 26656, to anyone
 # 26657, to tailscale

--- a/deploy/group_vars/all/main.yml
+++ b/deploy/group_vars/all/main.yml
@@ -26,16 +26,6 @@ dango:
     mint_amount: 1000000000
     liquidity_amount: 1000000000
 
-    app_settings__sleep__min: 0s
-    app_settings__sleep__max: 0s
-    app_settings__size_percent__min: 0.005
-    app_settings__size_percent__max: 0.03
-    app_settings__price_percent__min: 0.05
-    app_settings__price_percent__max: 0.2
-    app_settings__order_number__min: 100
-    app_settings__order_number__max: 100
-    app_settings__order_type: market
-
 ports:
   dango_port: 8080
   dango_frontend_port: 8081

--- a/deploy/roles/full-app/tasks/check_cometbft_sync.yml
+++ b/deploy/roles/full-app/tasks/check_cometbft_sync.yml
@@ -59,10 +59,10 @@
       indexed: {{ dango_up.json.indexed_block_height }}
       git: {{ dango_up.json.git_commit }}
 
-# - name: Assert indexing lag ≤ 3 blocks
-#   ansible.builtin.assert:
-#     that:
-#       - (dango_up.json.block.height | int) - (dango_up.json.indexed_block_height | int) <= 3
-#     fail_msg: >-
-#       Index lag too high: height={{ dango_up.json.block.height }},
-#       indexed={{ dango_up.json.indexed_block_height }}
+- name: Assert indexing lag ≤ 3 blocks
+  ansible.builtin.assert:
+    that:
+      - (dango_up.json.block.height | int) - (dango_up.json.indexed_block_height | int) <= 3
+    fail_msg: >-
+      Index lag too high: height={{ dango_up.json.block.height }},
+      indexed={{ dango_up.json.indexed_block_height }}

--- a/deploy/roles/full-app/tasks/check_cometbft_sync.yml
+++ b/deploy/roles/full-app/tasks/check_cometbft_sync.yml
@@ -59,10 +59,10 @@
       indexed: {{ dango_up.json.indexed_block_height }}
       git: {{ dango_up.json.git_commit }}
 
-- name: Assert indexing lag ≤ 3 blocks
-  ansible.builtin.assert:
-    that:
-      - (dango_up.json.block.height | int) - (dango_up.json.indexed_block_height | int) <= 3
-    fail_msg: >-
-      Index lag too high: height={{ dango_up.json.block.height }},
-      indexed={{ dango_up.json.indexed_block_height }}
+# - name: Assert indexing lag ≤ 3 blocks
+#   ansible.builtin.assert:
+#     that:
+#       - (dango_up.json.block.height | int) - (dango_up.json.indexed_block_height | int) <= 3
+#     fail_msg: >-
+#       Index lag too high: height={{ dango_up.json.block.height }},
+#       indexed={{ dango_up.json.indexed_block_height }}

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -261,14 +261,14 @@ services:
       http_url: "http://dango:8080"
       chain_id: ${CHAIN_ID}
       # Mandatory else fails with `file not found: /root/.dango-dex/config.json`
-      app_settings__sleep__min: 0s
-      app_settings__sleep__max: 0s
+      app_settings__sleep__min: 1s
+      app_settings__sleep__max: 1s
       app_settings__size_percent__min: "0.000005"
       app_settings__size_percent__max: "0.00003"
       app_settings__price_percent__min: 0.05
       app_settings__price_percent__max: 0.2
-      app_settings__order_number__min: 100
-      app_settings__order_number__max: 100
+      app_settings__order_number__min: 50
+      app_settings__order_number__max: 50
       app_settings__order_type: market
       app_settings__healthcheck_file: /tmp/dango_dex_app_healthcheck
     healthcheck:

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -263,8 +263,8 @@ services:
       # Mandatory else fails with `file not found: /root/.dango-dex/config.json`
       app_settings__sleep__min: 0s
       app_settings__sleep__max: 0s
-      app_settings__size_percent__min: 0.000005
-      app_settings__size_percent__max: 0.00003
+      app_settings__size_percent__min: "0.000005"
+      app_settings__size_percent__max: "0.00003"
       app_settings__price_percent__min: 0.05
       app_settings__price_percent__max: 0.2
       app_settings__order_number__min: 100

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -267,8 +267,8 @@ services:
       app_settings__size_percent__max: "0.00003"
       app_settings__price_percent__min: 0.05
       app_settings__price_percent__max: 0.2
-      app_settings__order_number__min: 50
-      app_settings__order_number__max: 50
+      app_settings__order_number__min: 100
+      app_settings__order_number__max: 100
       app_settings__order_type: market
       app_settings__healthcheck_file: /tmp/dango_dex_app_healthcheck
     healthcheck:

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -261,14 +261,14 @@ services:
       http_url: "http://dango:8080"
       chain_id: ${CHAIN_ID}
       # Mandatory else fails with `file not found: /root/.dango-dex/config.json`
-      app_settings__sleep__min: 1s
-      app_settings__sleep__max: 2s
-      app_settings__size_percent__min: 0.0005
-      app_settings__size_percent__max: 0.003
+      app_settings__sleep__min: 0s
+      app_settings__sleep__max: 0s
+      app_settings__size_percent__min: 0.000005
+      app_settings__size_percent__max: 0.00003
       app_settings__price_percent__min: 0.05
       app_settings__price_percent__max: 0.2
-      app_settings__order_number__min: 1
-      app_settings__order_number__max: 5
+      app_settings__order_number__min: 100
+      app_settings__order_number__max: 100
       app_settings__order_type: market
       app_settings__healthcheck_file: /tmp/dango_dex_app_healthcheck
     healthcheck:

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -261,8 +261,8 @@ services:
       http_url: "http://dango:8080"
       chain_id: ${CHAIN_ID}
       # Mandatory else fails with `file not found: /root/.dango-dex/config.json`
-      app_settings__sleep__min: 500ms
-      app_settings__sleep__max: 500ms
+      app_settings__sleep__min: 200ms
+      app_settings__sleep__max: 200ms
       app_settings__size_percent__min: "0.000005"
       app_settings__size_percent__max: "0.00003"
       app_settings__price_percent__min: 0.05

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -261,8 +261,8 @@ services:
       http_url: "http://dango:8080"
       chain_id: ${CHAIN_ID}
       # Mandatory else fails with `file not found: /root/.dango-dex/config.json`
-      app_settings__sleep__min: 200ms
-      app_settings__sleep__max: 200ms
+      app_settings__sleep__min: 1s
+      app_settings__sleep__max: 1s
       app_settings__size_percent__min: "0.000005"
       app_settings__size_percent__max: "0.00003"
       app_settings__price_percent__min: 0.05

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -261,8 +261,8 @@ services:
       http_url: "http://dango:8080"
       chain_id: ${CHAIN_ID}
       # Mandatory else fails with `file not found: /root/.dango-dex/config.json`
-      app_settings__sleep__min: 1s
-      app_settings__sleep__max: 1s
+      app_settings__sleep__min: 500ms
+      app_settings__sleep__max: 500ms
       app_settings__size_percent__min: "0.000005"
       app_settings__size_percent__max: "0.00003"
       app_settings__price_percent__min: 0.05

--- a/networks/localdango/docker-compose.yml
+++ b/networks/localdango/docker-compose.yml
@@ -150,8 +150,8 @@ services:
       minter_private_key: ${DEX_BOT_MINTER_PRIVATE_KEY}
       app_settings__sleep__min: 0s
       app_settings__sleep__max: 0s
-      app_settings__size_percent__min: 0.00005
-      app_settings__size_percent__max: 0.0003
+      app_settings__size_percent__min: "0.00005"
+      app_settings__size_percent__max: "0.0003"
       app_settings__price_percent__min: 0.05
       app_settings__price_percent__max: 0.2
       app_settings__order_number__min: 100

--- a/networks/localdango/docker-compose.yml
+++ b/networks/localdango/docker-compose.yml
@@ -148,14 +148,14 @@ services:
       minter_address: ${DEX_BOT_MINTER_ADDRESS}
       minter_username: ${DEX_BOT_MINTER_USERNAME}
       minter_private_key: ${DEX_BOT_MINTER_PRIVATE_KEY}
-      app_settings__sleep__min: 1s
-      app_settings__sleep__max: 2s
-      app_settings__size_percent__min: 0.0005
-      app_settings__size_percent__max: 0.003
+      app_settings__sleep__min: 0s
+      app_settings__sleep__max: 0s
+      app_settings__size_percent__min: 0.00005
+      app_settings__size_percent__max: 0.0003
       app_settings__price_percent__min: 0.05
       app_settings__price_percent__max: 0.2
-      app_settings__order_number__min: 1
-      app_settings__order_number__max: 5
+      app_settings__order_number__min: 100
+      app_settings__order_number__max: 100
       app_settings__order_type: market
     command: sh -c "dex liquidity mint --url $$http_url $$mint_amount $$address --address $$minter_address --username $$minter_username --private-key $$minter_private_key; dex liquidity provide --url $$http_url $$mint_amount --address $$minter_address --username $$minter_username --private-key $$minter_private_key"
     restart: "no"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Test DEX performance by adjusting `dex-bot` settings in `docker-compose.yml` files, including sleep times, size percentages, and order numbers.
> 
>   - **Behavior**:
>     - Adjust `dex-bot` settings in `docker-compose.yml` files to test performance.
>     - Change `app_settings__sleep__min` and `app_settings__sleep__max` to 0s in `networks/localdango/docker-compose.yml`.
>     - Update `app_settings__size_percent__min` to "0.000005" and `app_settings__size_percent__max` to "0.00003" in `deploy/roles/full-app/templates/docker-compose.yml`.
>     - Set `app_settings__order_number__min` and `app_settings__order_number__max` to 100 in both `docker-compose.yml` files.
>   - **Misc**:
>     - Add newline in `deploy/group_vars/all/main.yml` for formatting.
>     - Remove newline in `deploy/group_vars/all/main.yml` for formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 857f17008574b0060e48d1c21f117645b8060576. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->