### PR TITLE
add just command to delete pr data

### DIFF
--- a/deploy/justfile
+++ b/deploy/justfile
@@ -45,6 +45,9 @@ deploy-devnet:
 deploy-preview-latest:
   ansible-playbook full-app.yml -e '{"expose_ports": true, "dex_bot_enabled":true, "cometbft_generate_keys":true}' -e deploy_env=preview -e dango_image_tag=latest -e dango_network=previewnet -e frontend_image_tag=latest -e chain_id=preview
 
+delete-pr number:
+  ansible-playbook delete-full-app.yml -e deployment_name=pr-{{number}}
+
 deploy-dozzle:
   ansible-playbook dozzle.yml
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `delete-pr` command to `deploy/justfile` for deleting PR data using Ansible.
> 
>   - **New Command**:
>     - Adds `delete-pr` command to `deploy/justfile`.
>     - Executes `ansible-playbook delete-full-app.yml` with `deployment_name=pr-{{number}}` to delete PR data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 6e4aa7f67e9e9c045ab40c68eb36d6ee073969ad. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->