### PR TITLE
fix(dango): change testnet hyperlane domain id to 88888887

### DIFF
--- a/deploy/roles/full-app/templates/config/cometbft/genesis-testnet.json
+++ b/deploy/roles/full-app/templates/config/cometbft/genesis-testnet.json
@@ -272,7 +272,7 @@
           "msg": {
             "config": {
               "default_ism": "0xdc68d6c82f5e4386294e7fda27317ab6ae8ff54c",
-              "local_domain": 88888888
+              "local_domain": 88888887
             }
           },
           "salt": "aHlwZXJsYW5lL21haWxib3g="


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `local_domain` in `genesis-testnet.json` from `88888888` to `88888887` for testnet configuration.
> 
>   - **Configuration Change**:
>     - Update `local_domain` from `88888888` to `88888887` in `genesis-testnet.json` under `deploy/roles/full-app/templates/config/cometbft/`.
>     - Affects the `hyperlane` configuration for the testnet.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c5f4b48741c516b8097775603d012b4728c49d29. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->