### PR TITLE
fix spread percentage precision

### DIFF
--- a/dango/dex/src/metrics.rs
+++ b/dango/dex/src/metrics.rs
@@ -321,7 +321,7 @@ pub mod emit {
             .set(spread_absolute_f64);
 
             let spread_percentage = spread_absolute.checked_div(mid)?;
-            let spread_percentage_f64 = to_float(spread_percentage, scale_tokens_precision);
+            let spread_percentage_f64 = to_float(spread_percentage, Price::DECIMAL_PLACES as i32);
 
             metrics::gauge!(
                 crate::metrics::LABEL_SPREAD_PERCENTAGE,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes precision of spread percentage calculation in `spread()` function in `metrics.rs`.
> 
>   - **Behavior**:
>     - Fixes precision of `spread_percentage_f64` in `spread()` function in `metrics.rs` by using `Price::DECIMAL_PLACES` instead of `scale_tokens_precision`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 9702170f2dd675032aef4331ebdd9c7eedcfc588. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->