### PR TITLE
Add dev 6 documentation

### DIFF
--- a/book/networks/dev-6.md
+++ b/book/networks/dev-6.md
@@ -1,0 +1,31 @@
+# dev-6
+
+- Genesis time: 3 January 2026
+- Dango version: [`14fce0e`](https://github.com/left-curve/left-curve/tree/14fce0e)
+- Cometbft version: [`0.38.17+d03254d35`](https://github.com/cometbft/cometbft/releases/tag/v0.38.17)
+
+| Contract            | Address                                      |
+| ------------------- | -------------------------------------------- |
+| `account_factory`   | `0x18d28bafcdf9d4574f920ea004dea2d13ec16f6b` |
+| `bank`              | `0xe0b49f70991ecab05d5d7dc1f71e4ede63c8f2b7` |
+| `dex`               | `0xda32476efe31e535207f0ad690d337a4ebf54a22` |
+| `gateway`           | `0xc51e2cbe9636a90c86463ac3eb18fbee92b700d1` |
+| `hyperlane/fee`     | `0x1820557f629fa72caf0cab710640e44c9826deb2` |
+| `hyperlane/ism`     | `0xdc68d6c82f5e4386294e7fda27317ab6ae8ff54c` |
+| `hyperlane/mailbox` | `0x974e57564ed3ed7d8f99d0c359fd03f3d78259c7` |
+| `hyperlane/va`      | `0x75f38c6fcfc2fb8333e5c3ef89d13b7036abe3ff` |
+| `lending`           | `0x53373c59e508bd6cb903e3c00b7b224d2180982f` |
+| `oracle`            | `0xcedc5f73cbb963a48471b849c3650e6e34cd3b6d` |
+| `owner`             | `0xc4a8f7bbadd1457092a8cd182480230c0a848331` |
+| `taxman`            | `0xda70a9c1417aee00f960fe896add9d571f9c365b` |
+| `vesting`           | `0x69ee3f5f2a8300c96d008865c2b2df4e40ec48cc` |
+| `user1`             | `0xa689d271b926305be99dc7a7a04f5f793af252cc` |
+| `user2`             | `0x6043c1bed0fc45131e48ee38ceff36e36d6a8734` |
+| `user3`             | `0xf5f3dd21f6a19fea1e85df6e4f72779331ff45a2` |
+| `user4`             | `0x365beaf8e8dd6c1a378bcf130df03de7b724602d` |
+| `user5`             | `0xa34470089d2e0130832cd14618fae67e0bc3de80` |
+| `user6`             | `0xee3df368a78cfacf9f9cfe3bcf514ed9e21abf97` |
+| `user7`             | `0xa0db99b6fad46412c3fdc65802f3fe62e307f8e6` |
+| `user8`             | `0x7f360aa0806f41aabe9fc43bfc1254e5bafe7583` |
+| `user9`             | `0x6f95c4f169f38f598dd571084daa5c799c5743de` |
+| `warp`              | `0x3792b060a077fceca337334adf53f695e1362397` |

--- a/dango/scripts/examples/print_addresses.rs
+++ b/dango/scripts/examples/print_addresses.rs
@@ -1,0 +1,40 @@
+use {
+    dango_types::{
+        account_factory::{QueryUserRequest, UserIndexOrName},
+        config::AppConfig,
+    },
+    grug::QueryClientExt,
+    indexer_client::HttpClient,
+};
+
+// This script prints the address of the chain and the first 10 user accounts (by index) from the account factory
+// (mostly used to update documentation).
+#[tokio::main]
+async fn main() {
+    let client = HttpClient::new("https://api-devnet.dango.zone").unwrap();
+
+    let app_config: AppConfig = client.query_app_config(None).await.unwrap();
+
+    println!("{:#?}", app_config.addresses);
+
+    let config = client.query_config(None).await.unwrap();
+    println!("owner {}", config.owner);
+    println!("bank {}", config.bank);
+
+    // Query the user addresses
+    for i in 1..10 {
+        let (user_address, _) = client
+            .query_wasm_smart(
+                app_config.addresses.account_factory,
+                QueryUserRequest(UserIndexOrName::Index(i)),
+                None,
+            )
+            .await
+            .unwrap()
+            .accounts
+            .pop_first()
+            .unwrap();
+
+        println!("user address {}: {}", i, user_address);
+    }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add dev-6 network documentation and a script to print chain and user addresses for documentation updates.
> 
>   - **Documentation**:
>     - Adds `dev-6.md` with genesis time, Dango and Cometbft versions, and contract addresses.
>   - **Scripts**:
>     - Adds `print_addresses.rs` to query and print chain and user account addresses for documentation updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for e0e433c92260b53d3a385d53b43c9f66e600bede. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->