### PR TITLE
allow chain owner to recover orphaned transfers

### DIFF
--- a/dango/bank/src/execute.rs
+++ b/dango/bank/src/execute.rs
@@ -199,8 +199,10 @@ fn force_transfer(ctx: MutableCtx, from: Addr, to: Addr, coins: Coins) -> anyhow
 
 fn recover_transfer(ctx: MutableCtx, sender: Addr, recipient: Addr) -> anyhow::Result<Response> {
     ensure!(
-        ctx.sender == sender || ctx.sender == recipient,
-        "only the sender or the recipient can recover an orphaned transfer"
+        ctx.sender == sender
+            || ctx.sender == recipient
+            || ctx.sender == ctx.querier.query_owner()?,
+        "only the sender, the recipient, or the chain owner can recover an orphaned transfer"
     );
 
     let Some(coins) = ORPHANED_TRANSFERS.may_take(ctx.storage, (sender, recipient))? else {

--- a/dango/types/src/bank/msgs.rs
+++ b/dango/types/src/bank/msgs.rs
@@ -46,6 +46,7 @@ pub enum ExecuteMsg {
     /// Note: The `receive` method isn't invoked when calling this.
     ForceTransfer { from: Addr, to: Addr, coins: Coins },
     /// Retrieve funds sent to a non-existing recipient.
+    /// Can only be called by the transfer's sender, recipient, or the chain owner.
     RecoverTransfer { sender: Addr, recipient: Addr },
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow chain owner to recover orphaned transfers in `recover_transfer` function in `execute.rs`.
> 
>   - **Behavior**:
>     - `recover_transfer` in `execute.rs` now allows the chain owner to recover orphaned transfers, in addition to the sender and recipient.
>     - Updated documentation in `ExecuteMsg::RecoverTransfer` in `msgs.rs` to reflect this change.
>   - **Misc**:
>     - No changes to existing logic or other functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for c2005c6cf9474c5bf0cbf88a43fe65dba4c3adfe. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->