### PR TITLE
zexsor/lef-624-create-referral-contract

### DIFF
--- a/dango/account/factory/src/execute.rs
+++ b/dango/account/factory/src/execute.rs
@@ -133,7 +133,7 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
         ExecuteMsg::UpdateKey { key_hash, key } => update_key(ctx, key_hash, key),
         ExecuteMsg::UpdateAccount(updates) => update_account(ctx, updates),
         ExecuteMsg::UpdateUsername(username) => update_username(ctx, username),
-        ExecuteMsg::Referral { referrer_index } => referral(ctx, referrer_index),
+        ExecuteMsg::Referral { user } => referral(ctx, user),
     }
 }
 

--- a/dango/account/factory/src/query.rs
+++ b/dango/account/factory/src/query.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         ACCOUNTS, ACCOUNTS_BY_USER, CODE_HASHES, KEYS, NEXT_ACCOUNT_INDEX, NEXT_USER_INDEX,
-        USER_INDEXES_BY_NAME, USER_NAMES_BY_INDEX, USERS_BY_KEY,
+        REFEREE, REFEREE_COUNT, USER_INDEXES_BY_NAME, USER_NAMES_BY_INDEX, USERS_BY_KEY,
     },
     dango_types::{
         account_factory::{
@@ -78,6 +78,16 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             limit,
         } => {
             let res = forgot_username(ctx.storage, key_hash, start_after, limit)?;
+            res.to_json_value()
+        },
+        QueryMsg::Referrer {
+            user: referee_index,
+        } => {
+            let res = referrer(ctx.storage, referee_index)?;
+            res.to_json_value()
+        },
+        QueryMsg::RefereeCount { user } => {
+            let res = referee_count(ctx.storage, user);
             res.to_json_value()
         },
     }
@@ -241,4 +251,12 @@ fn get_user_index(storage: &dyn Storage, user: &UserIndexOrName) -> StdResult<Us
         UserIndexOrName::Index(index) => Ok(*index),
         UserIndexOrName::Name(name) => USER_INDEXES_BY_NAME.load(storage, name),
     }
+}
+
+fn referrer(storage: &dyn Storage, referee_index: UserIndex) -> StdResult<Option<UserIndex>> {
+    REFEREE.may_load(storage, referee_index)
+}
+
+fn referee_count(storage: &dyn Storage, user: UserIndex) -> u32 {
+    REFEREE_COUNT.load(storage, user).unwrap_or(0)
 }

--- a/dango/account/factory/src/state.rs
+++ b/dango/account/factory/src/state.rs
@@ -27,3 +27,9 @@ pub const ACCOUNT_COUNT_BY_USER: Counters<UserIndex, u8> = Counters::new("accoun
 pub const USER_NAMES_BY_INDEX: Map<UserIndex, Username> = Map::new("user_names__index");
 
 pub const USER_INDEXES_BY_NAME: Map<&Username, UserIndex> = Map::new("user_indexes__name");
+
+/// Maps a referee to their referrer.
+pub const REFEREE: Map<UserIndex, UserIndex> = Map::new("referee");
+
+/// Maps a referrer to the count of their referees.
+pub const REFEREE_COUNT: Map<UserIndex, u32> = Map::new("referee_count");

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -338,6 +338,7 @@ where
                     key: self.first_key(),
                     key_hash: self.first_key_hash(),
                     signature: self.sign_arbitrary(RegisterUserData { chain_id }).unwrap(),
+                    referrer_index: None,
                 },
                 funds,
             )

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -68,6 +68,7 @@ fn onboarding_without_deposit() {
                         chain_id: chain_id.clone(),
                     })
                     .unwrap(),
+                referrer_index: None,
             },
             Coins::new(),
         )
@@ -172,6 +173,7 @@ fn onboarding_without_deposit_when_minimum_deposit_is_zero() {
                 key_hash: user.first_key_hash(),
                 seed: 3,
                 signature: user.sign_arbitrary(RegisterUserData { chain_id }).unwrap(),
+                referrer_index: None,
             },
             Coins::new(),
         )
@@ -268,6 +270,7 @@ fn onboarding_with_deposit_when_minimum_deposit_is_zero() {
                 key_hash: user.first_key_hash(),
                 seed: 3,
                 signature,
+                referrer_index: None,
             },
             Coins::new(),
         )
@@ -325,6 +328,7 @@ fn update_key() {
                         chain_id: chain_id.clone(),
                     })
                     .unwrap(),
+                referrer_index: None,
             },
             Coins::new(),
         )

--- a/dango/testing/tests/referral.rs
+++ b/dango/testing/tests/referral.rs
@@ -1,0 +1,171 @@
+use {
+    dango_testing::{Factory, Preset, TestAccount, TestOption, TestSuite, setup_test},
+    dango_types::account_factory::{
+        ExecuteMsg, QueryAccountRequest, QueryRefereeCountRequest, QueryReferrerRequest,
+        RegisterUserData,
+    },
+    grug::{Addr, Addressable, Coins, HashExt, QuerierExt, ResultExt},
+};
+
+#[test]
+fn referral_during_user_register() {
+    let (mut suite, _, codes, contracts, ..) = setup_test(TestOption::preset_test());
+
+    suite.make_empty_block();
+
+    let chain_id = suite.chain_id.clone();
+
+    let user = TestAccount::new_random().predict_address(
+        contracts.account_factory,
+        3,
+        codes.account_single.to_bytes().hash256(),
+        true,
+    );
+
+    // Register a new user with User1 as referrer.
+    suite
+        .execute(
+            &mut Factory::new(contracts.account_factory),
+            contracts.account_factory,
+            &ExecuteMsg::RegisterUser {
+                key: user.first_key(),
+                key_hash: user.first_key_hash(),
+                seed: 3,
+                signature: user
+                    .sign_arbitrary(RegisterUserData {
+                        chain_id: chain_id.clone(),
+                    })
+                    .unwrap(),
+                referrer_index: Some(1),
+            },
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let user_index = suite
+        .query_wasm_smart(contracts.account_factory, QueryAccountRequest {
+            address: user.address(),
+        })
+        .should_succeed()
+        .params
+        .into_single()
+        .owner;
+
+    // Ensure the new user's referrer is User1.
+    assert_eq!(
+        suite
+            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest {
+                user: user_index
+            })
+            .should_succeed(),
+        Some(1)
+    );
+    // Ensure User1's referee count is now 1.
+    assert_eq!(
+        query_referrer_count(&mut suite, contracts.account_factory, 1),
+        1
+    );
+}
+
+#[test]
+fn referral_after_user_register() {
+    let (mut suite, mut accounts, _, contracts, ..) = setup_test(TestOption::preset_test());
+
+    // Initially, User1 has 0 referees.
+    assert_eq!(
+        query_referrer_count(&mut suite, contracts.account_factory, 1),
+        0
+    );
+
+    // Make User1 refer User2.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.account_factory,
+            &ExecuteMsg::Referral { referrer_index: 1 },
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Ensure User2's referrer is User1.
+    assert_eq!(
+        suite
+            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest {
+                user: 2
+            })
+            .should_succeed(),
+        Some(1)
+    );
+
+    // User1 should now have 1 referee.
+    assert_eq!(
+        query_referrer_count(&mut suite, contracts.account_factory, 1),
+        1
+    );
+
+    // Try to replace the User2 referrer (should fail).
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.account_factory,
+            &ExecuteMsg::Referral { referrer_index: 3 },
+            Coins::new(),
+        )
+        .should_fail_with_error("referral already registered for this user");
+
+    // Make User1 refer User3.
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.account_factory,
+            &ExecuteMsg::Referral { referrer_index: 1 },
+            Coins::new(),
+        )
+        .should_succeed();
+
+    assert_eq!(
+        suite
+            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest {
+                user: 3
+            })
+            .should_succeed(),
+        Some(1)
+    );
+
+    // User1 should now have 2 referees.
+    assert_eq!(
+        query_referrer_count(&mut suite, contracts.account_factory, 1),
+        2
+    );
+
+    // Make User2 refer User4.
+    suite
+        .execute(
+            &mut accounts.user4,
+            contracts.account_factory,
+            &ExecuteMsg::Referral { referrer_index: 2 },
+            Coins::new(),
+        )
+        .should_succeed();
+
+    assert_eq!(
+        suite
+            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest {
+                user: 4
+            })
+            .should_succeed(),
+        Some(2)
+    );
+
+    // User2 should now have 1 referee.
+    assert_eq!(
+        query_referrer_count(&mut suite, contracts.account_factory, 2),
+        1
+    );
+}
+
+fn query_referrer_count(suite: &mut TestSuite, account_factory: Addr, user: u32) -> u32 {
+    suite
+        .query_wasm_smart(account_factory, QueryRefereeCountRequest { user })
+        .should_succeed()
+}

--- a/dango/testing/tests/referral.rs
+++ b/dango/testing/tests/referral.rs
@@ -82,7 +82,7 @@ fn referral_after_user_register() {
         .execute(
             &mut accounts.user2,
             contracts.account_factory,
-            &ExecuteMsg::Referral { referrer_index: 1 },
+            &ExecuteMsg::Referral { user: 1 },
             Coins::new(),
         )
         .should_succeed();
@@ -90,9 +90,7 @@ fn referral_after_user_register() {
     // Ensure User2's referrer is User1.
     assert_eq!(
         suite
-            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest {
-                user: 2
-            })
+            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest { user: 2 })
             .should_succeed(),
         Some(1)
     );
@@ -108,7 +106,7 @@ fn referral_after_user_register() {
         .execute(
             &mut accounts.user2,
             contracts.account_factory,
-            &ExecuteMsg::Referral { referrer_index: 3 },
+            &ExecuteMsg::Referral { user: 3 },
             Coins::new(),
         )
         .should_fail_with_error("referral already registered for this user");
@@ -118,16 +116,14 @@ fn referral_after_user_register() {
         .execute(
             &mut accounts.user3,
             contracts.account_factory,
-            &ExecuteMsg::Referral { referrer_index: 1 },
+            &ExecuteMsg::Referral { user: 1 },
             Coins::new(),
         )
         .should_succeed();
 
     assert_eq!(
         suite
-            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest {
-                user: 3
-            })
+            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest { user: 3 })
             .should_succeed(),
         Some(1)
     );
@@ -143,16 +139,14 @@ fn referral_after_user_register() {
         .execute(
             &mut accounts.user4,
             contracts.account_factory,
-            &ExecuteMsg::Referral { referrer_index: 2 },
+            &ExecuteMsg::Referral { user: 2 },
             Coins::new(),
         )
         .should_succeed();
 
     assert_eq!(
         suite
-            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest {
-                user: 4
-            })
+            .query_wasm_smart(contracts.account_factory, QueryReferrerRequest { user: 4 })
             .should_succeed(),
         Some(2)
     );

--- a/dango/types/src/account_factory/msg.rs
+++ b/dango/types/src/account_factory/msg.rs
@@ -71,6 +71,8 @@ pub enum ExecuteMsg {
         seed: u32,
         /// A signature over the `RegisterUserData`.
         signature: Signature,
+        /// Optional referrer user index.
+        referrer_index: Option<UserIndex>,
     },
     /// Register a new account for an existing user.
     RegisterAccount { params: AccountParams },
@@ -83,6 +85,8 @@ pub enum ExecuteMsg {
     /// For now, we only support setting the username once when it's unset.
     /// We don't support changing the username when it's already set.
     UpdateUsername(Username),
+    /// Register the sender as a referral with the given user index.
+    Referral { user: UserIndex },
 }
 
 #[grug::derive(Serde, QueryRequest)]
@@ -151,6 +155,12 @@ pub enum QueryMsg {
         start_after: Option<UserIndexOrName>,
         limit: Option<u32>,
     },
+    /// Query the referrer of a given user.
+    #[returns(Option<UserIndex>)]
+    Referrer { user: UserIndex },
+    /// Query the number of referees a given user has.
+    #[returns(u32)]
+    RefereeCount { user: UserIndex },
 }
 
 #[grug::derive(Serde)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a referral system to the account factory, allowing users to register with a referrer and track referral counts, with corresponding updates to execution, query, state, and tests.
> 
>   - **Behavior**:
>     - Adds referral system to `execute.rs` with `ExecuteMsg::Referral` and `register_user()` now accepting `referrer_index`.
>     - Updates `query.rs` to handle `QueryMsg::Referrer` and `QueryMsg::RefereeCount`.
>   - **State**:
>     - Adds `REFEREE` and `REFEREE_COUNT` to `state.rs` to track referral relationships and counts.
>   - **Testing**:
>     - Adds `referral.rs` to test referral registration during and after user registration.
>     - Updates tests in `factory.rs` to include referral scenarios.
>   - **Misc**:
>     - Updates `msg.rs` to include new `ExecuteMsg` and `QueryMsg` variants for referral handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for eb5bb7a6d533345190c136ff7c25d74a2e311664. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->