### PR TITLE
rhaki/lef-627-expose-hyperlane-metrics-port

### DIFF
--- a/deploy/roles/hyperlane/defaults/main.yml
+++ b/deploy/roles/hyperlane/defaults/main.yml
@@ -14,3 +14,11 @@ hyperlane_instance_dir: "{{ hyperlane_agents_dir }}/{{ hyperlane_instance_name }
 
 # Docker image tag
 hyperlane_agents_tag: "latest"
+
+# Metrics ports for Hyperlane agents (host bindings).
+hyperlane_metrics_network_offset: >-
+  {{ 10 if hyperlane_agents_network == 'testnet' else 0 }}
+hyperlane_validator_metrics_host_port: >-
+  {{ 9500 + hyperlane_metrics_network_offset }}
+hyperlane_relayer_metrics_host_port: >-
+  {{ 9501 + hyperlane_metrics_network_offset }}

--- a/deploy/roles/hyperlane/files/docker-compose-relayer.yml
+++ b/deploy/roles/hyperlane/files/docker-compose-relayer.yml
@@ -12,5 +12,7 @@ services:
     environment:
       CONFIG_FILES: >-
         /config/config.json,/config/relayer-config.json,/config/relayer-${HYPERLANE_AGENTS_NETWORK}-config.json
+    ports:
+      - "${HYPERLANE_METRICS_HOST_PORT}:9090"
     command: ["./relayer"]
     restart: unless-stopped

--- a/deploy/roles/hyperlane/files/docker-compose-validator.yml
+++ b/deploy/roles/hyperlane/files/docker-compose-validator.yml
@@ -12,5 +12,7 @@ services:
     environment:
       CONFIG_FILES: >-
         /config/config.json,/config/validator-config.json,/config/validator-${HYPERLANE_AGENTS_NETWORK}-config.json
+    ports:
+      - "${HYPERLANE_METRICS_HOST_PORT}:9090"
     command: ["./validator"]
     restart: unless-stopped

--- a/deploy/roles/hyperlane/templates/relayer-mainnet.env.j2
+++ b/deploy/roles/hyperlane/templates/relayer-mainnet.env.j2
@@ -4,6 +4,7 @@ HYPERLANE_INSTANCE_DIR="{{ hyperlane_instance_dir }}"
 HYPERLANE_INSTANCE_NAME="{{ hyperlane_instance_name }}"
 HYPERLANE_AGENTS_TAG="{{ hyperlane_agents_tag }}"
 HYPERLANE_AGENTS_NETWORK="{{ hyperlane_agents_network }}"
+HYPERLANE_METRICS_HOST_PORT="{{ hyperlane_relayer_metrics_host_port }}"
 
 # Dango mainnet chain signer
 HYP_CHAINS_DANGO_SIGNER_KEY="{{ r.dango_signer_key }}"

--- a/deploy/roles/hyperlane/templates/relayer-testnet.env.j2
+++ b/deploy/roles/hyperlane/templates/relayer-testnet.env.j2
@@ -4,6 +4,7 @@ HYPERLANE_INSTANCE_DIR="{{ hyperlane_instance_dir }}"
 HYPERLANE_INSTANCE_NAME="{{ hyperlane_instance_name }}"
 HYPERLANE_AGENTS_TAG="{{ hyperlane_agents_tag }}"
 HYPERLANE_AGENTS_NETWORK="{{ hyperlane_agents_network }}"
+HYPERLANE_METRICS_HOST_PORT="{{ hyperlane_relayer_metrics_host_port }}"
 
 # Dango testnet chain signer
 HYP_CHAINS_DANGOTESTNET_SIGNER_KEY="{{ r.dango_signer_key }}"

--- a/deploy/roles/hyperlane/templates/validator-mainnet.env.j2
+++ b/deploy/roles/hyperlane/templates/validator-mainnet.env.j2
@@ -4,6 +4,7 @@ HYPERLANE_INSTANCE_DIR="{{ hyperlane_instance_dir }}"
 HYPERLANE_INSTANCE_NAME="{{ hyperlane_instance_name }}"
 HYPERLANE_AGENTS_TAG="{{ hyperlane_agents_tag }}"
 HYPERLANE_AGENTS_NETWORK="{{ hyperlane_agents_network }}"
+HYPERLANE_METRICS_HOST_PORT="{{ hyperlane_validator_metrics_host_port }}"
 
 AWS_ACCESS_KEY_ID="{{ v.aws_access_key_id }}"
 AWS_SECRET_ACCESS_KEY="{{ v.aws_secret_access_key }}"

--- a/deploy/roles/hyperlane/templates/validator-testnet.env.j2
+++ b/deploy/roles/hyperlane/templates/validator-testnet.env.j2
@@ -4,6 +4,7 @@ HYPERLANE_INSTANCE_DIR="{{ hyperlane_instance_dir }}"
 HYPERLANE_INSTANCE_NAME="{{ hyperlane_instance_name }}"
 HYPERLANE_AGENTS_TAG="{{ hyperlane_agents_tag }}"
 HYPERLANE_AGENTS_NETWORK="{{ hyperlane_agents_network }}"
+HYPERLANE_METRICS_HOST_PORT="{{ hyperlane_validator_metrics_host_port }}"
 
 AWS_ACCESS_KEY_ID="{{ v.aws_access_key_id }}"
 AWS_SECRET_ACCESS_KEY="{{ v.aws_secret_access_key }}"

--- a/deploy/roles/prometheus/templates/prometheus.yml
+++ b/deploy/roles/prometheus/templates/prometheus.yml
@@ -98,6 +98,74 @@ scrape_configs:
       target_label: instance
       replacement: 'ovh3:9080'
 
+  - job_name: 'hyperlane-relayer'
+    static_configs:
+      - targets: ['hetzner3:9501']
+        labels:
+          service: 'hyperlane'
+          role: 'relayer'
+          environment: 'production'
+          network: 'mainnet'
+          dango_network: 'mainnet'
+      - targets: ['hetzner4:9511']
+        labels:
+          service: 'hyperlane'
+          role: 'relayer'
+          environment: 'production'
+          network: 'testnet'
+          dango_network: 'testnet'
+
+  - job_name: 'hyperlane-validator'
+    static_configs:
+      - targets: ['inter1:9500']
+        labels:
+          service: 'hyperlane'
+          role: 'validator'
+          environment: 'production'
+          network: 'mainnet'
+          dango_network: 'mainnet'
+          validator_index: '1'
+      - targets: ['inter2:9500']
+        labels:
+          service: 'hyperlane'
+          role: 'validator'
+          environment: 'production'
+          network: 'mainnet'
+          dango_network: 'mainnet'
+          validator_index: '2'
+      - targets: ['hetzner1:9500']
+        labels:
+          service: 'hyperlane'
+          role: 'validator'
+          environment: 'production'
+          network: 'mainnet'
+          dango_network: 'mainnet'
+          validator_index: '3'
+      - targets: ['hetzner3:9500']
+        labels:
+          service: 'hyperlane'
+          role: 'validator'
+          environment: 'production'
+          network: 'mainnet'
+          dango_network: 'mainnet'
+          validator_index: '4'
+      - targets: ['hetzner2:9510']
+        labels:
+          service: 'hyperlane'
+          role: 'validator'
+          environment: 'production'
+          network: 'testnet'
+          dango_network: 'testnet'
+          validator_index: '1'
+      - targets: ['hetzner4:9510']
+        labels:
+          service: 'hyperlane'
+          role: 'validator'
+          environment: 'production'
+          network: 'testnet'
+          dango_network: 'testnet'
+          validator_index: '2'
+
   - job_name: 'preview-clickhouse'
     file_sd_configs:
       - files: ['/etc/prometheus/targets/*-clickhouse.yml']


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Expose Hyperlane agent metrics ports and update Prometheus configurations to scrape these metrics.
> 
>   - **Metrics Ports**:
>     - Added `hyperlane_metrics_network_offset`, `hyperlane_validator_metrics_host_port`, and `hyperlane_relayer_metrics_host_port` in `main.yml`.
>     - Updated `docker-compose-relayer.yml` and `docker-compose-validator.yml` to expose metrics ports using `${HYPERLANE_METRICS_HOST_PORT}`.
>   - **Environment Templates**:
>     - Added `HYPERLANE_METRICS_HOST_PORT` to `relayer-mainnet.env.j2`, `relayer-testnet.env.j2`, `validator-mainnet.env.j2`, and `validator-testnet.env.j2`.
>   - **Prometheus Configuration**:
>     - Added `hyperlane-relayer` and `hyperlane-validator` job configurations in `prometheus.yml` to scrape metrics from specified targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 53493dfe01ec61345586692538b513b3ef9c00f3. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->