### PR TITLE
add migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,8 @@ dependencies = [
 name = "dango-upgrade"
 version = "0.0.0"
 dependencies = [
+ "dango-account-factory",
+ "dango-types",
  "grug",
  "grug-app",
  "tracing",

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -9,6 +9,8 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 
 [dependencies]
-grug     = { workspace = true }
-grug-app = { workspace = true }
-tracing  = { workspace = true }
+dango-account-factory = { workspace = true }
+dango-types           = { workspace = true }
+grug                  = { workspace = true }
+grug-app              = { workspace = true }
+tracing               = { workspace = true }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,10 +1,31 @@
 use {
-    grug::{BlockInfo, Storage},
-    grug_app::AppResult,
+    dango_account_factory::{ACCOUNTS, MAIN_ACCOUNT},
+    dango_types::account_factory::AccountParams,
+    grug::{Addr, BlockInfo, Inner, StdResult, Storage, addr},
+    grug_app::{AppResult, CONTRACT_NAMESPACE, StorageProvider},
+    std::collections::BTreeMap,
 };
 
-pub fn do_upgrade<VM>(_storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
-    tracing::info!("No upgrade to do");
+const ACCOUNT_FACTORY: Addr = addr!("18d28bafcdf9d4574f920ea004dea2d13ec16f6b");
+
+pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
+    let mut account_factory_storage =
+        StorageProvider::new(storage, &[CONTRACT_NAMESPACE, ACCOUNT_FACTORY.inner()]);
+
+    // Load all the accounts from the account factory storage.
+    let accounts = ACCOUNTS
+        .range(&account_factory_storage, None, None, grug::Order::Ascending)
+        .collect::<StdResult<BTreeMap<_, _>>>()?;
+
+    for (addr, account) in accounts {
+        let AccountParams::Single(params) = account.params else {
+            // Only single accounts can be main account.
+            continue;
+        };
+
+        // Save the main account mapping.
+        MAIN_ACCOUNT.save(&mut account_factory_storage, params.owner, &addr)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add dependencies and update `do_upgrade` to handle account migrations by saving main account mappings for single accounts.
> 
>   - **Dependencies**:
>     - Add `dango-account-factory` and `dango-types` to `Cargo.toml` and `Cargo.lock`.
>   - **Functionality**:
>     - Update `do_upgrade` in `lib.rs` to load accounts from `account_factory_storage` and save main account mappings for single accounts using `MAIN_ACCOUNT.save()`.
>     - Use `AccountParams::Single` to filter accounts eligible for main account mapping.
>   - **Constants**:
>     - Define `ACCOUNT_FACTORY` constant in `lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for f1cb34d1ff205ec170e775f3b2085af276bbfdaf. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->