### PR TITLE
fix(grug): IndexMap `save` revert indexes state if an error occur

### DIFF
--- a/grug/types/src/imports/storage.rs
+++ b/grug/types/src/imports/storage.rs
@@ -139,5 +139,61 @@ impl Storage for Box<dyn Storage> {
     }
 }
 
+#[derive(Clone)]
+pub struct StorageWrapper<'a> {
+    storage: &'a dyn Storage,
+}
+
+impl<'a> StorageWrapper<'a> {
+    pub fn new(storage: &'a dyn Storage) -> Self {
+        Self { storage }
+    }
+}
+
+impl Storage for StorageWrapper<'_> {
+    fn read(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.storage.read(key)
+    }
+
+    fn scan<'a>(
+        &'a self,
+        min: Option<&[u8]>,
+        max: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = Record> + 'a> {
+        self.storage.scan(min, max, order)
+    }
+
+    fn scan_keys<'a>(
+        &'a self,
+        min: Option<&[u8]>,
+        max: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'a> {
+        self.storage.scan_keys(min, max, order)
+    }
+
+    fn scan_values<'a>(
+        &'a self,
+        min: Option<&[u8]>,
+        max: Option<&[u8]>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = Vec<u8>> + 'a> {
+        self.storage.scan_values(min, max, order)
+    }
+
+    fn write(&mut self, _key: &[u8], _value: &[u8]) {
+        unimplemented!("StorageWrapper is read-only");
+    }
+
+    fn remove(&mut self, _key: &[u8]) {
+        unimplemented!("StorageWrapper is read-only");
+    }
+
+    fn remove_range(&mut self, _min: Option<&[u8]>, _max: Option<&[u8]>) {
+        unimplemented!("StorageWrapper is read-only");
+    }
+}
+
 // derive std Clone trait for any type that implements Storage
 dyn_clone::clone_trait_object!(Storage);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps storage in a buffer to revert index state on error in `map.rs`, adds `StorageWrapper` for read-only storage view in `storage.rs`.
> 
>   - **Behavior**:
>     - Wraps storage in a `Buffer` using `StorageWrapper` in `replace()` in `map.rs` to revert index state on error.
>     - Calls `flush()` on storage with batch from buffer to apply changes.
>   - **Storage**:
>     - Adds `StorageWrapper` in `storage.rs` to provide a read-only view of `Storage`.
>     - Implements `Storage` trait for `StorageWrapper` with unimplemented write methods.
>   - **Tests**:
>     - Adds test in `tests` module in `map.rs` to verify index state reversion on error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=left-curve%2Fleft-curve&utm_source=github&utm_medium=referral)<sup> for 9ba174b7dee983afdae39cfccab595793c872b26. You can [customize](https://app.ellipsis.dev/left-curve/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->