### PR TITLE
fix(deploy): expose perp-liquidator metrics and add to dashboard

### DIFF
--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -315,10 +315,9 @@ services:
     restart: always
     env_file:
       - ./perp-liquidator/.env
-{% if expose_ports %}
     ports:
-      - "${PERP_LIQUIDATOR_HTTP_PORT:-0}:9310"
-{% endif %}
+      - "${WIREGUARD_IP}:${PERP_LIQUIDATOR_HTTP_PORT:-0}:9310"
+      - "${TAILSCALE_IP}:${PERP_LIQUIDATOR_HTTP_PORT:-0}:9310"
     networks:
       - default
       - traefik

--- a/deploy/roles/homer/templates/config.yml
+++ b/deploy/roles/homer/templates/config.yml
@@ -132,6 +132,13 @@ services:
         url: "http://ovh2:26657"
         target: "_blank"
 
+      - name: "Perp Liquidator"
+        icon: "fas fa-robot"
+        subtitle: "Port 9310"
+        tag: "testnet"
+        url: "http://hetzner2:9310/status"
+        target: "_blank"
+
   - name: "Devnet"
     icon: "fas fa-code"
     items:
@@ -171,6 +178,13 @@ services:
         subtitle: "Port 26657"
         tag: "devnet"
         url: "http://ovh1:26657"
+        target: "_blank"
+
+      - name: "Perp Liquidator"
+        icon: "fas fa-robot"
+        subtitle: "Port 9310"
+        tag: "devnet"
+        url: "http://ovh1:9310/status"
         target: "_blank"
 
   - name: "Logging Stack"
@@ -347,6 +361,20 @@ services:
         subtitle: "Port 26660"
         tag: "exporter"
         url: "http://ovh1:26660"
+        target: "_blank"
+
+      - name: "Testnet Perp Liquidator"
+        logo: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/prometheus.png"
+        subtitle: "Port 9310"
+        tag: "exporter"
+        url: "http://hetzner2:9310/metrics"
+        target: "_blank"
+
+      - name: "Devnet Perp Liquidator"
+        logo: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/prometheus.png"
+        subtitle: "Port 9310"
+        tag: "exporter"
+        url: "http://ovh1:9310/metrics"
         target: "_blank"
 
   - name: "Public Endpoints"


### PR DESCRIPTION
Bind perp-liquidator port 9310 to Wireguard/Tailscale IPs unconditionally (was gated behind expose_ports, preventing Prometheus from scraping). Add perp-liquidator entries to Homer dashboard for testnet and devnet (status + metrics exporters).