### PR TITLE
feat(deploy): add playbook to download points-bot database

### DIFF
--- a/dango/scripts/examples/enable_eth_vault_deposit.rs
+++ b/dango/scripts/examples/enable_eth_vault_deposit.rs
@@ -7,7 +7,9 @@ use {
         constants::perp_eth,
         perps::{self, PairId, PairParam},
     },
-    grug::{BroadcastClientExt, Coins, GasOption, JsonSerExt, Message, QueryClientExt, SearchTxClient},
+    grug::{
+        BroadcastClientExt, Coins, GasOption, JsonSerExt, Message, QueryClientExt, SearchTxClient,
+    },
     grug_app::GAS_COSTS,
     indexer_client::HttpClient,
     std::collections::BTreeMap,
@@ -20,7 +22,6 @@ async fn main() -> anyhow::Result<()> {
     let client = HttpClient::new(API_URL)?;
 
     let status = client.query_status(None).await?;
-    println!("Connected to devnet. Height: {}", status.last_finalized_block.height);
 
     let config = client.query_config(None).await?;
     let owner_address = config.owner;
@@ -64,10 +65,7 @@ async fn main() -> anyhow::Result<()> {
 
     let msg = Message::execute(
         perps_addr,
-        &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
-            param,
-            pair_params,
-        }),
+        &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure { param, pair_params }),
         Coins::new(),
     )?;
 

--- a/deploy/download-db-points-bot.yml
+++ b/deploy/download-db-points-bot.yml
@@ -1,0 +1,23 @@
+---
+- hosts: points-bot
+  become: true
+  become_user: "{{ deploy_user }}"
+  remote_user: deploy
+  collections:
+    - community.docker
+  pre_tasks:
+    - name: Get deploy user info
+      getent:
+        database: passwd
+        key: "{{ deploy_user }}"
+    - name: Set deploy_home fact
+      set_fact:
+        deploy_home: "{{ ansible_facts.getent_passwd[deploy_user][4] }}"
+  tasks:
+    - name: Download points-bot database
+      include_role:
+        name: points-bot
+        tasks_from: download-db-instance
+      loop: "{{ points_bot_networks }}"
+      loop_control:
+        loop_var: network

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -90,6 +90,9 @@ drop-db-points-bot network:
 drop-db-full-points-bot network:
   ansible-playbook drop-db-points-bot.yml -e '{"points_bot_networks": ["{{network}}"], "drop_db_full": true}' --limit points-bot-{{network}}
 
+download-db-points-bot network dest="./":
+  ansible-playbook download-db-points-bot.yml -e '{"points_bot_networks": ["{{network}}"], "download_dest": "{{dest}}"}' --limit points-bot-{{network}}
+
 delete-points-bot network:
   ansible-playbook delete-points-bot.yml -e '{"points_bot_networks": ["{{network}}"]}' --limit points-bot-{{network}}
 

--- a/deploy/roles/points-bot/tasks/download-db-instance.yml
+++ b/deploy/roles/points-bot/tasks/download-db-instance.yml
@@ -1,0 +1,29 @@
+---
+- name: "{{ network }} - Stop stack"
+  community.docker.docker_compose_v2:
+    project_src: "{{ points_bot_dir }}/{{ network }}"
+    state: stopped
+    pull: never
+
+- name: "{{ network }} - Compress db directory"
+  archive:
+    path: "{{ points_bot_dir }}/{{ network }}/db"
+    dest: "{{ points_bot_dir }}/{{ network }}/db.tar.gz"
+    format: gz
+
+- name: "{{ network }} - Restart stack"
+  community.docker.docker_compose_v2:
+    project_src: "{{ points_bot_dir }}/{{ network }}"
+    state: present
+    pull: never
+
+- name: "{{ network }} - Download db archive"
+  fetch:
+    src: "{{ points_bot_dir }}/{{ network }}/db.tar.gz"
+    dest: "{{ download_dest | default('./') }}/points-bot-{{ network }}-db.tar.gz"
+    flat: true
+
+- name: "{{ network }} - Remove remote archive"
+  file:
+    path: "{{ points_bot_dir }}/{{ network }}/db.tar.gz"
+    state: absent


### PR DESCRIPTION
## Summary
- Add Ansible playbook and task to compress and download the points-bot RocksDB database from remote servers
- The task stops the container, compresses the db directory, restarts the container immediately (minimizing downtime), then downloads the archive locally
- Add `just download-db-points-bot <network> [dest]` command

## Validation

### Completed
- [x] YAML follows existing playbook patterns
- [x] Task file matches role conventions (stop-instance, drop-db-instance, etc.)

### Remaining
- [ ] Test `just download-db-points-bot devnet` end-to-end

## Manual QA
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)