### PR TITLE
feat(perps): add IOC time-in-force for limit orders

### DIFF
--- a/book/perps/2-order-matching.md
+++ b/book/perps/2-order-matching.md
@@ -7,7 +7,10 @@ This chapter describes how orders are submitted, matched, filled, and settled in
 An order can be order:
 
 - **Market** — immediate-or-cancel (IOC). Specifies a `max_slippage` relative to the oracle price. Any unfilled remainder after matching is discarded (unless nothing filled at all, which is an error).
-- **Limit** — good-till-cancelled (GTC). Specifies a `limit_price`. Any unfilled remainder is stored as a resting order on the book. If `post_only` is set, the order is rejected if it would cross the best price on the opposite side — it takes a fast path and never enters the matching engine.
+- **Limit** — specifies a `limit_price` and a `time_in_force`:
+  - **GTC** (default): any unfilled remainder is stored as a resting order on the book.
+  - **IOC**: fills as much as possible, then discards the unfilled remainder. Errors if nothing fills.
+  - **Post-only**: the order is to be inserted into the book without entering the matching engine. Reject if it would cross the best price on the opposite side.
 
 Resting orders on the book are stored as:
 
@@ -215,8 +218,8 @@ A negative $\mathtt{vaultMargin}$ represents a deficit (bad debt not yet recover
 
 After matching completes:
 
-- **Market orders:** the unfilled remainder is silently discarded. If nothing was filled at all, the transaction reverts with _"no liquidity at acceptable price"_.
-- **Limit orders (GTC):** the unfilled remainder is stored as a resting order. Storage requires:
+- **Market orders and IOC limit orders:** the unfilled remainder is silently discarded. If nothing was filled at all, the transaction reverts with _"no liquidity at acceptable price"_.
+- **GTC limit orders:** the unfilled remainder is stored as a resting order. Storage requires:
   - `open_order_count` < `max_open_orders`
   - Price is aligned to the pair's tick size ($\mathtt{limitPrice} \bmod \mathtt{tickSize} = 0$)
   - Sufficient available margin (skipped for reduce-only orders) — see below

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -1462,7 +1462,7 @@ Place a resting order on the book:
           "kind": {
             "limit": {
               "limit_price": "65000.000000",
-              "post_only": false
+              "time_in_force": "GTC"
             }
           },
           "reduce_only": false
@@ -1476,13 +1476,17 @@ Place a resting order on the book:
 
 | Field         | Type          | Description                                                            |
 | ------------- | ------------- | ---------------------------------------------------------------------- |
-| `limit_price` | `UsdPrice`    | Limit price — must be aligned to `tick_size`                           |
-| `post_only`   | `bool`        | If `true`, rejected if it would match immediately (maker-only)         |
-| `reduce_only` | `bool`        | If `true`, only position-closing portion is kept                       |
-| `tp`          | `ChildOrder?` | Optional take-profit child order (see [§6.3](#63-submit-market-order)) |
-| `sl`          | `ChildOrder?` | Optional stop-loss child order (see [§6.3](#63-submit-market-order))   |
+| `limit_price`   | `UsdPrice`      | Limit price — must be aligned to `tick_size`                           |
+| `time_in_force` | `TimeInForce`   | `"GTC"` (default), `"IOC"`, or `"POST"` — see below                   |
+| `reduce_only`   | `bool`          | If `true`, only position-closing portion is kept                       |
+| `tp`            | `ChildOrder?`   | Optional take-profit child order (see [§6.3](#63-submit-market-order)) |
+| `sl`            | `ChildOrder?`   | Optional stop-loss child order (see [§6.3](#63-submit-market-order))   |
 
-Limit orders are GTC (good-till-cancelled). The matching portion fills immediately; any unfilled remainder is stored on the book. Margin is reserved for the unfilled portion.
+**Time-in-force options:**
+
+- **GTC** (Good-Til-Canceled, default): the matching portion fills immediately; any unfilled remainder is stored on the book. Margin is reserved for the unfilled portion.
+- **IOC** (Immediate-Or-Cancel): fills as much as possible against the book, then discards any unfilled remainder. Errors if nothing fills at all.
+- **POST** (Post-Only): the entire order is placed on the book without matching. Rejected if the limit price would cross the best offer on the opposite side.
 
 ### 6.5 Cancel order
 
@@ -1976,10 +1980,12 @@ Additional integer types:
 {
   "limit": {
     "limit_price": "65000.000000",
-    "post_only": false
+    "time_in_force": "GTC"
   }
 }
 ```
+
+**TimeInForce:** `"GTC"` | `"IOC"` | `"POST"` (defaults to `"GTC"` if omitted)
 
 **TriggerDirection:**
 

--- a/dango/perps/src/core/target_price.rs
+++ b/dango/perps/src/core/target_price.rs
@@ -83,7 +83,7 @@ mod tests {
             compute_target_price(
                 OrderKind::Limit {
                     limit_price: UsdPrice::new_int(limit),
-                    post_only: false,
+                    time_in_force: None,
                 },
                 UsdPrice::new_int(100),
                 is_bid

--- a/dango/perps/src/core/target_price.rs
+++ b/dango/perps/src/core/target_price.rs
@@ -48,7 +48,7 @@ pub fn is_price_constraint_violated(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, test_case::test_case};
+    use {super::*, dango_types::perps::TimeInForce, test_case::test_case};
 
     // oracle_price = 100
     #[test_case(  0, true,  100_000_000 ; "zero slippage bid")]
@@ -83,7 +83,7 @@ mod tests {
             compute_target_price(
                 OrderKind::Limit {
                     limit_price: UsdPrice::new_int(limit),
-                    time_in_force: None,
+                    time_in_force: TimeInForce::GoodTilCanceled,
                 },
                 UsdPrice::new_int(100),
                 is_bid

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -450,7 +450,8 @@ pub(crate) fn _submit_order(
 
     let order_to_store = if unfilled.is_non_zero() {
         match kind {
-            OrderKind::Limit {
+            OrderKind::Market { .. }
+            | OrderKind::Limit {
                 time_in_force: Some(TimeInForce::ImmediateOrCancel),
                 ..
             } => {
@@ -487,14 +488,6 @@ pub(crate) fn _submit_order(
                 taker_state = updated_taker_state;
 
                 Some((stored_price, order_id, order))
-            },
-            OrderKind::Market { .. } => {
-                ensure!(
-                    unfilled < fillable_size,
-                    "no liquidity at acceptable price! target_price: {target_price}"
-                );
-
-                None
             },
         }
     } else {

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -25,7 +25,7 @@ use {
         perps::{
             ChildOrder, ConditionalOrder, ConditionalOrderPlaced, LimitOrder, OrderFilled, OrderId,
             OrderKind, OrderPersisted, OrderRemoved, PairId, PairParam, PairState, Param,
-            ReasonForOrderRemoval, State, TriggerDirection, UserState,
+            ReasonForOrderRemoval, State, TimeInForce, TriggerDirection, UserState,
         },
     },
     grug::{
@@ -450,6 +450,18 @@ pub(crate) fn _submit_order(
 
     let order_to_store = if unfilled.is_non_zero() {
         match kind {
+            OrderKind::Limit {
+                time_in_force: Some(TimeInForce::ImmediateOrCancel),
+                ..
+            } => {
+                // IOC: discard unfilled remainder, same as market orders.
+                ensure!(
+                    unfilled < fillable_size,
+                    "no liquidity at acceptable price! target_price: {target_price}"
+                );
+
+                None
+            },
             OrderKind::Limit { limit_price, .. } => {
                 let StoreLimitOrderOutcome {
                     user_state: updated_taker_state,
@@ -1625,7 +1637,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                post_only: false,
+                time_in_force: None,
             },
             false,
             None,
@@ -1681,7 +1693,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                post_only: false,
+                time_in_force: None,
             },
             false,
             None,
@@ -1741,7 +1753,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                post_only: false,
+                time_in_force: None,
             },
             false,
             None,
@@ -1757,6 +1769,120 @@ mod tests {
         assert!(order_to_store.is_some());
         let (_, _, order) = order_to_store.unwrap();
         assert_eq!(order.size, Quantity::new_int(10));
+    }
+
+    // ======== Limit buy IOC: partial fill, remainder cancelled ================
+
+    #[test]
+    fn limit_buy_ioc_partial_fill_remainder_cancelled() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+        place_ask(&mut ctx.storage, MAKER_A, 50_000, 5, 100);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        let SubmitOrderOutcome {
+            taker_state,
+            order_to_store,
+            ..
+        } = _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Limit {
+                limit_price: UsdPrice::new_int(50_000),
+                time_in_force: Some(TimeInForce::ImmediateOrCancel),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .unwrap();
+
+        // 5 filled.
+        let pos = taker_state.positions.get(&pair_id()).unwrap();
+        assert_eq!(pos.size, Quantity::new_int(5));
+
+        // IOC: remainder discarded, not stored.
+        assert!(order_to_store.is_none());
+
+        // No reserved margin or open orders.
+        assert_eq!(taker_state.reserved_margin, UsdValue::ZERO);
+        assert_eq!(taker_state.open_order_count, 0);
+    }
+
+    // ======== Limit buy IOC: no fills at all → error ========================
+
+    #[test]
+    fn limit_buy_ioc_no_fill_errors() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+        // Ask at 51,000 — taker limit at 50,000 won't cross.
+        place_ask(&mut ctx.storage, MAKER_A, 51_000, 10, 100);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        let err = _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Limit {
+                limit_price: UsdPrice::new_int(50_000),
+                time_in_force: Some(TimeInForce::ImmediateOrCancel),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        );
+
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err()
+                .to_string()
+                .contains("no liquidity at acceptable price")
+        );
     }
 
     // ================== Reduce-only: only closes existing ====================
@@ -2097,7 +2223,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_100),
-                post_only: false,
+                time_in_force: None,
             },
             false,
             None,
@@ -2146,7 +2272,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_050),
-                post_only: false,
+                time_in_force: None,
             },
             false,
             None,
@@ -2969,7 +3095,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             false,
             None,
@@ -3022,7 +3148,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             false,
             None,
@@ -3068,7 +3194,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             false,
             None,
@@ -3120,7 +3246,7 @@ mod tests {
             Quantity::new_int(-10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             false,
             None,
@@ -3172,7 +3298,7 @@ mod tests {
             Quantity::new_int(-10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             false,
             None,
@@ -3223,7 +3349,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             false,
             None,
@@ -3285,7 +3411,7 @@ mod tests {
             Quantity::new_int(-5),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             true,
             None,
@@ -3344,7 +3470,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             },
             false,
             None,
@@ -3849,7 +3975,7 @@ mod tests {
                 Quantity::new_int(10),
                 OrderKind::Limit {
                     limit_price: UsdPrice::new_int(50_000),
-                    post_only: false,
+                    time_in_force: None,
                 },
                 false,
                 None,
@@ -4139,7 +4265,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                post_only: false,
+                time_in_force: None,
             },
             false,
             make_tp(55_000),
@@ -4205,7 +4331,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                post_only: false,
+                time_in_force: None,
             },
             false,
             make_tp(55_000),

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -452,7 +452,7 @@ pub(crate) fn _submit_order(
         match kind {
             OrderKind::Market { .. }
             | OrderKind::Limit {
-                time_in_force: Some(TimeInForce::ImmediateOrCancel),
+                time_in_force: TimeInForce::ImmediateOrCancel,
                 ..
             } => {
                 // IOC: discard unfilled remainder, same as market orders.
@@ -463,7 +463,10 @@ pub(crate) fn _submit_order(
 
                 None
             },
-            OrderKind::Limit { limit_price, .. } => {
+            OrderKind::Limit {
+                limit_price,
+                time_in_force: TimeInForce::GoodTilCanceled,
+            } => {
                 let StoreLimitOrderOutcome {
                     user_state: updated_taker_state,
                     stored_price,
@@ -489,6 +492,11 @@ pub(crate) fn _submit_order(
 
                 Some((stored_price, order_id, order))
             },
+            // PostOnly is intercepted at Step 4 and never reaches here.
+            OrderKind::Limit {
+                time_in_force: TimeInForce::PostOnly,
+                ..
+            } => unreachable!("post-only handled in Step 4"),
         }
     } else {
         None
@@ -1630,7 +1638,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: None,
+                time_in_force: TimeInForce::GoodTilCanceled,
             },
             false,
             None,
@@ -1686,7 +1694,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: None,
+                time_in_force: TimeInForce::GoodTilCanceled,
             },
             false,
             None,
@@ -1746,7 +1754,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: None,
+                time_in_force: TimeInForce::GoodTilCanceled,
             },
             false,
             None,
@@ -1804,7 +1812,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: Some(TimeInForce::ImmediateOrCancel),
+                time_in_force: TimeInForce::ImmediateOrCancel,
             },
             false,
             None,
@@ -1862,7 +1870,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: Some(TimeInForce::ImmediateOrCancel),
+                time_in_force: TimeInForce::ImmediateOrCancel,
             },
             false,
             None,
@@ -2216,7 +2224,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_100),
-                time_in_force: None,
+                time_in_force: TimeInForce::GoodTilCanceled,
             },
             false,
             None,
@@ -2265,7 +2273,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_050),
-                time_in_force: None,
+                time_in_force: TimeInForce::GoodTilCanceled,
             },
             false,
             None,
@@ -3088,7 +3096,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             false,
             None,
@@ -3141,7 +3149,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             false,
             None,
@@ -3187,7 +3195,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             false,
             None,
@@ -3239,7 +3247,7 @@ mod tests {
             Quantity::new_int(-10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             false,
             None,
@@ -3291,7 +3299,7 @@ mod tests {
             Quantity::new_int(-10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             false,
             None,
@@ -3342,7 +3350,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             false,
             None,
@@ -3404,7 +3412,7 @@ mod tests {
             Quantity::new_int(-5),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             true,
             None,
@@ -3463,7 +3471,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             },
             false,
             None,
@@ -3968,7 +3976,7 @@ mod tests {
                 Quantity::new_int(10),
                 OrderKind::Limit {
                     limit_price: UsdPrice::new_int(50_000),
-                    time_in_force: None,
+                    time_in_force: TimeInForce::GoodTilCanceled,
                 },
                 false,
                 None,
@@ -4258,7 +4266,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
-                time_in_force: None,
+                time_in_force: TimeInForce::GoodTilCanceled,
             },
             false,
             make_tp(55_000),
@@ -4324,7 +4332,7 @@ mod tests {
             Quantity::new_int(10),
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
-                time_in_force: None,
+                time_in_force: TimeInForce::GoodTilCanceled,
             },
             false,
             make_tp(55_000),

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -74,7 +74,7 @@ pub fn create_perps_fill(
                 size: Quantity::new_int(-(size as i128)),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(price as i128),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -74,7 +74,7 @@ pub fn create_perps_fill(
                 size: Quantity::new_int(-(size as i128)),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(price as i128),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -46,7 +46,7 @@ fn place_limit_ask(
                 size: Quantity::new_int(-(size as i128)),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(price as i128),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -46,7 +46,7 @@ fn place_limit_ask(
                 size: Quantity::new_int(-(size as i128)),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(price as i128),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -90,7 +90,7 @@ fn adl_bug_absurd_book_price() {
                 size: Quantity::new_int(5), // bid (buy)
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -181,7 +181,7 @@ fn adl_bug_absurd_book_price() {
                 size: Quantity::new_int(-1), // ask (sell) 1 ETH
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(100_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -90,7 +90,7 @@ fn adl_bug_absurd_book_price() {
                 size: Quantity::new_int(5), // bid (buy)
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -181,7 +181,7 @@ fn adl_bug_absurd_book_price() {
                 size: Quantity::new_int(-1), // ask (sell) 1 ETH
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(100_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -48,7 +48,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -132,7 +132,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_500),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -216,7 +216,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -270,7 +270,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -374,7 +374,7 @@ fn conditional_orders_follow_price_time_priority() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -481,7 +481,7 @@ fn conditional_orders_follow_price_time_priority() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_790),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -500,7 +500,7 @@ fn conditional_orders_follow_price_time_priority() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_770),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -639,7 +639,7 @@ fn conditional_order_failure_does_not_block_others() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -680,7 +680,7 @@ fn conditional_order_failure_does_not_block_others() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -787,7 +787,7 @@ fn conditional_order_failure_does_not_block_others() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -913,7 +913,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -953,7 +953,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 size: Quantity::new_int(1),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_950),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1126,7 +1126,7 @@ fn child_order_market_with_tp_triggers() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1184,7 +1184,7 @@ fn child_order_market_with_tp_triggers() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_500),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1244,7 +1244,7 @@ fn child_order_market_with_sl_triggers() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1302,7 +1302,7 @@ fn child_order_market_with_sl_triggers() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1359,7 +1359,7 @@ fn child_order_ignored_when_position_closed() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1397,7 +1397,7 @@ fn child_order_ignored_when_position_closed() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1475,7 +1475,7 @@ fn child_order_overwrites_existing() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1601,7 +1601,7 @@ fn conditional_order_overwrite_same_direction() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1714,7 +1714,7 @@ fn conditional_order_size_exceeds_position_allowed() {
                 size: Quantity::new_int(-3),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -48,7 +48,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -132,7 +132,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_500),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -216,7 +216,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -270,7 +270,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -374,7 +374,7 @@ fn conditional_orders_follow_price_time_priority() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -481,7 +481,7 @@ fn conditional_orders_follow_price_time_priority() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_790),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -500,7 +500,7 @@ fn conditional_orders_follow_price_time_priority() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_770),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -639,7 +639,7 @@ fn conditional_order_failure_does_not_block_others() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -680,7 +680,7 @@ fn conditional_order_failure_does_not_block_others() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -787,7 +787,7 @@ fn conditional_order_failure_does_not_block_others() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -913,7 +913,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -953,7 +953,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 size: Quantity::new_int(1),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_950),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1126,7 +1126,7 @@ fn child_order_market_with_tp_triggers() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1184,7 +1184,7 @@ fn child_order_market_with_tp_triggers() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_500),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1244,7 +1244,7 @@ fn child_order_market_with_sl_triggers() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1302,7 +1302,7 @@ fn child_order_market_with_sl_triggers() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1359,7 +1359,7 @@ fn child_order_ignored_when_position_closed() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1397,7 +1397,7 @@ fn child_order_ignored_when_position_closed() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1475,7 +1475,7 @@ fn child_order_overwrites_existing() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1601,7 +1601,7 @@ fn conditional_order_overwrite_same_direction() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1714,7 +1714,7 @@ fn conditional_order_size_exceeds_position_allowed() {
                 size: Quantity::new_int(-3),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -114,7 +114,7 @@ fn liquidation_on_order_book() {
                 size: Quantity::new_int(-5), // sell / ask
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -196,7 +196,7 @@ fn liquidation_on_order_book() {
                 size: Quantity::new_int(5), // buy / bid
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_450),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -400,7 +400,7 @@ fn liquidation_with_adl() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -465,7 +465,7 @@ fn liquidation_with_adl() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -658,7 +658,7 @@ fn liquidation_cancels_conditional_orders() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -757,7 +757,7 @@ fn liquidation_cancels_conditional_orders() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_450),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1031,7 +1031,7 @@ fn vault_liquidation_on_order_book() {
                 size: bid_size, // buy same size as vault's long
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_600),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -114,7 +114,7 @@ fn liquidation_on_order_book() {
                 size: Quantity::new_int(-5), // sell / ask
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -196,7 +196,7 @@ fn liquidation_on_order_book() {
                 size: Quantity::new_int(5), // buy / bid
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_450),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -400,7 +400,7 @@ fn liquidation_with_adl() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -465,7 +465,7 @@ fn liquidation_with_adl() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -658,7 +658,7 @@ fn liquidation_cancels_conditional_orders() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -757,7 +757,7 @@ fn liquidation_cancels_conditional_orders() {
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_450),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1031,7 +1031,7 @@ fn vault_liquidation_on_order_book() {
                 size: bid_size, // buy same size as vault's long
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_600),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -1281,7 +1281,7 @@ fn place_ask_order(
                 size: Quantity::new_int(-(size as i128)),
                 kind: perps::OrderKind::Limit {
                     limit_price: price,
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -1281,7 +1281,7 @@ fn place_ask_order(
                 size: Quantity::new_int(-(size as i128)),
                 kind: perps::OrderKind::Limit {
                     limit_price: price,
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -74,7 +74,7 @@ fn trading_lifecycle() {
                 size: Quantity::new_int(-10), // sell / ask
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -243,7 +243,7 @@ fn limit_order_partial_fill_and_cancel() {
                 size: Quantity::new_int(-5), // sell / ask 5 ETH
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -268,7 +268,7 @@ fn limit_order_partial_fill_and_cancel() {
                 size: Quantity::new_int(10), // buy 10 ETH
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: false,
+                    time_in_force: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -448,7 +448,7 @@ fn liquidity_depth_tracking() {
                 size: Quantity::new_int(-3),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -486,7 +486,7 @@ fn liquidity_depth_tracking() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -528,7 +528,7 @@ fn liquidity_depth_tracking() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: false,
+                    time_in_force: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -654,7 +654,7 @@ fn protocol_fee_accumulates_across_fills() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -705,7 +705,7 @@ fn protocol_fee_accumulates_across_fills() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -826,7 +826,7 @@ fn negative_maker_fee_rebate_lifecycle() {
                 size: Quantity::new_int(-50),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    post_only: true,
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
                 },
                 reduce_only: false,
                 tp: None,
@@ -911,4 +911,132 @@ fn negative_maker_fee_rebate_lifecycle() {
         UsdValue::new_int(4),
         "treasury should be $4 (taker $6 + maker -$2)"
     );
+}
+
+/// IOC limit order: partial fill with unfilled remainder cancelled (not stored).
+///
+/// | Step | Action                                        | Assert                                          |
+/// |------|-----------------------------------------------|-------------------------------------------------|
+/// | 1    | Both users deposit $10,000 USDC               | margin established                              |
+/// | 2    | Maker (user2) places post-only ask: 5 ETH     | ask on book                                     |
+/// | 3    | Taker (user1) IOC limit buy 10 ETH @ $2,000   | 5 fill, 5 cancelled                             |
+/// | 4    | Verify taker state                            | position=5, open_order_count=0, reserved=$0     |
+#[test]
+fn ioc_limit_order_partial_fill() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+
+    // -------------------------------------------------------------------------
+    // Step 1: Both users deposit $10,000 USDC.
+    // -------------------------------------------------------------------------
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // -------------------------------------------------------------------------
+    // Step 2: Maker (user2) places post-only ask: sell 5 ETH @ $2,000.
+    // -------------------------------------------------------------------------
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // -------------------------------------------------------------------------
+    // Step 3: Taker (user1) IOC limit buy 10 ETH @ $2,000.
+    // 5 fill against maker, 5 unfilled → cancelled (IOC).
+    // Fee = 5 × $2,000 × 0.1% = $10.
+    // -------------------------------------------------------------------------
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: Some(perps::TimeInForce::ImmediateOrCancel),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // -------------------------------------------------------------------------
+    // Step 4: Verify taker state.
+    // -------------------------------------------------------------------------
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    let pos = state
+        .positions
+        .get(&pair)
+        .expect("should have ETH position");
+
+    assert_eq!(pos.size, Quantity::new_int(5), "should be 5 ETH long");
+    assert_eq!(pos.entry_price, UsdPrice::new_int(2_000));
+    assert_eq!(
+        state.margin,
+        UsdValue::new_int(9_990),
+        "margin should be $9,990 after $10 taker fee"
+    );
+
+    // IOC: no resting order.
+    assert_eq!(
+        state.reserved_margin,
+        UsdValue::ZERO,
+        "reserved_margin should be $0 (IOC cancelled unfilled)"
+    );
+    assert_eq!(state.open_order_count, 0, "should have 0 open orders");
+
+    // Verify no resting orders on book.
+    let orders: BTreeMap<perps::OrderId, perps::QueryOrdersByUserResponseItem> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+
+    assert!(orders.is_empty(), "IOC taker should have no resting orders");
 }

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -1040,3 +1040,48 @@ fn ioc_limit_order_partial_fill() {
 
     assert!(orders.is_empty(), "IOC taker should have no resting orders");
 }
+
+/// IOC limit order with zero fills errors out.
+///
+/// | Step | Action                                          | Assert                         |
+/// |------|-------------------------------------------------|--------------------------------|
+/// | 1    | Taker deposits $10,000 USDC                     | margin established             |
+/// | 2    | Taker IOC limit buy 10 ETH @ $1,900 (empty book)| error: no liquidity            |
+#[test]
+fn ioc_limit_order_no_fill_rejected() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+
+    // Step 1: Deposit.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // Step 2: IOC limit buy against empty book → should fail.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(1_900),
+                    time_in_force: Some(perps::TimeInForce::ImmediateOrCancel),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_fail_with_error("no liquidity at acceptable price");
+}

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -74,7 +74,7 @@ fn trading_lifecycle() {
                 size: Quantity::new_int(-10), // sell / ask
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -243,7 +243,7 @@ fn limit_order_partial_fill_and_cancel() {
                 size: Quantity::new_int(-5), // sell / ask 5 ETH
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -268,7 +268,7 @@ fn limit_order_partial_fill_and_cancel() {
                 size: Quantity::new_int(10), // buy 10 ETH
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: None,
+                    time_in_force: perps::TimeInForce::GoodTilCanceled,
                 },
                 reduce_only: false,
                 tp: None,
@@ -448,7 +448,7 @@ fn liquidity_depth_tracking() {
                 size: Quantity::new_int(-3),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -486,7 +486,7 @@ fn liquidity_depth_tracking() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -528,7 +528,7 @@ fn liquidity_depth_tracking() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: None,
+                    time_in_force: perps::TimeInForce::GoodTilCanceled,
                 },
                 reduce_only: false,
                 tp: None,
@@ -654,7 +654,7 @@ fn protocol_fee_accumulates_across_fills() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -705,7 +705,7 @@ fn protocol_fee_accumulates_across_fills() {
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -826,7 +826,7 @@ fn negative_maker_fee_rebate_lifecycle() {
                 size: Quantity::new_int(-50),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -964,7 +964,7 @@ fn ioc_limit_order_partial_fill() {
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::PostOnly),
+                    time_in_force: perps::TimeInForce::PostOnly,
                 },
                 reduce_only: false,
                 tp: None,
@@ -989,7 +989,7 @@ fn ioc_limit_order_partial_fill() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
-                    time_in_force: Some(perps::TimeInForce::ImmediateOrCancel),
+                    time_in_force: perps::TimeInForce::ImmediateOrCancel,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1075,7 +1075,7 @@ fn ioc_limit_order_no_fill_rejected() {
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_900),
-                    time_in_force: Some(perps::TimeInForce::ImmediateOrCancel),
+                    time_in_force: perps::TimeInForce::ImmediateOrCancel,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -64,6 +64,23 @@ pub type CommissionRate = Dimensionless;
 
 #[grug::derive(Serde)]
 #[derive(Copy)]
+pub enum TimeInForce {
+    /// Persist the unfilled portion in the order book.
+    #[serde(rename = "GTC")]
+    GoodTilCanceled,
+
+    /// Cancel the unfilled portion immediately.
+    #[serde(rename = "IOC")]
+    ImmediateOrCancel,
+
+    /// Insert into the book without matching. The limit price must not cross
+    /// the best offer on the other side; reject if violated.
+    #[serde(rename = "POST")]
+    PostOnly,
+}
+
+#[grug::derive(Serde)]
+#[derive(Copy)]
 pub enum OrderKind {
     /// Trade at the best available prices in the order book, optionally
     /// with a slippage tolerance relative to the oracle price.
@@ -76,12 +93,15 @@ pub enum OrderKind {
     Limit {
         limit_price: UsdPrice,
 
-        /// Indicates the order is to be inserted into the book as a maker order
-        /// without being matched.
+        /// Controls what happens to the unfilled portion:
         ///
-        /// The order's limit price must not cross the best offer price on the
-        /// other side of the book. Reject if violated.
-        post_only: bool,
+        /// - GTC: persist in the order book;
+        /// - IOC: cancel;
+        /// - PostOnly: skip matching, rest entire order on book (reject if
+        ///   limit price crosses best offer).
+        ///
+        /// If unspecified, default to GTC.
+        time_in_force: Option<TimeInForce>,
     },
 }
 
@@ -92,7 +112,7 @@ impl OrderKind {
         match self {
             OrderKind::Limit {
                 limit_price,
-                post_only: true,
+                time_in_force: Some(TimeInForce::PostOnly),
             } => Some(limit_price),
             _ => None,
         }

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -63,9 +63,10 @@ pub type FeeShareRatio = Dimensionless;
 pub type CommissionRate = Dimensionless;
 
 #[grug::derive(Serde)]
-#[derive(Copy)]
+#[derive(Copy, Default)]
 pub enum TimeInForce {
     /// Persist the unfilled portion in the order book.
+    #[default]
     #[serde(rename = "GTC")]
     GoodTilCanceled,
 
@@ -99,9 +100,8 @@ pub enum OrderKind {
         /// - IOC: cancel;
         /// - PostOnly: skip matching, rest entire order on book (reject if
         ///   limit price crosses best offer).
-        ///
-        /// If unspecified, default to GTC.
-        time_in_force: Option<TimeInForce>,
+        #[serde(default)]
+        time_in_force: TimeInForce,
     },
 }
 
@@ -112,7 +112,7 @@ impl OrderKind {
         match self {
             OrderKind::Limit {
                 limit_price,
-                time_in_force: Some(TimeInForce::PostOnly),
+                time_in_force: TimeInForce::PostOnly,
             } => Some(limit_price),
             _ => None,
         }

--- a/sdk/dango/src/actions/perps/mutations/submitOrder.ts
+++ b/sdk/dango/src/actions/perps/mutations/submitOrder.ts
@@ -62,7 +62,9 @@ export async function submitPerpsOrder<transport extends Transport>(
         kind: [{ name: "limit", type: "Limit" }],
         Limit: [
           { name: "limitPrice", type: "string" },
-          { name: "postOnly", type: "bool" },
+          ...("limit" in kind && kind.limit.timeInForce
+            ? [{ name: "timeInForce", type: "string" }]
+            : []),
         ],
       };
 

--- a/sdk/dango/src/actions/perps/mutations/submitOrder.ts
+++ b/sdk/dango/src/actions/perps/mutations/submitOrder.ts
@@ -62,9 +62,7 @@ export async function submitPerpsOrder<transport extends Transport>(
         kind: [{ name: "limit", type: "Limit" }],
         Limit: [
           { name: "limitPrice", type: "string" },
-          ...("limit" in kind && kind.limit.timeInForce
-            ? [{ name: "timeInForce", type: "string" }]
-            : []),
+          { name: "timeInForce", type: "string" },
         ],
       };
 

--- a/sdk/dango/src/types/index.ts
+++ b/sdk/dango/src/types/index.ts
@@ -157,6 +157,7 @@ export type {
   PerpsPosition,
   PerpsUnlock,
   PerpsOrderKind,
+  PerpsTimeInForce,
   PerpsPairParam,
   PerpsPairState,
   PerpsParam,

--- a/sdk/dango/src/types/perps.ts
+++ b/sdk/dango/src/types/perps.ts
@@ -47,7 +47,7 @@ export type PerpsTimeInForce = "GTC" | "IOC" | "POST";
 
 export type PerpsOrderKind =
   | { market: { maxSlippage: string } }
-  | { limit: { limitPrice: string; timeInForce?: PerpsTimeInForce } };
+  | { limit: { limitPrice: string; timeInForce: PerpsTimeInForce } };
 
 export type PerpsPairParam = {
   tickSize: string;

--- a/sdk/dango/src/types/perps.ts
+++ b/sdk/dango/src/types/perps.ts
@@ -43,9 +43,11 @@ export type PerpsUserStateExtended = {
   availableMargin: string | null;
 };
 
+export type PerpsTimeInForce = "GTC" | "IOC" | "POST";
+
 export type PerpsOrderKind =
   | { market: { maxSlippage: string } }
-  | { limit: { limitPrice: string; postOnly: boolean } };
+  | { limit: { limitPrice: string; timeInForce?: PerpsTimeInForce } };
 
 export type PerpsPairParam = {
   tickSize: string;

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1161,7 +1161,7 @@
         "price": "Price",
         "timeInForce": "Time In Force",
         "reduceOnly": "Reduce Only",
-        "tpsl": "Take Profit/Stop Loss",
+        "tpsl": "Take Profit / Stop Loss",
         "tpPrice": "TP Price",
         "gain": "Gain",
         "slPrice": "SL Price",

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1159,6 +1159,7 @@
         "currentPosition": "Current Position",
         "size": "Size",
         "price": "Price",
+        "timeInForce": "Time In Force",
         "reduceOnly": "Reduce Only",
         "tpsl": "Take Profit/Stop Loss",
         "tpPrice": "TP Price",

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -29,6 +29,7 @@ import {
   InputSizeWithMax,
   Modals,
   Range,
+  Select,
   Tabs,
   numberMask,
   twMerge,
@@ -373,6 +374,9 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ controllers }) => {
 
   const [tpslEnabled, setTpslEnabled] = useState(false);
   const [reduceOnly, setReduceOnly] = useState(false);
+  const [timeInForce, setTimeInForce] = useState<"GTC" | "IOC" | "POST">("GTC");
+
+  useEffect(() => setTimeInForce("GTC"), [operation]);
 
   const { register, setValue, inputs, errors } = controllers;
   const size = inputs.size?.value || "0";
@@ -478,6 +482,7 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ controllers }) => {
     tpPrice: tpslEnabled && Number(tpPrice) > 0 ? tpPrice : undefined,
     slPrice: tpslEnabled && Number(slPrice) > 0 ? slPrice : undefined,
     reduceOnly,
+    timeInForce: operation === "limit" ? timeInForce : undefined,
     controllers,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["perpsTradeHistory", account?.address] });
@@ -606,6 +611,23 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ controllers }) => {
             startText="right"
             endContent="USD"
           />
+        ) : null}
+        {operation === "limit" ? (
+          <div className="flex items-center justify-between">
+            <span className="diatype-sm-regular text-ink-tertiary-500">
+              {m["dex.protrade.perps.timeInForce"]()}
+            </span>
+            <Select
+              value={timeInForce}
+              onChange={(v) => setTimeInForce(v as "GTC" | "IOC" | "POST")}
+              variant="plain"
+              classNames={{ listboxWrapper: "right-0" }}
+            >
+              <Select.Item value="GTC">GTC</Select.Item>
+              <Select.Item value="IOC">IOC</Select.Item>
+              <Select.Item value="POST">Post Only</Select.Item>
+            </Select>
+          </div>
         ) : null}
         <Checkbox
           radius="md"

--- a/ui/portal/web/src/components/dex/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/TradeMenu.tsx
@@ -40,6 +40,7 @@ import {
 import { Sheet } from "react-modal-sheet";
 
 import { Decimal, formatNumber, parseUnits } from "@left-curve/dango/utils";
+import type { PerpsTimeInForce } from "@left-curve/dango/types";
 import { m } from "@left-curve/foundation/paraglide/messages.js";
 import { orderBookStore } from "@left-curve/store";
 import { useTPSLPriceSync } from "./useTPSLPriceSync";
@@ -374,7 +375,7 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ controllers }) => {
 
   const [tpslEnabled, setTpslEnabled] = useState(false);
   const [reduceOnly, setReduceOnly] = useState(false);
-  const [timeInForce, setTimeInForce] = useState<"GTC" | "IOC" | "POST">("GTC");
+  const [timeInForce, setTimeInForce] = useState<PerpsTimeInForce>("GTC");
 
   useEffect(() => setTimeInForce("GTC"), [operation]);
 
@@ -619,7 +620,7 @@ const PerpsTradeMenu: React.FC<TradeMenuProps> = ({ controllers }) => {
             </span>
             <Select
               value={timeInForce}
-              onChange={(v) => setTimeInForce(v as "GTC" | "IOC" | "POST")}
+              onChange={(v) => setTimeInForce(v as PerpsTimeInForce)}
               variant="plain"
               classNames={{ listboxWrapper: "right-0" }}
             >

--- a/ui/store/src/hooks/usePerpsSubmission.ts
+++ b/ui/store/src/hooks/usePerpsSubmission.ts
@@ -66,7 +66,7 @@ export function usePerpsSubmission(parameters: UsePerpsSubmissionParameters) {
         const kind: PerpsOrderKind =
           operation === "market"
             ? { market: { maxSlippage: "0.05" } }
-            : { limit: { limitPrice: truncateDec(priceValue), timeInForce } };
+            : { limit: { limitPrice: truncateDec(priceValue), timeInForce: timeInForce ?? "GTC" } };
 
         const tp: ChildOrder | undefined =
           tpPrice && Number(tpPrice) > 0

--- a/ui/store/src/hooks/usePerpsSubmission.ts
+++ b/ui/store/src/hooks/usePerpsSubmission.ts
@@ -2,7 +2,7 @@ import { useSubmitTx } from "./useSubmitTx.js";
 import { useAccount } from "./useAccount.js";
 import { useSigningClient } from "./useSigningClient.js";
 
-import type { ChildOrder, PerpsOrderKind } from "@left-curve/dango/types";
+import type { ChildOrder, PerpsOrderKind, PerpsTimeInForce } from "@left-curve/dango/types";
 
 type UsePerpsSubmissionParameters = {
   perpsPairId: string;
@@ -13,6 +13,7 @@ type UsePerpsSubmissionParameters = {
   tpPrice?: string;
   slPrice?: string;
   reduceOnly?: boolean;
+  timeInForce?: PerpsTimeInForce;
   controllers: { reset: () => void };
   onSuccess?: () => void;
 };
@@ -45,6 +46,7 @@ export function usePerpsSubmission(parameters: UsePerpsSubmissionParameters) {
     tpPrice,
     slPrice,
     reduceOnly = false,
+    timeInForce,
     controllers,
     onSuccess,
   } = parameters;
@@ -64,7 +66,7 @@ export function usePerpsSubmission(parameters: UsePerpsSubmissionParameters) {
         const kind: PerpsOrderKind =
           operation === "market"
             ? { market: { maxSlippage: "0.05" } }
-            : { limit: { limitPrice: truncateDec(priceValue), postOnly: false } };
+            : { limit: { limitPrice: truncateDec(priceValue), timeInForce } };
 
         const tp: ChildOrder | undefined =
           tpPrice && Number(tpPrice) > 0


### PR DESCRIPTION
Previous to this PR, limit orders can only be GTC. This PR allows limit orders to be IOC in response to user request.

Refactor `OrderKind::Limit` to replace the `post_only: bool` field with a `TimeInForce` enum (`GTC`, `IOC`, `PostOnly`). IOC limit orders match against the book and silently discard any unfilled remainder (no event), matching market order behavior. Errors if nothing fills at all.
