### PR TITLE
style(dex): fix trade header alignment and simplify OI display

### DIFF
--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1117,7 +1117,7 @@
         "price": "Price",
         "24hChange": "24h Change",
         "volume": "24h Volume",
-        "openInterest": "Open Interest (Long / Short / Total)",
+        "openInterest": "Open Interest (Long + Short)",
         "funding": "Funding / Countdown",
         "oiLimitReached": "OI limit reached",
         "oiLimitDescription": "No new positions can be opened",

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1117,7 +1117,7 @@
         "price": "Price",
         "24hChange": "24h Change",
         "volume": "24h Volume",
-        "openInterest": "Open Interest (Long + Short)",
+        "openInterest": "Open Interest",
         "funding": "Funding / Countdown",
         "oiLimitReached": "OI limit reached",
         "oiLimitDescription": "No new positions can be opened",

--- a/ui/portal/web/src/components/dex/FundingCountdown.tsx
+++ b/ui/portal/web/src/components/dex/FundingCountdown.tsx
@@ -58,7 +58,7 @@ export const FundingCountdown: React.FC = () => {
   return (
     <div className="flex gap-1 flex-col items-start lg:min-w-[4rem]">
       <p className="diatype-xs-medium text-ink-tertiary-500">{m["dex.protrade.spot.funding"]()}</p>
-      <div className="flex items-baseline gap-2">
+      <div className="flex items-baseline gap-2 diatype-xs-medium">
         <Tooltip
           title={
             annualizedPercent

--- a/ui/portal/web/src/components/dex/FundingCountdown.tsx
+++ b/ui/portal/web/src/components/dex/FundingCountdown.tsx
@@ -58,7 +58,7 @@ export const FundingCountdown: React.FC = () => {
   return (
     <div className="flex gap-1 flex-col items-start lg:min-w-[4rem]">
       <p className="diatype-xs-medium text-ink-tertiary-500">{m["dex.protrade.spot.funding"]()}</p>
-      <div className="flex items-center gap-2">
+      <div className="flex items-baseline gap-2">
         <Tooltip
           title={
             annualizedPercent

--- a/ui/portal/web/src/components/dex/OpenInterestDisplay.tsx
+++ b/ui/portal/web/src/components/dex/OpenInterestDisplay.tsx
@@ -19,18 +19,16 @@ export const OpenInterestDisplay: React.FC = () => {
 
   const { data: pairParam } = usePerpsPairParam({ pairId: getPerpsPairId() });
 
-  const { longOiUsd, shortOiUsd, totalOiUsd, isAtLimit } = useMemo(() => {
+  const { totalOiUsd, isAtLimit } = useMemo(() => {
     if (!pairState || !currentPrice) {
-      return { longOiUsd: null, shortOiUsd: null, totalOiUsd: null, isAtLimit: false };
+      return { totalOiUsd: null, isAtLimit: false };
     }
 
     const price = Decimal(currentPrice);
     const longOi = Decimal(pairState.longOi);
     const shortOi = Decimal(pairState.shortOi);
 
-    const longOiUsd = longOi.mul(price);
-    const shortOiUsd = shortOi.mul(price);
-    const totalOiUsd = longOiUsd.plus(shortOiUsd);
+    const totalOiUsd = longOi.mul(price).plus(shortOi.mul(price));
 
     // Check if OI is at limit
     let isAtLimit = false;
@@ -40,8 +38,6 @@ export const OpenInterestDisplay: React.FC = () => {
     }
 
     return {
-      longOiUsd: longOiUsd.toString(),
-      shortOiUsd: shortOiUsd.toString(),
       totalOiUsd: totalOiUsd.toString(),
       isAtLimit,
     };
@@ -64,7 +60,6 @@ export const OpenInterestDisplay: React.FC = () => {
             isAtLimit ? "text-status-fail" : "text-ink-secondary-700",
           )}
         >
-          <OiValue value={longOiUsd} /> / <OiValue value={shortOiUsd} /> /{" "}
           <OiValue value={totalOiUsd} />
         </p>
         {isAtLimit && (


### PR DESCRIPTION
1. Replace the three open interest numbers (long, short, total) with just the total.
2. Make the texts in the chart header bar vertically aligned.