### PR TITLE
style(dex): add grid lines to TradingView dark theme

### DIFF
--- a/ui/portal/web/src/components/dex/TradingView.tsx
+++ b/ui/portal/web/src/components/dex/TradingView.tsx
@@ -102,6 +102,10 @@ export const TradingView: React.FC<TradingViewProps> = ({ coins, orders, mode = 
         "paneProperties.background": toolbar_bg,
         "paneProperties.topMargin": 10,
         "paneProperties.bottomMargin": 10,
+        ...(theme === "dark" && {
+          "paneProperties.vertGridProperties.color": "#ffffff0F",
+          "paneProperties.horzGridProperties.color": "#ffffff0F",
+        }),
       },
 
       studies_overrides: {
@@ -137,6 +141,10 @@ export const TradingView: React.FC<TradingViewProps> = ({ coins, orders, mode = 
       widget.applyOverrides({
         "paneProperties.background": toolbar_bg,
         "scalesProperties.textColor": textColor,
+        ...(theme === "dark" && {
+          "paneProperties.vertGridProperties.color": "#ffffff0F",
+          "paneProperties.horzGridProperties.color": "#ffffff0F",
+        }),
         timezone:
           timeZone === "utc"
             ? "Etc/UTC"


### PR DESCRIPTION
The dark theme uses the grid line color from light theme, which isn't visible under the dark background. This PR changes it to use a light color so it's visible.