### PR TITLE
feat(perps): add vault deposit cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4443,6 +4443,9 @@ dependencies = [
 name = "dango-upgrade"
 version = "0.0.0"
 dependencies = [
+ "borsh",
+ "dango-perps",
+ "dango-types",
  "grug",
  "grug-app",
  "tracing",

--- a/dango/perps/src/vault/add_liquidity.rs
+++ b/dango/perps/src/vault/add_liquidity.rs
@@ -471,4 +471,99 @@ mod tests {
         // floor(3M * 1M / 3M) = 1_000_000 (exact, no rounding needed).
         assert_eq!(user_state.vault_shares, Uint128::new(1_000_000));
     }
+
+    // ---- Test: deposit within cap succeeds ----
+    #[test]
+    fn deposit_within_cap_succeeds() {
+        let storage = MockStorage::new();
+        let mut oracle_querier = OracleQuerier::new_mock(hash_map! {});
+
+        let mut vault_share_supply = Uint128::ZERO;
+        let mut user_state = UserState {
+            margin: UsdValue::new_int(10),
+            ..Default::default()
+        };
+        let mut vault_user_state = UserState::default();
+        let perp_querier = NoCachePerpQuerier::new_local(&storage);
+
+        let shares = _add_liquidity(
+            &mut oracle_querier,
+            &mut vault_share_supply,
+            &perp_querier,
+            &mut user_state,
+            &mut vault_user_state,
+            UsdValue::new_int(5),
+            None,
+            Some(UsdValue::new_int(10)),
+        )
+        .unwrap();
+
+        assert!(shares > Uint128::ZERO);
+        assert_eq!(user_state.margin, UsdValue::new_int(5));
+    }
+
+    // ---- Test: deposit exceeding cap rejected ----
+    #[test]
+    fn deposit_exceeding_cap_rejected() {
+        let storage = MockStorage::new();
+        let mut oracle_querier = OracleQuerier::new_mock(hash_map! {});
+
+        let mut vault_share_supply = Uint128::ZERO;
+        let mut user_state = UserState {
+            margin: UsdValue::new_int(10),
+            ..Default::default()
+        };
+        let mut vault_user_state = UserState {
+            margin: UsdValue::new_int(5),
+            ..Default::default()
+        };
+        let perp_querier = NoCachePerpQuerier::new_local(&storage);
+
+        let err = _add_liquidity(
+            &mut oracle_querier,
+            &mut vault_share_supply,
+            &perp_querier,
+            &mut user_state,
+            &mut vault_user_state,
+            UsdValue::new_int(5),
+            None,
+            Some(UsdValue::new_int(8)),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("vault deposit cap exceeded"));
+    }
+
+    // ---- Test: deposit exactly at cap succeeds ----
+    #[test]
+    fn deposit_exactly_at_cap_succeeds() {
+        let storage = MockStorage::new();
+        let mut oracle_querier = OracleQuerier::new_mock(hash_map! {});
+
+        let mut vault_share_supply = Uint128::ZERO;
+        let mut user_state = UserState {
+            margin: UsdValue::new_int(10),
+            ..Default::default()
+        };
+        let mut vault_user_state = UserState {
+            margin: UsdValue::new_int(5),
+            ..Default::default()
+        };
+        let perp_querier = NoCachePerpQuerier::new_local(&storage);
+
+        let shares = _add_liquidity(
+            &mut oracle_querier,
+            &mut vault_share_supply,
+            &perp_querier,
+            &mut user_state,
+            &mut vault_user_state,
+            UsdValue::new_int(5),
+            None,
+            Some(UsdValue::new_int(10)),
+        )
+        .unwrap();
+
+        assert!(shares > Uint128::ZERO);
+        assert_eq!(vault_user_state.margin, UsdValue::new_int(10));
+    }
 }

--- a/dango/perps/src/vault/add_liquidity.rs
+++ b/dango/perps/src/vault/add_liquidity.rs
@@ -4,7 +4,7 @@ use {
         core::compute_user_equity,
         oracle,
         querier::NoCachePerpQuerier,
-        state::{STATE, USER_STATES},
+        state::{PARAM, STATE, USER_STATES},
     },
     anyhow::ensure,
     dango_oracle::OracleQuerier,
@@ -39,6 +39,8 @@ pub fn add_liquidity(
         .may_load(ctx.storage, ctx.sender)?
         .unwrap_or_default();
 
+    let param = PARAM.load(ctx.storage)?;
+
     let perp_querier = NoCachePerpQuerier::new_local(ctx.storage);
 
     let mut oracle_querier = OracleQuerier::new_remote(oracle(ctx.querier), ctx.querier);
@@ -53,6 +55,7 @@ pub fn add_liquidity(
         &mut vault_user_state,
         amount,
         min_shares_to_mint,
+        param.vault_deposit_cap,
     )?;
 
     // ------------------------ 3. Apply state changes -------------------------
@@ -94,6 +97,7 @@ fn _add_liquidity(
     vault_user_state: &mut UserState,
     amount: UsdValue,
     min_shares_to_mint: Option<Uint128>,
+    vault_deposit_cap: Option<UsdValue>,
 ) -> anyhow::Result<Uint128> {
     // ----------------------- Step 1. Validate deposit ------------------------
 
@@ -108,6 +112,17 @@ fn _add_liquidity(
         user_state.margin,
         amount
     );
+
+    if let Some(cap) = vault_deposit_cap {
+        let post_deposit_margin = vault_user_state.margin.checked_add(amount)?;
+        ensure!(
+            post_deposit_margin <= cap,
+            "vault deposit cap exceeded! current ({}) + deposit ({}) > cap ({})",
+            vault_user_state.margin,
+            amount,
+            cap,
+        );
+    }
 
     // --------------------- Step 2. Compute vault equity ----------------------
 
@@ -190,6 +205,7 @@ mod tests {
             &mut vault_user_state,
             UsdValue::new_int(1),
             None,
+            None,
         )
         .unwrap();
 
@@ -222,6 +238,7 @@ mod tests {
             &mut vault_user_state,
             UsdValue::new_int(1),
             None,
+            None,
         )
         .unwrap();
 
@@ -247,6 +264,7 @@ mod tests {
             &mut user_state,
             &mut vault_user_state,
             UsdValue::ZERO,
+            None,
             None,
         )
         .unwrap_err();
@@ -279,6 +297,7 @@ mod tests {
             &mut vault_user_state,
             UsdValue::new_int(1),
             None,
+            None,
         )
         .unwrap_err();
 
@@ -307,6 +326,7 @@ mod tests {
             &mut vault_user_state,
             UsdValue::new_int(1),
             Some(Uint128::new(1_000_000)),
+            None,
         )
         .unwrap();
 
@@ -335,6 +355,7 @@ mod tests {
             &mut vault_user_state,
             UsdValue::new_int(1),
             Some(Uint128::new(1_000_001)),
+            None,
         )
         .unwrap_err();
 
@@ -368,6 +389,7 @@ mod tests {
             &mut user_state,
             &mut vault_user_state,
             UsdValue::new_int(one_billion as i128),
+            None,
             None,
         )
         .unwrap();
@@ -409,6 +431,7 @@ mod tests {
             &mut vault_user_state,
             UsdValue::new_raw(1),
             None,
+            None,
         )
         .unwrap();
 
@@ -439,6 +462,7 @@ mod tests {
             &mut user_state,
             &mut vault_user_state,
             UsdValue::new_int(1),
+            None,
             None,
         )
         .unwrap();

--- a/dango/scripts/examples/perps_instantiate.rs
+++ b/dango/scripts/examples/perps_instantiate.rs
@@ -57,6 +57,7 @@ fn param() -> Param {
                 UsdValue::new_int(100_000_000) => Dimensionless::new_percent(30), // 30% at $100M+
             },
         },
+        vault_deposit_cap: Some(UsdValue::new_int(500_000)), // $500k
     }
 }
 

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -268,6 +268,11 @@ pub struct Param {
     /// Volume-tiered referrer commission rates. Highest qualifying tier wins;
     /// base rate applies when no tier is met.
     pub referrer_commission_rates: RateSchedule,
+
+    /// Maximum total margin the counterparty vault may hold. Deposits that
+    /// would push `vault_margin + deposit` above this cap are rejected.
+    /// `None` means no cap (unlimited deposits).
+    pub vault_deposit_cap: Option<UsdValue>,
 }
 
 /// Global state that concerns the counterparty vault and all trading pairs.

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -9,6 +9,9 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 
 [dependencies]
-grug     = { workspace = true }
-grug-app = { workspace = true }
-tracing  = { workspace = true }
+borsh       = { workspace = true }
+dango-perps = { workspace = true, features = ["library"] }
+dango-types = { workspace = true }
+grug        = { workspace = true }
+grug-app    = { workspace = true }
+tracing     = { workspace = true }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -9,9 +9,11 @@ use {
 
 const MAINNET_CHAIN_ID: &str = "dango-1";
 const MAINNET_PERPS_ADDRESS: Addr = addr!("90bc84df68d1aa59a857e04ed529e9a26edbea4f");
+const MAINNET_VAULT_DEPOSIT_CAP: Option<UsdValue> = Some(UsdValue::new_int(500_000));
 
 const TESTNET_CHAIN_ID: &str = "dango-testnet-1";
 const TESTNET_PERPS_ADDRESS: Addr = addr!("f6344c5e2792e8f9202c58a2d88fbbde4cd3142f");
+const TESTNET_VAULT_DEPOSIT_CAP: Option<UsdValue> = None;
 
 /// Legacy types matching the pre-upgrade Borsh layout.
 mod legacy {
@@ -42,21 +44,25 @@ mod legacy {
 pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
     let chain_id = CHAIN_ID.load(&storage)?;
 
-    let perps_address = match chain_id.as_str() {
-        MAINNET_CHAIN_ID => MAINNET_PERPS_ADDRESS,
-        TESTNET_CHAIN_ID => TESTNET_PERPS_ADDRESS,
+    let (perps_address, vault_deposit_cap) = match chain_id.as_str() {
+        MAINNET_CHAIN_ID => (MAINNET_PERPS_ADDRESS, MAINNET_VAULT_DEPOSIT_CAP),
+        TESTNET_CHAIN_ID => (TESTNET_PERPS_ADDRESS, TESTNET_VAULT_DEPOSIT_CAP),
         _ => panic!("unknown chain id: {chain_id}"),
     };
 
     let mut storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
 
-    Ok(_do_upgrade(&mut storage)?)
+    Ok(_do_upgrade(&mut storage, vault_deposit_cap)?)
 }
 
-fn _do_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
+fn _do_upgrade(storage: &mut dyn Storage, vault_deposit_cap: Option<UsdValue>) -> StdResult<()> {
     let old_param = legacy::PARAM.load(storage)?;
 
     let new_param = perps::Param {
+        // New!
+        vault_deposit_cap,
+
+        // Fields copied directly from the old `Param`.
         max_unlocks: old_param.max_unlocks,
         max_open_orders: old_param.max_open_orders,
         maker_fee_rates: old_param.maker_fee_rates,
@@ -70,12 +76,18 @@ fn _do_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
         referral_active: old_param.referral_active,
         min_referrer_volume: old_param.min_referrer_volume,
         referrer_commission_rates: old_param.referrer_commission_rates,
-        vault_deposit_cap: Some(UsdValue::new_int(500_000)),
     };
 
     dango_perps::state::PARAM.save(storage, &new_param)?;
 
-    tracing::info!("Migrated Param (added vault_deposit_cap = $500,000)");
+    tracing::info!(
+        "Migrated Param (added vault_deposit_cap = {})",
+        if let Some(cap) = vault_deposit_cap {
+            format!("Some(${cap})")
+        } else {
+            "None".to_string()
+        }
+    );
 
     Ok(())
 }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,10 +1,81 @@
 use {
-    grug::{BlockInfo, Storage},
-    grug_app::AppResult,
+    dango_types::{
+        Dimensionless, UsdValue,
+        perps::{self, RateSchedule},
+    },
+    grug::{Addr, BlockInfo, Duration, StdResult, Storage, addr},
+    grug_app::{AppResult, CHAIN_ID, CONTRACT_NAMESPACE, StorageProvider},
 };
 
-pub fn do_upgrade<VM>(_storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
-    tracing::info!("No upgrade necessary for this version");
+const MAINNET_CHAIN_ID: &str = "dango-1";
+const MAINNET_PERPS_ADDRESS: Addr = addr!("90bc84df68d1aa59a857e04ed529e9a26edbea4f");
+
+const TESTNET_CHAIN_ID: &str = "dango-testnet-1";
+const TESTNET_PERPS_ADDRESS: Addr = addr!("f6344c5e2792e8f9202c58a2d88fbbde4cd3142f");
+
+/// Legacy types matching the pre-upgrade Borsh layout.
+mod legacy {
+    use super::*;
+
+    pub const PARAM: grug::Item<Param> = grug::Item::new("param");
+
+    /// The Param struct before this upgrade, which does not contain the
+    /// `vault_deposit_cap` field.
+    #[derive(borsh::BorshDeserialize, borsh::BorshSerialize)]
+    pub struct Param {
+        pub max_unlocks: usize,
+        pub max_open_orders: usize,
+        pub maker_fee_rates: RateSchedule,
+        pub taker_fee_rates: RateSchedule,
+        pub protocol_fee_rate: Dimensionless,
+        pub liquidation_fee_rate: Dimensionless,
+        pub liquidation_buffer_ratio: Dimensionless,
+        pub funding_period: Duration,
+        pub vault_total_weight: Dimensionless,
+        pub vault_cooldown_period: Duration,
+        pub referral_active: bool,
+        pub min_referrer_volume: UsdValue,
+        pub referrer_commission_rates: RateSchedule,
+    }
+}
+
+pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
+    let chain_id = CHAIN_ID.load(&storage)?;
+
+    let perps_address = match chain_id.as_str() {
+        MAINNET_CHAIN_ID => MAINNET_PERPS_ADDRESS,
+        TESTNET_CHAIN_ID => TESTNET_PERPS_ADDRESS,
+        _ => panic!("unknown chain id: {chain_id}"),
+    };
+
+    let mut storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
+
+    Ok(_do_upgrade(&mut storage)?)
+}
+
+fn _do_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
+    let old_param = legacy::PARAM.load(storage)?;
+
+    let new_param = perps::Param {
+        max_unlocks: old_param.max_unlocks,
+        max_open_orders: old_param.max_open_orders,
+        maker_fee_rates: old_param.maker_fee_rates,
+        taker_fee_rates: old_param.taker_fee_rates,
+        protocol_fee_rate: old_param.protocol_fee_rate,
+        liquidation_fee_rate: old_param.liquidation_fee_rate,
+        liquidation_buffer_ratio: old_param.liquidation_buffer_ratio,
+        funding_period: old_param.funding_period,
+        vault_total_weight: old_param.vault_total_weight,
+        vault_cooldown_period: old_param.vault_cooldown_period,
+        referral_active: old_param.referral_active,
+        min_referrer_volume: old_param.min_referrer_volume,
+        referrer_commission_rates: old_param.referrer_commission_rates,
+        vault_deposit_cap: Some(UsdValue::new_int(500_000)),
+    };
+
+    dango_perps::state::PARAM.save(storage, &new_param)?;
+
+    tracing::info!("Migrated Param (added vault_deposit_cap = $500,000)");
 
     Ok(())
 }

--- a/deploy/roles/full-app/templates/config/cometbft/genesis.json
+++ b/deploy/roles/full-app/templates/config/cometbft/genesis.json
@@ -934,7 +934,7 @@
                 "tiers": {}
               },
               "vault_cooldown_period": "86400",
-              "vault_deposit_cap": "500000",
+              "vault_deposit_cap": null,
               "vault_total_weight": "7"
             }
           },

--- a/deploy/roles/full-app/templates/config/cometbft/genesis.json
+++ b/deploy/roles/full-app/templates/config/cometbft/genesis.json
@@ -934,6 +934,7 @@
                 "tiers": {}
               },
               "vault_cooldown_period": "86400",
+              "vault_deposit_cap": "500000",
               "vault_total_weight": "7"
             }
           },

--- a/localdango/configs/cometbft/config/genesis.json
+++ b/localdango/configs/cometbft/config/genesis.json
@@ -906,6 +906,7 @@
                 "tiers": {}
               },
               "vault_cooldown_period": "86400",
+              "vault_deposit_cap": "500000",
               "vault_total_weight": "0"
             }
           },

--- a/localdango/configs/cometbft/config/genesis.json
+++ b/localdango/configs/cometbft/config/genesis.json
@@ -906,7 +906,7 @@
                 "tiers": {}
               },
               "vault_cooldown_period": "86400",
-              "vault_deposit_cap": "500000",
+              "vault_deposit_cap": null,
               "vault_total_weight": "0"
             }
           },


### PR DESCRIPTION
Add an `Option<UsdValue>` deposit cap to the global `Param` struct. When `Some`, `add_liquidity` rejects deposits that would push the vault's total margin above the cap. `None` means unlimited.

Includes a chain upgrade migration that sets the cap to $500,000 on both mainnet and testnet.