### PR TITLE
feat(perps): add owner-only `force_set_fee_share_ratio`

### DIFF
--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -191,6 +191,9 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
                 user,
                 commission_rate,
             } => referral::set_commission_rate_override(ctx, user, commission_rate),
+            ReferralMsg::ForceSetFeeShareRatio { user, share_ratio } => {
+                referral::force_set_fee_share_ratio(ctx, user, share_ratio)
+            },
         },
     }
 }

--- a/dango/perps/src/referral.rs
+++ b/dango/perps/src/referral.rs
@@ -1,12 +1,13 @@
 mod apply_fee_commissions;
 mod commission;
+mod force_set_fee_share_ratio;
 mod set_commission_rate_override;
 mod set_fee_share_ratio;
 mod set_referral;
 
 pub use {
-    apply_fee_commissions::*, commission::*, set_commission_rate_override::*,
-    set_fee_share_ratio::*, set_referral::*,
+    apply_fee_commissions::*, commission::*, force_set_fee_share_ratio::*,
+    set_commission_rate_override::*, set_fee_share_ratio::*, set_referral::*,
 };
 
 use {

--- a/dango/perps/src/referral/force_set_fee_share_ratio.rs
+++ b/dango/perps/src/referral/force_set_fee_share_ratio.rs
@@ -25,11 +25,16 @@ pub fn force_set_fee_share_ratio(
     Ok(Response::new())
 }
 
+// ----------------------------------- tests -----------------------------------
+
 #[cfg(test)]
 mod tests {
     use {
         super::*,
-        grug::{Addr, Coins, Config, Duration, MockContext, MockQuerier, Permission, Permissions, ResultExt},
+        grug::{
+            Addr, Coins, Config, Duration, MockContext, MockQuerier, Permission, Permissions,
+            ResultExt,
+        },
         std::collections::BTreeMap,
     };
 

--- a/dango/perps/src/referral/force_set_fee_share_ratio.rs
+++ b/dango/perps/src/referral/force_set_fee_share_ratio.rs
@@ -1,0 +1,63 @@
+use {
+    crate::state::FEE_SHARE_RATIO,
+    anyhow::ensure,
+    dango_types::{account_factory::UserIndex, perps::FeeShareRatio},
+    grug::{MutableCtx, QuerierExt, Response},
+};
+
+/// Forcibly set a user's fee share ratio.
+///
+/// Only callable by the chain owner. Bypasses the maximum ratio cap,
+/// volume requirement, and only-increase restriction that apply to the
+/// normal [`set_fee_share_ratio`] path.
+pub fn force_set_fee_share_ratio(
+    ctx: MutableCtx,
+    user: UserIndex,
+    share_ratio: FeeShareRatio,
+) -> anyhow::Result<Response> {
+    ensure!(
+        ctx.sender == ctx.querier.query_owner()?,
+        "you don't have the right, O you don't have the right"
+    );
+
+    FEE_SHARE_RATIO.save(ctx.storage, user, &share_ratio)?;
+
+    Ok(Response::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        grug::{Addr, Coins, Config, Duration, MockContext, MockQuerier, Permission, Permissions, ResultExt},
+        std::collections::BTreeMap,
+    };
+
+    const OWNER: Addr = Addr::mock(1);
+    const NOT_OWNER: Addr = Addr::mock(2);
+
+    fn mock_config() -> Config {
+        Config {
+            owner: OWNER,
+            bank: Addr::mock(100),
+            taxman: Addr::mock(101),
+            cronjobs: BTreeMap::new(),
+            permissions: Permissions {
+                upload: Permission::Everybody,
+                instantiate: Permission::Everybody,
+            },
+            max_orphan_age: Duration::from_seconds(1000),
+        }
+    }
+
+    #[test]
+    fn only_owner_can_force_set() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(NOT_OWNER)
+            .with_funds(Coins::default());
+
+        force_set_fee_share_ratio(ctx.as_mutable(), 42, FeeShareRatio::new_percent(25))
+            .should_fail_with_error("you don't have the right");
+    }
+}

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -832,6 +832,19 @@ pub enum ReferralMsg {
         user: UserIndex,
         commission_rate: Op<CommissionRate>,
     },
+
+    /// Forcibly set a user's fee share ratio.
+    ///
+    /// Only callable by the chain owner.
+    ///
+    /// A referrer is only allowed to increase his fee share ratio, not decreasing
+    /// it. This is to prevent malicious referrers from rugpull their referees.
+    /// However, if a referrer makes an honest mistake setting the wrong ratio,
+    /// the owner can step in to correct it.
+    ForceSetFeeShareRatio {
+        user: UserIndex,
+        share_ratio: FeeShareRatio,
+    },
 }
 
 #[grug::derive(Serde, QueryRequest)]


### PR DESCRIPTION
Allow the chain owner to forcibly set a referrer's fee share ratio, bypassing the max-ratio cap, volume requirement, and only-increase restriction. Intended for correcting honest mistakes by referrers.