### PR TITLE
feat(perps): validate `Param` and `PairParam` in `configure`

### DIFF
--- a/dango/perps/src/maintain/configure.rs
+++ b/dango/perps/src/maintain/configure.rs
@@ -1,22 +1,54 @@
 use {
     crate::state::{PAIR_IDS, PAIR_PARAMS, PAIR_STATES, PARAM},
     anyhow::ensure,
-    dango_types::perps::{PairParam, PairState, Param},
-    grug::{Denom, GENESIS_SENDER, MutableCtx, QuerierExt, Response},
+    dango_types::{
+        Dimensionless, FundingRate, UsdPrice, UsdValue,
+        perps::{PairId, PairParam, PairState, Param, RateSchedule},
+    },
+    grug::{Duration, GENESIS_SENDER, MutableCtx, QuerierExt, Response},
     std::collections::BTreeMap,
 };
 
+/// Upper bound for `funding_period`. A period longer than a week would
+/// effectively suspend funding collection.
+const MAX_FUNDING_PERIOD: Duration = Duration::from_days(7);
+
+/// Upper bound for `vault_cooldown_period`. A cooldown longer than a month
+/// would effectively lock LPs out of their deposits.
+const MAX_VAULT_COOLDOWN_PERIOD: Duration = Duration::from_days(30);
+
+/// Upper bound for `max_abs_funding_rate` (per day). 100% per day already
+/// implies an OI-weighted funding payment equal to one day's notional —
+/// anything larger is pathological.
+const MAX_FUNDING_RATE_CAP: FundingRate = FundingRate::new_int(1);
+
 /// Update global and per-pair parameters.
 /// Callable by the chain owner or `GENESIS_SENDER` (during instantiation).
+///
+/// Validation runs before any state mutation: if any field or cross-struct
+/// invariant is rejected, `PARAM`, `PAIR_PARAMS`, `PAIR_STATES`, and
+/// `PAIR_IDS` are left untouched.
 pub fn configure(
     ctx: MutableCtx,
     param: Param,
-    pair_params: BTreeMap<Denom, PairParam>,
+    pair_params: BTreeMap<PairId, PairParam>,
 ) -> anyhow::Result<Response> {
+    // ---------------------------- 1. Validations -----------------------------
+
     ensure!(
         ctx.sender == ctx.querier.query_owner()? || ctx.sender == GENESIS_SENDER,
         "You don't have the right, O you don't have the right"
     );
+
+    validate_param(&param)?;
+
+    for (pair_id, pair_param) in &pair_params {
+        validate_pair_param(pair_id, pair_param)?;
+    }
+
+    validate_vault_total_weight(&param, &pair_params)?;
+
+    // --------------------------- 2. State changes ----------------------------
 
     PARAM.save(ctx.storage, &param)?;
 
@@ -31,4 +63,1141 @@ pub fn configure(
     PAIR_IDS.save(ctx.storage, &pair_params.into_keys().collect())?;
 
     Ok(Response::new())
+}
+
+/// Validate every field of the global `Param` struct.
+///
+/// Bounds are documented on each field in `dango_types::perps::Param`.
+fn validate_param(param: &Param) -> anyhow::Result<()> {
+    ensure!(
+        param.max_unlocks > 0,
+        "invalid `max_unlocks`! bounds: > 0, found: {}",
+        param.max_unlocks,
+    );
+
+    ensure!(
+        param.max_open_orders > 0,
+        "invalid `max_open_orders`! bounds: > 0, found: {}",
+        param.max_open_orders,
+    );
+
+    // Maker fees may be negative: a negative rate represents a rebate paid
+    // to the maker. Taker fees and referrer commissions are always non-negative.
+    validate_rate_schedule(
+        "maker_fee_rates",
+        &param.maker_fee_rates,
+        Dimensionless::new_int(-1),
+        Dimensionless::ONE,
+    )?;
+
+    validate_rate_schedule(
+        "taker_fee_rates",
+        &param.taker_fee_rates,
+        Dimensionless::ZERO,
+        Dimensionless::ONE,
+    )?;
+
+    validate_rate_schedule(
+        "referrer_commission_rates",
+        &param.referrer_commission_rates,
+        Dimensionless::ZERO,
+        Dimensionless::ONE,
+    )?;
+
+    ensure!(
+        (Dimensionless::ZERO..=Dimensionless::ONE).contains(&param.protocol_fee_rate),
+        "invalid `protocol_fee_rate`! bounds: [0, 1], found: {}",
+        param.protocol_fee_rate,
+    );
+
+    ensure!(
+        (Dimensionless::ZERO..=Dimensionless::ONE).contains(&param.liquidation_fee_rate),
+        "invalid `liquidation_fee_rate`! bounds: [0, 1], found: {}",
+        param.liquidation_fee_rate,
+    );
+
+    ensure!(
+        (Dimensionless::ZERO..Dimensionless::ONE).contains(&param.liquidation_buffer_ratio),
+        "invalid `liquidation_buffer_ratio`! bounds: [0, 1), found: {}",
+        param.liquidation_buffer_ratio,
+    );
+
+    ensure!(
+        param.funding_period > Duration::ZERO && param.funding_period <= MAX_FUNDING_PERIOD,
+        "invalid `funding_period`! bounds: (0, {:?}], found: {:?}",
+        MAX_FUNDING_PERIOD,
+        param.funding_period,
+    );
+
+    // `vault_total_weight` is cross-validated against the sum of per-pair
+    // weights in `validate_vault_total_weight`; no independent lower-bound
+    // check is needed here.
+
+    ensure!(
+        param.vault_cooldown_period > Duration::ZERO
+            && param.vault_cooldown_period <= MAX_VAULT_COOLDOWN_PERIOD,
+        "invalid `vault_cooldown_period`! bounds: (0, {:?}], found: {:?}",
+        MAX_VAULT_COOLDOWN_PERIOD,
+        param.vault_cooldown_period,
+    );
+
+    // `referral_active: bool` — always valid.
+
+    ensure!(
+        param.min_referrer_volume >= UsdValue::ZERO,
+        "invalid `min_referrer_volume`! bounds: >= 0, found: {}",
+        param.min_referrer_volume,
+    );
+
+    if let Some(cap) = param.vault_deposit_cap {
+        ensure!(
+            cap > UsdValue::ZERO,
+            "invalid `vault_deposit_cap`! bounds: if Some, > 0, found: {}",
+            cap,
+        );
+    }
+
+    Ok(())
+}
+
+/// Validate every field of a per-pair `PairParam` struct.
+///
+/// Bounds are documented on each field in `dango_types::perps::PairParam`.
+fn validate_pair_param(pair_id: &PairId, pair_param: &PairParam) -> anyhow::Result<()> {
+    ensure!(
+        pair_param.tick_size > UsdPrice::ZERO,
+        "invalid `tick_size`! pair id: {}, bounds: > 0, found: {}",
+        pair_id,
+        pair_param.tick_size,
+    );
+
+    ensure!(
+        pair_param.min_order_size >= UsdValue::ZERO,
+        "invalid `min_order_size`! pair id: {}, bounds: >= 0, found: {}",
+        pair_id,
+        pair_param.min_order_size,
+    );
+
+    ensure!(
+        pair_param.max_abs_oi.is_positive(),
+        "invalid `max_abs_oi`! pair id: {}, bounds: > 0, found: {}",
+        pair_id,
+        pair_param.max_abs_oi,
+    );
+
+    ensure!(
+        !pair_param.max_abs_funding_rate.is_negative()
+            && pair_param.max_abs_funding_rate <= MAX_FUNDING_RATE_CAP,
+        "invalid `max_abs_funding_rate`! pair id: {}, bounds: [0, {}], found: {}",
+        pair_id,
+        MAX_FUNDING_RATE_CAP,
+        pair_param.max_abs_funding_rate,
+    );
+
+    ensure!(
+        pair_param.initial_margin_ratio > Dimensionless::ZERO
+            && pair_param.initial_margin_ratio <= Dimensionless::ONE,
+        "invalid `initial_margin_ratio`! pair id: {}, bounds: (0, 1], found: {}",
+        pair_id,
+        pair_param.initial_margin_ratio,
+    );
+
+    ensure!(
+        pair_param.maintenance_margin_ratio > Dimensionless::ZERO
+            && pair_param.maintenance_margin_ratio <= Dimensionless::ONE,
+        "invalid `maintenance_margin_ratio`! pair id: {}, bounds: (0, 1], found: {}",
+        pair_id,
+        pair_param.maintenance_margin_ratio,
+    );
+
+    ensure!(
+        pair_param.maintenance_margin_ratio < pair_param.initial_margin_ratio,
+        "invalid `maintenance_margin_ratio`! pair id: {}, bounds: must be < `initial_margin_ratio` ({}), found: {}",
+        pair_id,
+        pair_param.initial_margin_ratio,
+        pair_param.maintenance_margin_ratio,
+    );
+
+    ensure!(
+        pair_param.impact_size > UsdValue::ZERO,
+        "invalid `impact_size`! pair id: {}, bounds: > 0, found: {}",
+        pair_id,
+        pair_param.impact_size,
+    );
+
+    ensure!(
+        pair_param.vault_liquidity_weight >= Dimensionless::ZERO,
+        "invalid `vault_liquidity_weight`! pair id: {}, bounds: >= 0, found: {}",
+        pair_id,
+        pair_param.vault_liquidity_weight,
+    );
+
+    ensure!(
+        pair_param.vault_half_spread > Dimensionless::ZERO
+            && pair_param.vault_half_spread < Dimensionless::ONE,
+        "invalid `vault_half_spread`! pair id: {}, bounds: (0, 1), found: {}",
+        pair_id,
+        pair_param.vault_half_spread,
+    );
+
+    ensure!(
+        pair_param.vault_max_quote_size.is_positive(),
+        "invalid `vault_max_quote_size`! pair id: {}, bounds: > 0, found: {}",
+        pair_id,
+        pair_param.vault_max_quote_size,
+    );
+
+    ensure!(
+        (Dimensionless::ZERO..=Dimensionless::ONE).contains(&pair_param.vault_size_skew_factor),
+        "invalid `vault_size_skew_factor`! pair id: {}, bounds: [0, 1], found: {}",
+        pair_id,
+        pair_param.vault_size_skew_factor,
+    );
+
+    ensure!(
+        (Dimensionless::ZERO..Dimensionless::ONE).contains(&pair_param.vault_spread_skew_factor),
+        "invalid `vault_spread_skew_factor`! pair id: {}, bounds: [0, 1), found: {}",
+        pair_id,
+        pair_param.vault_spread_skew_factor,
+    );
+
+    // Cross-field: under maximum positive skew, the bid-side effective spread
+    // is `vault_half_spread * (1 + vault_spread_skew_factor)`. We require
+    // this product to stay strictly below 1 so the vault's bid price never
+    // collapses to or below zero, even when inventory is fully skewed.
+    let one_plus_factor = Dimensionless::ONE.checked_add(pair_param.vault_spread_skew_factor)?;
+    let max_bid_effective_spread = pair_param.vault_half_spread.checked_mul(one_plus_factor)?;
+    ensure!(
+        max_bid_effective_spread < Dimensionless::ONE,
+        "invalid `vault_half_spread`/`vault_spread_skew_factor`! pair id: {}, bounds: vault_half_spread * (1 + vault_spread_skew_factor) < 1, found: {} * (1 + {}) = {}",
+        pair_id,
+        pair_param.vault_half_spread,
+        pair_param.vault_spread_skew_factor,
+        max_bid_effective_spread,
+    );
+
+    ensure!(
+        !pair_param.vault_max_skew_size.is_negative(),
+        "invalid `vault_max_skew_size`! pair id: {}, bounds: >= 0, found: {}",
+        pair_id,
+        pair_param.vault_max_skew_size,
+    );
+
+    for bucket_size in &pair_param.bucket_sizes {
+        ensure!(
+            *bucket_size > UsdPrice::ZERO,
+            "invalid `bucket_sizes`! pair id: {}, bounds: each entry > 0, found: {}",
+            pair_id,
+            bucket_size,
+        );
+    }
+
+    Ok(())
+}
+
+/// Cross-struct invariant: `param.vault_total_weight` must equal the sum of
+/// `vault_liquidity_weight` across all provided pairs. The sum is used as a
+/// divisor in `refresh_orders` when allocating vault margin across pairs;
+/// a drift between the precomputed total and the actual sum silently
+/// corrupts every subsequent allocation.
+fn validate_vault_total_weight(
+    param: &Param,
+    pair_params: &BTreeMap<PairId, PairParam>,
+) -> anyhow::Result<()> {
+    let mut expected = Dimensionless::ZERO;
+    for pair_param in pair_params.values() {
+        expected.checked_add_assign(pair_param.vault_liquidity_weight)?;
+    }
+
+    ensure!(
+        param.vault_total_weight == expected,
+        "invalid `vault_total_weight`! bounds: must equal sum of `vault_liquidity_weight` across all pairs, expected: {}, found: {}",
+        expected,
+        param.vault_total_weight,
+    );
+
+    Ok(())
+}
+
+/// Validate that every rate in a `RateSchedule` (base + all tier values) lies
+/// in the inclusive range `[min, max]`.
+fn validate_rate_schedule(
+    name: &str,
+    schedule: &RateSchedule,
+    min: Dimensionless,
+    max: Dimensionless,
+) -> anyhow::Result<()> {
+    ensure!(
+        (min..=max).contains(&schedule.base),
+        "invalid `{}.base`! bounds: [{}, {}], found: {}",
+        name,
+        min,
+        max,
+        schedule.base,
+    );
+
+    for (threshold, rate) in &schedule.tiers {
+        ensure!(
+            (min..=max).contains(rate),
+            "invalid `{}.tiers@{}`! bounds: [{}, {}], found: {}",
+            name,
+            threshold,
+            min,
+            max,
+            rate,
+        );
+    }
+
+    Ok(())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        dango_types::{FundingRate, Quantity},
+        grug::{Duration, Number as _, btree_map, btree_set},
+    };
+
+    /// A `Param` that passes validation. Individual tests mutate one field to
+    /// drive it out of range.
+    fn valid_param() -> Param {
+        Param {
+            max_unlocks: 10,
+            max_open_orders: 100,
+            maker_fee_rates: RateSchedule::default(),
+            taker_fee_rates: RateSchedule::default(),
+            protocol_fee_rate: Dimensionless::new_permille(200), // 20%
+            liquidation_fee_rate: Dimensionless::new_permille(10), // 1%
+            liquidation_buffer_ratio: Dimensionless::new_permille(50), // 5%
+            funding_period: Duration::from_hours(1),
+            vault_total_weight: Dimensionless::ZERO,
+            vault_cooldown_period: Duration::from_days(1),
+            referral_active: false,
+            min_referrer_volume: UsdValue::ZERO,
+            referrer_commission_rates: RateSchedule::default(),
+            vault_deposit_cap: None,
+        }
+    }
+
+    /// A `PairParam` that passes validation.
+    fn valid_pair_param() -> PairParam {
+        PairParam {
+            tick_size: UsdPrice::new_int(1),
+            min_order_size: UsdValue::ZERO,
+            max_abs_oi: Quantity::new_int(1_000_000),
+            max_abs_funding_rate: FundingRate::ZERO,
+            initial_margin_ratio: Dimensionless::new_permille(100), // 10%
+            maintenance_margin_ratio: Dimensionless::new_permille(50), // 5%
+            impact_size: UsdValue::new_int(10_000),
+            vault_liquidity_weight: Dimensionless::ZERO,
+            vault_half_spread: Dimensionless::new_permille(10), // 1%
+            vault_max_quote_size: Quantity::new_int(100),
+            vault_size_skew_factor: Dimensionless::ZERO,
+            vault_spread_skew_factor: Dimensionless::ZERO,
+            vault_max_skew_size: Quantity::ZERO,
+            bucket_sizes: btree_set! {},
+        }
+    }
+
+    fn pair() -> PairId {
+        "perp/ethusd".parse().unwrap()
+    }
+
+    // ------------------------------ validate_param ------------------------------
+
+    #[test]
+    fn param_default_is_valid() {
+        validate_param(&valid_param()).unwrap();
+    }
+
+    #[test]
+    fn param_zero_max_unlocks_rejected() {
+        let param = Param {
+            max_unlocks: 0,
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`max_unlocks`"), "{err}");
+        assert!(err.contains("> 0"), "{err}");
+    }
+
+    #[test]
+    fn param_zero_max_open_orders_rejected() {
+        let param = Param {
+            max_open_orders: 0,
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`max_open_orders`"), "{err}");
+    }
+
+    #[test]
+    fn param_negative_maker_fee_allowed() {
+        let param = Param {
+            maker_fee_rates: RateSchedule {
+                base: Dimensionless::new_raw(-100), // -1 bps rebate
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_maker_fee_below_minus_one_rejected() {
+        let param = Param {
+            maker_fee_rates: RateSchedule {
+                base: Dimensionless::new_int(-2),
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`maker_fee_rates.base`"), "{err}");
+    }
+
+    #[test]
+    fn param_negative_taker_fee_rejected() {
+        let param = Param {
+            taker_fee_rates: RateSchedule {
+                base: Dimensionless::new_raw(-1),
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`taker_fee_rates.base`"), "{err}");
+    }
+
+    #[test]
+    fn param_taker_fee_tier_out_of_range_rejected() {
+        let param = Param {
+            taker_fee_rates: RateSchedule {
+                base: Dimensionless::new_permille(1),
+                tiers: btree_map! {
+                    UsdValue::new_int(1_000) => Dimensionless::new_int(2), // 200%
+                },
+            },
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`taker_fee_rates.tiers"), "{err}");
+    }
+
+    #[test]
+    fn param_protocol_fee_above_one_rejected() {
+        let param = Param {
+            protocol_fee_rate: Dimensionless::new_int(2),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`protocol_fee_rate`"), "{err}");
+    }
+
+    #[test]
+    fn param_liquidation_buffer_ratio_one_rejected() {
+        // Bound is [0, 1) — exactly 1 is excluded.
+        let param = Param {
+            liquidation_buffer_ratio: Dimensionless::ONE,
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`liquidation_buffer_ratio`"), "{err}");
+        assert!(err.contains("[0, 1)"), "{err}");
+    }
+
+    #[test]
+    fn param_zero_funding_period_rejected() {
+        let param = Param {
+            funding_period: Duration::ZERO,
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`funding_period`"), "{err}");
+    }
+
+    #[test]
+    fn param_zero_vault_cooldown_rejected() {
+        let param = Param {
+            vault_cooldown_period: Duration::ZERO,
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`vault_cooldown_period`"), "{err}");
+    }
+
+    #[test]
+    fn param_zero_vault_deposit_cap_rejected() {
+        // `None` is allowed (unlimited), but `Some(0)` is not.
+        let param = Param {
+            vault_deposit_cap: Some(UsdValue::ZERO),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`vault_deposit_cap`"), "{err}");
+    }
+
+    // --------------------------- validate_pair_param ----------------------------
+
+    #[test]
+    fn pair_param_default_is_valid() {
+        validate_pair_param(&pair(), &valid_pair_param()).unwrap();
+    }
+
+    #[test]
+    fn pair_param_zero_tick_size_rejected() {
+        let p = PairParam {
+            tick_size: UsdPrice::ZERO,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`tick_size`"), "{err}");
+        assert!(err.contains("pair id:"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_zero_max_abs_oi_rejected() {
+        let p = PairParam {
+            max_abs_oi: Quantity::ZERO,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`max_abs_oi`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_max_abs_funding_rate_rejected() {
+        let p = PairParam {
+            max_abs_funding_rate: FundingRate::new_raw(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`max_abs_funding_rate`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_zero_initial_margin_ratio_rejected() {
+        let p = PairParam {
+            initial_margin_ratio: Dimensionless::ZERO,
+            maintenance_margin_ratio: Dimensionless::ZERO,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`initial_margin_ratio`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_imr_above_one_rejected() {
+        let p = PairParam {
+            initial_margin_ratio: Dimensionless::new_int(2),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`initial_margin_ratio`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_mmr_equal_to_imr_rejected() {
+        let p = PairParam {
+            initial_margin_ratio: Dimensionless::new_permille(100),
+            maintenance_margin_ratio: Dimensionless::new_permille(100),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`maintenance_margin_ratio`"), "{err}");
+        assert!(err.contains("< `initial_margin_ratio`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_mmr_above_imr_rejected() {
+        let p = PairParam {
+            initial_margin_ratio: Dimensionless::new_permille(100),
+            maintenance_margin_ratio: Dimensionless::new_permille(200),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`maintenance_margin_ratio`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_zero_impact_size_rejected() {
+        let p = PairParam {
+            impact_size: UsdValue::ZERO,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`impact_size`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_vault_half_spread_zero_rejected() {
+        // Zero would collapse bid and ask onto the oracle price.
+        let p = PairParam {
+            vault_half_spread: Dimensionless::ZERO,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_half_spread`"), "{err}");
+        assert!(err.contains("(0, 1)"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_vault_half_spread_one_rejected() {
+        let p = PairParam {
+            vault_half_spread: Dimensionless::ONE,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_half_spread`"), "{err}");
+        assert!(err.contains("(0, 1)"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_vault_max_quote_size_zero_rejected() {
+        let p = PairParam {
+            vault_max_quote_size: Quantity::ZERO,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_max_quote_size`"), "{err}");
+        assert!(err.contains("> 0"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_vault_max_quote_size_rejected() {
+        let p = PairParam {
+            vault_max_quote_size: Quantity::new_int(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_max_quote_size`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_size_skew_factor_above_one_rejected() {
+        let p = PairParam {
+            vault_size_skew_factor: Dimensionless::new_permille(1_500), // 1.5
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_size_skew_factor`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_spread_skew_factor_one_rejected() {
+        let p = PairParam {
+            vault_spread_skew_factor: Dimensionless::ONE,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_spread_skew_factor`"), "{err}");
+        assert!(err.contains("[0, 1)"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_vault_max_skew_size_rejected() {
+        let p = PairParam {
+            vault_max_skew_size: Quantity::new_int(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_max_skew_size`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_zero_bucket_size_rejected() {
+        let p = PairParam {
+            bucket_sizes: btree_set! { UsdPrice::ZERO },
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`bucket_sizes`"), "{err}");
+    }
+
+    // --------------- validate_param — negative-value branches ------------------
+
+    #[test]
+    fn param_negative_liquidation_buffer_ratio_rejected() {
+        let param = Param {
+            liquidation_buffer_ratio: Dimensionless::new_raw(-1),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`liquidation_buffer_ratio`"), "{err}");
+    }
+
+    #[test]
+    fn param_negative_min_referrer_volume_rejected() {
+        let param = Param {
+            min_referrer_volume: UsdValue::new_raw(-1),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`min_referrer_volume`"), "{err}");
+    }
+
+    #[test]
+    fn param_liquidation_fee_rate_above_one_rejected() {
+        let param = Param {
+            liquidation_fee_rate: Dimensionless::new_int(2),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`liquidation_fee_rate`"), "{err}");
+    }
+
+    #[test]
+    fn param_negative_liquidation_fee_rate_rejected() {
+        let param = Param {
+            liquidation_fee_rate: Dimensionless::new_raw(-1),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`liquidation_fee_rate`"), "{err}");
+    }
+
+    #[test]
+    fn param_negative_protocol_fee_rate_rejected() {
+        let param = Param {
+            protocol_fee_rate: Dimensionless::new_raw(-1),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`protocol_fee_rate`"), "{err}");
+    }
+
+    #[test]
+    fn param_negative_referrer_commission_rate_rejected() {
+        let param = Param {
+            referrer_commission_rates: RateSchedule {
+                base: Dimensionless::new_raw(-1),
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`referrer_commission_rates.base`"), "{err}");
+    }
+
+    #[test]
+    fn param_referrer_commission_tier_out_of_range_rejected() {
+        let param = Param {
+            referrer_commission_rates: RateSchedule {
+                base: Dimensionless::new_permille(100),
+                tiers: btree_map! {
+                    UsdValue::new_int(1_000) => Dimensionless::new_int(2),
+                },
+            },
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`referrer_commission_rates.tiers@"), "{err}");
+    }
+
+    // ------------------- validate_param — inclusive boundaries -----------------
+
+    #[test]
+    fn param_protocol_fee_rate_exactly_one_accepted() {
+        let param = Param {
+            protocol_fee_rate: Dimensionless::ONE,
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_liquidation_fee_rate_exactly_one_accepted() {
+        let param = Param {
+            liquidation_fee_rate: Dimensionless::ONE,
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_maker_fee_rate_exactly_one_accepted() {
+        let param = Param {
+            maker_fee_rates: RateSchedule {
+                base: Dimensionless::ONE,
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_maker_fee_rate_exactly_minus_one_accepted() {
+        let param = Param {
+            maker_fee_rates: RateSchedule {
+                base: Dimensionless::new_int(-1),
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_taker_fee_rate_exactly_one_accepted() {
+        let param = Param {
+            taker_fee_rates: RateSchedule {
+                base: Dimensionless::ONE,
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_referrer_commission_exactly_one_accepted() {
+        let param = Param {
+            referrer_commission_rates: RateSchedule {
+                base: Dimensionless::ONE,
+                ..Default::default()
+            },
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    // --------------- validate_param — time/rate upper bounds -------------------
+
+    #[test]
+    fn param_funding_period_at_max_accepted() {
+        let param = Param {
+            funding_period: MAX_FUNDING_PERIOD,
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_funding_period_above_max_rejected() {
+        let param = Param {
+            funding_period: MAX_FUNDING_PERIOD
+                .checked_add(Duration::from_seconds(1))
+                .unwrap(),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`funding_period`"), "{err}");
+    }
+
+    #[test]
+    fn param_vault_cooldown_at_max_accepted() {
+        let param = Param {
+            vault_cooldown_period: MAX_VAULT_COOLDOWN_PERIOD,
+            ..valid_param()
+        };
+        validate_param(&param).unwrap();
+    }
+
+    #[test]
+    fn param_vault_cooldown_above_max_rejected() {
+        let param = Param {
+            vault_cooldown_period: MAX_VAULT_COOLDOWN_PERIOD
+                .checked_add(Duration::from_seconds(1))
+                .unwrap(),
+            ..valid_param()
+        };
+        let err = validate_param(&param).unwrap_err().to_string();
+        assert!(err.contains("`vault_cooldown_period`"), "{err}");
+    }
+
+    // ---------------- validate_pair_param — negative-value branches ------------
+
+    #[test]
+    fn pair_param_negative_tick_size_rejected() {
+        let p = PairParam {
+            tick_size: UsdPrice::new_int(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`tick_size`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_min_order_size_rejected() {
+        let p = PairParam {
+            min_order_size: UsdValue::new_raw(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`min_order_size`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_max_abs_oi_rejected() {
+        let p = PairParam {
+            max_abs_oi: Quantity::new_int(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`max_abs_oi`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_mmr_zero_with_nonzero_imr_rejected() {
+        // Independently exercises the `mmr > 0` lower bound, so it's not
+        // masked by the `imr > 0` check tripping first.
+        let p = PairParam {
+            initial_margin_ratio: Dimensionless::new_permille(100),
+            maintenance_margin_ratio: Dimensionless::ZERO,
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`maintenance_margin_ratio`"), "{err}");
+        assert!(err.contains("(0, 1]"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_vault_liquidity_weight_rejected() {
+        let p = PairParam {
+            vault_liquidity_weight: Dimensionless::new_raw(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_liquidity_weight`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_vault_size_skew_factor_rejected() {
+        let p = PairParam {
+            vault_size_skew_factor: Dimensionless::new_raw(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_size_skew_factor`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_vault_spread_skew_factor_rejected() {
+        let p = PairParam {
+            vault_spread_skew_factor: Dimensionless::new_raw(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`vault_spread_skew_factor`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_bucket_size_rejected() {
+        let p = PairParam {
+            bucket_sizes: btree_set! { UsdPrice::new_int(-1) },
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`bucket_sizes`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_max_abs_funding_rate_above_cap_rejected() {
+        let p = PairParam {
+            max_abs_funding_rate: FundingRate::new_int(2),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`max_abs_funding_rate`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_max_abs_funding_rate_at_cap_accepted() {
+        let p = PairParam {
+            max_abs_funding_rate: MAX_FUNDING_RATE_CAP,
+            ..valid_pair_param()
+        };
+        validate_pair_param(&pair(), &p).unwrap();
+    }
+
+    // ------------------ validate_pair_param — happy-path cases -----------------
+
+    #[test]
+    fn pair_param_imr_exactly_one_accepted() {
+        let p = PairParam {
+            initial_margin_ratio: Dimensionless::ONE,
+            maintenance_margin_ratio: Dimensionless::new_permille(500), // 50%
+            ..valid_pair_param()
+        };
+        validate_pair_param(&pair(), &p).unwrap();
+    }
+
+    #[test]
+    fn pair_param_nonempty_bucket_sizes_accepted() {
+        let p = PairParam {
+            bucket_sizes: btree_set! {
+                UsdPrice::new_int(1),
+                UsdPrice::new_int(10),
+                UsdPrice::new_int(100),
+            },
+            ..valid_pair_param()
+        };
+        validate_pair_param(&pair(), &p).unwrap();
+    }
+
+    // --------- validate_pair_param — half_spread × spread_skew_factor ----------
+
+    #[test]
+    fn pair_param_half_spread_times_skew_factor_ge_one_rejected() {
+        // 0.9 * (1 + 0.5) = 1.35 — pathological: under max positive skew,
+        // the bid's effective spread exceeds 100% and the raw bid goes
+        // non-positive.
+        let p = PairParam {
+            vault_half_spread: Dimensionless::new_permille(900),
+            vault_spread_skew_factor: Dimensionless::new_permille(500),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(
+            err.contains("vault_half_spread * (1 + vault_spread_skew_factor) < 1"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn pair_param_half_spread_times_skew_factor_exactly_one_rejected() {
+        // 0.5 * (1 + 1) = 1.0 — boundary is strict (< 1, not <= 1).
+        // (vault_spread_skew_factor must be < 1 so use 0.5 * (1 + 0.999...)
+        //  — close enough; we pick 1/2 and factor that still tops out at 1.)
+        // Simpler: 0.5 * (1 + 1) is not reachable because skew_factor < 1.
+        // Instead pick half_spread = 0.5 and skew_factor just below 1:
+        // 0.5 * (1 + 0.999999) ≈ 0.9999995 — accepted. So we use half_spread
+        // slightly above 0.5 and skew_factor close to 1 to get >= 1:
+        // half_spread = 501 permille, skew_factor = 999 permille
+        //   → 0.501 * 1.999 = 1.001499 → rejected.
+        let p = PairParam {
+            vault_half_spread: Dimensionless::new_permille(501),
+            vault_spread_skew_factor: Dimensionless::new_permille(999),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(
+            err.contains("vault_half_spread * (1 + vault_spread_skew_factor) < 1"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn pair_param_half_spread_times_skew_factor_below_one_accepted() {
+        // 0.5 * (1 + 0.5) = 0.75 — well below 1.
+        let p = PairParam {
+            vault_half_spread: Dimensionless::new_permille(500),
+            vault_spread_skew_factor: Dimensionless::new_permille(500),
+            ..valid_pair_param()
+        };
+        validate_pair_param(&pair(), &p).unwrap();
+    }
+
+    // ------------------- validate_vault_total_weight ----------------------------
+
+    #[test]
+    fn vault_total_weight_matches_sum_single_pair() {
+        let param = Param {
+            vault_total_weight: Dimensionless::new_int(3),
+            ..valid_param()
+        };
+        let pp = btree_map! {
+            pair() => PairParam {
+                vault_liquidity_weight: Dimensionless::new_int(3),
+                ..valid_pair_param()
+            },
+        };
+        validate_vault_total_weight(&param, &pp).unwrap();
+    }
+
+    #[test]
+    fn vault_total_weight_matches_sum_multi_pair() {
+        let eth: PairId = "perp/ethusd".parse().unwrap();
+        let btc: PairId = "perp/btcusd".parse().unwrap();
+        let param = Param {
+            vault_total_weight: Dimensionless::new_int(3),
+            ..valid_param()
+        };
+        let pp = btree_map! {
+            eth => PairParam {
+                vault_liquidity_weight: Dimensionless::new_int(1),
+                ..valid_pair_param()
+            },
+            btc => PairParam {
+                vault_liquidity_weight: Dimensionless::new_int(2),
+                ..valid_pair_param()
+            },
+        };
+        validate_vault_total_weight(&param, &pp).unwrap();
+    }
+
+    #[test]
+    fn vault_total_weight_empty_pairs_matches_zero() {
+        let param = Param {
+            vault_total_weight: Dimensionless::ZERO,
+            ..valid_param()
+        };
+        let pp: BTreeMap<PairId, PairParam> = BTreeMap::new();
+        validate_vault_total_weight(&param, &pp).unwrap();
+    }
+
+    #[test]
+    fn vault_total_weight_greater_than_sum_rejected() {
+        let param = Param {
+            vault_total_weight: Dimensionless::new_int(2),
+            ..valid_param()
+        };
+        let pp = btree_map! {
+            pair() => PairParam {
+                vault_liquidity_weight: Dimensionless::new_int(1),
+                ..valid_pair_param()
+            },
+        };
+        let err = validate_vault_total_weight(&param, &pp)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("`vault_total_weight`"), "{err}");
+        assert!(err.contains("expected: 1"), "{err}");
+        assert!(err.contains("found: 2"), "{err}");
+    }
+
+    #[test]
+    fn vault_total_weight_less_than_sum_rejected() {
+        let eth: PairId = "perp/ethusd".parse().unwrap();
+        let btc: PairId = "perp/btcusd".parse().unwrap();
+        let param = Param {
+            vault_total_weight: Dimensionless::new_int(1),
+            ..valid_param()
+        };
+        let pp = btree_map! {
+            eth => PairParam {
+                vault_liquidity_weight: Dimensionless::new_int(1),
+                ..valid_pair_param()
+            },
+            btc => PairParam {
+                vault_liquidity_weight: Dimensionless::new_int(1),
+                ..valid_pair_param()
+            },
+        };
+        let err = validate_vault_total_weight(&param, &pp)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("`vault_total_weight`"), "{err}");
+        assert!(err.contains("expected: 2"), "{err}");
+        assert!(err.contains("found: 1"), "{err}");
+    }
+
+    #[test]
+    fn vault_total_weight_nonzero_with_empty_pairs_rejected() {
+        // If you bump the total but forget to supply any pair_params,
+        // the check catches it.
+        let param = Param {
+            vault_total_weight: Dimensionless::new_int(1),
+            ..valid_param()
+        };
+        let pp: BTreeMap<PairId, PairParam> = BTreeMap::new();
+        let err = validate_vault_total_weight(&param, &pp)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("`vault_total_weight`"), "{err}");
+    }
 }

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -203,22 +203,33 @@ pub enum ReferrerStatsOrderIndex {
 #[derive(Default)]
 pub struct Param {
     /// Maximum number of unlock requests a single user may have.
+    ///
+    /// Bounds: `> 0`.
     pub max_unlocks: usize,
 
     /// Maximum number of resting limit order a single user may have across all
     /// trading pairs.
+    ///
+    /// Bounds: `> 0`.
     pub max_open_orders: usize,
 
     /// Volume-tiered maker fee rates. Highest qualifying tier wins;
     /// base rate applies when no tier is met.
+    ///
+    /// Bounds: base and every tier rate in `[-1, 1]`. Negative values
+    /// represent a rebate paid to the maker.
     pub maker_fee_rates: RateSchedule,
 
     /// Volume-tiered taker fee rates. Highest qualifying tier wins;
     /// base rate applies when no tier is met.
+    ///
+    /// Bounds: base and all tier rates in `[0, 1]`.
     pub taker_fee_rates: RateSchedule,
 
     /// Fraction of each trading fee routed to the protocol treasury.
     /// The remainder (1 − `protocol_fee_rate`) stays with the vault.
+    ///
+    /// Bounds: `[0, 1]`.
     pub protocol_fee_rate: Dimensionless,
 
     /// Fee paid to the insurance fund as a fraction of the total notional
@@ -229,6 +240,8 @@ pub struct Param {
     ///   ceil(|position_size| * oracle_price * liquidation_fee_rate / settlement_currency_price),
     ///   user_remaining_margin
     /// )
+    ///
+    /// Bounds: `[0, 1]`.
     pub liquidation_fee_rate: Dimensionless,
 
     /// Buffer applied during liquidation so that the user's post-liquidation
@@ -240,21 +253,32 @@ pub struct Param {
     ///
     /// When `b = 0`, positions are closed to bring equity exactly to the
     /// maintenance margin boundary (default behavior). Recommended: 5-10%.
+    ///
+    /// Bounds: `[0, 1)`.
     pub liquidation_buffer_ratio: Dimensionless,
 
     /// Duration between funding collections. The cron job applies funding
     /// only when this period elapses.
+    ///
+    /// Bounds: `(0, 7 days]`. The upper bound is a governance guardrail —
+    /// a longer period would effectively suspend funding collection.
     pub funding_period: Duration,
 
     /// Sum of `vault_liquidity_weight` across all trading pairs.
     /// Precomputed to avoid iterating all pair params when placing
     /// vault orders. Must be kept in sync when pairs are added/removed
     /// or weights change.
+    ///
+    /// Bounds: `>= 0`. Must equal the sum of `vault_liquidity_weight`
+    /// across all pairs.
     pub vault_total_weight: Dimensionless,
 
     /// Once a request to withdraw liquidity from the counterparty vault has been
     /// submitted, the waiting time that must elapsed before the funds are released
     /// to the liquidity provider.
+    ///
+    /// Bounds: `(0, 30 days]`. The upper bound is a governance guardrail —
+    /// a longer cooldown would effectively lock LPs out of their deposits.
     pub vault_cooldown_period: Duration,
 
     /// Whether the referral commission system is active.
@@ -263,15 +287,21 @@ pub struct Param {
 
     /// Minimum lifetime perps trading volume a user must have
     /// before they can become a referrer by setting a fee share ratio.
+    ///
+    /// Bounds: `>= 0`. Zero means no minimum.
     pub min_referrer_volume: UsdValue,
 
     /// Volume-tiered referrer commission rates. Highest qualifying tier wins;
     /// base rate applies when no tier is met.
+    ///
+    /// Bounds: base and all tier rates in `[0, 1]`.
     pub referrer_commission_rates: RateSchedule,
 
     /// Maximum total margin the counterparty vault may hold. Deposits that
     /// would push `vault_margin + deposit` above this cap are rejected.
     /// `None` means no cap (unlimited deposits).
+    ///
+    /// Bounds: if `Some`, `> 0`. Use `None` for unlimited.
     pub vault_deposit_cap: Option<UsdValue>,
 }
 
@@ -329,7 +359,8 @@ pub struct PairParam {
     /// This prevents runaway rates from causing cascading liquidations and bad
     /// debt spirals during prolonged skew.
     ///
-    /// Bounds: `>= 0`.
+    /// Bounds: `[0, 1]`. 100% per day is already pathological — the upper
+    /// bound is a governance guardrail.
     pub max_abs_funding_rate: FundingRate,
 
     /// Margin requirement when opening or increasing a position in this trading
@@ -369,14 +400,21 @@ pub struct PairParam {
     /// vault places bids at `oracle_price * (1 - vault_half_spread)` and asks
     /// at `oracle_price * (1 + vault_half_spread)`.
     ///
-    /// Bounds: `(0, 1)`. Zero disables vault quoting; >= 1 would produce a
-    /// non-positive bid price.
+    /// Bounds: `(0, 1)`. Zero would collapse bid and ask onto the oracle
+    /// price; `>= 1` would produce a non-positive bid price. To disable the
+    /// vault for a pair, set `vault_liquidity_weight = 0` instead.
+    ///
+    /// Cross-field invariant: `vault_half_spread * (1 + vault_spread_skew_factor) < 1`.
+    /// Under maximum positive inventory skew the bid's effective spread
+    /// widens by this factor, and the product must stay strictly below 1
+    /// so the bid price never collapses to or below zero.
     pub vault_half_spread: Dimensionless,
 
     /// Maximum notional size (in quote currency) of the vault's resting orders
     /// on each side of the book. Limits the vault's exposure per pair.
     ///
-    /// Bounds: `> 0`. Zero disables vault quoting for this pair.
+    /// Bounds: `> 0`. To disable the vault for a pair, set
+    /// `vault_liquidity_weight = 0` instead.
     pub vault_max_quote_size: Quantity,
 
     /// How aggressively to tilt order sizes based on inventory.
@@ -412,6 +450,8 @@ impl PairParam {
         Self {
             max_abs_oi: Quantity::new_int(1_000_000),
             impact_size: UsdValue::new_int(10_000),
+            vault_half_spread: Dimensionless::new_permille(10), // 1%
+            vault_max_quote_size: Quantity::new_int(100),
             ..Default::default()
         }
     }

--- a/localdango/configs/cometbft/config/genesis.json
+++ b/localdango/configs/cometbft/config/genesis.json
@@ -914,7 +914,7 @@
               },
               "vault_cooldown_period": "86400",
               "vault_deposit_cap": null,
-              "vault_total_weight": "0"
+              "vault_total_weight": "3"
             }
           },
           "salt": "ZGFuZ28vcGVycHM="

--- a/localdango/configs/cometbft/config/genesis.json
+++ b/localdango/configs/cometbft/config/genesis.json
@@ -871,11 +871,7 @@
           "msg": {
             "pair_params": {
               "perp/ethusd": {
-                "bucket_sizes": [
-                  "1",
-                  "10",
-                  "100"
-                ],
+                "bucket_sizes": [],
                 "impact_size": "10000",
                 "initial_margin_ratio": "0.1",
                 "maintenance_margin_ratio": "0.05",

--- a/localdango/configs/cometbft/config/genesis.json
+++ b/localdango/configs/cometbft/config/genesis.json
@@ -871,7 +871,11 @@
           "msg": {
             "pair_params": {
               "perp/ethusd": {
-                "bucket_sizes": [],
+                "bucket_sizes": [
+                  "1",
+                  "10",
+                  "100"
+                ],
                 "impact_size": "10000",
                 "initial_margin_ratio": "0.1",
                 "maintenance_margin_ratio": "0.05",
@@ -879,9 +883,9 @@
                 "max_abs_oi": "1000000",
                 "min_order_size": "0",
                 "tick_size": "1",
-                "vault_half_spread": "0",
-                "vault_liquidity_weight": "0",
-                "vault_max_quote_size": "0",
+                "vault_half_spread": "0.0006",
+                "vault_liquidity_weight": "3",
+                "vault_max_quote_size": "2000",
                 "vault_max_skew_size": "0",
                 "vault_size_skew_factor": "0",
                 "vault_spread_skew_factor": "0"


### PR DESCRIPTION
Add comprehensive field-level and cross-struct validation to the perps `configure` entry point so misconfigured governance updates fail loudly before touching storage.