### PR TITLE
refactor(perps): derive funding rate with mid price of impact prices

### DIFF
--- a/book/perps/3-funding.md
+++ b/book/perps/3-funding.md
@@ -4,7 +4,7 @@ Fundings are periodic payments between longs and shorts that anchor the perpetua
 
 ## 1. Premium
 
-Each funding cycle begins with measuring how far the order book deviates from the oracle. The contract computes two **impact prices** by walking the book:
+Each funding cycle begins with measuring how far the on-chain book has drifted from the oracle. The contract computes two **impact prices** by walking the book, takes their midpoint, and compares it to the oracle:
 
 - **Impact bid** — the volume-weighted average price (VWAP) obtained by selling $\mathtt{impactSize}$ worth of base asset into the bid side.
 - **Impact ask** — the VWAP obtained by buying $\mathtt{impactSize}$ worth from the ask side.
@@ -12,10 +12,14 @@ Each funding cycle begins with measuring how far the order book deviates from th
 The premium is then:
 
 $$
-\mathtt{premium} = \frac{\max(0,\;\mathtt{impactBid} - \mathtt{oracle}) - \max(0,\;\mathtt{oracle} - \mathtt{impactAsk})}{\mathtt{oracle}}
+\mathtt{midImpactPrice} = \frac{\mathtt{impactBid} + \mathtt{impactAsk}}{2}
 $$
 
-If either side has insufficient depth to fill $\mathtt{impactSize}$, its $\max(0, \ldots)$ term contributes zero. When both sides lack depth, the premium is zero.
+$$
+\mathtt{premium} = \frac{\mathtt{midImpactPrice} - \mathtt{oracle}}{\mathtt{oracle}}
+$$
+
+If a side of the book has less than $\mathtt{impactSize}$ of depth, the walk returns the VWAP of whatever depth is available. If a side has no depth at all, the sample is skipped for that cycle rather than a one-sided mid being computed. In steady state both sides are always populated by the vault.
 
 ## 2. Sampling
 
@@ -29,7 +33,7 @@ $$
 \mathtt{premiumSamples} \mathrel{+}= 1
 $$
 
-Sampling more frequently than collecting gives the average premium resilience against momentary spikes — a single large order cannot dominate the rate.
+Sampling at a cadence close to the block rate gives each observation roughly equal weight. A resting order that momentarily drags the mid can only influence the average in proportion to how long it sits on the book relative to the full funding period.
 
 ## 3. Collection
 
@@ -79,8 +83,40 @@ $$
 
 ## 5. Parameters
 
-| Field                  | Type          | Description                                                                                                             |
-| ---------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `funding_period`       | `Duration`    | Minimum time between funding collections.                                                                               |
-| `impact_size`          | `UsdValue`    | Notional depth walked on each side of the book to compute impact prices.                                                |
-| `max_abs_funding_rate` | `FundingRate` | Symmetric clamp applied to the average premium before scaling to a delta. Prevents runaway rates during prolonged skew. |
+| Field                  | Type          | Description                                                                                                                                                                                                     |
+| ---------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `funding_period`       | `Duration`    | Minimum time between funding collections.                                                                                                                                                                       |
+| `impact_size`          | `UsdValue`    | Notional depth walked on each side of the book to compute impact prices. A larger value dilutes the influence of any single resting order on the premium in proportion to the fraction of the walk it occupies. |
+| `max_abs_funding_rate` | `FundingRate` | Symmetric clamp applied to the average premium before scaling to a delta. Prevents runaway rates during prolonged skew.                                                                                         |
+
+## 6. Discussions
+
+### Vault being the sole maker
+
+As of today, the [protocol-owned vault](5-vault.md) is the dominant maker in Dango's markets. The [vault's inventory-skew-aware quoting policy](5-vault.md#5-market-making-policy) causes the book mid to drift from the oracle whenever the vault holds inventory:
+
+$$
+\mathtt{vaultBid} = \mathtt{oracle} \cdot (1 - \mathtt{halfSpread} \cdot (1 + \mathtt{skew} \cdot \mathtt{spreadSkewFactor}))
+$$
+
+$$
+\mathtt{vaultAsk} = \mathtt{oracle} \cdot (1 + \mathtt{halfSpread} \cdot (1 - \mathtt{skew} \cdot \mathtt{spreadSkewFactor}))
+$$
+
+Suppose the vault is literally the only maker in the entire market, we can substitute the vault's bid and ask into the $\mathtt{midImpactPrice}$ formula:
+
+$$
+\mathtt{midImpactPrice} = \mathtt{oracle} \cdot (1 - \mathtt{halfSpread} \cdot \mathtt{skew} \cdot \mathtt{spreadSkewFactor})
+$$
+
+and therefore
+
+$$
+\mathtt{premium} = -\mathtt{halfSpread} \cdot \mathtt{skew} \cdot \mathtt{spreadSkewFactor}
+$$
+
+Positive skew (vault long, because sell flow has dominated) produces a negative premium, so longs receive funding from shorts — which credits the vault-as-long for absorbed inventory. Symmetric when short. The sign is economically correct by construction.
+
+### Comparison with other exchanges
+
+The "book mid minus oracle" premium is the dominant on-chain perpetual-funding pattern — see [Drift](https://docs.drift.trade/protocol/trading/perpetuals-trading/funding-rates) (bid/ask TWAP mid vs oracle TWAP), [Vertex](https://vertex-protocol.gitbook.io/docs/basics/funding-rates) (mark vs spot index), [Paradex](https://docs.paradex.trade/risk/funding-mechanism) (Fair Basis from mark), and [MCDEX v2](https://mcdex.medium.com/introduce-mcdex-v2-perpetual-c97b18ff4e23) (AMM mid vs index). Dango's formulation differs in reading impact prices (depth-walked VWAPs) rather than top-of-book, which bakes depth distribution into the primitive and forces any book-level manipulation to commit notional proportional to $\mathtt{impactSize}$.

--- a/dango/perps/src/core/funding.rs
+++ b/dango/perps/src/core/funding.rs
@@ -4,14 +4,15 @@ use {
 };
 
 /// Walk an ordered sequence of `(limit_price, size)` pairs and compute the
-/// volume-weighted average execution price for filling `impact_size` worth
-/// of notional value.
+/// volume-weighted average execution price for filling up to `impact_size`
+/// worth of notional value.
 ///
 /// Each item is `(limit_price, absolute_order_size)`. The caller is responsible
 /// for iterating the correct side of the book (bids or asks) in price-priority
 /// order and mapping storage entries to `(real_price, absolute_size)`.
 ///
-/// Returns: `Some(vwap)` if enough depth exists, `None` otherwise.
+/// Returns: `Some(vwap)` of whatever depth was walked, up to `impact_size`.
+/// `None` only if the side has no depth at all.
 pub fn compute_impact_price(
     orders: impl Iterator<Item = StdResult<(UsdPrice, Quantity)>>,
     impact_size: UsdValue,
@@ -38,39 +39,34 @@ pub fn compute_impact_price(
         total_notional.checked_add_assign(order_notional)?;
     }
 
-    if total_notional < impact_size {
+    if total_size.is_zero() {
         return Ok(None);
     }
 
     Ok(Some(total_notional.checked_div(total_size)?))
 }
 
-/// Compute the premium from impact bid/ask prices relative to the oracle price.
+/// Compute the premium from the midpoint of the two impact prices relative
+/// to the oracle price.
 ///
 /// Formula:
 /// ```text
-/// premium = [max(0, impact_bid - oracle) - max(0, oracle - impact_ask)] / oracle
+/// mid     = (impact_bid + impact_ask) / 2
+/// premium = (mid - oracle) / oracle
 /// ```
 ///
-/// If a side is `None`, its `max(0, ...)` term is zero.
+/// The caller is responsible for passing non-missing impact prices: if either
+/// side of the book is empty, the caller should skip the sample rather than
+/// attempt to compute a one-sided mid.
 ///
 /// Returns: premium as a `Dimensionless` value.
 pub fn compute_premium(
-    impact_bid: Option<UsdPrice>,
-    impact_ask: Option<UsdPrice>,
+    impact_bid: UsdPrice,
+    impact_ask: UsdPrice,
     oracle_price: UsdPrice,
 ) -> MathResult<Dimensionless> {
-    let bid_term = match impact_bid {
-        Some(bid) if bid > oracle_price => bid.checked_sub(oracle_price)?,
-        _ => UsdPrice::ZERO,
-    };
-
-    let ask_term = match impact_ask {
-        Some(ask) if ask < oracle_price => oracle_price.checked_sub(ask)?,
-        _ => UsdPrice::ZERO,
-    };
-
-    bid_term.checked_sub(ask_term)?.checked_div(oracle_price)
+    let mid = impact_bid.checked_add(impact_ask)?.half();
+    mid.checked_sub(oracle_price)?.checked_div(oracle_price)
 }
 
 /// Compute the funding delta to apply to the `funding_per_unit` accumulator,
@@ -125,11 +121,12 @@ mod tests {
     }
 
     #[test]
-    fn impact_price_insufficient_depth() {
+    fn impact_price_partial_depth_returns_vwap_of_walked() {
+        // Need 100_000 notional but only 50_000 of depth is available.
+        // The walk returns the VWAP of the one available order: 50_000 / 1 = 50_000.
         let orders = vec![Ok((UsdPrice::new_int(50_000), Quantity::new_int(1)))];
-        // Need 100_000 notional but only have 50_000
         let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(100_000)).unwrap();
-        assert_eq!(result, None);
+        assert_eq!(result, Some(UsdPrice::new_int(50_000)));
     }
 
     #[test]
@@ -171,22 +168,14 @@ mod tests {
 
     // ---- compute_premium tests ----
 
-    #[test_case(Some(101), Some(99),  100,       0 ; "symmetric around oracle")]
-    #[test_case(Some(103), Some(99),  100,  20_000 ; "bid skewed above oracle")]
-    #[test_case(Some(99),  Some(97),  100, -30_000 ; "ask skewed below oracle")]
-    #[test_case(Some(102), None,      100,  20_000 ; "bid only")]
-    #[test_case(None,      Some(98),  100, -20_000 ; "ask only")]
-    #[test_case(None,      None,      100,       0 ; "both none")]
-    #[test_case(Some(99),  Some(101), 100,       0 ; "bid below ask above oracle")]
-    #[test_case(Some(100), Some(100), 100,       0 ; "bid and ask at oracle")]
-    fn compute_premium_works(
-        bid: Option<i128>,
-        ask: Option<i128>,
-        oracle: i128,
-        expected_raw: i128,
-    ) {
-        let impact_bid = bid.map(UsdPrice::new_int);
-        let impact_ask = ask.map(UsdPrice::new_int);
+    #[test_case( 99, 101, 100,       0 ; "mid exactly at oracle")]
+    #[test_case(101, 103, 100,  20_000 ; "mid above oracle (vault short skew)")]
+    #[test_case( 97,  99, 100, -20_000 ; "mid below oracle (vault long skew)")]
+    #[test_case(100, 100, 100,       0 ; "bid and ask at oracle")]
+    #[test_case( 99, 103, 100,  10_000 ; "asymmetric spread, mid above oracle")]
+    fn compute_premium_works(bid: i128, ask: i128, oracle: i128, expected_raw: i128) {
+        let impact_bid = UsdPrice::new_int(bid);
+        let impact_ask = UsdPrice::new_int(ask);
         let oracle_price = UsdPrice::new_int(oracle);
 
         let premium = compute_premium(impact_bid, impact_ask, oracle_price).unwrap();

--- a/dango/perps/src/core/funding.rs
+++ b/dango/perps/src/core/funding.rs
@@ -4,15 +4,14 @@ use {
 };
 
 /// Walk an ordered sequence of `(limit_price, size)` pairs and compute the
-/// volume-weighted average execution price for filling up to `impact_size`
-/// worth of notional value.
+/// volume-weighted average execution price for filling `impact_size` worth
+/// of notional value.
 ///
 /// Each item is `(limit_price, absolute_order_size)`. The caller is responsible
 /// for iterating the correct side of the book (bids or asks) in price-priority
 /// order and mapping storage entries to `(real_price, absolute_size)`.
 ///
-/// Returns: `Some(vwap)` of whatever depth was walked, up to `impact_size`.
-/// `None` only if the side has no depth at all.
+/// Returns: `Some(vwap)` if enough depth exists, `None` otherwise.
 pub fn compute_impact_price(
     orders: impl Iterator<Item = StdResult<(UsdPrice, Quantity)>>,
     impact_size: UsdValue,
@@ -39,7 +38,7 @@ pub fn compute_impact_price(
         total_notional.checked_add_assign(order_notional)?;
     }
 
-    if total_size.is_zero() {
+    if total_notional < impact_size {
         return Ok(None);
     }
 
@@ -121,12 +120,11 @@ mod tests {
     }
 
     #[test]
-    fn impact_price_partial_depth_returns_vwap_of_walked() {
-        // Need 100_000 notional but only 50_000 of depth is available.
-        // The walk returns the VWAP of the one available order: 50_000 / 1 = 50_000.
+    fn impact_price_insufficient_depth() {
         let orders = vec![Ok((UsdPrice::new_int(50_000), Quantity::new_int(1)))];
+        // Need 100_000 notional but only have 50_000
         let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(100_000)).unwrap();
-        assert_eq!(result, Some(UsdPrice::new_int(50_000)));
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/dango/perps/src/core/funding.rs
+++ b/dango/perps/src/core/funding.rs
@@ -171,6 +171,7 @@ mod tests {
     #[test_case( 97,  99, 100, -20_000 ; "mid below oracle (vault long skew)")]
     #[test_case(100, 100, 100,       0 ; "bid and ask at oracle")]
     #[test_case( 99, 103, 100,  10_000 ; "asymmetric spread, mid above oracle")]
+    #[test_case( 99, 100, 100,  -5_000 ; "odd sum, mid below oracle by half unit")]
     fn compute_premium_works(bid: i128, ask: i128, oracle: i128, expected_raw: i128) {
         let impact_bid = UsdPrice::new_int(bid);
         let impact_ask = UsdPrice::new_int(ask);

--- a/dango/perps/src/cron.rs
+++ b/dango/perps/src/cron.rs
@@ -1100,6 +1100,128 @@ mod tests {
     }
 
     #[test]
+    fn funding_empty_book_zeros_rate_and_preserves_accumulator() {
+        let mut storage = MockStorage::new();
+        let pair_id = btc_pair_id();
+
+        // Seed non-zero initial state so the zero-out and preserve
+        // semantics of the `(None, None)` fallback arm are observable.
+        let initial_funding_per_unit = FundingPerUnit::new_int(1_234);
+        let initial_funding_rate = FundingRate::new_raw(42_000);
+
+        init_funding_storage(
+            &mut storage,
+            &pair_id,
+            &default_funding_pair_param(),
+            &PairState {
+                funding_per_unit: initial_funding_per_unit,
+                funding_rate: initial_funding_rate,
+                ..Default::default()
+            },
+            3600,
+            0,
+        );
+
+        let mut oracle = OracleQuerier::new_mock(hash_map! {
+            pair_id.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(5_000_000), // $50,000
+                Timestamp::from_seconds(0),
+                8,
+            ),
+        });
+
+        process_funding(&mut storage, Timestamp::from_seconds(3600), &mut oracle).unwrap();
+
+        // Empty book → premium = 0 → rate overwritten to zero; the
+        // accumulator receives a zero delta, so it is preserved.
+        let pair_state = PAIR_STATES.load(&storage, &pair_id).unwrap();
+        assert_eq!(pair_state.funding_rate, FundingRate::ZERO);
+        assert_eq!(pair_state.funding_per_unit, initial_funding_per_unit);
+    }
+
+    #[test]
+    fn funding_one_sided_book_bid_only_zeros_rate() {
+        let mut storage = MockStorage::new();
+        let pair_id = btc_pair_id();
+
+        let initial_funding_per_unit = FundingPerUnit::new_int(1_234);
+        let initial_funding_rate = FundingRate::new_raw(42_000);
+
+        init_funding_storage(
+            &mut storage,
+            &pair_id,
+            &default_funding_pair_param(),
+            &PairState {
+                funding_per_unit: initial_funding_per_unit,
+                funding_rate: initial_funding_rate,
+                ..Default::default()
+            },
+            3600,
+            0,
+        );
+
+        // Only the bid side has depth. `compute_impact_price` returns
+        // `None` for the empty ask side, so the match falls into the
+        // `(Some, None)` arm → premium = 0.
+        place_bid_order(&mut storage, &pair_id, 51_000, 1, 1);
+
+        let mut oracle = OracleQuerier::new_mock(hash_map! {
+            pair_id.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(5_000_000), // $50,000
+                Timestamp::from_seconds(0),
+                8,
+            ),
+        });
+
+        process_funding(&mut storage, Timestamp::from_seconds(3600), &mut oracle).unwrap();
+
+        let pair_state = PAIR_STATES.load(&storage, &pair_id).unwrap();
+        assert_eq!(pair_state.funding_rate, FundingRate::ZERO);
+        assert_eq!(pair_state.funding_per_unit, initial_funding_per_unit);
+    }
+
+    #[test]
+    fn funding_one_sided_book_ask_only_zeros_rate() {
+        let mut storage = MockStorage::new();
+        let pair_id = btc_pair_id();
+
+        let initial_funding_per_unit = FundingPerUnit::new_int(1_234);
+        let initial_funding_rate = FundingRate::new_raw(42_000);
+
+        init_funding_storage(
+            &mut storage,
+            &pair_id,
+            &default_funding_pair_param(),
+            &PairState {
+                funding_per_unit: initial_funding_per_unit,
+                funding_rate: initial_funding_rate,
+                ..Default::default()
+            },
+            3600,
+            0,
+        );
+
+        // Only the ask side has depth. `compute_impact_price` returns
+        // `None` for the empty bid side, so the match falls into the
+        // `(None, Some)` arm → premium = 0.
+        place_ask_order(&mut storage, &pair_id, 49_000, 1, 1);
+
+        let mut oracle = OracleQuerier::new_mock(hash_map! {
+            pair_id.clone() => PrecisionedPrice::new(
+                Udec128::new_percent(5_000_000), // $50,000
+                Timestamp::from_seconds(0),
+                8,
+            ),
+        });
+
+        process_funding(&mut storage, Timestamp::from_seconds(3600), &mut oracle).unwrap();
+
+        let pair_state = PAIR_STATES.load(&storage, &pair_id).unwrap();
+        assert_eq!(pair_state.funding_rate, FundingRate::ZERO);
+        assert_eq!(pair_state.funding_per_unit, initial_funding_per_unit);
+    }
+
+    #[test]
     fn funding_multiple_pairs() {
         let mut storage = MockStorage::new();
         let btc = btc_pair_id();
@@ -1157,13 +1279,15 @@ mod tests {
         let state = STATE.load(&storage).unwrap();
         assert_eq!(state.last_funding_time, Timestamp::from_seconds(3600));
 
+        // BTC: mid $52,000 above oracle $50,000 → strictly positive.
         let btc_state = PAIR_STATES.load(&storage, &btc).unwrap();
-        assert_ne!(btc_state.funding_per_unit, FundingPerUnit::ZERO);
-        assert_ne!(btc_state.funding_rate, FundingRate::ZERO);
+        assert!(btc_state.funding_per_unit > FundingPerUnit::ZERO);
+        assert!(btc_state.funding_rate > FundingRate::ZERO);
 
+        // ETH: mid $2,850 below oracle $3,000 → strictly negative.
         let eth_state = PAIR_STATES.load(&storage, &eth).unwrap();
-        assert_ne!(eth_state.funding_per_unit, FundingPerUnit::ZERO);
-        assert_ne!(eth_state.funding_rate, FundingRate::ZERO);
+        assert!(eth_state.funding_per_unit < FundingPerUnit::ZERO);
+        assert!(eth_state.funding_rate < FundingRate::ZERO);
     }
 
     #[test]

--- a/dango/perps/src/cron.rs
+++ b/dango/perps/src/cron.rs
@@ -191,8 +191,15 @@ fn process_funding_for_pair(
             Ok((stored_price, order.size.checked_abs()?))
         });
 
-    let impact_bid = compute_impact_price(bid_iter, pair_param.impact_size)?;
-    let impact_ask = compute_impact_price(ask_iter, pair_param.impact_size)?;
+    let (Some(impact_bid), Some(impact_ask)) = (
+        compute_impact_price(bid_iter, pair_param.impact_size)?,
+        compute_impact_price(ask_iter, pair_param.impact_size)?,
+    ) else {
+        // One or both sides of the book are empty — skip this pair's
+        // funding update for this cycle. Its `funding_per_unit` and
+        // `funding_rate` remain at their previous values.
+        return Ok(());
+    };
 
     let premium = compute_premium(impact_bid, impact_ask, oracle_price)?;
 
@@ -1034,8 +1041,10 @@ mod tests {
             0,
         );
 
-        // Bid at $51,000 above oracle $50,000 → positive premium.
+        // Bid $51,000 and ask $53,000 around oracle $50,000 → mid $52,000
+        // → positive premium.
         place_bid_order(&mut storage, &pair_id, 51_000, 1, 1);
+        place_ask_order(&mut storage, &pair_id, 53_000, 1, 2);
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
             pair_id.clone() => PrecisionedPrice::new(
@@ -1119,10 +1128,14 @@ mod tests {
             .save(&mut storage, &eth, &PairState::default())
             .unwrap();
 
-        // BTC: bid above oracle → positive premium.
+        // BTC: bid $51,000 and ask $53,000 around oracle $50,000 → mid
+        // $52,000 → positive premium.
         place_bid_order(&mut storage, &btc, 51_000, 1, 1);
-        // ETH: ask below oracle → negative premium.
-        place_ask_order(&mut storage, &eth, 2_900, 10, 2);
+        place_ask_order(&mut storage, &btc, 53_000, 1, 2);
+        // ETH: bid $2,800 and ask $2,900 below oracle $3,000 → mid $2,850
+        // → negative premium.
+        place_bid_order(&mut storage, &eth, 2_800, 10, 3);
+        place_ask_order(&mut storage, &eth, 2_900, 10, 4);
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
             btc.clone() => PrecisionedPrice::new(
@@ -1169,8 +1182,10 @@ mod tests {
             0,
         );
 
-        // Bid above oracle → positive delta added to existing accumulator.
+        // Bid $51,000 and ask $53,000 around oracle $50,000 → mid $52,000
+        // → positive delta added to existing accumulator.
         place_bid_order(&mut storage, &pair_id, 51_000, 1, 1);
+        place_ask_order(&mut storage, &pair_id, 53_000, 1, 2);
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
             pair_id.clone() => PrecisionedPrice::new(

--- a/dango/perps/src/cron.rs
+++ b/dango/perps/src/cron.rs
@@ -20,7 +20,7 @@ use {
     },
     dango_oracle::OracleQuerier,
     dango_types::{
-        Days, UsdPrice, UsdValue,
+        Days, Dimensionless, UsdPrice, UsdValue,
         perps::{
             ConditionalOrderRemoved, ConditionalOrderTriggered, LiquidityReleased, OrderKind,
             PairId, PairParam, PairState, Param, ReasonForOrderRemoval, State, TriggerDirection,
@@ -191,17 +191,19 @@ fn process_funding_for_pair(
             Ok((stored_price, order.size.checked_abs()?))
         });
 
-    let (Some(impact_bid), Some(impact_ask)) = (
-        compute_impact_price(bid_iter, pair_param.impact_size)?,
-        compute_impact_price(ask_iter, pair_param.impact_size)?,
-    ) else {
-        // One or both sides of the book are empty — skip this pair's
-        // funding update for this cycle. Its `funding_per_unit` and
-        // `funding_rate` remain at their previous values.
-        return Ok(());
-    };
+    let impact_bid = compute_impact_price(bid_iter, pair_param.impact_size)?;
+    let impact_ask = compute_impact_price(ask_iter, pair_param.impact_size)?;
 
-    let premium = compute_premium(impact_bid, impact_ask, oracle_price)?;
+    // Fall back to zero premium when either side of the book lacks the
+    // depth to compute an impact price. Matches the pre-change behavior:
+    // `funding_rate` is zeroed for this cycle and `funding_per_unit` is
+    // left unchanged.
+    let premium = match (impact_bid, impact_ask) {
+        (Some(impact_bid), Some(impact_ask)) => {
+            compute_premium(impact_bid, impact_ask, oracle_price)?
+        },
+        _ => Dimensionless::ZERO,
+    };
 
     let (funding_delta, funding_rate) = compute_funding_delta(
         premium,


### PR DESCRIPTION
The previous

```
premium := max(0, impactBid - oracle) - max(0, oracle - impactAsk)
```

formula only produces a non-zero signal when the book crosses the oracle. Under Dango's sole-maker vault with skew-aware quoting, the clips are always zero and the funding rate is stuck at zero regardless of flow.

Replace with

```
premium := (impactBid + impactAsk) / 2
```

compared to the oracle.

Under the vault's quotes this simplifies to

```
premium := -halfSpread * skew * spreadSkewFactor
```

which is non-zero whenever the vault holds inventory and has the economically correct sign (shorts pay the vault when the vault is long).

Move the derivation and the comparison with other on-chain perps exchanges into a new "Discussions" section, keeping section 1 focused on the formula. Refresh impact_size's parameter description to reflect its new role in diluting the influence of any single resting
order on the premium.