### PR TITLE
fix(ui): various fixes and styling changes to the chart header bar

### DIFF
--- a/ui/applets/kit/src/components/Tooltip.tsx
+++ b/ui/applets/kit/src/components/Tooltip.tsx
@@ -202,7 +202,7 @@ export const Tooltip: React.FC<PropsWithChildren<TooltipProps>> = ({
       onMouseEnter={handleOpen}
       onMouseLeave={handleClose}
       onMouseMove={handleMouseMove}
-      className="relative w-fit cursor-pointer"
+      className="relative w-fit cursor-pointer text-[0px]"
     >
       {children ? children : <IconInfo className="text-ink-tertiary-500" />}
       {typeof document !== "undefined"

--- a/ui/applets/kit/src/components/Tooltip.tsx
+++ b/ui/applets/kit/src/components/Tooltip.tsx
@@ -171,10 +171,10 @@ export const Tooltip: React.FC<PropsWithChildren<TooltipProps>> = ({
           {title || description ? (
             <div className="flex flex-col">
               {title ? (
-                <p className="diatype-sm-bold text-primitives-white-light-100">{title}</p>
+                <p className="diatype-xs-medium text-primitives-white-light-100">{title}</p>
               ) : null}
               {description ? (
-                <p className="diatype-sm-regular text-primitives-gray-dark-200">{description}</p>
+                <p className="diatype-xs-regular text-primitives-gray-dark-200">{description}</p>
               ) : null}
             </div>
           ) : (
@@ -215,7 +215,7 @@ export const Tooltip: React.FC<PropsWithChildren<TooltipProps>> = ({
 export const tooltipVariants = tv({
   slots: {
     panel:
-      "fixed bg-primitives-gray-dark-950 text-primitives-gray-dark-200 p-3 rounded-2xl shadow-account-card max-w-[18rem] w-max text-left min-w-[8rem] diatype-sm-regular z-50",
+      "fixed bg-primitives-gray-dark-950 text-primitives-gray-dark-200 p-3 rounded-2xl shadow-account-card max-w-[18rem] w-max text-left min-w-[8rem] diatype-xs-regular z-50",
     arrow: "absolute w-3 h-3 rotate-45 bg-primitives-gray-dark-950",
   },
   variants: {

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1132,7 +1132,7 @@
         "24hChange": "24h Change",
         "volume": "24h Volume",
         "openInterest": "Open Interest",
-        "funding": "Funding / Countdown",
+        "funding": "Funding (1h) / Countdown",
         "oiLimitReached": "OI limit reached",
         "oiLimitDescription": "No new positions can be opened",
         "fees": "Fees",

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1125,7 +1125,7 @@
       },
       "spot": {
         "price": "Price",
-        "lastPrice": "Mark",
+        "lastPrice": "Last",
         "lastPriceTooltip": "Price of the last filled order",
         "oraclePrice": "Oracle",
         "oraclePriceTooltip": "Price reported by offchain oracle. Used for computing margin requirement, unrealized PnL, liquidation and TP/SL trigger.",

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1132,7 +1132,7 @@
         "24hChange": "24h Change",
         "volume": "24h Volume",
         "openInterest": "Open Interest",
-        "funding": "Funding (1h) / Countdown",
+        "funding": "Funding / Countdown",
         "oiLimitReached": "OI limit reached",
         "oiLimitDescription": "No new positions can be opened",
         "fees": "Fees",

--- a/ui/portal/web/src/components/dex/FundingCountdown.tsx
+++ b/ui/portal/web/src/components/dex/FundingCountdown.tsx
@@ -38,16 +38,16 @@ export const FundingCountdown: React.FC = () => {
     showLeadingZeros: true,
   });
 
-  const { dailyRate, percentValue, annualizedPercent, isPositive } = useMemo(() => {
+  const { hourlyRate, percentValue, annualizedPercent, isPositive } = useMemo(() => {
     if (!pairState?.fundingRate) {
-      return { dailyRate: null, percentValue: null, annualizedPercent: null, isPositive: true };
+      return { hourlyRate: null, percentValue: null, annualizedPercent: null, isPositive: true };
     }
 
     const rate = Decimal(pairState.fundingRate);
 
     return {
-      dailyRate: rate.toString(),
-      percentValue: rate.mul(100).toString(),
+      hourlyRate: rate.toString(),
+      percentValue: rate.mul(100).div(24).toString(),
       annualizedPercent: rate.mul(100).mul(365).toString(),
       isPositive: rate.gte(0),
     };
@@ -69,7 +69,7 @@ export const FundingCountdown: React.FC = () => {
           <span
             className={twMerge(
               "diatype-xs-medium cursor-help",
-              dailyRate === null
+              hourlyRate === null
                 ? "text-ink-secondary-700"
                 : isPositive
                   ? "text-status-success"

--- a/ui/portal/web/src/components/dex/FundingCountdown.tsx
+++ b/ui/portal/web/src/components/dex/FundingCountdown.tsx
@@ -58,7 +58,7 @@ export const FundingCountdown: React.FC = () => {
   return (
     <div className="flex gap-1 flex-col items-start lg:min-w-[4rem]">
       <Tooltip title="The hourly funding rate and the remaining time until the next funding collection. Positive rate means longs pay shorts; negative means shorts pay longs.">
-        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[4px] decoration-current">
           {m["dex.protrade.spot.funding"]()}
         </p>
       </Tooltip>

--- a/ui/portal/web/src/components/dex/FundingCountdown.tsx
+++ b/ui/portal/web/src/components/dex/FundingCountdown.tsx
@@ -57,7 +57,11 @@ export const FundingCountdown: React.FC = () => {
 
   return (
     <div className="flex gap-1 flex-col items-start lg:min-w-[4rem]">
-      <p className="diatype-xs-medium text-ink-tertiary-500">{m["dex.protrade.spot.funding"]()}</p>
+      <Tooltip title="The hourly funding rate and the remaining time until the next funding collection. Positive rate means longs pay shorts; negative means shorts pay longs.">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
+          {m["dex.protrade.spot.funding"]()}
+        </p>
+      </Tooltip>
       <div className="flex items-baseline gap-2">
         <Tooltip
           title={

--- a/ui/portal/web/src/components/dex/OpenInterestDisplay.tsx
+++ b/ui/portal/web/src/components/dex/OpenInterestDisplay.tsx
@@ -51,7 +51,7 @@ export const OpenInterestDisplay: React.FC = () => {
   return (
     <div className="flex gap-1 flex-col items-start lg:min-w-[4rem] col-span-3 lg:col-span-1">
       <Tooltip title="The sum of the notional values of all long and short positions.">
-        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[4px] decoration-current">
           {m["dex.protrade.spot.openInterest"]()}
         </p>
       </Tooltip>

--- a/ui/portal/web/src/components/dex/OpenInterestDisplay.tsx
+++ b/ui/portal/web/src/components/dex/OpenInterestDisplay.tsx
@@ -50,9 +50,11 @@ export const OpenInterestDisplay: React.FC = () => {
 
   return (
     <div className="flex gap-1 flex-col items-start lg:min-w-[4rem] col-span-3 lg:col-span-1">
-      <p className="diatype-xs-medium text-ink-tertiary-500">
-        {m["dex.protrade.spot.openInterest"]()}
-      </p>
+      <Tooltip title="The sum of the notional values of all long and short positions.">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
+          {m["dex.protrade.spot.openInterest"]()}
+        </p>
+      </Tooltip>
       <div className="flex items-center gap-1">
         <p
           className={twMerge(

--- a/ui/portal/web/src/components/dex/TradeHeader.tsx
+++ b/ui/portal/web/src/components/dex/TradeHeader.tsx
@@ -127,7 +127,7 @@ const HeaderPrice: React.FC = () => {
   return (
     <div className="flex gap-1 flex-col lg:min-w-[4rem] items-start">
       <Tooltip title={m["dex.protrade.spot.lastPriceTooltip"]()}>
-        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
           {m["dex.protrade.spot.lastPrice"]()}
         </p>
       </Tooltip>
@@ -154,7 +154,7 @@ const HeaderOraclePrice: React.FC<{ baseDenom: string }> = ({ baseDenom }) => {
   return (
     <div className="flex gap-1 flex-col lg:min-w-[4rem] items-start">
       <Tooltip title={m["dex.protrade.spot.oraclePriceTooltip"]()}>
-        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
           {m["dex.protrade.spot.oraclePrice"]()}
         </p>
       </Tooltip>

--- a/ui/portal/web/src/components/dex/TradeHeader.tsx
+++ b/ui/portal/web/src/components/dex/TradeHeader.tsx
@@ -127,7 +127,7 @@ const HeaderPrice: React.FC = () => {
   return (
     <div className="flex gap-1 flex-col lg:min-w-[4rem] items-start">
       <Tooltip title={m["dex.protrade.spot.lastPriceTooltip"]()}>
-        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[4px] decoration-current">
           {m["dex.protrade.spot.lastPrice"]()}
         </p>
       </Tooltip>
@@ -154,7 +154,7 @@ const HeaderOraclePrice: React.FC<{ denom: string }> = ({ denom }) => {
   return (
     <div className="flex gap-1 flex-col lg:min-w-[4rem] items-start">
       <Tooltip title={m["dex.protrade.spot.oraclePriceTooltip"]()}>
-        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[3px] decoration-current">
+        <p className="diatype-xs-medium text-ink-tertiary-500 cursor-help underline decoration-dashed underline-offset-[4px] decoration-current">
           {m["dex.protrade.spot.oraclePrice"]()}
         </p>
       </Tooltip>

--- a/ui/portal/web/src/components/dex/TradeHeader.tsx
+++ b/ui/portal/web/src/components/dex/TradeHeader.tsx
@@ -92,7 +92,7 @@ export const TradeHeader: React.FC = () => {
           >
             <span className="h-[1px] w-full bg-outline-tertiary-rice col-span-3 lg:hidden mt-2" />
             <HeaderPrice />
-            {mode === "perps" && <HeaderOraclePrice baseDenom={pairId.baseDenom} />}
+            {mode === "perps" && <HeaderOraclePrice denom={getPerpsPairId()} />}
             <Header24hChange
               currentPrice={pairStatsData?.currentPrice}
               price24HAgo={pairStatsData?.price24HAgo}
@@ -147,9 +147,9 @@ const HeaderPrice: React.FC = () => {
   );
 };
 
-const HeaderOraclePrice: React.FC<{ baseDenom: string }> = ({ baseDenom }) => {
+const HeaderOraclePrice: React.FC<{ denom: string }> = ({ denom }) => {
   const { getPrice } = usePrices();
-  const oraclePrice = getPrice(1, baseDenom);
+  const oraclePrice = getPrice(1, denom);
 
   return (
     <div className="flex gap-1 flex-col lg:min-w-[4rem] items-start">


### PR DESCRIPTION
- Fix oracle price showing "-" by using perps pair ID (`perp/btcusd`) instead of spot denom (`bridge/btc`) for oracle lookup                
- Rename "Mark" to "Last" to avoid confusion with mark price (oracle price is the liquidation trigger)
- Reduce tooltip text from 14px bold to 12px medium to match surrounding UI                                                             
- Fix Tooltip trigger div inflating line-height from 24px to 16.8px by zeroing inherited font-size                                      
- Show hourly funding rate (÷24) instead of daily, matching other exchanges                                                             
- Add dashed underlines to hoverable header labels (Last, Oracle, Open Interest, Funding / Countdown) for visual interactivity cue      
- Add tooltip descriptions to "Open Interest" and "Funding / Countdown" labels