### PR TITLE
Chain restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,10 +4445,14 @@ name = "dango-upgrade"
 version = "0.0.0"
 dependencies = [
  "borsh",
+ "dango-bank",
+ "dango-genesis",
  "dango-perps",
  "dango-types",
  "grug",
  "grug-app",
+ "grug-db-disk",
+ "grug-vm-rust",
  "tracing",
 ]
 

--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -126,6 +126,7 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
                 maintain::configure(ctx, param, pair_params)
             },
             MaintainerMsg::Liquidate { user } => maintain::liquidate(ctx, user),
+            MaintainerMsg::Donate {} => maintain::donate(ctx),
         },
         ExecuteMsg::Trade(msg) => match msg {
             TraderMsg::Deposit { to } => trade::deposit(ctx, to),

--- a/dango/perps/src/maintain.rs
+++ b/dango/perps/src/maintain.rs
@@ -1,4 +1,5 @@
 mod configure;
+mod donate;
 mod liquidate;
 
-pub use {configure::*, liquidate::*};
+pub use {configure::*, donate::*, liquidate::*};

--- a/dango/perps/src/maintain/donate.rs
+++ b/dango/perps/src/maintain/donate.rs
@@ -1,0 +1,111 @@
+use {
+    anyhow::ensure,
+    dango_types::perps::settlement_currency,
+    grug::{IsZero, MutableCtx, QuerierExt, Response},
+};
+
+/// Accept a USDC donation to the perps contract.
+///
+/// The donated tokens stay in the perps contract's bank balance, covering the
+/// shortfall between user liabilities and contract assets after the exploit.
+pub fn donate(mut ctx: MutableCtx) -> anyhow::Result<Response> {
+    // 1. Only the chain owner may donate.
+    ensure!(
+        ctx.sender == ctx.querier.query_owner()?,
+        "only the chain owner can donate"
+    );
+
+    // 2. Must attach a nonzero amount of USDC.
+
+    ensure!(
+        {
+            let amount = ctx.funds.take(settlement_currency::DENOM.clone()).amount;
+            amount.is_non_zero()
+        },
+        "nothing to donate"
+    );
+
+    // 3. Must not attach any other tokens.
+    ensure!(ctx.funds.is_empty(), "unexpected tokens: {}", ctx.funds);
+
+    Ok(Response::new())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        dango_types::constants::usdc,
+        grug::{
+            Addr, Coins, Config, Denom, Duration, MockContext, MockQuerier, Permission,
+            Permissions, ResultExt, Uint128,
+        },
+        std::collections::BTreeMap,
+    };
+
+    const OWNER: Addr = Addr::mock(0);
+    const NON_OWNER: Addr = Addr::mock(1);
+
+    fn mock_config() -> Config {
+        Config {
+            owner: OWNER,
+            bank: Addr::mock(2),
+            taxman: Addr::mock(3),
+            cronjobs: BTreeMap::new(),
+            permissions: Permissions {
+                upload: Permission::Nobody,
+                instantiate: Permission::Nobody,
+            },
+            max_orphan_age: Duration::from_seconds(0),
+        }
+    }
+
+    fn usdc_coins(whole: u128) -> Coins {
+        Coins::one(usdc::DENOM.clone(), Uint128::new(whole * 1_000_000)).unwrap()
+    }
+
+    #[test]
+    fn non_owner_rejected() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(NON_OWNER)
+            .with_funds(usdc_coins(100));
+
+        donate(ctx.as_mutable()).should_fail_with_error("only the chain owner can donate");
+    }
+
+    #[test]
+    fn zero_amount_rejected() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        donate(ctx.as_mutable()).should_fail_with_error("nothing to donate");
+    }
+
+    #[test]
+    fn wrong_denom_rejected() {
+        let other_denom: Denom = "factory/other".parse().unwrap();
+        let wrong_coins = Coins::one(other_denom, Uint128::new(100)).unwrap();
+
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(wrong_coins);
+
+        donate(ctx.as_mutable()).should_fail_with_error("nothing to donate");
+    }
+
+    #[test]
+    fn owner_donates_usdc_succeeds() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(usdc_coins(1_000));
+
+        donate(ctx.as_mutable()).should_succeed();
+    }
+}

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -809,6 +809,10 @@ pub enum MaintainerMsg {
     /// Unfilled positions are ADL'd against counter-parties at the bankruptcy
     /// price. Any remaining bad debt is absorbed by the insurance fund.
     Liquidate { user: Addr },
+
+    /// Accept a USDC donation to the perps contract.
+    /// Only callable by the chain owner. Must attach exactly USDC, nonzero.
+    Donate {},
 }
 
 #[grug::derive(Serde)]

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -10,6 +10,7 @@ rust-version  = { workspace = true }
 
 [dependencies]
 borsh       = { workspace = true }
+dango-bank  = { workspace = true, features = ["library"] }
 dango-perps = { workspace = true, features = ["library"] }
 dango-types = { workspace = true }
 grug        = { workspace = true }

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -16,3 +16,8 @@ dango-types = { workspace = true }
 grug        = { workspace = true }
 grug-app    = { workspace = true }
 tracing     = { workspace = true }
+
+[dev-dependencies]
+dango-genesis = { workspace = true }
+grug-db-disk  = { workspace = true }
+grug-vm-rust  = { workspace = true }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,3 +1,27 @@
+//! Post-exploit chain upgrade handler (2026-04-13 insurance fund drain).
+//!
+//! The chain was halted after detection. During downtime, asset prices moved
+//! but users couldn't close positions, so the only fair restart is to
+//! close everything and let users re-enter at current prices.
+//!
+//! The upgrade runs in three phases:
+//!
+//! 1. **Claw back attacker funds.** Both attacker accounts still hold ~$1M
+//!    USDC on-chain (the rest was bridged to Ethereum). Zero their bank
+//!    balances and credit the sum to the perps contract.
+//!
+//! 2. **Clear all perps state.** Cancel every resting order (BIDS, ASKS,
+//!    DEPTHS), close every position (LONGS, SHORTS, USER_STATES.positions),
+//!    zero OI and funding rates on all pairs, and zero the insurance fund.
+//!    User margins, vault shares, and pending unlocks are preserved — those
+//!    are what users are owed.
+//!
+//! 3. **Log the shortfall.** After claw-back, the perps contract's USDC
+//!    balance is still less than total user liabilities (margin + unlocks)
+//!    by roughly the amount the attacker bridged off-chain. The shortfall
+//!    is logged via `tracing::warn!` so the team can bridge the returned
+//!    funds back and donate them through `MaintainerMsg::Donate`.
+
 use {
     dango_bank::BALANCES,
     dango_perps::state::{ASKS, BIDS, DEPTHS, LONGS, PAIR_STATES, SHORTS, STATE, USER_STATES},

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -259,6 +259,13 @@ fn clear_perps_state(storage: &mut dyn Storage) -> StdResult<UsdValue> {
 }
 
 fn assert_invariants(storage: &dyn Storage) -> StdResult<()> {
+    // The maps that have been cleared must be empty.
+    assert!(BIDS.is_empty(storage), "BIDS map isn't empty!");
+    assert!(ASKS.is_empty(storage), "ASKS map isn't empty!");
+    assert!(LONGS.is_empty(storage), "LONGS map isn't empty!");
+    assert!(SHORTS.is_empty(storage), "SHORTS map isn't empty!");
+    assert!(DEPTHS.is_empty(storage), "DEPTHS map isn't empty!");
+
     // All pair states must have zero OI.
     for entry in PAIR_STATES.range(storage, None, None, IterationOrder::Ascending) {
         let (pair_id, ps) = entry?;

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,11 +1,8 @@
 use {
-    dango_types::{
-        Dimensionless, FundingRate, Quantity, UsdPrice, UsdValue,
-        perps::{self, PairId},
-    },
+    dango_perps::state::{ASKS, BIDS, DEPTHS, LONGS, PAIR_STATES, SHORTS, STATE, USER_STATES},
+    dango_types::{FundingRate, Quantity, UsdValue},
     grug::{Addr, BlockInfo, Order as IterationOrder, StdResult, Storage, addr},
     grug_app::{AppResult, CHAIN_ID, CONTRACT_NAMESPACE, StorageProvider},
-    std::collections::BTreeSet,
 };
 
 const MAINNET_CHAIN_ID: &str = "dango-1";
@@ -14,34 +11,8 @@ const MAINNET_PERPS_ADDRESS: Addr = addr!("90bc84df68d1aa59a857e04ed529e9a26edbe
 const TESTNET_CHAIN_ID: &str = "dango-testnet-1";
 const TESTNET_PERPS_ADDRESS: Addr = addr!("f6344c5e2792e8f9202c58a2d88fbbde4cd3142f");
 
-/// Legacy types matching the pre-upgrade Borsh layout.
-///
-/// `PairParam` before this upgrade does not contain the three inventory
-/// skew fields: `vault_size_skew_factor`, `vault_spread_skew_factor`,
-/// `vault_max_skew_size`.
-mod legacy {
-    use super::*;
-
-    pub const PAIR_PARAMS: grug::Map<&PairId, PairParam> = grug::Map::new("pair_param");
-
-    #[derive(borsh::BorshDeserialize, borsh::BorshSerialize)]
-    pub struct PairParam {
-        pub tick_size: UsdPrice,
-        pub min_order_size: UsdValue,
-        pub max_abs_oi: Quantity,
-        pub max_abs_funding_rate: FundingRate,
-        pub initial_margin_ratio: Dimensionless,
-        pub maintenance_margin_ratio: Dimensionless,
-        pub impact_size: UsdValue,
-        pub vault_liquidity_weight: Dimensionless,
-        pub vault_half_spread: Dimensionless,
-        pub vault_max_quote_size: Quantity,
-        pub bucket_sizes: BTreeSet<UsdPrice>,
-    }
-}
-
 pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
-    let chain_id = CHAIN_ID.load(&storage)?;
+    let chain_id = CHAIN_ID.load(&*storage)?;
 
     let perps_address = match chain_id.as_str() {
         MAINNET_CHAIN_ID => MAINNET_PERPS_ADDRESS,
@@ -49,41 +20,142 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
         _ => panic!("unknown chain id: {chain_id}"),
     };
 
-    let mut storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
+    let mut perps_storage =
+        StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
 
-    Ok(_do_upgrade(&mut storage)?)
+    let _total_liability = clear_perps_state(&mut perps_storage)?;
+
+    Ok(())
 }
 
-fn _do_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
-    let old_params: Vec<_> = legacy::PAIR_PARAMS
+/// Close all positions, cancel all orders, zero out OI/insurance fund.
+///
+/// Returns `total_liability`: sum of all user margins + all pending unlock
+/// amounts. This is the amount the perps contract owes its users.
+fn clear_perps_state(storage: &mut dyn Storage) -> StdResult<UsdValue> {
+    // -------------------------------------------------------------------------
+    // 1. Clear order book and position indexes
+    // -------------------------------------------------------------------------
+
+    BIDS.clear_all(storage);
+    ASKS.clear_all(storage);
+    LONGS.clear(storage, None, None);
+    SHORTS.clear(storage, None, None);
+    DEPTHS.clear(storage, None, None);
+
+    tracing::info!("Cleared BIDS, ASKS, LONGS, SHORTS, DEPTHS");
+
+    // -------------------------------------------------------------------------
+    // 2. Reset user states: clear positions, zero reserved_margin/open_order_count
+    // -------------------------------------------------------------------------
+
+    let user_states: Vec<_> = USER_STATES
         .range(storage, None, None, IterationOrder::Ascending)
         .collect::<StdResult<_>>()?;
 
-    let count = old_params.len();
+    let user_count = user_states.len();
+    let mut total_margin = UsdValue::ZERO;
+    let mut total_unlocks = UsdValue::ZERO;
 
-    for (pair_id, old) in old_params {
-        let new = perps::PairParam {
-            tick_size: old.tick_size,
-            min_order_size: old.min_order_size,
-            max_abs_oi: old.max_abs_oi,
-            max_abs_funding_rate: old.max_abs_funding_rate,
-            initial_margin_ratio: old.initial_margin_ratio,
-            maintenance_margin_ratio: old.maintenance_margin_ratio,
-            impact_size: old.impact_size,
-            vault_liquidity_weight: old.vault_liquidity_weight,
-            vault_half_spread: old.vault_half_spread,
-            vault_max_quote_size: old.vault_max_quote_size,
-            // New fields — disabled (zero) until governance sets real values.
-            vault_size_skew_factor: Dimensionless::ZERO,
-            vault_spread_skew_factor: Dimensionless::ZERO,
-            vault_max_skew_size: Quantity::ZERO,
-            bucket_sizes: old.bucket_sizes,
-        };
+    for (addr, mut user_state) in user_states {
+        user_state.positions.clear();
+        user_state.reserved_margin = UsdValue::ZERO;
+        user_state.open_order_count = 0;
 
-        dango_perps::state::PAIR_PARAMS.save(storage, &pair_id, &new)?;
+        // Accumulate liabilities (margin owed + pending vault unlock releases).
+        total_margin.checked_add_assign(user_state.margin)?;
+        for unlock in &user_state.unlocks {
+            total_unlocks.checked_add_assign(unlock.amount_to_release)?;
+        }
+
+        USER_STATES.save(storage, addr, &user_state)?;
     }
 
-    tracing::info!("Migrated {count} PairParam entries (added inventory skew fields)");
+    let total_liability = total_margin.checked_add(total_unlocks)?;
+
+    tracing::info!(
+        user_count,
+        %total_margin,
+        %total_unlocks,
+        %total_liability,
+        "Reset user states"
+    );
+
+    // -------------------------------------------------------------------------
+    // 3. Zero out pair state OI and funding rate
+    // -------------------------------------------------------------------------
+
+    let pair_states: Vec<_> = PAIR_STATES
+        .range(storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<_>>()?;
+
+    let pair_count = pair_states.len();
+
+    for (pair_id, mut pair_state) in pair_states {
+        pair_state.long_oi = Quantity::ZERO;
+        pair_state.short_oi = Quantity::ZERO;
+        pair_state.funding_rate = FundingRate::ZERO;
+        PAIR_STATES.save(storage, &pair_id, &pair_state)?;
+    }
+
+    tracing::info!(pair_count, "Zeroed pair state OI and funding rates");
+
+    // -------------------------------------------------------------------------
+    // 4. Zero insurance fund
+    // -------------------------------------------------------------------------
+
+    let mut state = STATE.load(storage)?;
+    state.insurance_fund = UsdValue::ZERO;
+    STATE.save(storage, &state)?;
+
+    tracing::info!("Zeroed insurance fund");
+
+    // -------------------------------------------------------------------------
+    // 5. Assert invariants
+    // -------------------------------------------------------------------------
+
+    assert_invariants(storage)?;
+
+    Ok(total_liability)
+}
+
+fn assert_invariants(storage: &dyn Storage) -> StdResult<()> {
+    // All pair states must have zero OI.
+    for entry in PAIR_STATES.range(storage, None, None, IterationOrder::Ascending) {
+        let (pair_id, ps) = entry?;
+        assert!(
+            ps.long_oi.is_zero() && ps.short_oi.is_zero(),
+            "pair {pair_id} still has nonzero OI: long={}, short={}",
+            ps.long_oi,
+            ps.short_oi,
+        );
+    }
+
+    // Insurance fund must be zero.
+    let state = STATE.load(storage)?;
+    assert!(state.insurance_fund.is_zero(), "insurance fund not zero");
+
+    // No user should have positions, reserved_margin, or open orders.
+    for entry in USER_STATES.range(storage, None, None, IterationOrder::Ascending) {
+        let (addr, us) = entry?;
+        assert!(
+            us.positions.is_empty(),
+            "user {addr} still has {} positions",
+            us.positions.len(),
+        );
+        assert!(
+            us.reserved_margin.is_zero(),
+            "user {addr} still has reserved margin: {}",
+            us.reserved_margin,
+        );
+        assert!(
+            us.open_order_count == 0,
+            "user {addr} still has {} open orders",
+            us.open_order_count,
+        );
+    }
+
+    tracing::info!("All invariants passed");
 
     Ok(())
 }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,7 +1,11 @@
 use {
     dango_bank::BALANCES,
     dango_perps::state::{ASKS, BIDS, DEPTHS, LONGS, PAIR_STATES, SHORTS, STATE, USER_STATES},
-    dango_types::{FundingRate, Quantity, UsdValue, constants::usdc},
+    dango_types::{
+        FundingRate, Quantity, UsdValue,
+        constants::usdc,
+        perps::{SETTLEMENT_CURRENCY_PRICE, settlement_currency},
+    },
     grug::{
         Addr, BlockInfo, Denom, Number, NumberConst, Order as IterationOrder, StdResult, Storage,
         Uint128, addr,
@@ -37,9 +41,17 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
     }
 
     // Phase 2: Clear perps state (perps storage scope).
-    let mut perps_storage =
-        StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
-    let _total_liability = clear_perps_state(&mut perps_storage)?;
+    let total_liability = {
+        let mut perps_storage =
+            StorageProvider::new(storage.clone(), &[CONTRACT_NAMESPACE, &perps_address]);
+        clear_perps_state(&mut perps_storage)?
+    };
+
+    // Phase 3: Calculate and log shortfall.
+    {
+        let bank_storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &config.bank]);
+        log_shortfall(&bank_storage, &perps_address, &usdc_denom, total_liability)?;
+    }
 
     Ok(())
 }
@@ -68,7 +80,11 @@ fn claw_back_attacker_funds(
     let perps_bal = BALANCES
         .may_load(storage, (perps_address, usdc_denom))?
         .unwrap_or_default();
-    BALANCES.save(storage, (perps_address, usdc_denom), &perps_bal.checked_add(clawed_back)?)?;
+    BALANCES.save(
+        storage,
+        (perps_address, usdc_denom),
+        &perps_bal.checked_add(clawed_back)?,
+    )?;
 
     tracing::info!(
         attacker_1 = %bal1,
@@ -79,6 +95,48 @@ fn claw_back_attacker_funds(
     );
 
     Ok(clawed_back)
+}
+
+/// Read the perps contract's USDC balance, convert to UsdValue, and log the
+/// shortfall (liability minus asset). This is the amount that must be bridged
+/// back and donated to the perps contract to make users whole.
+fn log_shortfall(
+    storage: &dyn Storage,
+    perps_address: &Addr,
+    usdc_denom: &Denom,
+    total_liability: UsdValue,
+) -> StdResult<()> {
+    let perps_usdc_balance = BALANCES
+        .may_load(storage, (perps_address, usdc_denom))?
+        .unwrap_or_default();
+
+    // Convert raw USDC (base units) to UsdValue via the same path as deposit.rs:
+    // Quantity::from_base(amount, decimals) * SETTLEMENT_CURRENCY_PRICE
+    let asset = Quantity::from_base(perps_usdc_balance, settlement_currency::DECIMAL)?
+        .checked_mul(SETTLEMENT_CURRENCY_PRICE)?;
+
+    let shortfall = total_liability.checked_sub(asset)?;
+
+    if shortfall.is_positive() {
+        tracing::warn!(
+            %total_liability,
+            perps_usdc_balance = %perps_usdc_balance,
+            asset_usd = %asset,
+            %shortfall,
+            "!!! SHORTFALL: perps contract liabilities exceed assets. \
+             Bridge the returned funds back to dango and donate to the perps contract. !!!"
+        );
+    } else {
+        tracing::info!(
+            %total_liability,
+            perps_usdc_balance = %perps_usdc_balance,
+            asset_usd = %asset,
+            %shortfall,
+            "No shortfall"
+        );
+    }
+
+    Ok(())
 }
 
 /// Close all positions, cancel all orders, zero out OI/insurance fund.

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -240,14 +240,15 @@ fn clear_perps_state(storage: &mut dyn Storage) -> StdResult<UsdValue> {
     tracing::info!(pair_count, "Zeroed pair state OI and funding rates");
 
     // -------------------------------------------------------------------------
-    // 4. Zero insurance fund
+    // 4. Zero treasury and insurance fund
     // -------------------------------------------------------------------------
 
     let mut state = STATE.load(storage)?;
     state.insurance_fund = UsdValue::ZERO;
+    state.treasury = UsdValue::ZERO;
     STATE.save(storage, &state)?;
 
-    tracing::info!("Zeroed insurance fund");
+    tracing::info!("Zeroed treasury and insurance fund");
 
     // -------------------------------------------------------------------------
     // 5. Assert invariants
@@ -277,9 +278,18 @@ fn assert_invariants(storage: &dyn Storage) -> StdResult<()> {
         );
     }
 
-    // Insurance fund must be zero.
+    // Trasury and insurance fund must be zero.
     let state = STATE.load(storage)?;
-    assert!(state.insurance_fund.is_zero(), "insurance fund not zero");
+    assert!(
+        state.treasury.is_zero(),
+        "treasury not zero: {}",
+        state.treasury
+    );
+    assert!(
+        state.insurance_fund.is_zero(),
+        "insurance fund not zero: {}",
+        state.insurance_fund
+    );
 
     // No user should have positions, reserved_margin, or open orders.
     // The attacker must additionally have the margin zeroed out.

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,8 +1,12 @@
 use {
+    dango_bank::BALANCES,
     dango_perps::state::{ASKS, BIDS, DEPTHS, LONGS, PAIR_STATES, SHORTS, STATE, USER_STATES},
-    dango_types::{FundingRate, Quantity, UsdValue},
-    grug::{Addr, BlockInfo, Order as IterationOrder, StdResult, Storage, addr},
-    grug_app::{AppResult, CHAIN_ID, CONTRACT_NAMESPACE, StorageProvider},
+    dango_types::{FundingRate, Quantity, UsdValue, constants::usdc},
+    grug::{
+        Addr, BlockInfo, Denom, Number, NumberConst, Order as IterationOrder, StdResult, Storage,
+        Uint128, addr,
+    },
+    grug_app::{AppResult, CHAIN_ID, CONFIG, CONTRACT_NAMESPACE, StorageProvider},
 };
 
 const MAINNET_CHAIN_ID: &str = "dango-1";
@@ -11,8 +15,12 @@ const MAINNET_PERPS_ADDRESS: Addr = addr!("90bc84df68d1aa59a857e04ed529e9a26edbe
 const TESTNET_CHAIN_ID: &str = "dango-testnet-1";
 const TESTNET_PERPS_ADDRESS: Addr = addr!("f6344c5e2792e8f9202c58a2d88fbbde4cd3142f");
 
+const ATTACKER_1: Addr = addr!("023ef9e3e20caca6ef3743cbfba6469d69978999");
+const ATTACKER_2: Addr = addr!("0e85f43a9e45a7c8835ded188890b7e57033b78f");
+
 pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
     let chain_id = CHAIN_ID.load(&*storage)?;
+    let config = CONFIG.load(&*storage)?;
 
     let perps_address = match chain_id.as_str() {
         MAINNET_CHAIN_ID => MAINNET_PERPS_ADDRESS,
@@ -20,12 +28,57 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
         _ => panic!("unknown chain id: {chain_id}"),
     };
 
+    // Phase 1: Claw back attacker funds (bank storage scope).
+    let usdc_denom = usdc::DENOM.clone();
+    {
+        let mut bank_storage =
+            StorageProvider::new(storage.clone(), &[CONTRACT_NAMESPACE, &config.bank]);
+        claw_back_attacker_funds(&mut bank_storage, &perps_address, &usdc_denom)?;
+    }
+
+    // Phase 2: Clear perps state (perps storage scope).
     let mut perps_storage =
         StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
-
     let _total_liability = clear_perps_state(&mut perps_storage)?;
 
     Ok(())
+}
+
+/// Zero out USDC balances of the two attacker accounts and add the sum to
+/// the perps contract's balance. Operates on the bank contract's storage.
+fn claw_back_attacker_funds(
+    storage: &mut dyn Storage,
+    perps_address: &Addr,
+    usdc_denom: &Denom,
+) -> StdResult<Uint128> {
+    let bal1 = BALANCES
+        .may_load(storage, (&ATTACKER_1, usdc_denom))?
+        .unwrap_or_default();
+    let bal2 = BALANCES
+        .may_load(storage, (&ATTACKER_2, usdc_denom))?
+        .unwrap_or_default();
+
+    let clawed_back = bal1.checked_add(bal2)?;
+
+    // Zero attacker balances.
+    BALANCES.save(storage, (&ATTACKER_1, usdc_denom), &Uint128::ZERO)?;
+    BALANCES.save(storage, (&ATTACKER_2, usdc_denom), &Uint128::ZERO)?;
+
+    // Credit the clawed-back amount to the perps contract.
+    let perps_bal = BALANCES
+        .may_load(storage, (perps_address, usdc_denom))?
+        .unwrap_or_default();
+    BALANCES.save(storage, (perps_address, usdc_denom), &perps_bal.checked_add(clawed_back)?)?;
+
+    tracing::info!(
+        attacker_1 = %bal1,
+        attacker_2 = %bal2,
+        total_clawed_back = %clawed_back,
+        new_perps_balance = %(perps_bal.checked_add(clawed_back)?),
+        "Clawed back attacker USDC funds to perps contract"
+    );
+
+    Ok(clawed_back)
 }
 
 /// Close all positions, cancel all orders, zero out OI/insurance fund.

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -197,6 +197,11 @@ fn clear_perps_state(storage: &mut dyn Storage) -> StdResult<UsdValue> {
         user_state.reserved_margin = UsdValue::ZERO;
         user_state.open_order_count = 0;
 
+        // If the account is the attacker's, additionally zero out the margin.
+        if [ATTACKER_1, ATTACKER_2].contains(&addr) {
+            user_state.margin = UsdValue::ZERO;
+        }
+
         // Accumulate liabilities (margin owed + pending vault unlock releases).
         total_margin.checked_add_assign(user_state.margin)?;
         for unlock in &user_state.unlocks {
@@ -271,8 +276,10 @@ fn assert_invariants(storage: &dyn Storage) -> StdResult<()> {
     assert!(state.insurance_fund.is_zero(), "insurance fund not zero");
 
     // No user should have positions, reserved_margin, or open orders.
+    // The attacker must additionally have the margin zeroed out.
     for entry in USER_STATES.range(storage, None, None, IterationOrder::Ascending) {
         let (addr, us) = entry?;
+
         assert!(
             us.positions.is_empty(),
             "user {addr} still has {} positions",
@@ -288,6 +295,14 @@ fn assert_invariants(storage: &dyn Storage) -> StdResult<()> {
             "user {addr} still has {} open orders",
             us.open_order_count,
         );
+
+        if [ATTACKER_1, ATTACKER_2].contains(&addr) {
+            assert!(
+                us.margin.is_zero(),
+                "attacker {addr} still has a non-zero margin of {}",
+                us.margin
+            );
+        }
     }
 
     tracing::info!("All invariants passed");

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -31,8 +31,7 @@ use {
         perps::{SETTLEMENT_CURRENCY_PRICE, settlement_currency},
     },
     grug::{
-        Addr, BlockInfo, Denom, Number, NumberConst, Order as IterationOrder, StdResult, Storage,
-        Uint128, addr,
+        Addr, BlockInfo, Denom, Number, Order as IterationOrder, StdResult, Storage, Uint128, addr,
     },
     grug_app::{AppResult, CHAIN_ID, CONFIG, CONTRACT_NAMESPACE, StorageProvider},
 };
@@ -97,8 +96,8 @@ fn claw_back_attacker_funds(
     let clawed_back = bal1.checked_add(bal2)?;
 
     // Zero attacker balances.
-    BALANCES.save(storage, (&ATTACKER_1, usdc_denom), &Uint128::ZERO)?;
-    BALANCES.save(storage, (&ATTACKER_2, usdc_denom), &Uint128::ZERO)?;
+    BALANCES.remove(storage, (&ATTACKER_1, usdc_denom));
+    BALANCES.remove(storage, (&ATTACKER_2, usdc_denom));
 
     // Credit the clawed-back amount to the perps contract.
     let perps_bal = BALANCES

--- a/dango/upgrade/tests/mainnet_upgrade.rs
+++ b/dango/upgrade/tests/mainnet_upgrade.rs
@@ -8,6 +8,7 @@ use {
 };
 
 #[test]
+#[ignore = "requires mainnet rocksdb data which is not committed"]
 fn mainnet_upgrade_succeeds() {
     let db_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -15,11 +16,6 @@ fn mainnet_upgrade_succeeds() {
         .parent()
         .unwrap()
         .join("deploy/downloaded-db/mainnet/inter1/data");
-
-    if !db_path.exists() {
-        eprintln!("Skipping test: mainnet DB not found at {}", db_path.display());
-        return;
-    }
 
     // Register contract wrappers so the RustVm can resolve code hashes.
     let _codes = RustVm::genesis_codes();

--- a/dango/upgrade/tests/mainnet_upgrade.rs
+++ b/dango/upgrade/tests/mainnet_upgrade.rs
@@ -1,0 +1,38 @@
+use {
+    dango_genesis::GenesisCodes,
+    grug::{Buffer, Shared},
+    grug_app::{Db, LAST_FINALIZED_BLOCK, SimpleCommitment},
+    grug_db_disk::DiskDb,
+    grug_vm_rust::RustVm,
+    std::path::PathBuf,
+};
+
+#[test]
+fn mainnet_upgrade_succeeds() {
+    let db_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("deploy/downloaded-db/mainnet/inter1/data");
+
+    if !db_path.exists() {
+        eprintln!("Skipping test: mainnet DB not found at {}", db_path.display());
+        return;
+    }
+
+    // Register contract wrappers so the RustVm can resolve code hashes.
+    let _codes = RustVm::genesis_codes();
+
+    let db = DiskDb::<SimpleCommitment>::open(&db_path).unwrap();
+    let storage = db.state_storage(None).unwrap();
+
+    let block = LAST_FINALIZED_BLOCK.load(&storage).unwrap();
+
+    // Wrap in a writable buffer, matching how app.rs calls the upgrade handler.
+    let buffer = Shared::new(Buffer::new(storage, None, "upgrade_test"));
+
+    // Run the upgrade handler. The invariant assertions inside will panic on
+    // failure, so reaching the end means everything passed.
+    dango_upgrade::do_upgrade(Box::new(buffer), RustVm::new(), block).unwrap();
+}

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -7,14 +7,14 @@ use grug_types::{HashExt, JsonDeExt};
 use {
     crate::{
         APP_CONFIG, AppError, AppResult, CHAIN_ID, CODES, CONFIG, Db, EventResult, GasTracker,
-        Indexer, LAST_FINALIZED_BLOCK, NEXT_CRONJOBS, NEXT_UPGRADE, NaiveProposalPreparer,
-        NaiveQuerier, NullIndexer, PAST_UPGRADES, ProposalPreparer, QuerierProviderImpl,
-        TraceOption, Vm, catch_and_push_event, catch_and_update_event, do_authenticate, do_backrun,
-        do_configure, do_cron_execute, do_execute, do_finalize_fee, do_instantiate, do_migrate,
-        do_transfer, do_upgrade, do_upload, do_withhold_fee, query_app_config, query_balance,
-        query_balances, query_code, query_codes, query_config, query_contract, query_contracts,
-        query_next_upgrade, query_past_upgrades, query_status, query_supplies, query_supply,
-        query_wasm_raw, query_wasm_scan, query_wasm_smart,
+        Indexer, LAST_FINALIZED_BLOCK, NEXT_CRONJOBS, NaiveProposalPreparer, NaiveQuerier,
+        NullIndexer, PAST_UPGRADES, ProposalPreparer, QuerierProviderImpl, TraceOption, Vm,
+        catch_and_push_event, catch_and_update_event, do_authenticate, do_backrun, do_configure,
+        do_cron_execute, do_execute, do_finalize_fee, do_instantiate, do_migrate, do_transfer,
+        do_upgrade, do_upload, do_withhold_fee, query_app_config, query_balance, query_balances,
+        query_code, query_codes, query_config, query_contract, query_contracts, query_next_upgrade,
+        query_past_upgrades, query_status, query_supplies, query_supply, query_wasm_raw,
+        query_wasm_scan, query_wasm_smart,
     },
     grug_storage::PrefixBound,
     grug_types::{
@@ -349,86 +349,151 @@ where
             ));
         }
 
-        // If a planned upgrade exists and the block height is reached, then run
-        // the chain upgrade logic.
-        if let Some(upgrade) = NEXT_UPGRADE.may_load(&buffer)?
-            && block.info.height >= upgrade.height
+        // TODO: delete this hardfork block and uncomment the original upgrade
+        // logic below once the post-exploit upgrade has been completed.
         {
-            // Current node software version doesn't match the upgrade version.
-            // Exit early, halt the chain, awaiting the node operator to deploy
-            // the right version.
-            //
-            // See the equivalent code is Cosmos SDK:
-            // https://github.com/cosmos/cosmos-sdk/blob/v0.53.4/baseapp/abci.go#L708-L710
-            if self.cargo_version != upgrade.cargo_version {
+            use grug_types::PastUpgrade;
+
+            const MAINNET_CHAIN_ID: &str = "dango-1";
+            const MAINNET_UPGRADE_HEIGHT: u64 = 17708992;
+            const MAINNET_UPGRADE_CARGO_VERSION: &str = "v0.12.0";
+
+            let chain_id = CHAIN_ID.load(&buffer)?;
+
+            if chain_id == MAINNET_CHAIN_ID && block.info.height == MAINNET_UPGRADE_HEIGHT {
+                assert_eq!(
+                    self.cargo_version, MAINNET_UPGRADE_CARGO_VERSION,
+                    "mainnet upgrade planned, but cargo version doesn't match"
+                );
+
+                let Some(handler) = self.upgrade_handler else {
+                    panic!("mainnet upgrade planned, but no upgrade handler not found!");
+                };
+
                 #[cfg(feature = "tracing")]
                 {
-                    tracing::warn!(
-                        last_finalized_height = last_finalized_block.height,
-                        current_version = self.cargo_version,
-                        upgrade_version = upgrade.cargo_version,
-                        "!!! PRE-PLANNED CHAIN HALT !!!"
-                    );
+                    tracing::info!(height = block.info.height, "Performing chain upgrade");
                 }
 
-                return Err(AppError::upgrade_incorrect_version(
-                    self.cargo_version.clone(),
-                    upgrade.cargo_version,
-                ));
-            }
-
-            // Now the current node software version matches the upgrade version.
-            // We can proceed with the upgrade.
-            //
-            // If an action is specified in the `upgrade_handler`, then execute it.
-            // This action MUST succeed. If not, it's considered a critical error.
-            // We halt the chain, awaiting a fix.
-            if let Some(handler) = self.upgrade_handler {
-                #[cfg(feature = "tracing")]
-                {
-                    tracing::info!(
-                        height = block.info.height,
-                        cargo_version = upgrade.cargo_version,
-                        "Performing chain upgrade"
-                    );
-                }
-
-                // If executing the action errors, an error is returned in the
-                // ABCI response, which leads to a chain halt (as intended).
-                (handler)(Box::new(buffer.clone()), self.vm.clone(), block.info).inspect_err(
-                    |_err| {
+                (handler)(Box::new(buffer.clone()), self.vm.clone(), block.info).unwrap_or_else(
+                    |err| {
                         #[cfg(feature = "tracing")]
                         {
-                            tracing::error!(reason = %_err, "!!! UPGRADE FAILED !!!");
+                            tracing::error!(reason = %err, "!!! UPGRADE FAILED !!!");
                         }
+
+                        panic!("upgrade failed: {}", err.to_string());
                     },
-                )?;
+                );
 
                 #[cfg(feature = "tracing")]
                 {
-                    tracing::info!(
-                        height = block.info.height,
-                        cargo_version = upgrade.cargo_version,
-                        "Completed chain upgrade"
-                    );
+                    tracing::info!(height = block.info.height, "Completed chain upgrade");
                 }
+
+                PAST_UPGRADES.save(&mut buffer, block.info.height, &PastUpgrade {
+                    cargo_version: self.cargo_version.clone(),
+                    git_tag: Some("v0.12.0".to_string()),
+                    url: Some(
+                        "https://github.com/left-curve/left-curve/releases/tag/v0.12.0".to_string(),
+                    ),
+                })?;
             } else {
                 #[cfg(feature = "tracing")]
                 {
                     tracing::info!(
+                        chain_id = chain_id,
+                        mainnet_chain_id = MAINNET_CHAIN_ID,
                         height = block.info.height,
-                        cargo_version = upgrade.cargo_version,
-                        "No handler specified for the chain upgrade. Skipping..."
+                        mainnet_upgrade_height = MAINNET_UPGRADE_HEIGHT,
+                        cargo_version = self.cargo_version,
+                        mainnet_upgrade_cargo_version = MAINNET_UPGRADE_CARGO_VERSION,
+                        "Current chain does not match mainnet upgrade plan. Upgrade is skipped"
                     );
                 }
             }
-
-            // Delete the scheduled upgrade, as it's already done.
-            NEXT_UPGRADE.remove(&mut buffer);
-
-            // Save the upgrade to the logs.
-            PAST_UPGRADES.save(&mut buffer, block.info.height, &upgrade.into())?;
         }
+
+        // // If a planned upgrade exists and the block height is reached, then run
+        // // the chain upgrade logic.
+        // if let Some(upgrade) = NEXT_UPGRADE.may_load(&buffer)?
+        //     && block.info.height >= upgrade.height
+        // {
+        //     // Current node software version doesn't match the upgrade version.
+        //     // Exit early, halt the chain, awaiting the node operator to deploy
+        //     // the right version.
+        //     //
+        //     // See the equivalent code is Cosmos SDK:
+        //     // https://github.com/cosmos/cosmos-sdk/blob/v0.53.4/baseapp/abci.go#L708-L710
+        //     if self.cargo_version != upgrade.cargo_version {
+        //         #[cfg(feature = "tracing")]
+        //         {
+        //             tracing::warn!(
+        //                 last_finalized_height = last_finalized_block.height,
+        //                 current_version = self.cargo_version,
+        //                 upgrade_version = upgrade.cargo_version,
+        //                 "!!! PRE-PLANNED CHAIN HALT !!!"
+        //             );
+        //         }
+        //
+        //         return Err(AppError::upgrade_incorrect_version(
+        //             self.cargo_version.clone(),
+        //             upgrade.cargo_version,
+        //         ));
+        //     }
+        //
+        //     // Now the current node software version matches the upgrade version.
+        //     // We can proceed with the upgrade.
+        //     //
+        //     // If an action is specified in the `upgrade_handler`, then execute it.
+        //     // This action MUST succeed. If not, it's considered a critical error.
+        //     // We halt the chain, awaiting a fix.
+        //     if let Some(handler) = self.upgrade_handler {
+        //         #[cfg(feature = "tracing")]
+        //         {
+        //             tracing::info!(
+        //                 height = block.info.height,
+        //                 cargo_version = upgrade.cargo_version,
+        //                 "Performing chain upgrade"
+        //             );
+        //         }
+        //
+        //         // If executing the action errors, an error is returned in the
+        //         // ABCI response, which leads to a chain halt (as intended).
+        //         (handler)(Box::new(buffer.clone()), self.vm.clone(), block.info).inspect_err(
+        //             |_err| {
+        //                 #[cfg(feature = "tracing")]
+        //                 {
+        //                     tracing::error!(reason = %_err, "!!! UPGRADE FAILED !!!");
+        //                 }
+        //             },
+        //         )?;
+        //
+        //         #[cfg(feature = "tracing")]
+        //         {
+        //             tracing::info!(
+        //                 height = block.info.height,
+        //                 cargo_version = upgrade.cargo_version,
+        //                 "Completed chain upgrade"
+        //             );
+        //         }
+        //     } else {
+        //         #[cfg(feature = "tracing")]
+        //         {
+        //             tracing::info!(
+        //                 height = block.info.height,
+        //                 cargo_version = upgrade.cargo_version,
+        //                 "No handler specified for the chain upgrade. Skipping..."
+        //             );
+        //         }
+        //     }
+        //
+        //     // Delete the scheduled upgrade, as it's already done.
+        //     NEXT_UPGRADE.remove(&mut buffer);
+        //
+        //     // Save the upgrade to the logs.
+        //     PAST_UPGRADES.save(&mut buffer, block.info.height, &upgrade.into())?;
+        // }
 
         let mut cron_outcomes = vec![];
         let mut tx_outcomes = vec![];

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -382,7 +382,7 @@ where
                             tracing::error!(reason = %err, "!!! UPGRADE FAILED !!!");
                         }
 
-                        panic!("upgrade failed: {}", err.to_string());
+                        panic!("upgrade failed: {err}");
                     },
                 );
 

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -349,8 +349,8 @@ where
             ));
         }
 
-        // TODO: delete this hardfork block and uncomment the original upgrade
-        // logic below once the post-exploit upgrade has been completed.
+        // ============================= BEGIN ONE-OFF MAINNET UPGRADE =============================
+        // TODO: delete after mainnet upgrade is completed.
         {
             use grug_types::PastUpgrade;
 
@@ -413,6 +413,7 @@ where
                 }
             }
         }
+        // ============================== END ONE-OFF MAINNET UPGRADE ==============================
 
         // // If a planned upgrade exists and the block height is reached, then run
         // // the chain upgrade logic.

--- a/grug/testing/tests/upgrade.rs
+++ b/grug/testing/tests/upgrade.rs
@@ -48,6 +48,7 @@ fn error_cases() {
 /// This is otherwise not possible through normal transactions.
 /// This upgrade doesn't involve any contract calls.
 #[test]
+#[ignore = "temporarily disabled; to be re-enabled after mainnet upgrade"] // FIXME
 fn upgrading_without_calling_contract() {
     const OLD_CHAIN_ID: &str = "oonga";
     const NEW_CHAIN_ID: &str = "boonga";
@@ -146,6 +147,7 @@ fn upgrading_without_calling_contract() {
 /// In practice, this can be easily done with a simple contract migration, but
 /// here for testing purpose, we go with a full chain upgrade.
 #[test]
+#[ignore = "temporarily disabled; to be re-enabled after mainnet upgrade"] // FIXME
 fn upgrading_with_calling_contract() {
     mod new_mock_bank {
         use {


### PR DESCRIPTION
- upgrade handler:
  - claw back funds from attacker accounts, add to the perps contract balance
  - cancel all resting orders, close all positions, discarding unrealized PnL
- edit the upgrade trigger in `app.rs` for this one-off upgrade
- add a `MaintainerMsg::Donate {}` so that the team can replenish the perp contract's balance.