### PR TITLE
fix(perps): harden user-supplied input validation

### DIFF
--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -16,6 +16,7 @@ pub mod volume;
 
 use {
     crate::state::{NEXT_ORDER_ID, PAIR_PARAMS, PAIR_STATES, PARAM, STATE, USER_STATES},
+    anyhow::ensure,
     dango_oracle::OracleQuerier,
     dango_types::{
         DangoQuerier, UsdValue,
@@ -120,6 +121,17 @@ pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
+    // Only `Deposit` accepts attached funds (settlement currency). Every other
+    // endpoint must be called without funds — tokens sent here would otherwise
+    // be silently absorbed by the contract, lost to the sender.
+    if !matches!(msg, ExecuteMsg::Trade(TraderMsg::Deposit { .. })) {
+        ensure!(
+            ctx.funds.is_empty(),
+            "unexpected funds sent to non-deposit endpoint: {}",
+            ctx.funds
+        );
+    }
+
     match msg {
         ExecuteMsg::Maintain(msg) => match msg {
             MaintainerMsg::Configure { param, pair_params } => {

--- a/dango/perps/src/referral/force_set_fee_share_ratio.rs
+++ b/dango/perps/src/referral/force_set_fee_share_ratio.rs
@@ -20,6 +20,11 @@ pub fn force_set_fee_share_ratio(
         "you don't have the right, O you don't have the right"
     );
 
+    ensure!(
+        !share_ratio.is_negative(),
+        "fee share ratio cannot be negative, found: {share_ratio}"
+    );
+
     FEE_SHARE_RATIO.save(ctx.storage, user, &share_ratio)?;
 
     Ok(Response::new())
@@ -64,5 +69,38 @@ mod tests {
 
         force_set_fee_share_ratio(ctx.as_mutable(), 42, FeeShareRatio::new_percent(25))
             .should_fail_with_error("you don't have the right");
+    }
+
+    #[test]
+    fn negative_share_ratio_rejected() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        force_set_fee_share_ratio(ctx.as_mutable(), 42, FeeShareRatio::new_percent(-10))
+            .should_fail_with_error("fee share ratio cannot be negative");
+    }
+
+    #[test]
+    fn zero_share_ratio_accepted() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        force_set_fee_share_ratio(ctx.as_mutable(), 42, FeeShareRatio::ZERO).should_succeed();
+    }
+
+    /// The force path intentionally allows ratios above the normal 50% cap.
+    #[test]
+    fn above_normal_cap_accepted() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        force_set_fee_share_ratio(ctx.as_mutable(), 42, FeeShareRatio::new_percent(75))
+            .should_succeed();
     }
 }

--- a/dango/perps/src/referral/set_commission_rate_override.rs
+++ b/dango/perps/src/referral/set_commission_rate_override.rs
@@ -20,6 +20,10 @@ pub fn set_commission_rate_override(
 
     match commission_rate {
         Op::Insert(rate) => {
+            ensure!(
+                !rate.is_negative() && rate <= CommissionRate::ONE,
+                "commission rate must be in [0, 1], found: {rate}"
+            );
             COMMISSION_RATE_OVERRIDES.save(ctx.storage, user, &rate)?;
         },
         Op::Delete => {
@@ -28,4 +32,104 @@ pub fn set_commission_rate_override(
     }
 
     Ok(Response::new())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        grug::{
+            Addr, Coins, Config, Duration, MockContext, MockQuerier, Permission, Permissions,
+            ResultExt,
+        },
+        std::collections::BTreeMap,
+    };
+
+    const OWNER: Addr = Addr::mock(1);
+
+    fn mock_config() -> Config {
+        Config {
+            owner: OWNER,
+            bank: Addr::mock(100),
+            taxman: Addr::mock(101),
+            cronjobs: BTreeMap::new(),
+            permissions: Permissions {
+                upload: Permission::Everybody,
+                instantiate: Permission::Everybody,
+            },
+            max_orphan_age: Duration::from_seconds(1000),
+        }
+    }
+
+    #[test]
+    fn negative_commission_rate_rejected() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        set_commission_rate_override(
+            ctx.as_mutable(),
+            42,
+            Op::Insert(CommissionRate::new_percent(-10)),
+        )
+        .should_fail_with_error("commission rate must be in [0, 1]");
+    }
+
+    #[test]
+    fn commission_rate_above_one_rejected() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        set_commission_rate_override(
+            ctx.as_mutable(),
+            42,
+            Op::Insert(CommissionRate::new_percent(150)),
+        )
+        .should_fail_with_error("commission rate must be in [0, 1]");
+    }
+
+    #[test]
+    fn valid_commission_rate_accepted() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        set_commission_rate_override(
+            ctx.as_mutable(),
+            42,
+            Op::Insert(CommissionRate::new_percent(25)),
+        )
+        .should_succeed();
+
+        let stored = COMMISSION_RATE_OVERRIDES.load(&ctx.storage, 42).unwrap();
+        assert_eq!(stored, CommissionRate::new_percent(25));
+    }
+
+    #[test]
+    fn zero_commission_rate_accepted() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        set_commission_rate_override(ctx.as_mutable(), 42, Op::Insert(CommissionRate::ZERO))
+            .should_succeed();
+    }
+
+    #[test]
+    fn one_commission_rate_accepted() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        set_commission_rate_override(ctx.as_mutable(), 42, Op::Insert(CommissionRate::ONE))
+            .should_succeed();
+    }
 }


### PR DESCRIPTION
- Reject unexpected funds on all non-Deposit endpoints. Tokens sent to any other ExecuteMsg variant would be silently absorbed by the contract and lost. A single top-level guard in `execute()` covers all current and future endpoints.
- Validate `commission_rate` in `set_commission_rate_override` is in `[0, 1]`. A negative rate would drain user margin via `credit_commission`; a rate above 1 would extract more than the vault fee.
- Reject negative `share_ratio` in `force_set_fee_share_ratio`. The force path intentionally bypasses the 50% cap and the increase-only restriction, but a negative ratio enables the same drain vector fixed in 8c4e322.