### PR TITLE
feat(perps): add payer address to FeeDistributed event

### DIFF
--- a/dango/perps/src/referral/apply_fee_commissions.rs
+++ b/dango/perps/src/referral/apply_fee_commissions.rs
@@ -228,6 +228,7 @@ pub fn apply_fee_commissions(
 
         events.push(FeeDistributed {
             payer: payer_index,
+            payer_addr: payer,
             protocol_fee: fee_breakdown.protocol_fee,
             vault_fee,
             commissions,

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1380,6 +1380,9 @@ pub struct FeeDistributed {
     /// User index of the fee payer.
     pub payer: UserIndex,
 
+    /// Address of the fee payer.
+    pub payer_addr: Addr,
+
     /// Protocol treasury portion of the fee.
     pub protocol_fee: UsdValue,
 


### PR DESCRIPTION
Include the payer's Addr alongside the existing UserIndex in the commission refund event so downstream consumers can correlate fees directly to an address without an extra lookup.