### PR TITLE
fix: four issues identified during review of the v0.11.0 → main delta

### DIFF
--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -124,7 +124,11 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     // Only `Deposit` accepts attached funds (settlement currency). Every other
     // endpoint must be called without funds — tokens sent here would otherwise
     // be silently absorbed by the contract, lost to the sender.
-    if !matches!(msg, ExecuteMsg::Trade(TraderMsg::Deposit { .. })) {
+    if !matches!(
+        msg,
+        ExecuteMsg::Trade(TraderMsg::Deposit { .. })
+            | ExecuteMsg::Maintain(MaintainerMsg::Donate {})
+    ) {
         ensure!(
             ctx.funds.is_empty(),
             "unexpected funds sent to non-deposit endpoint: {}",

--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -121,19 +121,19 @@ pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
 
 #[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
-    // Only `Deposit` accepts attached funds (settlement currency). Every other
-    // endpoint must be called without funds — tokens sent here would otherwise
-    // be silently absorbed by the contract, lost to the sender.
-    if !matches!(
-        msg,
+    // Only `Deposit` and `Donate` methods accept attached funds (settlement currency).
+    // Every other endpoint must be called without funds — tokens sent here would
+    // otherwise be silently absorbed by the contract, lost to the sender.
+    match msg {
         ExecuteMsg::Trade(TraderMsg::Deposit { .. })
-            | ExecuteMsg::Maintain(MaintainerMsg::Donate {})
-    ) {
-        ensure!(
-            ctx.funds.is_empty(),
-            "unexpected funds sent to non-deposit endpoint: {}",
-            ctx.funds
-        );
+        | ExecuteMsg::Maintain(MaintainerMsg::Donate {}) => {},
+        _ => {
+            ensure!(
+                ctx.funds.is_empty(),
+                "unexpected funds sent to non-deposit endpoint: {}",
+                ctx.funds
+            );
+        },
     }
 
     match msg {

--- a/dango/perps/src/referral/set_fee_share_ratio.rs
+++ b/dango/perps/src/referral/set_fee_share_ratio.rs
@@ -26,7 +26,7 @@ pub fn set_fee_share_ratio(
 ) -> anyhow::Result<Response> {
     // Share ratio must be non-negative.
     ensure!(
-        share_ratio.is_positive(),
+        !share_ratio.is_negative(),
         "fee share ratio cannot be negative"
     );
 

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -360,6 +360,20 @@ fn negative_share_ratio_fails() {
     .should_fail_with_error("fee share ratio cannot be negative");
 }
 
+/// Zero is a valid share ratio (referrer takes no commission from the referee).
+#[test]
+fn zero_share_ratio_accepted() {
+    let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
+
+    set_fee_share_ratio(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user1,
+        Dimensionless::ZERO,
+    )
+    .should_succeed();
+}
+
 /// Setting the fee share ratio requires sufficient perps trading volume
 /// when `volume_to_be_referrer` is non-zero.
 #[test]

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -207,7 +207,11 @@ fn clear_perps_state(storage: &mut dyn Storage) -> StdResult<UsdValue> {
             total_unlocks.checked_add_assign(unlock.amount_to_release)?;
         }
 
-        USER_STATES.save(storage, addr, &user_state)?;
+        if user_state.is_empty() {
+            USER_STATES.remove(storage, addr)?;
+        } else {
+            USER_STATES.save(storage, addr, &user_state)?;
+        }
     }
 
     let total_liability = total_margin.checked_add(total_unlocks)?;
@@ -319,6 +323,11 @@ fn assert_invariants(storage: &dyn Storage) -> StdResult<()> {
                 us.margin
             );
         }
+
+        assert!(
+            !us.is_empty(),
+            "user {addr} has an empty state that should have been pruned",
+        );
     }
 
     tracing::info!("All invariants passed");

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -356,7 +356,7 @@ where
 
             const MAINNET_CHAIN_ID: &str = "dango-1";
             const MAINNET_UPGRADE_HEIGHT: u64 = 17708992;
-            const MAINNET_UPGRADE_CARGO_VERSION: &str = "v0.12.0";
+            const MAINNET_UPGRADE_CARGO_VERSION: &str = "0.12.0";
 
             let chain_id = CHAIN_ID.load(&buffer)?;
 


### PR DESCRIPTION
- **Version mismatch panic**: `MAINNET_UPGRADE_CARGO_VERSION` was `"v0.12.0"` but `env!("CARGO_PKG_VERSION")` yields `"0.12.0"` (no `v` prefix). The `assert_eq!` would panic at block 17708992, crashing all validators before the upgrade handler ran.                                                  
- **Donate endpoint unreachable**: The `execute()` funds guard rejected all non-Deposit messages carrying tokens, but `MaintainerMsg::Donate` requires USDC attached. This blocked the solvency restoration step (bridging returned funds back and donating to cover the ~$400k shortfall).        
- **Zero share ratio rejected**: `set_fee_share_ratio` used `is_positive()` (rejects zero) while `force_set_fee_share_ratio` used `!is_negative()` (accepts zero). Aligned both to accept zero, which is harmless (referrer takes no commission from the referee).                                   
- **Empty UserState entries not pruned**: After the upgrade clears positions and zeros attacker margins, some `UserState` entries become fully default-valued. These are now removed instead of saved, with an invariant assertion that all remaining entries are non-empty.