### PR TITLE
fix(perps): reject max_slippage >= 100% in order submission

### DIFF
--- a/dango/perps/src/core.rs
+++ b/dango/perps/src/core.rs
@@ -7,10 +7,11 @@ mod liq_price;
 mod margin;
 mod min_size;
 mod oi;
+mod slippage;
 mod target_price;
 mod vault;
 
 pub use {
     closure::*, decompose::*, fees::*, fill::*, funding::*, liq_price::*, margin::*, min_size::*,
-    oi::*, target_price::*, vault::*,
+    oi::*, slippage::*, target_price::*, vault::*,
 };

--- a/dango/perps/src/core/slippage.rs
+++ b/dango/perps/src/core/slippage.rs
@@ -1,0 +1,49 @@
+use {anyhow::ensure, dango_types::Dimensionless};
+
+/// Validate that `max_slippage` is in the range `[0, 1)`.
+pub fn validate_slippage(max_slippage: Dimensionless) -> anyhow::Result<()> {
+    ensure!(
+        !max_slippage.is_negative(),
+        "max_slippage can't be negative: {max_slippage}"
+    );
+    ensure!(
+        max_slippage < Dimensionless::ONE,
+        "max_slippage must be less than 1, got {max_slippage}"
+    );
+    Ok(())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {super::*, grug::ResultExt};
+
+    #[test]
+    fn accept_zero_slippage() {
+        validate_slippage(Dimensionless::ZERO).should_succeed();
+    }
+
+    #[test]
+    fn accept_50pct_slippage() {
+        validate_slippage(Dimensionless::new_permille(500)).should_succeed();
+    }
+
+    #[test]
+    fn reject_negative_slippage() {
+        validate_slippage(Dimensionless::new_int(-1))
+            .should_fail_with_error("max_slippage can't be negative");
+    }
+
+    #[test]
+    fn reject_100pct_slippage() {
+        validate_slippage(Dimensionless::ONE)
+            .should_fail_with_error("max_slippage must be less than 1, got");
+    }
+
+    #[test]
+    fn reject_150pct_slippage() {
+        validate_slippage(Dimensionless::new_permille(1500))
+            .should_fail_with_error("max_slippage must be less than 1, got");
+    }
+}

--- a/dango/perps/src/core/slippage.rs
+++ b/dango/perps/src/core/slippage.rs
@@ -4,12 +4,14 @@ use {anyhow::ensure, dango_types::Dimensionless};
 pub fn validate_slippage(max_slippage: Dimensionless) -> anyhow::Result<()> {
     ensure!(
         !max_slippage.is_negative(),
-        "max_slippage can't be negative: {max_slippage}"
+        "max slippage can't be negative: {max_slippage}"
     );
+
     ensure!(
         max_slippage < Dimensionless::ONE,
-        "max_slippage must be less than 1, got {max_slippage}"
+        "max slippage must be less than 1, got {max_slippage}"
     );
+
     Ok(())
 }
 
@@ -32,18 +34,18 @@ mod tests {
     #[test]
     fn reject_negative_slippage() {
         validate_slippage(Dimensionless::new_int(-1))
-            .should_fail_with_error("max_slippage can't be negative");
+            .should_fail_with_error("max slippage can't be negative");
     }
 
     #[test]
     fn reject_100pct_slippage() {
         validate_slippage(Dimensionless::ONE)
-            .should_fail_with_error("max_slippage must be less than 1, got");
+            .should_fail_with_error("max slippage must be less than 1, got");
     }
 
     #[test]
     fn reject_150pct_slippage() {
         validate_slippage(Dimensionless::new_permille(1500))
-            .should_fail_with_error("max_slippage must be less than 1, got");
+            .should_fail_with_error("max slippage must be less than 1, got");
     }
 }

--- a/dango/perps/src/trade/submit_conditional_order.rs
+++ b/dango/perps/src/trade/submit_conditional_order.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{NEXT_ORDER_ID, USER_STATES},
+    crate::{NEXT_ORDER_ID, USER_STATES, core::validate_slippage},
     anyhow::{anyhow, ensure},
     dango_types::{
         Dimensionless, Quantity, UsdPrice,
@@ -27,10 +27,7 @@ pub fn submit_conditional_order(
         "price must be positive: {trigger_price}"
     );
 
-    ensure!(
-        !max_slippage.is_negative(),
-        "max_slippage can't be negative: {max_slippage}"
-    );
+    validate_slippage(max_slippage)?;
 
     // 1. User must have an open position in this pair.
     // 2. If size is specified: sign must oppose position, |size| <= |position.size|.
@@ -564,5 +561,49 @@ mod tests {
             Dimensionless::new_int(-1),
         )
         .should_fail_with_error("max_slippage can't be negative");
+    }
+
+    #[test]
+    fn p12_reject_100pct_max_slippage() {
+        let mut ctx = MockContext::new()
+            .with_sender(USER)
+            .with_funds(Coins::default());
+
+        init_storage(
+            &mut ctx.storage,
+            user_state_with_position(long_position(10)),
+        );
+
+        submit_conditional_order(
+            ctx.as_mutable(),
+            pair_id(),
+            Some(Quantity::new_int(-5)),
+            UsdPrice::new_int(2_500),
+            TriggerDirection::Above,
+            Dimensionless::new_percent(100),
+        )
+        .should_fail_with_error("max_slippage must be less than 1, got");
+    }
+
+    #[test]
+    fn p13_reject_150pct_max_slippage() {
+        let mut ctx = MockContext::new()
+            .with_sender(USER)
+            .with_funds(Coins::default());
+
+        init_storage(
+            &mut ctx.storage,
+            user_state_with_position(long_position(10)),
+        );
+
+        submit_conditional_order(
+            ctx.as_mutable(),
+            pair_id(),
+            Some(Quantity::new_int(-5)),
+            UsdPrice::new_int(2_500),
+            TriggerDirection::Above,
+            Dimensionless::new_percent(150),
+        )
+        .should_fail_with_error("max_slippage must be less than 1, got");
     }
 }

--- a/dango/perps/src/trade/submit_conditional_order.rs
+++ b/dango/perps/src/trade/submit_conditional_order.rs
@@ -560,7 +560,7 @@ mod tests {
             TriggerDirection::Above,
             Dimensionless::new_int(-1),
         )
-        .should_fail_with_error("max_slippage can't be negative");
+        .should_fail_with_error("max slippage can't be negative");
     }
 
     #[test]
@@ -582,7 +582,7 @@ mod tests {
             TriggerDirection::Above,
             Dimensionless::new_percent(100),
         )
-        .should_fail_with_error("max_slippage must be less than 1, got");
+        .should_fail_with_error("max slippage must be less than 1, got");
     }
 
     #[test]
@@ -604,6 +604,6 @@ mod tests {
             TriggerDirection::Above,
             Dimensionless::new_percent(150),
         )
-        .should_fail_with_error("max_slippage must be less than 1, got");
+        .should_fail_with_error("max slippage must be less than 1, got");
     }
 }

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -4876,7 +4876,7 @@ mod tests {
             None,
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max_slippage can't be negative");
+        .should_fail_with_error("max slippage can't be negative");
     }
 
     /// A limit order with a negative limit_price must be rejected.
@@ -5111,7 +5111,7 @@ mod tests {
             None,
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max_slippage can't be negative");
+        .should_fail_with_error("max slippage can't be negative");
     }
 
     /// SL child order with negative max_slippage must be rejected.
@@ -5159,7 +5159,7 @@ mod tests {
             }),
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max_slippage can't be negative");
+        .should_fail_with_error("max slippage can't be negative");
     }
 
     /// TP child order with 100% max_slippage must be rejected.
@@ -5207,7 +5207,7 @@ mod tests {
             None,
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max_slippage must be less than 1, got");
+        .should_fail_with_error("max slippage must be less than 1, got");
     }
 
     /// SL child order with 150% max_slippage must be rejected.
@@ -5255,7 +5255,7 @@ mod tests {
             }),
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max_slippage must be less than 1, got");
+        .should_fail_with_error("max slippage must be less than 1, got");
     }
 
     // ============ max_slippage >= 100% must be rejected =======================
@@ -5300,7 +5300,7 @@ mod tests {
             None,
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max_slippage must be less than 1, got");
+        .should_fail_with_error("max slippage must be less than 1, got");
     }
 
     #[test]
@@ -5343,7 +5343,7 @@ mod tests {
             None,
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max_slippage must be less than 1, got");
+        .should_fail_with_error("max slippage must be less than 1, got");
     }
 
     /// Helper: load taker state (returns default if missing).

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -4,7 +4,7 @@ use {
         core::{
             check_margin, check_minimum_order_size, check_oi_constraint, compute_available_margin,
             compute_notional, compute_required_margin, compute_target_price, compute_trading_fee,
-            decompose_fill, execute_fill, is_price_constraint_violated,
+            decompose_fill, execute_fill, is_price_constraint_violated, validate_slippage,
         },
         liquidity_depth::{decrease_liquidity_depths, increase_liquidity_depths},
         oracle,
@@ -311,10 +311,7 @@ pub(crate) fn _submit_order(
 
     match &kind {
         OrderKind::Market { max_slippage } => {
-            ensure!(
-                !max_slippage.is_negative(),
-                "max_slippage can't be negative: {max_slippage}"
-            );
+            validate_slippage(*max_slippage)?;
         },
         OrderKind::Limit { limit_price, .. } => {
             ensure!(
@@ -331,11 +328,7 @@ pub(crate) fn _submit_order(
             child_order.trigger_price
         );
 
-        ensure!(
-            !child_order.max_slippage.is_negative(),
-            "max slippage can't be negative: {}",
-            child_order.max_slippage
-        );
+        validate_slippage(child_order.max_slippage)?;
     }
 
     // -------------- Step 1. Check minimum order size -------------------------
@@ -5118,7 +5111,7 @@ mod tests {
             None,
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max slippage can't be negative");
+        .should_fail_with_error("max_slippage can't be negative");
     }
 
     /// SL child order with negative max_slippage must be rejected.
@@ -5166,7 +5159,191 @@ mod tests {
             }),
             &mut EventBuilder::new(),
         )
-        .should_fail_with_error("max slippage can't be negative");
+        .should_fail_with_error("max_slippage can't be negative");
+    }
+
+    /// TP child order with 100% max_slippage must be rejected.
+    #[test]
+    fn reject_tp_100pct_max_slippage() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+        place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 100);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_permille(100),
+            },
+            false,
+            Some(ChildOrder {
+                trigger_price: UsdPrice::new_int(60_000),
+                max_slippage: Dimensionless::new_percent(100),
+                size: None,
+            }),
+            None,
+            &mut EventBuilder::new(),
+        )
+        .should_fail_with_error("max_slippage must be less than 1, got");
+    }
+
+    /// SL child order with 150% max_slippage must be rejected.
+    #[test]
+    fn reject_sl_100pct_max_slippage() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+        place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 100);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_permille(150),
+            },
+            false,
+            None,
+            Some(ChildOrder {
+                trigger_price: UsdPrice::new_int(40_000),
+                max_slippage: Dimensionless::new_percent(150),
+                size: None,
+            }),
+            &mut EventBuilder::new(),
+        )
+        .should_fail_with_error("max_slippage must be less than 1, got");
+    }
+
+    // ============ max_slippage >= 100% must be rejected =======================
+
+    #[test]
+    fn reject_market_order_with_100pct_slippage() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+        place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 100);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_percent(100),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .should_fail_with_error("max_slippage must be less than 1, got");
+    }
+
+    #[test]
+    fn reject_market_order_with_150pct_slippage() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+        place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 100);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(-10), // sell order
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_percent(150),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .should_fail_with_error("max_slippage must be less than 1, got");
     }
 
     /// Helper: load taker state (returns default if missing).

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -92,7 +92,7 @@ pub fn create_perps_fill(
                 pair_id: pair_id.clone(),
                 size: Quantity::new_int(size as i128),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -72,7 +72,7 @@ fn market_buy(
                 pair_id: pair_id(),
                 size: Quantity::new_int(size as i128),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -125,7 +125,7 @@ fn adl_bug_absurd_book_price() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5), // ask (sell)
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -67,7 +67,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -234,7 +234,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -396,7 +396,7 @@ fn conditional_orders_follow_price_time_priority() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -418,7 +418,7 @@ fn conditional_orders_follow_price_time_priority() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -657,7 +657,7 @@ fn conditional_order_failure_does_not_block_others() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -698,7 +698,7 @@ fn conditional_order_failure_does_not_block_others() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -932,7 +932,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1068,7 +1068,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-1),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1145,7 +1145,7 @@ fn child_order_market_with_tp_triggers() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: Some(perps::ChildOrder {
@@ -1263,7 +1263,7 @@ fn child_order_market_with_sl_triggers() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1377,7 +1377,7 @@ fn child_order_ignored_when_position_closed() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1415,7 +1415,7 @@ fn child_order_ignored_when_position_closed() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5), // close the long
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: Some(perps::ChildOrder {
@@ -1493,7 +1493,7 @@ fn child_order_overwrites_existing() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1528,7 +1528,7 @@ fn child_order_overwrites_existing() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: Some(perps::ChildOrder {
@@ -1619,7 +1619,7 @@ fn conditional_order_overwrite_same_direction() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1732,7 +1732,7 @@ fn conditional_order_size_exceeds_position_allowed() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(3),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -137,7 +137,7 @@ fn liquidation_on_order_book() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5), // buy
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -423,7 +423,7 @@ fn liquidation_with_adl() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -487,7 +487,7 @@ fn liquidation_with_adl() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -677,7 +677,7 @@ fn liquidation_cancels_conditional_orders() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -941,7 +941,7 @@ fn vault_liquidation_on_order_book() {
                 pair_id: pair.clone(),
                 size: bid_size.checked_neg().unwrap(),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -1343,7 +1343,7 @@ fn place_market_buy(
                 pair_id: dango_testing::perps::pair_id(),
                 size: Quantity::new_int(size as i128),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -106,7 +106,7 @@ fn trading_lifecycle() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10), // buy
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -672,7 +672,7 @@ fn protocol_fee_accumulates_across_fills() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -723,7 +723,7 @@ fn protocol_fee_accumulates_across_fills() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -852,7 +852,7 @@ fn negative_maker_fee_rebate_lifecycle() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(50),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -188,7 +188,7 @@ fn vault_lp_lifecycle() {
                 pair_id: pair.clone(),
                 size: vault_bid_size.checked_neg().unwrap(), // sell
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -249,7 +249,7 @@ fn vault_lp_lifecycle() {
                 pair_id: pair.clone(),
                 size: vault_long_size, // buy same amount (closes taker's short)
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -790,7 +790,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
                 pair_id: pair.clone(),
                 size: round1_bid_size.checked_neg().unwrap(),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,
@@ -916,7 +916,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
                 pair_id: pair.clone(),
                 size: round1_bid_size.checked_neg().unwrap(),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::ONE,
+                    max_slippage: Dimensionless::new_percent(50),
                 },
                 reduce_only: false,
                 tp: None,


### PR DESCRIPTION
For sell (ask) orders, target_price = oracle * (1 - max_slippage). When max_slippage >= 1.0, the target price becomes zero or negative, which means the price constraint is never violated and the seller silently accepts any fill price including near-zero.

Extract a shared `validate_slippage` function that ensures max_slippage is in [0, 1) and use it in submit_order (market + child TP/SL orders) and submit_conditional_order.