### PR TITLE
chore(deploy): add reset_data param to download-db recipe

### DIFF
--- a/deploy/justfile
+++ b/deploy/justfile
@@ -409,9 +409,10 @@ b2-mark-bucket-deletable name:
 
 # Download Grug RocksDB — interactive host selection (no tee, prompt needs direct stdout)
 # Usage: just download-db testnet
-download-db network:
+download-db network reset_data="false":
   ansible-playbook download-db.yml \
-    -e dango_network={{network}}
+    -e dango_network={{network}} \
+    -e reset_data={{reset_data}}
 
 # Download Points Bot RocksDB — interactive host selection (no tee, prompt needs direct stdout)
 # Usage: just download-db-points-bot testnet


### PR DESCRIPTION
## Summary

- Add `reset_data` parameter (default `"false"`) to the `download-db` just recipe, forwarding it to the `download-db.yml` ansible playbook so data can be wiped before downloading a fresh snapshot.

## Validation

### Completed
- [x] Verified the justfile syntax is correct

### Remaining
- [ ] Test `just download-db testnet true` against a target host

## Manual QA
None — deploy-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)