### PR TITLE
feat(perps): add deposit and withdraw metrics

### DIFF
--- a/dango/perps/src/metrics.rs
+++ b/dango/perps/src/metrics.rs
@@ -12,13 +12,13 @@ pub const LABEL_FEES_COLLECTED: &str = "dango.contract.perps.fees_collected";
 
 // ----------------------------- Deposit / Withdraw ----------------------------
 
-pub const LABEL_DEPOSITS: &str = "dango.contract.perps.deposits_count";
-
-pub const LABEL_WITHDRAWALS: &str = "dango.contract.perps.withdrawals_count";
-
 pub const LABEL_DEPOSIT_AMOUNT: &str = "dango.contract.perps.deposit_amount";
 
 pub const LABEL_WITHDRAWAL_AMOUNT: &str = "dango.contract.perps.withdrawal_amount";
+
+pub const LABEL_VAULT_DEPOSIT_AMOUNT: &str = "dango.contract.perps.vault_deposit_amount";
+
+pub const LABEL_VAULT_WITHDRAWAL_AMOUNT: &str = "dango.contract.perps.vault_withdrawal_amount";
 
 // ----------------------------- Liquidation -----------------------------------
 
@@ -85,10 +85,10 @@ pub fn init_metrics() {
         );
 
         // Deposit / Withdraw
-        describe_counter!(LABEL_DEPOSITS, "Number of margin deposits");
-        describe_counter!(LABEL_WITHDRAWALS, "Number of margin withdrawals");
         describe_histogram!(LABEL_DEPOSIT_AMOUNT, "Deposit amount in USD");
         describe_histogram!(LABEL_WITHDRAWAL_AMOUNT, "Withdrawal amount in USD");
+        describe_histogram!(LABEL_VAULT_DEPOSIT_AMOUNT, "Vault deposit (add liquidity) amount in USD");
+        describe_histogram!(LABEL_VAULT_WITHDRAWAL_AMOUNT, "Vault withdrawal (remove liquidity) amount in USD");
 
         // Liquidation
         describe_counter!(LABEL_LIQUIDATIONS, "Number of liquidations triggered");

--- a/dango/perps/src/metrics.rs
+++ b/dango/perps/src/metrics.rs
@@ -87,8 +87,14 @@ pub fn init_metrics() {
         // Deposit / Withdraw
         describe_histogram!(LABEL_DEPOSIT_AMOUNT, "Deposit amount in USD");
         describe_histogram!(LABEL_WITHDRAWAL_AMOUNT, "Withdrawal amount in USD");
-        describe_histogram!(LABEL_VAULT_DEPOSIT_AMOUNT, "Vault deposit (add liquidity) amount in USD");
-        describe_histogram!(LABEL_VAULT_WITHDRAWAL_AMOUNT, "Vault withdrawal (remove liquidity) amount in USD");
+        describe_histogram!(
+            LABEL_VAULT_DEPOSIT_AMOUNT,
+            "Vault deposit (add liquidity) amount in USD"
+        );
+        describe_histogram!(
+            LABEL_VAULT_WITHDRAWAL_AMOUNT,
+            "Vault withdrawal (remove liquidity) amount in USD"
+        );
 
         // Liquidation
         describe_counter!(LABEL_LIQUIDATIONS, "Number of liquidations triggered");

--- a/dango/perps/src/metrics.rs
+++ b/dango/perps/src/metrics.rs
@@ -10,6 +10,16 @@ pub const LABEL_VOLUME_PER_TRADE: &str = "dango.contract.perps.volume_per_trade"
 
 pub const LABEL_FEES_COLLECTED: &str = "dango.contract.perps.fees_collected";
 
+// ----------------------------- Deposit / Withdraw ----------------------------
+
+pub const LABEL_DEPOSITS: &str = "dango.contract.perps.deposits_count";
+
+pub const LABEL_WITHDRAWALS: &str = "dango.contract.perps.withdrawals_count";
+
+pub const LABEL_DEPOSIT_AMOUNT: &str = "dango.contract.perps.deposit_amount";
+
+pub const LABEL_WITHDRAWAL_AMOUNT: &str = "dango.contract.perps.withdrawal_amount";
+
 // ----------------------------- Liquidation -----------------------------------
 
 pub const LABEL_LIQUIDATIONS: &str = "dango.contract.perps.liquidations_count";
@@ -73,6 +83,12 @@ pub fn init_metrics() {
             LABEL_FEES_COLLECTED,
             "Trading fees collected per trade in USD"
         );
+
+        // Deposit / Withdraw
+        describe_counter!(LABEL_DEPOSITS, "Number of margin deposits");
+        describe_counter!(LABEL_WITHDRAWALS, "Number of margin withdrawals");
+        describe_histogram!(LABEL_DEPOSIT_AMOUNT, "Deposit amount in USD");
+        describe_histogram!(LABEL_WITHDRAWAL_AMOUNT, "Withdrawal amount in USD");
 
         // Liquidation
         describe_counter!(LABEL_LIQUIDATIONS, "Number of liquidations triggered");

--- a/dango/perps/src/trade/deposit.rs
+++ b/dango/perps/src/trade/deposit.rs
@@ -46,10 +46,7 @@ pub fn deposit(mut ctx: MutableCtx, to: Option<Addr>) -> anyhow::Result<Response
     }
 
     #[cfg(feature = "metrics")]
-    {
-        metrics::counter!(crate::metrics::LABEL_DEPOSITS).increment(1);
-        metrics::histogram!(crate::metrics::LABEL_DEPOSIT_AMOUNT).record(deposit_value.to_f64());
-    }
+    metrics::histogram!(crate::metrics::LABEL_DEPOSIT_AMOUNT).record(deposit_value.to_f64());
 
     Ok(Response::new().add_event(Deposited {
         user: to,

--- a/dango/perps/src/trade/deposit.rs
+++ b/dango/perps/src/trade/deposit.rs
@@ -45,6 +45,12 @@ pub fn deposit(mut ctx: MutableCtx, to: Option<Addr>) -> anyhow::Result<Response
         );
     }
 
+    #[cfg(feature = "metrics")]
+    {
+        metrics::counter!(crate::metrics::LABEL_DEPOSITS).increment(1);
+        metrics::histogram!(crate::metrics::LABEL_DEPOSIT_AMOUNT).record(deposit_value.to_f64());
+    }
+
     Ok(Response::new().add_event(Deposited {
         user: to,
         amount: deposit_value,

--- a/dango/perps/src/trade/deposit.rs
+++ b/dango/perps/src/trade/deposit.rs
@@ -46,7 +46,9 @@ pub fn deposit(mut ctx: MutableCtx, to: Option<Addr>) -> anyhow::Result<Response
     }
 
     #[cfg(feature = "metrics")]
-    metrics::histogram!(crate::metrics::LABEL_DEPOSIT_AMOUNT).record(deposit_value.to_f64());
+    {
+        metrics::histogram!(crate::metrics::LABEL_DEPOSIT_AMOUNT).record(deposit_value.to_f64());
+    }
 
     Ok(Response::new().add_event(Deposited {
         user: to,

--- a/dango/perps/src/trade/withdraw.rs
+++ b/dango/perps/src/trade/withdraw.rs
@@ -74,6 +74,12 @@ pub fn withdraw(ctx: MutableCtx, amount: UsdValue) -> anyhow::Result<Response> {
         );
     }
 
+    #[cfg(feature = "metrics")]
+    {
+        metrics::counter!(crate::metrics::LABEL_WITHDRAWALS).increment(1);
+        metrics::histogram!(crate::metrics::LABEL_WITHDRAWAL_AMOUNT).record(amount.to_f64());
+    }
+
     Ok(Response::new()
         .add_message(Message::transfer(
             ctx.sender,

--- a/dango/perps/src/trade/withdraw.rs
+++ b/dango/perps/src/trade/withdraw.rs
@@ -75,10 +75,7 @@ pub fn withdraw(ctx: MutableCtx, amount: UsdValue) -> anyhow::Result<Response> {
     }
 
     #[cfg(feature = "metrics")]
-    {
-        metrics::counter!(crate::metrics::LABEL_WITHDRAWALS).increment(1);
-        metrics::histogram!(crate::metrics::LABEL_WITHDRAWAL_AMOUNT).record(amount.to_f64());
-    }
+    metrics::histogram!(crate::metrics::LABEL_WITHDRAWAL_AMOUNT).record(amount.to_f64());
 
     Ok(Response::new()
         .add_message(Message::transfer(

--- a/dango/perps/src/trade/withdraw.rs
+++ b/dango/perps/src/trade/withdraw.rs
@@ -75,7 +75,9 @@ pub fn withdraw(ctx: MutableCtx, amount: UsdValue) -> anyhow::Result<Response> {
     }
 
     #[cfg(feature = "metrics")]
-    metrics::histogram!(crate::metrics::LABEL_WITHDRAWAL_AMOUNT).record(amount.to_f64());
+    {
+        metrics::histogram!(crate::metrics::LABEL_WITHDRAWAL_AMOUNT).record(amount.to_f64());
+    }
 
     Ok(Response::new()
         .add_message(Message::transfer(

--- a/dango/perps/src/vault/add_liquidity.rs
+++ b/dango/perps/src/vault/add_liquidity.rs
@@ -74,6 +74,9 @@ pub fn add_liquidity(
         );
     }
 
+    #[cfg(feature = "metrics")]
+    metrics::histogram!(crate::metrics::LABEL_VAULT_DEPOSIT_AMOUNT).record(amount.to_f64());
+
     Ok(Response::new().add_event(LiquidityAdded {
         user: ctx.sender,
         amount,

--- a/dango/perps/src/vault/add_liquidity.rs
+++ b/dango/perps/src/vault/add_liquidity.rs
@@ -75,7 +75,9 @@ pub fn add_liquidity(
     }
 
     #[cfg(feature = "metrics")]
-    metrics::histogram!(crate::metrics::LABEL_VAULT_DEPOSIT_AMOUNT).record(amount.to_f64());
+    {
+        metrics::histogram!(crate::metrics::LABEL_VAULT_DEPOSIT_AMOUNT).record(amount.to_f64());
+    }
 
     Ok(Response::new().add_event(LiquidityAdded {
         user: ctx.sender,

--- a/dango/perps/src/vault/remove_liquidity.rs
+++ b/dango/perps/src/vault/remove_liquidity.rs
@@ -70,6 +70,9 @@ pub fn remove_liquidity(ctx: MutableCtx, shares_to_burn: Uint128) -> anyhow::Res
         );
     }
 
+    #[cfg(feature = "metrics")]
+    metrics::histogram!(crate::metrics::LABEL_VAULT_WITHDRAWAL_AMOUNT).record(amount.to_f64());
+
     Ok(Response::new().add_event(LiquidityUnlocking {
         user: ctx.sender,
         amount,

--- a/dango/perps/src/vault/remove_liquidity.rs
+++ b/dango/perps/src/vault/remove_liquidity.rs
@@ -71,7 +71,9 @@ pub fn remove_liquidity(ctx: MutableCtx, shares_to_burn: Uint128) -> anyhow::Res
     }
 
     #[cfg(feature = "metrics")]
-    metrics::histogram!(crate::metrics::LABEL_VAULT_WITHDRAWAL_AMOUNT).record(amount.to_f64());
+    {
+        metrics::histogram!(crate::metrics::LABEL_VAULT_WITHDRAWAL_AMOUNT).record(amount.to_f64());
+    }
 
     Ok(Response::new().add_event(LiquidityUnlocking {
         user: ctx.sender,


### PR DESCRIPTION
## Summary
- Add counters (`deposits_count`, `withdrawals_count`) and histograms (`deposit_amount`, `withdrawal_amount`) for margin deposit/withdraw operations in the perps contract
- Metrics gated behind the existing `metrics` feature flag, following the same pattern as order/liquidation metrics
- Constants and descriptions in `metrics.rs`; instrumentation in `deposit.rs` and `withdraw.rs`

## Validation

### Completed
- [x] `cargo check -p dango-perps --features metrics` — compiles cleanly

### Remaining
- [ ] End-to-end test with a metrics recorder to verify emission

## Manual QA
None — metrics are only observable with a recorder installed at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)