### PR TITLE
fix(perps): tighten pre-fill margin check for orders

### DIFF
--- a/book/perps/1-margin.md
+++ b/book/perps/1-margin.md
@@ -61,10 +61,8 @@ $$
 
 where $\mathtt{imr}$ is the per-pair **initial margin ratio**. IM is the minimum equity required to **open or hold** positions. It is used in two places:
 
-- **Pre-match margin check** — verifies the taker can afford the worst-case 100 % fill (see [Order matching §5](2-order-matching.md#5-pre-match-margin-check)).
+- **Pre-match margin check** — the caller simulates the fill at the target price first, then computes IM on the resulting (post-fill) positions (see [Order matching §5](2-order-matching.md#5-pre-match-margin-check)).
 - **Available margin calculation** — determines how much can be withdrawn or committed to new limit orders (see [§8](#8-available-margin) below).
-
-When checking a new order the IM is computed with a **projected** size: the user's current position in that pair is replaced by the hypothetical post-fill position ($\mathtt{currentSize} + \mathtt{orderSize}$). Positions in other pairs use their actual sizes.
 
 ## 6. Maintenance margin (MM)
 

--- a/book/perps/2-order-matching.md
+++ b/book/perps/2-order-matching.md
@@ -87,19 +87,18 @@ After each fill the maker order is updated: reserved margin is released proporti
 
 ## 5. Pre-match margin check
 
-Before matching begins, the taker's margin is verified (skipped for reduce-only orders). The check ensures the user can afford the **worst case** — a 100 % fill:
+Before matching begins, the taker's margin is verified for **all** order types (including reduce-only and post-only). The check simulates the worst-case 100 % fill at the target price on a throwaway clone of the user's state:
+
+1. Run `execute_fill` at `target_price` to settle funding, realize closing PnL, and update positions.
+2. Settle the realized PnL and trading fee into the projected margin.
+3. Compute post-fill equity and initial margin on the projected state.
+4. Verify:
 
 $$
-\mathtt{equity} \geq \mathtt{projectedIM} + \mathtt{projectedFee} + \mathtt{reservedMargin}
+\mathtt{postFillEquity} \geq \mathtt{postFillIM} + \mathtt{reservedMargin}
 $$
 
-where $\mathtt{projectedIM}$ is the initial margin assuming the full order fills (see [Margin §5](1-margin.md#5-initial-margin-im)) and $\mathtt{projectedFee}$ is
-
-$$
-|\mathtt{size}| \times \mathtt{oraclePrice} \times \mathtt{takerFeeRate}
-$$
-
-This prevents a taker from submitting orders they cannot collateralise.
+This catches both bad-price closes (catastrophic realized PnL when selling far below or buying far above entry) and bad-price opens (immediate unrealized loss when the entry price diverges significantly from the oracle price).
 
 ## 6. Self-trade prevention
 

--- a/dango/perps/src/core/fill.rs
+++ b/dango/perps/src/core/fill.rs
@@ -157,7 +157,7 @@ fn update_oi(
 ///
 /// - Long positions: profit when exit > entry
 /// - Short positions: profit when entry > exit
-pub fn compute_pnl_to_realize(
+fn compute_pnl_to_realize(
     position: &Position,
     closing_size: Quantity,
     fill_price: UsdPrice,

--- a/dango/perps/src/core/fill.rs
+++ b/dango/perps/src/core/fill.rs
@@ -157,7 +157,7 @@ fn update_oi(
 ///
 /// - Long positions: profit when exit > entry
 /// - Short positions: profit when entry > exit
-fn compute_pnl_to_realize(
+pub fn compute_pnl_to_realize(
     position: &Position,
     closing_size: Quantity,
     fill_price: UsdPrice,

--- a/dango/perps/src/core/margin.rs
+++ b/dango/perps/src/core/margin.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{core::compute_trading_fee, querier::NoCachePerpQuerier},
+    crate::{
+        core::{compute_trading_fee, execute_fill},
+        querier::NoCachePerpQuerier,
+    },
     anyhow::ensure,
     dango_oracle::OracleQuerier,
     dango_types::{
@@ -227,9 +230,16 @@ pub fn compute_available_margin(
         .max(UsdValue::ZERO))
 }
 
-/// Ensure the user's collateral balance satisfies the 100%-fill scenario:
-/// user's equity must be no less than required initial margin + reserved
-/// margin for existing resting orders + fee.
+/// Ensure the user can afford the worst-case 100%-fill scenario.
+///
+/// Simulates the fill at `target_price` on a throwaway clone:
+///
+/// 1. Run `execute_fill` at `target_price` to realize PnL and update positions.
+/// 2. Settle PnL and fees into margin.
+/// 3. Verify post-fill equity ≥ post-fill initial margin + reserved margin.
+///
+/// This catches both bad-price closes (catastrophic realized PnL) and
+/// bad-price opens (immediate unrealized loss from entry far from oracle).
 ///
 /// The 0%-fill scenario (limit-order reservation) is checked separately
 /// inside `store_limit_order`.
@@ -237,43 +247,56 @@ pub fn check_margin(
     oracle_querier: &mut OracleQuerier,
     pair_id: &PairId,
     perp_querier: &NoCachePerpQuerier,
+    pair_state: &PairState,
     taker_state: &UserState,
     taker_fee_rate: Dimensionless,
-    oracle_price: UsdPrice,
-    size: Quantity,
+    target_price: UsdPrice,
+    closing_size: Quantity,
+    opening_size: Quantity,
 ) -> anyhow::Result<()> {
-    let equity = compute_user_equity(oracle_querier, perp_querier, taker_state)?;
+    // Simulate the fill at worst-case price on throwaway clones.
+    let mut projected = taker_state.clone();
+    let mut pair_state = pair_state.clone();
 
-    let projected_size = {
-        let current_position = taker_state
-            .positions
-            .get(pair_id)
-            .map(|p| p.size)
-            .unwrap_or_default();
-        current_position.checked_add(size)?
-    };
-
-    let projected_im = compute_initial_margin(
-        oracle_querier,
-        perp_querier,
-        taker_state,
+    let pnl = execute_fill(
         pair_id,
-        projected_size,
+        &mut pair_state,
+        &mut projected,
+        target_price,
+        closing_size,
+        opening_size,
     )?;
 
-    let projected_fee = compute_trading_fee(size, oracle_price, taker_fee_rate)?;
+    // Settle PnL and fee into margin (mirrors settle_pnls).
+    projected.margin.checked_add_assign(pnl)?;
 
-    let required_margin = projected_im
-        .checked_add(projected_fee)?
-        .checked_add(taker_state.reserved_margin)?;
+    let fillable_size = closing_size.checked_add(opening_size)?;
+    let fee = compute_trading_fee(fillable_size, target_price, taker_fee_rate)?;
+    projected.margin.checked_sub_assign(fee)?;
+
+    // Check post-fill health.
+    let equity = compute_user_equity(oracle_querier, perp_querier, &projected)?;
+
+    let post_fill_size = projected
+        .positions
+        .get(pair_id)
+        .map(|p| p.size)
+        .unwrap_or_default();
+
+    let im = compute_initial_margin(
+        oracle_querier,
+        perp_querier,
+        &projected,
+        pair_id,
+        post_fill_size,
+    )?;
+
+    let required = im.checked_add(projected.reserved_margin)?;
 
     ensure!(
-        equity >= required_margin,
-        "insufficient margin: equity ({}) < initial margin ({}) + fee ({}) + reserved ({})",
-        equity,
-        projected_im,
-        projected_fee,
-        taker_state.reserved_margin
+        equity >= required,
+        "insufficient margin: projected equity ({equity}) < initial margin ({im}) + reserved ({})",
+        projected.reserved_margin,
     );
 
     Ok(())
@@ -1137,14 +1160,16 @@ mod tests {
 
     // ---- check_margin tests ----
 
-    /// 100%-fill check fails: equity ($25,200) < IM ($25,000) + fee ($500) = $25,500
+    /// 100%-fill check fails for a pure opening order at oracle price.
     ///
     /// No existing position. oracle = $50,000, IMR = 5%, taker_fee = 0.1%
-    /// Buy 10 BTC
+    /// Buy 10 BTC (target = oracle = $50,000, pure opening).
     ///
+    ///   Post-fill: long 10 @ $50,000. Unrealized PnL = 0.
+    ///   margin after fee = $25,200 - $500 = $24,700
+    ///   equity = $24,700
     ///   projected_im = |10| * 50,000 * 0.05 = $25,000
-    ///   fee          = |10| * 50,000 * 0.001 = $500
-    ///   Need equity >= $25,500, but equity = $25,200 → FAILS
+    ///   $24,700 < $25,000 → FAILS
     #[test]
     fn margin_check_full_fill_fails() {
         let pair_id: PairId = "perp/btcusd".parse().unwrap();
@@ -1179,21 +1204,25 @@ mod tests {
             ),
         });
 
+        // Pure opening: closing_size = 0, opening_size = 10.
+        // target_price = oracle (no slippage).
         let result = check_margin(
             &mut oracle_querier,
             &pair_id,
             &perp_querier,
+            &PairState::default(),
             &taker_state,
             param.taker_fee_rates.base,
             UsdPrice::new_int(50_000),
+            Quantity::ZERO,
             Quantity::new_int(10),
         );
 
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
-            msg.contains("insufficient margin:"),
-            "expected 100%-fill margin error, got: {msg}"
+            msg.contains("insufficient margin"),
+            "expected margin error, got: {msg}"
         );
     }
 }

--- a/dango/perps/src/core/margin.rs
+++ b/dango/perps/src/core/margin.rs
@@ -112,56 +112,24 @@ pub fn compute_maintenance_margin(
     Ok(total)
 }
 
-/// Compute the margin required to open a new position, in USD.
-///
-/// For each position, the initial margin is:
+/// Compute the initial margin required across all of a user's open positions.
 ///
 /// ```plain
-/// |position.size| * oracle_price * initial_margin_ratio
+/// IM = Σ |position.size| * oracle_price * initial_margin_ratio
 /// ```
-///
-/// The total initial margin is the sum of that of all positions.
-/// One position's size is overriden by a "projected" value, reflecting the size
-/// if the order is executed.
-///
-/// When submitting an order, the user must have no less collateral than the
-/// initial margin, otherwise the order is rejected.
 pub(super) fn compute_initial_margin(
     oracle_querier: &mut OracleQuerier,
     perp_querier: &NoCachePerpQuerier,
     user_state: &UserState,
-    projected_pair_id: &PairId,
-    projected_size: Quantity,
 ) -> anyhow::Result<UsdValue> {
     let mut total = UsdValue::ZERO;
-    let mut projected_pair_seen = false;
 
     for (pair_id, position) in &user_state.positions {
         let oracle_price = oracle_querier.query_price_for_perps(pair_id)?;
         let pair_param = perp_querier.query_pair_param(pair_id)?;
 
-        let size = if pair_id == projected_pair_id {
-            projected_pair_seen = true;
-            projected_size
-        } else {
-            position.size
-        };
-
-        let margin = size
-            .checked_abs()?
-            .checked_mul(oracle_price)?
-            .checked_mul(pair_param.initial_margin_ratio)?;
-
-        total.checked_add_assign(margin)?;
-    }
-
-    // If the projected pair is not in existing positions and the projected size
-    // is non-zero, add its margin contribution.
-    if !projected_pair_seen && projected_size.is_non_zero() {
-        let oracle_price = oracle_querier.query_price_for_perps(projected_pair_id)?;
-        let pair_param = perp_querier.query_pair_param(projected_pair_id)?;
-
-        let margin = projected_size
+        let margin = position
+            .size
             .checked_abs()?
             .checked_mul(oracle_price)?
             .checked_mul(pair_param.initial_margin_ratio)?;
@@ -277,19 +245,7 @@ pub fn check_margin(
     // Check post-fill health.
     let equity = compute_user_equity(oracle_querier, perp_querier, &projected)?;
 
-    let post_fill_size = projected
-        .positions
-        .get(pair_id)
-        .map(|p| p.size)
-        .unwrap_or_default();
-
-    let im = compute_initial_margin(
-        oracle_querier,
-        perp_querier,
-        &projected,
-        pair_id,
-        post_fill_size,
-    )?;
+    let im = compute_initial_margin(oracle_querier, perp_querier, &projected)?;
 
     let required = im.checked_add(projected.reserved_margin)?;
 
@@ -686,93 +642,10 @@ mod tests {
 
     // ---- compute_initial_margin tests ----
 
-    // No existing positions; project 10 ETH @ $2000, 10% IMR
-    // margin = |10| * 2000 * 0.10 = $2000
+    // ETH long 10, oracle=$2000, IMR=10%
+    // IM = |10| * 2000 * 0.10 = $2000
     #[test]
-    fn initial_margin_no_existing_positions() {
-        let user_state = UserState::default();
-        let perp_querier = NoCachePerpQuerier::new_mock(
-            hash_map! {
-                eth::DENOM.clone() => PairParam {
-                    initial_margin_ratio: Dimensionless::new_permille(100),
-                    ..Default::default()
-                },
-            },
-            HashMap::new(),
-        );
-        let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
-                Timestamp::from_seconds(0),
-                18,
-            ),
-        });
-
-        assert_eq!(
-            compute_initial_margin(
-                &mut oracle_querier,
-                &perp_querier,
-                &user_state,
-                &eth::DENOM,
-                Quantity::new_int(10),
-            )
-            .unwrap(),
-            UsdValue::new_int(2000),
-        );
-    }
-
-    // Has 5 ETH position; project to 10 ETH → uses projected size (10)
-    // margin = |10| * 2000 * 0.10 = $2000
-    #[test]
-    fn initial_margin_projects_existing_position() {
-        let user_state = UserState {
-            positions: btree_map! {
-                eth::DENOM.clone() => Position {
-                    size: Quantity::new_int(5),
-                    entry_price: UsdPrice::new_int(2000),
-                    entry_funding_per_unit: FundingPerUnit::new_int(0),
-                    conditional_order_above: None,
-                    conditional_order_below: None,
-                },
-            },
-            ..Default::default()
-        };
-        let perp_querier = NoCachePerpQuerier::new_mock(
-            hash_map! {
-                eth::DENOM.clone() => PairParam {
-                    initial_margin_ratio: Dimensionless::new_permille(100),
-                    ..Default::default()
-                },
-            },
-            HashMap::new(),
-        );
-        let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
-                Timestamp::from_seconds(0),
-                18,
-            ),
-        });
-
-        assert_eq!(
-            compute_initial_margin(
-                &mut oracle_querier,
-                &perp_querier,
-                &user_state,
-                &eth::DENOM,
-                Quantity::new_int(10),
-            )
-            .unwrap(),
-            UsdValue::new_int(2000),
-        );
-    }
-
-    // Has ETH position; project BTC (not in positions)
-    // ETH: |10| * 2000 * 0.10 = $2000
-    // BTC: |1|  * 50000 * 0.10 = $5000
-    // Total = $7000
-    #[test]
-    fn initial_margin_adds_new_pair() {
+    fn initial_margin_single_position() {
         let user_state = UserState {
             positions: btree_map! {
                 eth::DENOM.clone() => Position {
@@ -791,10 +664,6 @@ mod tests {
                     initial_margin_ratio: Dimensionless::new_permille(100),
                     ..Default::default()
                 },
-                btc::DENOM.clone() => PairParam {
-                    initial_margin_ratio: Dimensionless::new_permille(100),
-                    ..Default::default()
-                },
             },
             HashMap::new(),
         );
@@ -804,66 +673,33 @@ mod tests {
                 Timestamp::from_seconds(0),
                 18,
             ),
-            btc::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000),
-                Timestamp::from_seconds(0),
-                8,
-            ),
         });
 
         assert_eq!(
-            compute_initial_margin(
-                &mut oracle_querier,
-                &perp_querier,
-                &user_state,
-                &btc::DENOM,
-                Quantity::new_int(1),
-            )
-            .unwrap(),
-            UsdValue::new_int(7000),
+            compute_initial_margin(&mut oracle_querier, &perp_querier, &user_state).unwrap(),
+            UsdValue::new_int(2000),
         );
     }
 
-    // No positions; project 0 size → $0 (new pair with zero size not added)
+    // No positions → $0
     #[test]
-    fn initial_margin_zero_projected_size_skipped() {
+    fn initial_margin_no_positions() {
         let user_state = UserState::default();
-        let perp_querier = NoCachePerpQuerier::new_mock(
-            hash_map! {
-                eth::DENOM.clone() => PairParam {
-                    initial_margin_ratio: Dimensionless::new_permille(100),
-                    ..Default::default()
-                },
-            },
-            HashMap::new(),
-        );
-        let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
-                Timestamp::from_seconds(0),
-                18,
-            ),
-        });
+        let perp_querier = NoCachePerpQuerier::new_mock(HashMap::new(), HashMap::new());
+        let mut oracle_querier = OracleQuerier::new_mock(HashMap::new());
 
         assert_eq!(
-            compute_initial_margin(
-                &mut oracle_querier,
-                &perp_querier,
-                &user_state,
-                &eth::DENOM,
-                Quantity::ZERO,
-            )
-            .unwrap(),
+            compute_initial_margin(&mut oracle_querier, &perp_querier, &user_state).unwrap(),
             UsdValue::ZERO,
         );
     }
 
-    // Has ETH + BTC; project ETH to 20
-    // ETH: |20| * 2000 * 0.10 = $4000 (projected)
-    // BTC: |1|  * 50000 * 0.05 = $2500 (existing)
-    // Total = $6500
+    // ETH long 10 + BTC short 1, different IMRs
+    // ETH: |10| * 2000 * 0.10 = $2000
+    // BTC: |-1| * 50000 * 0.05 = $2500
+    // Total = $4500
     #[test]
-    fn initial_margin_mixed() {
+    fn initial_margin_multiple_positions() {
         let user_state = UserState {
             positions: btree_map! {
                 eth::DENOM.clone() => Position {
@@ -910,15 +746,8 @@ mod tests {
         });
 
         assert_eq!(
-            compute_initial_margin(
-                &mut oracle_querier,
-                &perp_querier,
-                &user_state,
-                &eth::DENOM,
-                Quantity::new_int(20),
-            )
-            .unwrap(),
-            UsdValue::new_int(6500),
+            compute_initial_margin(&mut oracle_querier, &perp_querier, &user_state).unwrap(),
+            UsdValue::new_int(4500),
         );
     }
 

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -365,7 +365,40 @@ pub(crate) fn _submit_order(
     let taker_order_id = NEXT_ORDER_ID.load(storage)?;
     let mut next_order_id = taker_order_id + OrderId::ONE;
 
-    // ---------------------- Step 4. Post-only fast path ----------------------
+    // --------------------- Step 4. Compute target price -----------------------
+
+    let taker_is_bid = size.is_positive();
+    let target_price = compute_target_price(kind, oracle_price, taker_is_bid)?;
+
+    // ----------------- Step 5: Pre-match taker margin check ------------------
+    //
+    // Simulates the full fill at target_price and verifies post-fill equity
+    // covers initial margin. Runs for all orders (including reduce-only and
+    // post-only) before any matching or order storage.
+
+    {
+        let perp_querier = NoCachePerpQuerier::new_local(storage);
+
+        let taker_fee_rate = {
+            let volume_since = Some(current_time.saturating_sub(VOLUME_LOOKBACK));
+            let taker_volume = query_volume(storage, taker, volume_since)?;
+            param.taker_fee_rates.resolve(taker_volume)
+        };
+
+        check_margin(
+            oracle_querier,
+            pair_id,
+            &perp_querier,
+            &pair_state,
+            &taker_state,
+            taker_fee_rate,
+            target_price,
+            closing_size,
+            opening_size,
+        )?;
+    }
+
+    // ---------------------- Step 6. Post-only fast path ----------------------
 
     if let Some(limit_price) = kind.post_only_price() {
         let StoreLimitOrderOutcome {
@@ -405,35 +438,6 @@ pub(crate) fn _submit_order(
             fee_breakdowns: BTreeMap::new(),
         });
     }
-
-    // ----------------- Step 5: Pre-match taker margin check ------------------
-    //
-    // Reduce-only orders only reduce exposure, so they skip the check.
-
-    if !reduce_only {
-        let perp_querier = NoCachePerpQuerier::new_local(storage);
-
-        let taker_fee_rate = {
-            let volume_since = Some(current_time.saturating_sub(VOLUME_LOOKBACK));
-            let taker_volume = query_volume(storage, taker, volume_since)?;
-            param.taker_fee_rates.resolve(taker_volume)
-        };
-
-        check_margin(
-            oracle_querier,
-            pair_id,
-            &perp_querier,
-            &taker_state,
-            taker_fee_rate,
-            oracle_price,
-            size,
-        )?;
-    }
-
-    // --------------------- Step 6. Compute target price ----------------------
-
-    let taker_is_bid = size.is_positive();
-    let target_price = compute_target_price(kind, oracle_price, taker_is_bid)?;
 
     // ---------------------- Step 7. Match against book -----------------------
 
@@ -1204,6 +1208,9 @@ fn store_limit_order(
     let margin_to_reserve = compute_required_margin(size, limit_price, pair_param)?;
 
     // 0%-fill margin check: verify the user can afford this reservation.
+    // Reduce-only orders skip this since they only close (no opening exposure).
+    // Solvency at fill price is already checked by the caller (step 5 in
+    // _submit_order) before we get here.
     if !reduce_only {
         let perp_querier = NoCachePerpQuerier::new_local(storage);
 
@@ -3514,8 +3521,8 @@ mod tests {
         assert!(err.is_err());
         let msg = err.unwrap_err().to_string();
         assert!(
-            msg.contains("insufficient margin for limit order"),
-            "expected limit-order margin error, got: {msg}"
+            msg.contains("insufficient margin"),
+            "expected margin error, got: {msg}"
         );
     }
 

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -125,7 +125,7 @@ fn adl_bug_absurd_book_price() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5), // ask (sell)
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::ZERO,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -67,7 +67,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -234,7 +234,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -396,7 +396,7 @@ fn conditional_orders_follow_price_time_priority() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -418,7 +418,7 @@ fn conditional_orders_follow_price_time_priority() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -657,7 +657,7 @@ fn conditional_order_failure_does_not_block_others() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -698,7 +698,7 @@ fn conditional_order_failure_does_not_block_others() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -932,7 +932,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1068,7 +1068,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-1),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1145,7 +1145,7 @@ fn child_order_market_with_tp_triggers() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: Some(perps::ChildOrder {
@@ -1263,7 +1263,7 @@ fn child_order_market_with_sl_triggers() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1377,7 +1377,7 @@ fn child_order_ignored_when_position_closed() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1415,7 +1415,7 @@ fn child_order_ignored_when_position_closed() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5), // close the long
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: Some(perps::ChildOrder {
@@ -1493,7 +1493,7 @@ fn child_order_overwrites_existing() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1528,7 +1528,7 @@ fn child_order_overwrites_existing() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: Some(perps::ChildOrder {
@@ -1619,7 +1619,7 @@ fn conditional_order_overwrite_same_direction() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -1732,7 +1732,7 @@ fn conditional_order_size_exceeds_position_allowed() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(3),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -137,7 +137,7 @@ fn liquidation_on_order_book() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5), // buy
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -423,7 +423,7 @@ fn liquidation_with_adl() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::ZERO,
                 },
                 reduce_only: false,
                 tp: None,
@@ -487,7 +487,7 @@ fn liquidation_with_adl() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -677,7 +677,7 @@ fn liquidation_cancels_conditional_orders() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(5),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -941,7 +941,7 @@ fn vault_liquidation_on_order_book() {
                 pair_id: pair.clone(),
                 size: bid_size.checked_neg().unwrap(),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -13,6 +13,7 @@ use {
 mod adl_bug_reproduction;
 mod conditional_orders;
 mod liquidation;
+mod margin_check;
 mod referral;
 mod trading;
 mod vault;

--- a/dango/testing/tests/perps/margin_check.rs
+++ b/dango/testing/tests/perps/margin_check.rs
@@ -90,7 +90,7 @@ fn reduce_only_market_sell_pushes_margin_negative() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -144,8 +144,7 @@ fn reduce_only_market_sell_pushes_margin_negative() {
         .should_succeed();
 
     // Step 4: User1 reduce-only market sells 10 ETH with 90% slippage.
-    // Target = $2,000 × 0.1 = $200. Fills against User3's bid at $200.
-    // PnL = 10 × ($200 − $2,000) = −$18,000. Fee = 10 × $200 × 0.1% = $2.
+    // Target = $2,000 × 0.1 = $200. Now rejected by the pre-fill margin check.
 
     suite
         .execute(
@@ -163,22 +162,17 @@ fn reduce_only_market_sell_pushes_margin_negative() {
             }),
             Coins::new(),
         )
-        .should_succeed();
+        .should_fail_with_error("insufficient margin");
 
-    // Step 5: Assert margin is deeply negative and position is gone.
-
-    let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
-        .should_succeed()
-        .unwrap();
-
-    assert!(
-        state.positions.is_empty(),
-        "position should be fully closed after reduce-only fill"
-    );
-    assert_eq!(state.margin, UsdValue::new_int(-8_022));
+    // Old behavior (before fix): order succeeded and pushed margin negative.
+    // let state: UserState = suite
+    //     .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+    //         user: accounts.user1.address(),
+    //     })
+    //     .should_succeed()
+    //     .unwrap();
+    // assert!(state.positions.is_empty());
+    // assert_eq!(state.margin, UsdValue::new_int(-8_022));
 }
 
 /// Reduce-only market buy closes a short at a catastrophically high price.
@@ -246,7 +240,7 @@ fn reduce_only_market_buy_pushes_margin_negative() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -300,8 +294,7 @@ fn reduce_only_market_buy_pushes_margin_negative() {
         .should_succeed();
 
     // Step 4: User1 reduce-only market buys 10 ETH with 90% slippage.
-    // Target = $2,000 × 1.9 = $3,800. Fills against User3's ask at $3,800.
-    // PnL = 10 × ($2,000 − $3,800) = −$18,000. Fee = 10 × $3,800 × 0.1% = $38.
+    // Target = $2,000 × 1.9 = $3,800. Now rejected by the pre-fill margin check.
 
     suite
         .execute(
@@ -319,22 +312,17 @@ fn reduce_only_market_buy_pushes_margin_negative() {
             }),
             Coins::new(),
         )
-        .should_succeed();
+        .should_fail_with_error("insufficient margin");
 
-    // Step 5: Assert margin is deeply negative and position is gone.
-
-    let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
-        .should_succeed()
-        .unwrap();
-
-    assert!(
-        state.positions.is_empty(),
-        "position should be fully closed after reduce-only fill"
-    );
-    assert_eq!(state.margin, UsdValue::new_int(-8_058));
+    // Old behavior (before fix): order succeeded and pushed margin negative.
+    // let state: UserState = suite
+    //     .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+    //         user: accounts.user1.address(),
+    //     })
+    //     .should_succeed()
+    //     .unwrap();
+    // assert!(state.positions.is_empty());
+    // assert_eq!(state.margin, UsdValue::new_int(-8_058));
 }
 
 /// Reduce-only GTC limit sell rests at a terrible price, then a taker fills it.
@@ -401,7 +389,7 @@ fn reduce_only_limit_sell_pushes_margin_negative() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -440,52 +428,18 @@ fn reduce_only_limit_sell_pushes_margin_negative() {
             }),
             Coins::new(),
         )
-        .should_succeed();
+        .should_fail_with_error("insufficient margin");
 
-    // Step 4: User3 market buys 10 ETH — fills against User1's resting ask at $200.
-    // User1 (maker, 0% maker fee): PnL = 10 × ($200 − $2,000) = −$18,000.
-
-    suite
-        .execute(
-            &mut accounts.user3,
-            contracts.perps,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
-            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
-        )
-        .should_succeed();
-
-    suite
-        .execute(
-            &mut accounts.user3,
-            contracts.perps,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
-                pair_id: pair.clone(),
-                size: Quantity::new_int(10),
-                kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
-                },
-                reduce_only: false,
-                tp: None,
-                sl: None,
-            }),
-            Coins::new(),
-        )
-        .should_succeed();
-
-    // Step 5: Assert User1's margin is deeply negative and position is gone.
-
-    let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
-        .should_succeed()
-        .unwrap();
-
-    assert!(
-        state.positions.is_empty(),
-        "position should be fully closed after reduce-only fill"
-    );
-    assert_eq!(state.margin, UsdValue::new_int(-8_020));
+    // Old behavior (before fix): order rested, then step 4 filled and pushed margin negative.
+    // Step 4 (User3 market buys) and step 5 assertions are now unreachable.
+    // let state: UserState = suite
+    //     .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+    //         user: accounts.user1.address(),
+    //     })
+    //     .should_succeed()
+    //     .unwrap();
+    // assert!(state.positions.is_empty());
+    // assert_eq!(state.margin, UsdValue::new_int(-8_020));
 }
 
 /// Reduce-only GTC limit buy rests at a terrible price, then a taker fills it.
@@ -494,9 +448,7 @@ fn reduce_only_limit_sell_pushes_margin_negative() {
 /// |------|------------------------------------------------------|-----------------------------------------------------------|
 /// | 1    | User2 deposits $100k; PostOnly buy 10 ETH @ $2,000   | provides opening-side liquidity                           |
 /// | 2    | User1 deposits $10k; market sells 10 ETH             | fee=$20; margin=$9,980; short 10 @ $2,000                 |
-/// | 3    | User1 places reduce-only GTC buy 10 ETH @ $3,800     | rests as bid; margin check skipped                        |
-/// | 4    | User3 deposits $100k; market sells 10 ETH            | fills against User1's bid @ $3,800; User1 PnL=−$18,000   |
-/// | 5    | Assert                                               | margin=−$8,020; position closed; account deeply negative  |
+/// | 3    | User1 places reduce-only GTC buy 10 ETH @ $3,800     | now rejected by margin check in store_limit_order         |
 #[test]
 fn reduce_only_limit_buy_pushes_margin_negative() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
@@ -553,7 +505,7 @@ fn reduce_only_limit_buy_pushes_margin_negative() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -596,52 +548,18 @@ fn reduce_only_limit_buy_pushes_margin_negative() {
             }),
             Coins::new(),
         )
-        .should_succeed();
+        .should_fail_with_error("insufficient margin");
 
-    // Step 4: User3 market sells 10 ETH — fills against User1's resting bid at $3,800.
-    // User1 (maker, 0% maker fee): PnL = 10 × ($2,000 − $3,800) = −$18,000.
-
-    suite
-        .execute(
-            &mut accounts.user3,
-            contracts.perps,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
-            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
-        )
-        .should_succeed();
-
-    suite
-        .execute(
-            &mut accounts.user3,
-            contracts.perps,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
-                pair_id: pair.clone(),
-                size: Quantity::new_int(-10),
-                kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
-                },
-                reduce_only: false,
-                tp: None,
-                sl: None,
-            }),
-            Coins::new(),
-        )
-        .should_succeed();
-
-    // Step 5: Assert User1's margin is deeply negative and position is gone.
-
-    let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
-        .should_succeed()
-        .unwrap();
-
-    assert!(
-        state.positions.is_empty(),
-        "position should be fully closed after reduce-only fill"
-    );
-    assert_eq!(state.margin, UsdValue::new_int(-8_020));
+    // Old behavior (before fix): order rested, then step 4 filled and pushed margin negative.
+    // Step 4 (User3 market sells) and step 5 assertions are now unreachable.
+    // let state: UserState = suite
+    //     .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+    //         user: accounts.user1.address(),
+    //     })
+    //     .should_succeed()
+    //     .unwrap();
+    // assert!(state.positions.is_empty());
+    // assert_eq!(state.margin, UsdValue::new_int(-8_020));
 }
 
 // =============================================================================
@@ -649,11 +567,7 @@ fn reduce_only_limit_buy_pushes_margin_negative() {
 // =============================================================================
 
 /// Non-reduce-only sell partially closes a long at a bad price. The pre-fill
-/// check passes (projected IM shrinks with smaller position) but ignores that
-/// realized PnL at the fill price pushes margin deeply negative.
-///
-/// Pre-fill check: equity=$2,980, projIM=5×$2k×10%=$1,000, fee=$10.
-/// $2,980 ≥ $1,010 → passes. But fill at $200 realizes −$9,000 PnL.
+/// check now catches the catastrophic PnL at the target price and rejects.
 ///
 /// | Step | Action                                               | Key numbers                                               |
 /// |------|------------------------------------------------------|-----------------------------------------------------------|
@@ -719,7 +633,7 @@ fn partial_close_sell_at_bad_price_pushes_margin_negative() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -789,52 +703,24 @@ fn partial_close_sell_at_bad_price_pushes_margin_negative() {
             }),
             Coins::new(),
         )
-        .should_succeed();
+        .should_fail_with_error("insufficient margin");
 
-    // Step 5: Assert margin is deeply negative with a remaining position.
-
-    let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
-        .should_succeed()
-        .unwrap();
-
-    assert_eq!(state.margin, UsdValue::new_int(-6_021));
-
-    // Remaining long 5 @ $2,000 — account is immediately liquidatable.
-    let pos = state.positions.get(&pair).unwrap();
-    assert_eq!(pos.size, Quantity::new_int(5));
-    assert_eq!(pos.entry_price, UsdPrice::new_int(2_000));
-
-    // Equity (= margin + unrealized PnL at oracle) = −$6,021 + 0 = −$6,021.
-    // MM = 5 × $2,000 × 5% = $500. Equity ≪ MM.
-    let ext: perps::UserStateExtended = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
-            user: accounts.user1.address(),
-            include_equity: true,
-            include_available_margin: false,
-            include_maintenance_margin: true,
-            include_unrealized_pnl: false,
-            include_unrealized_funding: false,
-            include_liquidation_price: false,
-            include_all: false,
-        })
-        .should_succeed();
-
-    let equity = ext.equity.unwrap();
-    let mm = ext.maintenance_margin.unwrap();
-    assert!(
-        equity < mm,
-        "account should be liquidatable: equity ({equity}) < MM ({mm})"
-    );
+    // Old behavior (before fix): order succeeded and pushed margin negative.
+    // let state: UserState = suite
+    //     .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+    //         user: accounts.user1.address(),
+    //     })
+    //     .should_succeed()
+    //     .unwrap();
+    // assert_eq!(state.margin, UsdValue::new_int(-6_021));
+    // let pos = state.positions.get(&pair).unwrap();
+    // assert_eq!(pos.size, Quantity::new_int(5));
+    // assert_eq!(pos.entry_price, UsdPrice::new_int(2_000));
+    // // Equity = −$6,021. MM = $500. Account immediately liquidatable.
 }
 
-/// Non-reduce-only buy partially closes a short at a bad price. Same mechanism
-/// as above but for the short side.
-///
-/// Pre-fill check: equity=$2,980, projIM=5×$2k×10%=$1,000, fee=$10.
-/// $2,980 ≥ $1,010 → passes. But fill at $3,800 realizes −$9,000 PnL.
+/// Non-reduce-only buy partially closes a short at a bad price. The pre-fill
+/// check now catches the catastrophic PnL at the target price and rejects.
 ///
 /// | Step | Action                                               | Key numbers                                               |
 /// |------|------------------------------------------------------|-----------------------------------------------------------|
@@ -899,7 +785,7 @@ fn partial_close_buy_at_bad_price_pushes_margin_negative() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(-10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -953,9 +839,8 @@ fn partial_close_buy_at_bad_price_pushes_margin_negative() {
         .should_succeed();
 
     // Step 4: User1 market buys 5 ETH (NOT reduce-only) with 90% slippage.
-    // Pre-fill check: equity=$2,980, projSize=-5, projIM=5×$2k×10%=$1,000,
-    //   fee=5×$2k×0.1%=$10, required=$1,010. $2,980 ≥ $1,010 → passes.
-    // Fills at $3,800: PnL = 5 × ($2,000 − $3,800) = −$9,000. Fee = $19.
+    // Now rejected: the pre-fill check simulates the fill at target=$3,800 and
+    // sees the resulting equity would be deeply negative.
 
     suite
         .execute(
@@ -973,42 +858,18 @@ fn partial_close_buy_at_bad_price_pushes_margin_negative() {
             }),
             Coins::new(),
         )
-        .should_succeed();
+        .should_fail_with_error("insufficient margin");
 
-    // Step 5: Assert margin is deeply negative with a remaining position.
-
-    let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
-        .should_succeed()
-        .unwrap();
-
-    assert_eq!(state.margin, UsdValue::new_int(-6_039));
-
-    // Remaining short 5 @ $2,000 — account is immediately liquidatable.
-    let pos = state.positions.get(&pair).unwrap();
-    assert_eq!(pos.size, Quantity::new_int(-5));
-    assert_eq!(pos.entry_price, UsdPrice::new_int(2_000));
-
-    // Equity = −$6,039. MM = 5 × $2,000 × 5% = $500. Equity ≪ MM.
-    let ext: perps::UserStateExtended = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
-            user: accounts.user1.address(),
-            include_equity: true,
-            include_available_margin: false,
-            include_maintenance_margin: true,
-            include_unrealized_pnl: false,
-            include_unrealized_funding: false,
-            include_liquidation_price: false,
-            include_all: false,
-        })
-        .should_succeed();
-
-    let equity = ext.equity.unwrap();
-    let mm = ext.maintenance_margin.unwrap();
-    assert!(
-        equity < mm,
-        "account should be liquidatable: equity ({equity}) < MM ({mm})"
-    );
+    // Old behavior (before fix): order succeeded and pushed margin negative.
+    // let state: UserState = suite
+    //     .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+    //         user: accounts.user1.address(),
+    //     })
+    //     .should_succeed()
+    //     .unwrap();
+    // assert_eq!(state.margin, UsdValue::new_int(-6_039));
+    // let pos = state.positions.get(&pair).unwrap();
+    // assert_eq!(pos.size, Quantity::new_int(-5));
+    // assert_eq!(pos.entry_price, UsdPrice::new_int(2_000));
+    // // Equity = −$6,039. MM = $500. Account immediately liquidatable.
 }

--- a/dango/testing/tests/perps/margin_check.rs
+++ b/dango/testing/tests/perps/margin_check.rs
@@ -1,0 +1,1014 @@
+//! Regression tests for pre-fill margin check gaps.
+//!
+//! The pre-fill margin check (`check_margin`) computes equity and projected
+//! initial margin at oracle prices, ignoring that the actual fill price may
+//! differ drastically. This allows orders to push accounts into deeply negative
+//! equity through realized PnL at bad fill prices.
+//!
+//! **Group A** (tests 1–4): Reduce-only orders skip the margin check entirely.
+//! **Group B** (tests 5–6): Non-reduce-only partial closes pass the check but
+//! still push margin negative because the check doesn't account for PnL
+//! realization at the execution price.
+
+use {
+    crate::register_oracle_prices,
+    dango_testing::{TestOption, perps::pair_id, setup_test_naive},
+    dango_types::{
+        Dimensionless, Quantity, UsdPrice, UsdValue,
+        constants::usdc,
+        perps::{self, UserState},
+    },
+    grug::{Addressable, Coins, QuerierExt, ResultExt, Uint128},
+};
+
+// =============================================================================
+// Group A: Reduce-only orders (margin check skipped entirely)
+// =============================================================================
+
+/// Reduce-only market sell closes a long at a catastrophically low price.
+///
+/// | Step | Action                                               | Key numbers                                               |
+/// |------|------------------------------------------------------|-----------------------------------------------------------|
+/// | 1    | User2 deposits $100k; PostOnly sell 10 ETH @ $2,000  | provides opening-side liquidity                           |
+/// | 2    | User1 deposits $10k; market buys 10 ETH              | fee=$20; margin=$9,980; long 10 @ $2,000                  |
+/// | 3    | User3 deposits $100k; PostOnly buy 10 ETH @ $200     | bad-price bid                                             |
+/// | 4    | User1 reduce-only market sell 10 ETH (90% slippage)  | target=$200; fills @ $200; PnL=−$18,000; fee=$2           |
+/// | 5    | Assert                                               | margin=−$8,022; position closed; account deeply negative  |
+#[test]
+fn reduce_only_market_sell_pushes_margin_negative() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    let pair = pair_id();
+
+    // Step 1: User2 provides opening liquidity (PostOnly sell 10 ETH @ $2,000).
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 2: User1 deposits $10,000 and market buys 10 ETH.
+    // Fee = 10 × $2,000 × 0.1% = $20. Margin = $9,980.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(9_980));
+    assert_eq!(
+        state.positions.get(&pair).unwrap().size,
+        Quantity::new_int(10)
+    );
+
+    // Step 3: User3 places bad-price bid (PostOnly buy 10 ETH @ $200).
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(200),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 4: User1 reduce-only market sells 10 ETH with 90% slippage.
+    // Target = $2,000 × 0.1 = $200. Fills against User3's bid at $200.
+    // PnL = 10 × ($200 − $2,000) = −$18,000. Fee = 10 × $200 × 0.1% = $2.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(90),
+                },
+                reduce_only: true,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 5: Assert margin is deeply negative and position is gone.
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert!(
+        state.positions.is_empty(),
+        "position should be fully closed after reduce-only fill"
+    );
+    assert_eq!(state.margin, UsdValue::new_int(-8_022));
+}
+
+/// Reduce-only market buy closes a short at a catastrophically high price.
+///
+/// | Step | Action                                               | Key numbers                                               |
+/// |------|------------------------------------------------------|-----------------------------------------------------------|
+/// | 1    | User2 deposits $100k; PostOnly buy 10 ETH @ $2,000   | provides opening-side liquidity                           |
+/// | 2    | User1 deposits $10k; market sells 10 ETH             | fee=$20; margin=$9,980; short 10 @ $2,000                 |
+/// | 3    | User3 deposits $100k; PostOnly sell 10 ETH @ $3,800  | bad-price ask                                             |
+/// | 4    | User1 reduce-only market buy 10 ETH (90% slippage)   | target=$3,800; fills @ $3,800; PnL=−$18,000; fee=$38     |
+/// | 5    | Assert                                               | margin=−$8,058; position closed; account deeply negative  |
+#[test]
+fn reduce_only_market_buy_pushes_margin_negative() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    let pair = pair_id();
+
+    // Step 1: User2 provides opening liquidity (PostOnly buy 10 ETH @ $2,000).
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 2: User1 deposits $10,000 and market sells 10 ETH.
+    // Fee = 10 × $2,000 × 0.1% = $20. Margin = $9,980.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(9_980));
+    assert_eq!(
+        state.positions.get(&pair).unwrap().size,
+        Quantity::new_int(-10)
+    );
+
+    // Step 3: User3 places bad-price ask (PostOnly sell 10 ETH @ $3,800).
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(3_800),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 4: User1 reduce-only market buys 10 ETH with 90% slippage.
+    // Target = $2,000 × 1.9 = $3,800. Fills against User3's ask at $3,800.
+    // PnL = 10 × ($2,000 − $3,800) = −$18,000. Fee = 10 × $3,800 × 0.1% = $38.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(90),
+                },
+                reduce_only: true,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 5: Assert margin is deeply negative and position is gone.
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert!(
+        state.positions.is_empty(),
+        "position should be fully closed after reduce-only fill"
+    );
+    assert_eq!(state.margin, UsdValue::new_int(-8_058));
+}
+
+/// Reduce-only GTC limit sell rests at a terrible price, then a taker fills it.
+///
+/// | Step | Action                                               | Key numbers                                               |
+/// |------|------------------------------------------------------|-----------------------------------------------------------|
+/// | 1    | User2 deposits $100k; PostOnly sell 10 ETH @ $2,000  | provides opening-side liquidity                           |
+/// | 2    | User1 deposits $10k; market buys 10 ETH              | fee=$20; margin=$9,980; long 10 @ $2,000                  |
+/// | 3    | User1 places reduce-only GTC sell 10 ETH @ $200      | rests as ask; margin check skipped                        |
+/// | 4    | User3 deposits $100k; market buys 10 ETH             | fills against User1's ask @ $200; User1 PnL=−$18,000     |
+/// | 5    | Assert                                               | margin=−$8,020; position closed; account deeply negative  |
+#[test]
+fn reduce_only_limit_sell_pushes_margin_negative() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    let pair = pair_id();
+
+    // Step 1: User2 provides opening liquidity (PostOnly sell 10 ETH @ $2,000).
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 2: User1 deposits $10,000 and market buys 10 ETH.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(9_980));
+
+    // Step 3: User1 places reduce-only GTC sell 10 ETH @ $200.
+    // Margin check skipped because reduce_only = true. Order rests as ask.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(200),
+                    time_in_force: perps::TimeInForce::GoodTilCanceled,
+                },
+                reduce_only: true,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 4: User3 market buys 10 ETH — fills against User1's resting ask at $200.
+    // User1 (maker, 0% maker fee): PnL = 10 × ($200 − $2,000) = −$18,000.
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 5: Assert User1's margin is deeply negative and position is gone.
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert!(
+        state.positions.is_empty(),
+        "position should be fully closed after reduce-only fill"
+    );
+    assert_eq!(state.margin, UsdValue::new_int(-8_020));
+}
+
+/// Reduce-only GTC limit buy rests at a terrible price, then a taker fills it.
+///
+/// | Step | Action                                               | Key numbers                                               |
+/// |------|------------------------------------------------------|-----------------------------------------------------------|
+/// | 1    | User2 deposits $100k; PostOnly buy 10 ETH @ $2,000   | provides opening-side liquidity                           |
+/// | 2    | User1 deposits $10k; market sells 10 ETH             | fee=$20; margin=$9,980; short 10 @ $2,000                 |
+/// | 3    | User1 places reduce-only GTC buy 10 ETH @ $3,800     | rests as bid; margin check skipped                        |
+/// | 4    | User3 deposits $100k; market sells 10 ETH            | fills against User1's bid @ $3,800; User1 PnL=−$18,000   |
+/// | 5    | Assert                                               | margin=−$8,020; position closed; account deeply negative  |
+#[test]
+fn reduce_only_limit_buy_pushes_margin_negative() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    let pair = pair_id();
+
+    // Step 1: User2 provides opening liquidity (PostOnly buy 10 ETH @ $2,000).
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 2: User1 deposits $10,000 and market sells 10 ETH.
+    // Fee = 10 × $2,000 × 0.1% = $20. Margin = $9,980.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(9_980));
+    assert_eq!(
+        state.positions.get(&pair).unwrap().size,
+        Quantity::new_int(-10)
+    );
+
+    // Step 3: User1 places reduce-only GTC buy 10 ETH @ $3,800.
+    // Margin check skipped because reduce_only = true. Order rests as bid.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(3_800),
+                    time_in_force: perps::TimeInForce::GoodTilCanceled,
+                },
+                reduce_only: true,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 4: User3 market sells 10 ETH — fills against User1's resting bid at $3,800.
+    // User1 (maker, 0% maker fee): PnL = 10 × ($2,000 − $3,800) = −$18,000.
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 5: Assert User1's margin is deeply negative and position is gone.
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert!(
+        state.positions.is_empty(),
+        "position should be fully closed after reduce-only fill"
+    );
+    assert_eq!(state.margin, UsdValue::new_int(-8_020));
+}
+
+// =============================================================================
+// Group B: Non-reduce-only partial close (margin check passes but insufficient)
+// =============================================================================
+
+/// Non-reduce-only sell partially closes a long at a bad price. The pre-fill
+/// check passes (projected IM shrinks with smaller position) but ignores that
+/// realized PnL at the fill price pushes margin deeply negative.
+///
+/// Pre-fill check: equity=$2,980, projIM=5×$2k×10%=$1,000, fee=$10.
+/// $2,980 ≥ $1,010 → passes. But fill at $200 realizes −$9,000 PnL.
+///
+/// | Step | Action                                               | Key numbers                                               |
+/// |------|------------------------------------------------------|-----------------------------------------------------------|
+/// | 1    | User2 deposits $100k; PostOnly sell 10 ETH @ $2,000  | provides opening-side liquidity                           |
+/// | 2    | User1 deposits $3k; market buys 10 ETH               | fee=$20; margin=$2,980; long 10 @ $2,000                  |
+/// | 3    | User3 deposits $100k; PostOnly buy 5 ETH @ $200      | bad-price bid for partial close                           |
+/// | 4    | User1 market sells 5 ETH (90% slippage, NOT reduce)  | check passes; fills @ $200; PnL=−$9,000; fee=$1          |
+/// | 5    | Assert                                               | margin=−$6,021; long 5 remains; equity ≪ MM=$500         |
+#[test]
+fn partial_close_sell_at_bad_price_pushes_margin_negative() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    let pair = pair_id();
+
+    // Step 1: User2 provides opening liquidity (PostOnly sell 10 ETH @ $2,000).
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 2: User1 deposits $3,000 (minimum viable) and market buys 10 ETH.
+    // Margin check: equity=$3,000 ≥ IM($2,000) + fee($20) = $2,020. Passes.
+    // Fee = 10 × $2,000 × 0.1% = $20. Margin = $2,980.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(3_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(2_980));
+
+    // Step 3: User3 places bad-price bid (PostOnly buy 5 ETH @ $200).
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(200),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 4: User1 market sells 5 ETH (NOT reduce-only) with 90% slippage.
+    // Pre-fill check: equity=$2,980, projSize=5, projIM=5×$2k×10%=$1,000,
+    //   fee=5×$2k×0.1%=$10, required=$1,010. $2,980 ≥ $1,010 → passes.
+    // Fills at $200: PnL = 5 × ($200 − $2,000) = −$9,000. Fee = $1.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-5),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(90),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 5: Assert margin is deeply negative with a remaining position.
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(-6_021));
+
+    // Remaining long 5 @ $2,000 — account is immediately liquidatable.
+    let pos = state.positions.get(&pair).unwrap();
+    assert_eq!(pos.size, Quantity::new_int(5));
+    assert_eq!(pos.entry_price, UsdPrice::new_int(2_000));
+
+    // Equity (= margin + unrealized PnL at oracle) = −$6,021 + 0 = −$6,021.
+    // MM = 5 × $2,000 × 5% = $500. Equity ≪ MM.
+    let ext: perps::UserStateExtended = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
+            user: accounts.user1.address(),
+            include_equity: true,
+            include_available_margin: false,
+            include_maintenance_margin: true,
+            include_unrealized_pnl: false,
+            include_unrealized_funding: false,
+            include_liquidation_price: false,
+            include_all: false,
+        })
+        .should_succeed();
+
+    let equity = ext.equity.unwrap();
+    let mm = ext.maintenance_margin.unwrap();
+    assert!(
+        equity < mm,
+        "account should be liquidatable: equity ({equity}) < MM ({mm})"
+    );
+}
+
+/// Non-reduce-only buy partially closes a short at a bad price. Same mechanism
+/// as above but for the short side.
+///
+/// Pre-fill check: equity=$2,980, projIM=5×$2k×10%=$1,000, fee=$10.
+/// $2,980 ≥ $1,010 → passes. But fill at $3,800 realizes −$9,000 PnL.
+///
+/// | Step | Action                                               | Key numbers                                               |
+/// |------|------------------------------------------------------|-----------------------------------------------------------|
+/// | 1    | User2 deposits $100k; PostOnly buy 10 ETH @ $2,000   | provides opening-side liquidity                           |
+/// | 2    | User1 deposits $3k; market sells 10 ETH              | fee=$20; margin=$2,980; short 10 @ $2,000                 |
+/// | 3    | User3 deposits $100k; PostOnly sell 5 ETH @ $3,800   | bad-price ask for partial close                           |
+/// | 4    | User1 market buys 5 ETH (90% slippage, NOT reduce)   | check passes; fills @ $3,800; PnL=−$9,000; fee=$19       |
+/// | 5    | Assert                                               | margin=−$6,039; short 5 remains; equity ≪ MM=$500        |
+#[test]
+fn partial_close_buy_at_bad_price_pushes_margin_negative() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    let pair = pair_id();
+
+    // Step 1: User2 provides opening liquidity (PostOnly buy 10 ETH @ $2,000).
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 2: User1 deposits $3,000 and market sells 10 ETH.
+    // Fee = 10 × $2,000 × 0.1% = $20. Margin = $2,980.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(3_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(2_980));
+    assert_eq!(
+        state.positions.get(&pair).unwrap().size,
+        Quantity::new_int(-10)
+    );
+
+    // Step 3: User3 places bad-price ask (PostOnly sell 5 ETH @ $3,800).
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(3_800),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 4: User1 market buys 5 ETH (NOT reduce-only) with 90% slippage.
+    // Pre-fill check: equity=$2,980, projSize=-5, projIM=5×$2k×10%=$1,000,
+    //   fee=5×$2k×0.1%=$10, required=$1,010. $2,980 ≥ $1,010 → passes.
+    // Fills at $3,800: PnL = 5 × ($2,000 − $3,800) = −$9,000. Fee = $19.
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(90),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Step 5: Assert margin is deeply negative with a remaining position.
+
+    let state: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(state.margin, UsdValue::new_int(-6_039));
+
+    // Remaining short 5 @ $2,000 — account is immediately liquidatable.
+    let pos = state.positions.get(&pair).unwrap();
+    assert_eq!(pos.size, Quantity::new_int(-5));
+    assert_eq!(pos.entry_price, UsdPrice::new_int(2_000));
+
+    // Equity = −$6,039. MM = 5 × $2,000 × 5% = $500. Equity ≪ MM.
+    let ext: perps::UserStateExtended = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
+            user: accounts.user1.address(),
+            include_equity: true,
+            include_available_margin: false,
+            include_maintenance_margin: true,
+            include_unrealized_pnl: false,
+            include_unrealized_funding: false,
+            include_liquidation_price: false,
+            include_all: false,
+        })
+        .should_succeed();
+
+    let equity = ext.equity.unwrap();
+    let mm = ext.maintenance_margin.unwrap();
+    assert!(
+        equity < mm,
+        "account should be liquidatable: equity ({equity}) < MM ({mm})"
+    );
+}

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -1343,7 +1343,7 @@ fn place_market_buy(
                 pair_id: dango_testing::perps::pair_id(),
                 size: Quantity::new_int(size as i128),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -106,7 +106,7 @@ fn trading_lifecycle() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10), // buy
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -672,7 +672,7 @@ fn protocol_fee_accumulates_across_fills() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -723,7 +723,7 @@ fn protocol_fee_accumulates_across_fills() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(10),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -852,7 +852,7 @@ fn negative_maker_fee_rebate_lifecycle() {
                 pair_id: pair.clone(),
                 size: Quantity::new_int(50),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -188,7 +188,7 @@ fn vault_lp_lifecycle() {
                 pair_id: pair.clone(),
                 size: vault_bid_size.checked_neg().unwrap(), // sell
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(10),
                 },
                 reduce_only: false,
                 tp: None,
@@ -249,7 +249,7 @@ fn vault_lp_lifecycle() {
                 pair_id: pair.clone(),
                 size: vault_long_size, // buy same amount (closes taker's short)
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(10),
                 },
                 reduce_only: false,
                 tp: None,
@@ -790,7 +790,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
                 pair_id: pair.clone(),
                 size: round1_bid_size.checked_neg().unwrap(),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,
@@ -916,7 +916,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
                 pair_id: pair.clone(),
                 size: round1_bid_size.checked_neg().unwrap(),
                 kind: perps::OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
+                    max_slippage: Dimensionless::new_percent(1),
                 },
                 reduce_only: false,
                 tp: None,


### PR DESCRIPTION
Previously: 1) for closing orders, PnL wasn't counted in margin check; 2) for reduce-only and post-only orders, margin check was skipped completely. 

Now: margin check is done for all orders, and takes PnL into account, assuming the order fills fully at the worst possible price.