### PR TITLE
fix(referral): volume by user

### DIFF
--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -290,6 +290,10 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = query::query_volume(ctx.storage, user, since)?;
             res.to_json_value()
         },
+        QueryMsg::VolumeByUser { user, since } => {
+            let res = query::query_volume_by_user(ctx, user, since)?;
+            res.to_json_value()
+        },
         QueryMsg::Referrer { referee } => {
             let res = query::query_referrer(ctx.storage, referee)?;
             res.to_json_value()

--- a/dango/perps/src/query.rs
+++ b/dango/perps/src/query.rs
@@ -19,7 +19,7 @@ use {
     dango_oracle::OracleQuerier,
     dango_types::{
         UsdPrice, UsdValue,
-        account_factory::UserIndex,
+        account_factory::{self, UserIndex},
         perps::{
             CommissionRate, LimitOrder, LiquidityDepth, LiquidityDepthResponse, OrderId, PairId,
             PairParam, PairState, PositionExtended, QueryOrderResponse,
@@ -30,7 +30,7 @@ use {
     },
     grug::{
         Addr, Bound, DEFAULT_PAGE_LIMIT, ImmutableCtx, MultiIndex, Order as IterationOrder,
-        PrefixBound, PrimaryKey, StdResult, Storage, Timestamp,
+        PrefixBound, PrimaryKey, StdResult, Storage, StorageQuerier, Timestamp,
     },
     std::collections::BTreeMap,
 };
@@ -328,6 +328,25 @@ pub fn query_volume(
             Ok(latest.checked_sub(baseline)?)
         },
     }
+}
+
+pub fn query_volume_by_user(
+    ctx: ImmutableCtx,
+    user: UserIndex,
+    since: Option<Timestamp>,
+) -> anyhow::Result<UsdValue> {
+    let account_factory = crate::account_factory(ctx.querier);
+
+    let user_data = ctx
+        .querier
+        .query_wasm_path(account_factory, &dango_account_factory::USERS.path(user))?;
+
+    let mut total = UsdValue::ZERO;
+    for addr in user_data.accounts.values() {
+        total = total.checked_add(query_volume(ctx.storage, *addr, since)?)?;
+    }
+
+    Ok(total)
 }
 
 pub fn query_referrer(storage: &dyn Storage, referee: UserIndex) -> StdResult<Option<Referrer>> {

--- a/dango/perps/src/query.rs
+++ b/dango/perps/src/query.rs
@@ -19,7 +19,7 @@ use {
     dango_oracle::OracleQuerier,
     dango_types::{
         UsdPrice, UsdValue,
-        account_factory::{self, UserIndex},
+        account_factory::UserIndex,
         perps::{
             CommissionRate, LimitOrder, LiquidityDepth, LiquidityDepthResponse, OrderId, PairId,
             PairParam, PairState, PositionExtended, QueryOrderResponse,

--- a/dango/perps/src/query.rs
+++ b/dango/perps/src/query.rs
@@ -336,14 +336,23 @@ pub fn query_volume_by_user(
     since: Option<Timestamp>,
 ) -> anyhow::Result<UsdValue> {
     let account_factory = crate::account_factory(ctx.querier);
+    compute_user_volume(ctx.storage, ctx.querier, account_factory, user, since)
+}
 
-    let user_data = ctx
-        .querier
-        .query_wasm_path(account_factory, &dango_account_factory::USERS.path(user))?;
+/// Sum cumulative volume across all accounts belonging to a user.
+pub fn compute_user_volume(
+    storage: &dyn Storage,
+    querier: impl StorageQuerier,
+    account_factory: Addr,
+    user: UserIndex,
+    since: Option<Timestamp>,
+) -> anyhow::Result<UsdValue> {
+    let user_data =
+        querier.query_wasm_path(account_factory, &dango_account_factory::USERS.path(user))?;
 
     let mut total = UsdValue::ZERO;
     for addr in user_data.accounts.values() {
-        total = total.checked_add(query_volume(ctx.storage, *addr, since)?)?;
+        total = total.checked_add(query_volume(storage, *addr, since)?)?;
     }
 
     Ok(total)

--- a/dango/perps/src/referral/set_fee_share_ratio.rs
+++ b/dango/perps/src/referral/set_fee_share_ratio.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         account_factory,
-        query::query_volume,
+        query::compute_user_volume,
         state::{COMMISSION_RATE_OVERRIDES, FEE_SHARE_RATIO, PARAM},
     },
     anyhow::ensure,
@@ -49,10 +49,12 @@ pub fn set_fee_share_ratio(
     let user_index = account.owner;
 
     // Users with a commission rate override bypass the volume requirement.
-    // Otherwise, the caller must have enough lifetime perps volume.
+    // Otherwise, the caller must have enough lifetime perps volume across all
+    // accounts belonging to the user.
     if !COMMISSION_RATE_OVERRIDES.has(ctx.storage, user_index) {
         let param = PARAM.load(ctx.storage)?;
-        let volume = query_volume(ctx.storage, ctx.sender, None)?;
+        let volume =
+            compute_user_volume(ctx.storage, ctx.querier, account_factory, user_index, None)?;
 
         ensure!(
             volume >= param.min_referrer_volume,

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -414,6 +414,89 @@ fn set_share_ratio_requires_volume() {
     .should_fail_with_error("insufficient perps volume to become a referrer");
 }
 
+/// Volume for referrer eligibility is aggregated across all accounts of a user.
+/// User1 has two accounts that each trade below the threshold individually,
+/// but together meet the $10,000 minimum.
+#[test]
+fn set_share_ratio_aggregates_volume_across_accounts() {
+    let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
+
+    // Configure the perps contract to require $10,000 volume to become a referrer.
+    let mut param: perps::Param = suite
+        .query_wasm_smart(contracts.perps, perps::QueryParamRequest {})
+        .should_succeed();
+
+    param.min_referrer_volume = UsdValue::new_int(10_000);
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param,
+                pair_params: Default::default(),
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Register oracle prices: ETH = $1,000.
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_000);
+
+    // Create a second account for user1 (same user_index, different address).
+    let mut user1_account2 = accounts
+        .user1
+        .register_new_account(
+            &mut suite,
+            contracts.account_factory,
+            Coins::one(usdc::DENOM.clone(), 50_000_000_000).unwrap(),
+        )
+        .unwrap();
+
+    // Deposit margin: user1 accounts and user2 (counterparty).
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 10_000);
+    deposit_margin(&mut suite, contracts.perps, &mut user1_account2, 10_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 50_000);
+
+    // Trade 1: user2 sells 7 ETH at $1,000, user1 account1 buys → $7,000 notional.
+    place_ask_order(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user2,
+        UsdPrice::new_int(1_000),
+        7,
+    );
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user1, 7);
+
+    // With only $7,000 volume, user1 cannot become a referrer.
+    set_fee_share_ratio(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user1,
+        Dimensionless::new_percent(50),
+    )
+    .should_fail_with_error("insufficient perps volume to become a referrer");
+
+    // Trade 2: user2 sells 3 ETH at $1,000, user1 account2 buys → $3,000 notional.
+    place_ask_order(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user2,
+        UsdPrice::new_int(1_000),
+        3,
+    );
+    place_market_buy(&mut suite, contracts.perps, &mut user1_account2, 3);
+
+    // Now the combined volume across both accounts is $10,000 — should succeed.
+    set_fee_share_ratio(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user1,
+        Dimensionless::new_percent(50),
+    )
+    .should_succeed();
+}
+
 /// When `referral.active` is false, no fee commissions are applied.
 #[test]
 fn referral_active_flag() {

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1030,11 +1030,21 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
 
-    /// Query a user's cumulative trading volume.
+    /// Query a user's cumulative trading volume by address.
     /// `since: None` -> lifetime volume. `since: Some(ts)` -> volume since ts.
     #[returns(UsdValue)]
     Volume {
         user: Addr,
+        since: Option<Timestamp>,
+    },
+
+    /// Query a user's cumulative trading volume by user index.
+    /// Resolves the `UserIndex` to the master account address via the account
+    /// factory, then returns cumulative volume.
+    /// `since: None` -> lifetime volume. `since: Some(ts)` -> volume since ts.
+    #[returns(UsdValue)]
+    VolumeByUser {
+        user: UserIndex,
         since: Option<Timestamp>,
     },
 


### PR DESCRIPTION
Summary

  - Adds a VolumeByUser query that resolves a UserIndex to all its accounts via the account factory and sums their cumulative trading volume
  - Fixes set_fee_share_ratio to check the user's total volume across all accounts instead of only the calling address, so users with multiple accounts can meet the
  referrer volume threshold
  - Extracts compute_user_volume helper for reuse across query and execute paths