### PR TITLE
Fix requester IP resolution across proxy chain

### DIFF
--- a/deploy/roles/traefik/templates/traefik-dango.yml
+++ b/deploy/roles/traefik/templates/traefik-dango.yml
@@ -142,4 +142,6 @@ accessLog:
         CF-Connecting-IP: keep
         X-Forwarded-For: keep
         Forwarded: keep
+        True-Client-IP: keep
+        X-Real-IP: keep
         Cf-Ray: keep

--- a/deploy/roles/traefik/templates/traefik-ovh3.yml
+++ b/deploy/roles/traefik/templates/traefik-ovh3.yml
@@ -77,4 +77,6 @@ accessLog:
         CF-Connecting-IP: keep
         X-Forwarded-For: keep
         Forwarded: keep
+        True-Client-IP: keep
+        X-Real-IP: keep
         Cf-Ray: keep

--- a/grug/httpd/src/request_ip.rs
+++ b/grug/httpd/src/request_ip.rs
@@ -26,10 +26,16 @@ impl RequesterIp {
             header_value(req.headers(), "cf-connecting-ip").map(ToOwned::to_owned);
         let true_client_ip = header_value(req.headers(), "true-client-ip").map(ToOwned::to_owned);
         let x_real_ip = header_value(req.headers(), "x-real-ip").map(ToOwned::to_owned);
+        #[cfg(feature = "tracing")]
+        let cf_ray = header_value(req.headers(), "cf-ray").map(ToOwned::to_owned);
 
         let real_ip = req
             .connection_info()
             .realip_remote_addr()
+            .and_then(parse_ip_candidate);
+        let peer_ip = req
+            .connection_info()
+            .peer_addr()
             .and_then(parse_ip_candidate);
 
         let remote_ip = if real_ip.as_ref().is_some_and(|ip| !is_proxy_hop_ip(ip)) {
@@ -37,19 +43,28 @@ impl RequesterIp {
         } else {
             original_client_ip_from_headers(req.headers())
                 .or(real_ip)
-                .or_else(|| {
-                    req.connection_info()
-                        .peer_addr()
-                        .and_then(parse_ip_candidate)
-                })
+                .or_else(|| peer_ip.clone())
         };
+
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            method = %req.method(),
+            path = %req.path(),
+            remote_ip = remote_ip.as_deref().unwrap_or("unknown"),
+            peer_ip = peer_ip.as_deref().unwrap_or("unknown"),
+            real_ip = req.connection_info().realip_remote_addr().unwrap_or("unknown"),
+            x_forwarded_for = x_forwarded_for.as_deref().unwrap_or("-"),
+            forwarded = forwarded.as_deref().unwrap_or("-"),
+            cf_connecting_ip = cf_connecting_ip.as_deref().unwrap_or("-"),
+            true_client_ip = true_client_ip.as_deref().unwrap_or("-"),
+            x_real_ip = x_real_ip.as_deref().unwrap_or("-"),
+            cf_ray = cf_ray.as_deref().unwrap_or("-"),
+            "resolved requester IP headers"
+        );
 
         Self {
             remote_ip,
-            peer_ip: req
-                .connection_info()
-                .peer_addr()
-                .and_then(parse_ip_candidate),
+            peer_ip,
             x_forwarded_for,
             forwarded,
             cf_connecting_ip,
@@ -64,16 +79,20 @@ impl RequesterIp {
 }
 
 fn original_client_ip_from_headers(headers: &HeaderMap) -> Option<String> {
-    [
-        header_value(headers, "x-forwarded-for").and_then(parse_ip_list_header),
-        header_value(headers, "forwarded").and_then(parse_forwarded_header),
+    let candidates = [
         header_value(headers, "cf-connecting-ip").and_then(parse_ip_candidate),
         header_value(headers, "true-client-ip").and_then(parse_ip_candidate),
+        header_value(headers, "forwarded").and_then(parse_forwarded_header),
+        header_value(headers, "x-forwarded-for").and_then(parse_ip_list_header),
         header_value(headers, "x-real-ip").and_then(parse_ip_candidate),
-    ]
-    .into_iter()
-    .flatten()
-    .next()
+    ];
+
+    candidates
+        .iter()
+        .flatten()
+        .find(|ip| !is_proxy_hop_ip(ip))
+        .cloned()
+        .or_else(|| candidates.into_iter().flatten().next())
 }
 
 fn header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
@@ -81,21 +100,40 @@ fn header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
 }
 
 fn parse_ip_list_header(value: &str) -> Option<String> {
-    value.split(',').find_map(parse_ip_candidate)
+    choose_best_ip_candidate(value.split(',').filter_map(parse_ip_candidate))
 }
 
 fn parse_forwarded_header(value: &str) -> Option<String> {
-    value
-        .split(',')
-        .flat_map(|segment| segment.split(';'))
-        .filter_map(|pair| pair.split_once('='))
-        .find_map(|(key, raw_value)| {
+    choose_best_ip_candidate(value.split(',').flat_map(|segment| {
+        segment.split(';').filter_map(|pair| {
+            let (key, raw_value) = pair.split_once('=')?;
+
             if key.trim().eq_ignore_ascii_case("for") {
                 parse_ip_candidate(raw_value)
             } else {
                 None
             }
         })
+    }))
+}
+
+fn choose_best_ip_candidate<I>(candidates: I) -> Option<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut first = None;
+
+    for candidate in candidates {
+        if first.is_none() {
+            first = Some(candidate.clone());
+        }
+
+        if !is_proxy_hop_ip(&candidate) {
+            return Some(candidate);
+        }
+    }
+
+    first
 }
 
 fn parse_ip_candidate(value: &str) -> Option<String> {
@@ -157,6 +195,14 @@ mod tests {
     }
 
     #[test]
+    fn forwarded_for_skips_proxy_hops_when_public_ip_is_present() {
+        assert_eq!(
+            parse_ip_list_header("172.22.0.2, 198.51.100.10"),
+            Some("198.51.100.10".to_string())
+        );
+    }
+
+    #[test]
     fn parses_forwarded_header() {
         assert_eq!(
             parse_forwarded_header("for=198.51.100.10;proto=https, for=172.22.0.2"),
@@ -196,5 +242,20 @@ mod tests {
 
         assert_eq!(requester_ip.remote_ip, Some("198.51.100.10".to_string()));
         assert_eq!(requester_ip.peer_ip, Some("172.22.0.2".to_string()));
+    }
+
+    #[test]
+    fn requester_ip_prefers_cf_connecting_ip_when_forwarded_headers_only_show_proxy_hops() {
+        let req = TestRequest::default()
+            .insert_header(("x-forwarded-for", "172.23.0.2"))
+            .insert_header(("x-real-ip", "172.23.0.2"))
+            .insert_header(("cf-connecting-ip", "2001:db8::1234"))
+            .peer_addr("172.26.0.4:1234".parse().unwrap())
+            .to_http_request();
+
+        let requester_ip = RequesterIp::from_request(&req);
+
+        assert_eq!(requester_ip.remote_ip, Some("2001:db8::1234".to_string()));
+        assert_eq!(requester_ip.peer_ip, Some("172.26.0.4".to_string()));
     }
 }

--- a/indexer/testing/tests/graphql/grug.rs
+++ b/indexer/testing/tests/graphql/grug.rs
@@ -200,3 +200,48 @@ async fn graphql_returns_requester_ip() -> anyhow::Result<()> {
         })
         .await?
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn graphql_prefers_cf_connecting_ip_when_forwarded_headers_are_proxy_hops()
+-> anyhow::Result<()> {
+    let (httpd_context, _client, ..) = create_block().await?;
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let app = build_app_service(httpd_context);
+                let response = call_graphql_with_headers::<RequesterIpGraphqlResponse, _, _, _>(
+                    app,
+                    GraphQLCustomRequest {
+                        name: "requesterIp",
+                        query: "query RequesterIp { requesterIp { remoteIp peerIp xForwardedFor forwarded cfConnectingIp trueClientIp xRealIp } }",
+                        variables: Default::default(),
+                    },
+                    &[
+                        ("X-Forwarded-For", "172.23.0.2"),
+                        ("X-Real-Ip", "172.23.0.2"),
+                        ("CF-Connecting-IP", "2001:db8::1234"),
+                    ],
+                )
+                .await?;
+
+                assert_that!(response.data.remote_ip)
+                    .is_equal_to(Some("2001:db8::1234".to_string()));
+                assert_that!(response.data.peer_ip).is_some();
+                assert_that!(response.data.x_forwarded_for)
+                    .is_equal_to(Some("172.23.0.2".to_string()));
+                assert_that!(response.data.forwarded).is_none();
+                assert_that!(response.data.cf_connecting_ip)
+                    .is_equal_to(Some("2001:db8::1234".to_string()));
+                assert_that!(response.data.true_client_ip).is_none();
+                assert_that!(response.data.x_real_ip)
+                    .is_equal_to(Some("172.23.0.2".to_string()));
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}

--- a/ui/portal/web/tests/pages/convert.spec.ts
+++ b/ui/portal/web/tests/pages/convert.spec.ts
@@ -1,12 +1,20 @@
 import { expect, test, type Page } from "@playwright/test";
-import { registerUser } from "../utils/registerUser";
+import {
+  dismissActivateAccountModal,
+  registerUser,
+} from "../utils/registerUser";
 import { waitForStorageHydration } from "../utils/indexeddb";
+
+async function gotoConvertPage(page: Page): Promise<void> {
+  await page.goto("/convert");
+  await waitForStorageHydration(page);
+  await dismissActivateAccountModal(page);
+}
 
 test.describe("Convert Applet", () => {
   test.describe("Not Authenticated", () => {
     test.beforeEach(async ({ page }) => {
-      await page.goto("/convert");
-      await waitForStorageHydration(page);
+      await gotoConvertPage(page);
     });
 
     test("Log In button is visible instead of Swap", async ({ page }) => {
@@ -103,8 +111,7 @@ test.describe("Convert Applet", () => {
     });
 
     test("Swap button is visible instead of Log In", async () => {
-      await sharedPage.goto("/convert");
-      await waitForStorageHydration(sharedPage);
+      await gotoConvertPage(sharedPage);
 
       const swapButton = sharedPage.getByRole("button", { name: /swap/i });
       await expect(swapButton.first()).toBeVisible();
@@ -117,8 +124,7 @@ test.describe("Convert Applet", () => {
     });
 
     test("Swap button is disabled when no amount entered", async () => {
-      await sharedPage.goto("/convert");
-      await waitForStorageHydration(sharedPage);
+      await gotoConvertPage(sharedPage);
 
       const swapButton = sharedPage.getByRole("button", { name: /swap/i });
       await expect(swapButton.first()).toBeVisible();
@@ -128,8 +134,7 @@ test.describe("Convert Applet", () => {
     });
 
     test("Swap button remains disabled with zero amount", async () => {
-      await sharedPage.goto("/convert");
-      await waitForStorageHydration(sharedPage);
+      await gotoConvertPage(sharedPage);
 
       const amountInput = sharedPage
         .locator('input[type="text"], input[type="number"]')
@@ -145,8 +150,7 @@ test.describe("Convert Applet", () => {
     });
 
     test("swap direction toggle switches inputs", async () => {
-      await sharedPage.goto("/convert");
-      await waitForStorageHydration(sharedPage);
+      await gotoConvertPage(sharedPage);
 
       const directionToggle = sharedPage
         .getByText("You swap")
@@ -170,8 +174,7 @@ test.describe("Convert Applet", () => {
     });
 
     test("entering amount triggers simulation", async () => {
-      await sharedPage.goto("/convert");
-      await waitForStorageHydration(sharedPage);
+      await gotoConvertPage(sharedPage);
 
       const amountInput = sharedPage
         .locator('input[type="text"], input[type="number"]')
@@ -193,8 +196,7 @@ test.describe("Convert Applet", () => {
     });
 
     test("convert details section shows fee information", async () => {
-      await sharedPage.goto("/convert");
-      await waitForStorageHydration(sharedPage);
+      await gotoConvertPage(sharedPage);
 
       const amountInput = sharedPage
         .locator('input[type="text"], input[type="number"]')
@@ -222,8 +224,7 @@ test.describe("Convert Applet", () => {
     });
 
     test("form is visible and interactive", async () => {
-      await sharedPage.goto("/convert");
-      await waitForStorageHydration(sharedPage);
+      await gotoConvertPage(sharedPage);
 
       const form = sharedPage.locator("#convert-form, form");
       await expect(form.first()).toBeVisible();

--- a/ui/portal/web/tests/utils/registerUser.ts
+++ b/ui/portal/web/tests/utils/registerUser.ts
@@ -6,6 +6,25 @@ export interface RegisterUserOptions {
   privateKey?: Hex;
 }
 
+export async function dismissActivateAccountModal(
+  page: Page,
+  timeout = 2_000,
+): Promise<void> {
+  const heading = page.getByRole("heading", { name: "Activate Account" });
+
+  const isVisible = await heading
+    .waitFor({ state: "visible", timeout })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!isVisible) {
+    return;
+  }
+
+  await page.getByText("do this later", { exact: false }).click();
+  await heading.waitFor({ state: "hidden", timeout: 10_000 });
+}
+
 /**
  * Registers a new user using the Mock E2E Wallet.
  * This utility handles the full registration flow:
@@ -66,7 +85,7 @@ export async function registerUser(page: Page, options: RegisterUserOptions = {}
   await page.addLocatorHandler(
     page.getByRole("heading", { name: "Activate Account" }),
     async () => {
-      await page.getByText("do this later", { exact: false }).click();
+      await dismissActivateAccountModal(page, 10_000);
     },
   );
 }


### PR DESCRIPTION
## Summary

Prefer real client IP headers over proxy-hop addresses when resolving `requesterIp`, so Cloudflare tunnel and Traefik deployments stop surfacing internal bridge IPs as the caller.

This also adds more hop-level observability:
- prefer `CF-Connecting-IP` and other non-proxy candidates over private `X-Forwarded-For` / `X-Real-IP` values
- log the resolved requester IP plus the full inbound proxy header chain in `grug-httpd`
- retain `True-Client-IP` and `X-Real-IP` in Traefik access logs
- add a regression test for the live devnet header mix where `X-Forwarded-For` only contains an internal hop but `CF-Connecting-IP` contains the real client address

Root cause: the previous resolver accepted the first parsed forwarded address too early, even when that value was clearly an internal proxy hop. In the deployed Cloudflare tunnel path, that caused `remoteIp` to remain a Docker bridge IP.

## Validation

### Completed
- [x] `just fmt`
- [x] `cargo test -p grug-httpd request_ip -- --nocapture`
- [x] `cargo test -p indexer-testing graphql_prefers_cf_connecting_ip_when_forwarded_headers_are_proxy_hops -- --nocapture`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`

### Remaining
- [x] None

## Manual QA

- Redeploy the branch to devnet-like ingress.
- Run `query RequesterIp { requesterIp { remoteIp peerIp xForwardedFor forwarded cfConnectingIp trueClientIp xRealIp } }` against `https://api-devnet.dango.zone/graphql` and confirm `remoteIp` matches the external client IP instead of a `172.x.x.x` bridge address.
- Check Traefik access logs for the same request and confirm `CF-Connecting-IP`, `X-Forwarded-For`, `Forwarded`, `True-Client-IP`, `X-Real-IP`, and `Cf-Ray` are present.
- Check `grug-httpd` logs for the matching request and confirm the resolved `remote_ip` matches the Cloudflare client header rather than the proxy hop.
