### PR TITLE
feat(deploy): add deploy-mainnet-sha just command

### DIFF
--- a/deploy/justfile
+++ b/deploy/justfile
@@ -229,6 +229,16 @@ deploy-mainnet:
       --limit 100.89.7.33,100.66.234.16,100.126.8.2,100.76.197.30 \
       2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet.log
 
+# Deploy mainnet with a specific image tag (git SHA or docker tag)
+# Usage: just deploy-mainnet-sha abc123def
+deploy-mainnet-sha tag:
+  mkdir -p {{justfile_directory()}}/logs \
+    && ansible-playbook full-app.yml \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "faucet_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "frontend_image_tag": "latest"}' \
+      -e dango_image_tag={{tag}} \
+      --limit 100.89.7.33,100.66.234.16,100.126.8.2,100.76.197.30 \
+      2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-sha.log
+
 stop-mainnet:
   mkdir -p {{justfile_directory()}}/logs \
     && ansible-playbook stop-services.yml \


### PR DESCRIPTION
## Summary
- Add `deploy-mainnet-sha` just recipe to deploy mainnet with a specific docker image tag (git SHA or custom tag) instead of always using `latest`
- Usage: `just deploy-mainnet-sha <tag>`

## Validation

### Completed
- [x] Verified justfile syntax is correct
- [x] Confirmed `-e dango_image_tag={{tag}}` overrides the JSON defaults

### Remaining
- [x] None

## Manual QA
None — deploy recipe only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)