### PR TITLE
fix(ui): clarify trade page table column labels

### DIFF
--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1125,6 +1125,7 @@
         "type": "Type",
         "price": "Price",
         "size": "Size ({symbol})",
+        "tradeValue": "Trade Value",
         "dateAndTime": "Date & Time"
       },
       "history": {
@@ -1237,7 +1238,7 @@
         "pair": "Pair",
         "side": "Side",
         "size": "Size",
-        "notional": "Order Value",
+        "positionValue": "Position Value",
         "entryPrice": "Entry Price",
         "markPrice": "Mark Price",
         "pnl": "PnL",
@@ -1259,7 +1260,7 @@
         "type": "Type",
         "price": "Price",
         "size": "Size",
-        "tradeValue": "Trade Value",
+        "orderValue": "Order Value",
         "filled": "Filled",
         "reduceOnly": "Reduce Only",
         "tpsl": "TP/SL",

--- a/ui/portal/web/src/components/dex/ProTrade.tsx
+++ b/ui/portal/web/src/components/dex/ProTrade.tsx
@@ -354,15 +354,26 @@ const PerpsPositionsTable: React.FC = () => {
       },
       {
         header: m["dex.protrade.positions.size"](),
-        cell: ({ row }) => (
-          <Cell.Number
-            formatOptions={formatNumberOptions}
-            value={Math.abs(Number(row.original.size)).toString()}
-          />
-        ),
+        cell: ({ row }) => {
+          const absSize = Math.abs(Number(row.original.size)).toString();
+          return (
+            <Cell.Text
+              text={
+                <>
+                  <FormattedNumber
+                    number={absSize}
+                    formatOptions={formatNumberOptions}
+                    as="span"
+                  />{" "}
+                  {row.original.symbol}
+                </>
+              }
+            />
+          );
+        },
       },
       {
-        header: m["dex.protrade.positions.notional"](),
+        header: m["dex.protrade.positions.positionValue"](),
         cell: ({ row }) => {
           const notional = Decimal(row.original.size).abs().times(Decimal(row.original.entryPrice)).toFixed();
           return (
@@ -714,7 +725,7 @@ const UnifiedOpenOrders: React.FC = () => {
       ),
     },
     {
-      header: m["dex.protrade.orders.tradeValue"](),
+      header: m["dex.protrade.orders.orderValue"](),
       cell: ({ row }) => {
         const tradeValue = Decimal(row.original.size).times(Decimal(row.original.rawPrice)).toFixed();
         return (

--- a/ui/portal/web/src/components/dex/TradeHistory/PerpsTradeHistory.tsx
+++ b/ui/portal/web/src/components/dex/TradeHistory/PerpsTradeHistory.tsx
@@ -97,7 +97,7 @@ export const PerpsTradeHistory: React.FC = () => {
       },
     },
     {
-      header: m["dex.protrade.positions.notional"](),
+      header: m["dex.protrade.tradeHistory.tradeValue"](),
       cell: ({ row }) => {
         const size = getPerpsEventSize(row.original.eventType, row.original.data);
         const price = getPerpsEventPrice(row.original.eventType, row.original.data);


### PR DESCRIPTION
- Show token symbol next to Size in Positions table, matching the other tables on the trade page.
- Rename Positions column header "Order Value" to "Position Value".
- Rename Open Orders column header "Trade Value" to "Order Value".
- Rename Perps Trade History column header "Order Value" to "Trade Value".