### PR TITLE
feat(perps): client order ID       

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -942,21 +942,21 @@ query {
 }
 ```
 
-| Field                       | Type            | Description                                                          |
-| --------------------------- | --------------- | -------------------------------------------------------------------- |
-| `tick_size`                 | `UsdPrice`      | Minimum price increment for limit orders                             |
-| `min_order_size`            | `UsdValue`      | Minimum notional value (reduce-only exempt)                          |
-| `max_abs_oi`                | `Quantity`      | Maximum open interest per side                                       |
-| `max_abs_funding_rate`      | `FundingRate`   | Daily funding rate cap                                               |
-| `initial_margin_ratio`      | `Dimensionless` | Margin to open (e.g. 0.05 = 20x max leverage)                        |
-| `maintenance_margin_ratio`  | `Dimensionless` | Margin to stay open (liquidation threshold)                          |
-| `impact_size`               | `UsdValue`      | Notional for impact price calculation                                |
-| `vault_liquidity_weight`    | `Dimensionless` | Vault allocation weight for this pair                                |
-| `vault_half_spread`         | `Dimensionless` | Half the vault's bid-ask spread                                      |
-| `vault_max_quote_size`      | `Quantity`      | Maximum vault resting size per side                                  |
-| `max_limit_price_deviation` | `Dimensionless` | Max symmetric deviation of a limit price from oracle at submission   |
-| `max_market_slippage`       | `Dimensionless` | Max `max_slippage` a user may set on a market or TP/SL child order   |
-| `bucket_sizes`              | `[UsdPrice]`    | Price bucket granularities for depth queries                         |
+| Field                       | Type            | Description                                                        |
+| --------------------------- | --------------- | ------------------------------------------------------------------ |
+| `tick_size`                 | `UsdPrice`      | Minimum price increment for limit orders                           |
+| `min_order_size`            | `UsdValue`      | Minimum notional value (reduce-only exempt)                        |
+| `max_abs_oi`                | `Quantity`      | Maximum open interest per side                                     |
+| `max_abs_funding_rate`      | `FundingRate`   | Daily funding rate cap                                             |
+| `initial_margin_ratio`      | `Dimensionless` | Margin to open (e.g. 0.05 = 20x max leverage)                      |
+| `maintenance_margin_ratio`  | `Dimensionless` | Margin to stay open (liquidation threshold)                        |
+| `impact_size`               | `UsdValue`      | Notional for impact price calculation                              |
+| `vault_liquidity_weight`    | `Dimensionless` | Vault allocation weight for this pair                              |
+| `vault_half_spread`         | `Dimensionless` | Half the vault's bid-ask spread                                    |
+| `vault_max_quote_size`      | `Quantity`      | Maximum vault resting size per side                                |
+| `max_limit_price_deviation` | `Dimensionless` | Max symmetric deviation of a limit price from oracle at submission |
+| `max_market_slippage`       | `Dimensionless` | Max `max_slippage` a user may set on a market or TP/SL child order |
+| `bucket_sizes`              | `[UsdPrice]`    | Price bucket granularities for depth queries                       |
 
 For the relationship between margin ratios and leverage, see [Risk §2](6-risk.md).
 
@@ -1666,7 +1666,8 @@ Place a resting order on the book:
           "kind": {
             "limit": {
               "limit_price": "65000.000000",
-              "time_in_force": "GTC"
+              "time_in_force": "GTC",
+              "client_order_id": "42"
             }
           },
           "reduce_only": false
@@ -1678,13 +1679,14 @@ Place a resting order on the book:
 }
 ```
 
-| Field           | Type          | Description                                                            |
-| --------------- | ------------- | ---------------------------------------------------------------------- |
-| `limit_price`   | `UsdPrice`    | Limit price — must be aligned to `tick_size`                           |
-| `time_in_force` | `TimeInForce` | `"GTC"` (default), `"IOC"`, or `"POST"` — see below                    |
-| `reduce_only`   | `bool`        | If `true`, only position-closing portion is kept                       |
-| `tp`            | `ChildOrder?` | Optional take-profit child order (see [§6.3](#63-submit-market-order)) |
-| `sl`            | `ChildOrder?` | Optional stop-loss child order (see [§6.3](#63-submit-market-order))   |
+| Field             | Type             | Description                                                            |
+| ----------------- | ---------------- | ---------------------------------------------------------------------- |
+| `limit_price`     | `UsdPrice`       | Limit price — must be aligned to `tick_size`                           |
+| `time_in_force`   | `TimeInForce`    | `"GTC"` (default), `"IOC"`, or `"POST"` — see below                    |
+| `client_order_id` | `ClientOrderId?` | Optional caller-assigned id for in-flight cancel — see below           |
+| `reduce_only`     | `bool`           | If `true`, only position-closing portion is kept                       |
+| `tp`              | `ChildOrder?`    | Optional take-profit child order (see [§6.3](#63-submit-market-order)) |
+| `sl`              | `ChildOrder?`    | Optional stop-loss child order (see [§6.3](#63-submit-market-order))   |
 
 **Time-in-force options:**
 
@@ -1692,9 +1694,17 @@ Place a resting order on the book:
 - **IOC** (Immediate-Or-Cancel): fills as much as possible against the book, then discards any unfilled remainder. Errors if nothing fills at all.
 - **POST** (Post-Only): the entire order is placed on the book without matching. Rejected if the limit price would cross the best offer on the opposite side.
 
+**Client order id:**
+
+`client_order_id` is a caller-assigned `Uint64` that lets an algo trader cancel an order in the same block it was submitted, without round-tripping through the server response to learn the system-assigned `OrderId`. Cancel via [`CancelOrderRequest::OneByClientOrderId`](#65-cancel-order).
+
+- Uniqueness scope: per-sender, across the sender's _active_ (resting) limit orders only. The contract does not remember client order ids of orders that have been canceled or filled, so they can be reused freely.
+- Submitting a second order with a `client_order_id` that the sender already has on the book fails with `duplicate_data`.
+- Not allowed with `time_in_force: "IOC"` — IOC never enters the book, so the alias would be unreachable. Submission is rejected with a clear error.
+
 ### 6.5 Cancel order
 
-**Cancel a single order:**
+**Cancel a single order by system-assigned `OrderId`:**
 
 ```json
 {
@@ -1711,6 +1721,28 @@ Place a resting order on the book:
   }
 }
 ```
+
+**Cancel a single order by caller-assigned `ClientOrderId`:**
+
+```json
+{
+  "execute": {
+    "contract": "PERPS_CONTRACT",
+    "msg": {
+      "trade": {
+        "cancel_order": {
+          "one_by_client_order_id": "42"
+        }
+      }
+    },
+    "funds": {}
+  }
+}
+```
+
+This resolves to the active order owned by the sender that carries the given `client_order_id` (see [§6.4](#64-submit-limit-order)). It bails if no such order exists. The lookup is per-sender, so two traders can independently use the same `client_order_id` value without colliding.
+
+Pattern: an algo trader can submit and cancel in the same block by reusing the `client_order_id` they assigned at submission, without waiting for the server response.
 
 **Cancel all orders:**
 
@@ -2094,11 +2126,13 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 ### Order events
 
-| Event             | Fields                                                                                                          | Description                     |
-| ----------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `fee` | Order partially or fully filled |
-| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`                                                            | Limit order placed on book      |
-| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`                                                                         | Order removed from book         |
+| Event             | Fields                                                                                                                              | Description                     |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `fee`, `client_order_id?` | Order partially or fully filled |
+| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                            | Limit order placed on book      |
+| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                         | Order removed from book         |
+
+`client_order_id` is `null` if the order was submitted without one. Off-chain consumers can use it to correlate fills, persistence, and removal with the originally-submitted client id.
 
 ### Conditional order events
 
@@ -2162,6 +2196,7 @@ Additional integer types:
 | `PairId`             | `perp/<base><quote>`            | `"perp/btcusd"`, `"perp/ethusd"` |
 | `OrderId`            | `Uint64` (string)               | `"42"`                           |
 | `ConditionalOrderId` | `Uint64` (shared counter)       | `"43"`                           |
+| `ClientOrderId`      | `Uint64` (caller-assigned)      | `"42"`                           |
 | `Addr`               | Hex address                     | `"0x1234...abcd"`                |
 | `Hash256`            | 64-char hex                     | `"a1b2c3d4e5f6..."`              |
 | `UserIndex`          | `u32`                           | `0`                              |
@@ -2186,10 +2221,13 @@ Additional integer types:
 {
   "limit": {
     "limit_price": "65000.000000",
-    "time_in_force": "GTC"
+    "time_in_force": "GTC",
+    "client_order_id": "42"
   }
 }
 ```
+
+`client_order_id` is optional. Defaults to `null` when omitted; not allowed with `time_in_force: "IOC"`.
 
 **TimeInForce:** `"GTC"` | `"IOC"` | `"POST"` (defaults to `"GTC"` if omitted)
 
@@ -2208,6 +2246,12 @@ Additional integer types:
 ```json
 {
   "one": "42"
+}
+```
+
+```json
+{
+  "one_by_client_order_id": "42"
 }
 ```
 

--- a/dango/perps/src/core/target_price.rs
+++ b/dango/perps/src/core/target_price.rs
@@ -84,6 +84,7 @@ mod tests {
                 OrderKind::Limit {
                     limit_price: UsdPrice::new_int(limit),
                     time_in_force: TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
                 },
                 UsdPrice::new_int(100),
                 is_bid

--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -173,6 +173,9 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
             TraderMsg::CancelOrder(CancelOrderRequest::One(order_id)) => {
                 trade::cancel_one_order(ctx, order_id)
             },
+            TraderMsg::CancelOrder(CancelOrderRequest::OneByClientOrderId(cid)) => {
+                trade::cancel_one_order_by_client_order_id(ctx, cid)
+            },
             TraderMsg::CancelOrder(CancelOrderRequest::All) => trade::cancel_all_orders(ctx),
             TraderMsg::SubmitConditionalOrder {
                 pair_id,

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -997,6 +997,7 @@ mod tests {
             created_at: Timestamp::ZERO,
             tp: None,
             sl: None,
+            client_order_id: None,
         };
         BIDS.save(storage, key, &order).unwrap();
     }
@@ -1020,6 +1021,7 @@ mod tests {
             created_at: Timestamp::ZERO,
             tp: None,
             sl: None,
+            client_order_id: None,
         };
         ASKS.save(storage, key, &order).unwrap();
     }
@@ -2205,6 +2207,7 @@ mod tests {
                     max_slippage: Dimensionless::new_percent(2),
                     size: None,
                 }),
+                client_order_id: None,
             };
             BIDS.save(&mut ctx.storage, key, &order).unwrap();
         }

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -591,8 +591,8 @@ fn execute_close_schedule(
             user_state,
             taker_is_bid,
             OrderId::ZERO,
-            None, // liquidation has no client_order_id
-            Dimensionless::ZERO, // zero trading fee for the liquidated taker
+            None,                      // liquidation has no client_order_id
+            Dimensionless::ZERO,       // zero trading fee for the liquidated taker
             Some(Dimensionless::ZERO), // zero trading fee for makers, even if they have overrides
             maker_states,
             target_price,

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -591,6 +591,7 @@ fn execute_close_schedule(
             user_state,
             taker_is_bid,
             OrderId::ZERO,
+            None, // liquidation has no client_order_id
             Dimensionless::ZERO, // zero trading fee for the liquidated taker
             Some(Dimensionless::ZERO), // zero trading fee for makers, even if they have overrides
             maker_states,

--- a/dango/perps/src/state.rs
+++ b/dango/perps/src/state.rs
@@ -3,9 +3,9 @@ use {
         Dimensionless, Quantity, UsdPrice, UsdValue,
         account_factory::UserIndex,
         perps::{
-            CommissionRate, ConditionalOrderId, FeeShareRatio, LimitOrder, OrderId, PairId,
-            PairParam, PairState, Param, Referee, RefereeStats, Referrer, State, TriggerDirection,
-            UserReferralData, UserState,
+            ClientOrderId, CommissionRate, ConditionalOrderId, FeeShareRatio, LimitOrder, OrderId,
+            PairId, PairParam, PairState, Param, Referee, RefereeStats, Referrer, State,
+            TriggerDirection, UserReferralData, UserState,
         },
     },
     grug::{Addr, IndexedMap, Item, Map, MultiIndex, Set, Timestamp, UniqueIndex},
@@ -44,12 +44,16 @@ pub const LONGS: Set<(PairId, UsdPrice, Addr)> = Set::new("long");
 pub const SHORTS: Set<(PairId, UsdPrice, Addr)> = Set::new("short");
 
 /// Buy orders.
-pub const BIDS: IndexedMap<OrderKey, LimitOrder, OrderIndexes> =
-    IndexedMap::new("bid", OrderIndexes::new("bid", "bid__id", "bid__user"));
+pub const BIDS: IndexedMap<OrderKey, LimitOrder, OrderIndexes> = IndexedMap::new(
+    "bid",
+    OrderIndexes::new("bid", "bid__id", "bid__user", "bid__cid"),
+);
 
 /// Sell orders.
-pub const ASKS: IndexedMap<OrderKey, LimitOrder, OrderIndexes> =
-    IndexedMap::new("ask", OrderIndexes::new("ask", "ask__id", "ask__user"));
+pub const ASKS: IndexedMap<OrderKey, LimitOrder, OrderIndexes> = IndexedMap::new(
+    "ask",
+    OrderIndexes::new("ask", "ask__id", "ask__user", "ask__cid"),
+);
 
 /// Liquidity depths of the order book.
 pub const DEPTHS: Map<DepthKey, (Quantity, UsdValue)> = Map::new("depth");
@@ -100,6 +104,12 @@ pub type OrderKey = (PairId, UsdPrice, OrderId);
 pub struct OrderIndexes<'a> {
     pub order_id: UniqueIndex<'a, OrderKey, OrderId, LimitOrder>,
     pub user: MultiIndex<'a, OrderKey, Addr, LimitOrder>,
+    /// Lets a trader cancel an order in the same block it was submitted, by
+    /// the caller-assigned `client_order_id`. The index function returns at
+    /// most one key — empty `Vec` for orders submitted without a
+    /// `client_order_id`. Uniqueness is per-sender, enforced by
+    /// `UniqueIndex` (returns `StdError::duplicate_data` on collision).
+    pub client_order_id: UniqueIndex<'a, OrderKey, (Addr, ClientOrderId), LimitOrder>,
 }
 
 impl OrderIndexes<'static> {
@@ -107,6 +117,7 @@ impl OrderIndexes<'static> {
         pk_namespace: &'static str,
         order_id_namespace: &'static str,
         user_namespace: &'static str,
+        client_order_id_namespace: &'static str,
     ) -> Self {
         OrderIndexes {
             order_id: UniqueIndex::new(
@@ -115,6 +126,14 @@ impl OrderIndexes<'static> {
                 order_id_namespace,
             ),
             user: MultiIndex::new(|_, order| order.user, pk_namespace, user_namespace),
+            client_order_id: UniqueIndex::new2(
+                |_, order| match order.client_order_id {
+                    Some(cid) => vec![(order.user, cid)],
+                    None => Vec::new(),
+                },
+                pk_namespace,
+                client_order_id_namespace,
+            ),
         }
     }
 }

--- a/dango/perps/src/trade/cancel_order.rs
+++ b/dango/perps/src/trade/cancel_order.rs
@@ -106,6 +106,7 @@ where
             pair_id,
             user: order.user,
             reason,
+            client_order_id: order.client_order_id,
         })?;
     }
 
@@ -256,7 +257,7 @@ mod tests {
             FundingPerUnit, Quantity, UsdPrice, UsdValue,
             perps::{LimitOrder, PairId, PairParam, Position, UserState},
         },
-        grug::{Addr, Coins, MockContext, ResultExt, Storage, Timestamp, Uint64},
+        grug::{Addr, Coins, EventName, JsonDeExt, MockContext, ResultExt, Storage, Timestamp, Uint64},
         std::collections::{BTreeMap, VecDeque},
     };
 
@@ -793,6 +794,30 @@ mod tests {
 
         cancel_one_order_by_client_order_id(ctx.as_mutable(), Uint64::new(99))
             .should_fail_with_error("order not found");
+    }
+
+    /// `OrderRemoved` events emitted by `cancel_one_order` carry the
+    /// resting order's `client_order_id`, so off-chain consumers can
+    /// correlate the cancellation with the originally-submitted cid.
+    #[test]
+    fn cancel_emits_order_removed_with_client_order_id() {
+        let mut ctx = MockContext::new()
+            .with_sender(USER)
+            .with_funds(Coins::default());
+
+        save_bid_with_cid(&mut ctx.storage, 1, USER, 10, 100, 7);
+        save_user_state(&mut ctx.storage, USER, 1, 100, BTreeMap::new());
+
+        let response = cancel_one_order(ctx.as_mutable(), Uint64::new(1)).unwrap();
+        let event = response
+            .subevents
+            .iter()
+            .find(|e| e.ty == OrderRemoved::EVENT_NAME)
+            .expect("OrderRemoved event missing");
+        let order_removed: OrderRemoved = event.data.clone().deserialize_json().unwrap();
+        assert_eq!(order_removed.order_id, Uint64::new(1));
+        assert_eq!(order_removed.user, USER);
+        assert_eq!(order_removed.client_order_id, Some(Uint64::new(7)));
     }
 
     /// Two different users can independently use the same `client_order_id`

--- a/dango/perps/src/trade/cancel_order.rs
+++ b/dango/perps/src/trade/cancel_order.rs
@@ -7,7 +7,8 @@ use {
     },
     anyhow::{anyhow, ensure},
     dango_types::perps::{
-        LimitOrder, OrderId, OrderRemoved, PairId, PairParam, ReasonForOrderRemoval, UserState,
+        ClientOrderId, LimitOrder, OrderId, OrderRemoved, PairId, PairParam, ReasonForOrderRemoval,
+        UserState,
     },
     grug::{Addr, EventBuilder, MutableCtx, Order as IterationOrder, Response, StdResult, Storage},
     std::collections::{BTreeMap, BTreeSet},
@@ -109,6 +110,34 @@ where
     }
 
     Ok(())
+}
+
+/// Cancel one of the sender's resting limit orders, looked up by the
+/// `ClientOrderId` the sender assigned at submission time.
+///
+/// The `(sender, client_order_id)` index on `BIDS` / `ASKS` is consulted
+/// — that index is per-sender, so the lookup can only ever return orders
+/// owned by `ctx.sender`. The actual cancellation delegates to
+/// [`cancel_one_order`].
+pub fn cancel_one_order_by_client_order_id(
+    ctx: MutableCtx,
+    client_order_id: ClientOrderId,
+) -> anyhow::Result<Response> {
+    let key = (ctx.sender, client_order_id);
+
+    let (_, _, order_id) = BIDS
+        .idx
+        .client_order_id
+        .may_load_key(ctx.storage, key)?
+        .or(ASKS.idx.client_order_id.may_load_key(ctx.storage, key)?)
+        .ok_or_else(|| {
+            anyhow!(
+                "order not found with user {} and client_order_id {client_order_id}",
+                ctx.sender
+            )
+        })?;
+
+    cancel_one_order(ctx, order_id)
 }
 
 pub fn cancel_all_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
@@ -295,6 +324,57 @@ mod tests {
             tp: None,
             sl: None,
             client_order_id: None,
+        };
+
+        ASKS.save(storage, key, &order).unwrap();
+    }
+
+    /// Save a bid carrying a `client_order_id` so the
+    /// `cancel_one_order_by_client_order_id` tests can resolve it.
+    fn save_bid_with_cid(
+        storage: &mut dyn Storage,
+        order_id: u64,
+        user: Addr,
+        size: i128,
+        reserved_margin: i128,
+        cid: u64,
+    ) {
+        ensure_pair_param(storage);
+        let key = order_key(order_id);
+        let order = LimitOrder {
+            user,
+            size: Quantity::new_int(size),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(reserved_margin),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: Some(Uint64::new(cid)),
+        };
+
+        BIDS.save(storage, key, &order).unwrap();
+    }
+
+    /// Same as [`save_bid_with_cid`] but for asks.
+    fn save_ask_with_cid(
+        storage: &mut dyn Storage,
+        order_id: u64,
+        user: Addr,
+        size: i128,
+        reserved_margin: i128,
+        cid: u64,
+    ) {
+        ensure_pair_param(storage);
+        let key = order_key(order_id);
+        let order = LimitOrder {
+            user,
+            size: Quantity::new_int(size),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(reserved_margin),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: Some(Uint64::new(cid)),
         };
 
         ASKS.save(storage, key, &order).unwrap();
@@ -640,5 +720,119 @@ mod tests {
         assert_eq!(state.open_order_count, 0);
         assert_eq!(state.reserved_margin, UsdValue::ZERO);
         assert!(!state.is_empty());
+    }
+
+    // ============== cancel_one_order_by_client_order_id tests ====================
+
+    #[test]
+    fn cancel_one_order_by_client_order_id_bid() {
+        let mut ctx = MockContext::new()
+            .with_sender(USER)
+            .with_funds(Coins::default());
+
+        save_bid_with_cid(&mut ctx.storage, 1, USER, 10, 100, 7);
+        save_user_state(&mut ctx.storage, USER, 1, 100, BTreeMap::new());
+
+        cancel_one_order_by_client_order_id(ctx.as_mutable(), Uint64::new(7)).should_succeed();
+
+        // Primary entry gone.
+        assert!(
+            BIDS.idx
+                .order_id
+                .may_load(&ctx.storage, Uint64::new(1))
+                .unwrap()
+                .is_none()
+        );
+
+        // Index entry gone — the same `cid` is reusable.
+        assert!(
+            BIDS.idx
+                .client_order_id
+                .may_load_key(&ctx.storage, (USER, Uint64::new(7)))
+                .unwrap()
+                .is_none()
+        );
+
+        // User state cleaned up (was empty).
+        assert!(USER_STATES.may_load(&ctx.storage, USER).unwrap().is_none());
+    }
+
+    #[test]
+    fn cancel_one_order_by_client_order_id_ask() {
+        let mut ctx = MockContext::new()
+            .with_sender(USER)
+            .with_funds(Coins::default());
+
+        save_ask_with_cid(&mut ctx.storage, 1, USER, -10, 100, 7);
+        save_user_state(&mut ctx.storage, USER, 1, 100, BTreeMap::new());
+
+        cancel_one_order_by_client_order_id(ctx.as_mutable(), Uint64::new(7)).should_succeed();
+
+        assert!(
+            ASKS.idx
+                .order_id
+                .may_load(&ctx.storage, Uint64::new(1))
+                .unwrap()
+                .is_none()
+        );
+
+        assert!(
+            ASKS.idx
+                .client_order_id
+                .may_load_key(&ctx.storage, (USER, Uint64::new(7)))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn cancel_one_order_by_client_order_id_not_found() {
+        let mut ctx = MockContext::new()
+            .with_sender(USER)
+            .with_funds(Coins::default());
+
+        cancel_one_order_by_client_order_id(ctx.as_mutable(), Uint64::new(99))
+            .should_fail_with_error("order not found");
+    }
+
+    /// Two different users can independently use the same `client_order_id`
+    /// value; each can only cancel their own.
+    #[test]
+    fn cancel_one_order_by_client_order_id_other_user_isolated() {
+        let mut ctx = MockContext::new()
+            .with_sender(USER)
+            .with_funds(Coins::default());
+
+        // OTHER_USER also uses cid=7, on a separate order id.
+        save_bid_with_cid(&mut ctx.storage, 1, USER, 10, 100, 7);
+        save_bid_with_cid(&mut ctx.storage, 2, OTHER_USER, 5, 50, 7);
+        save_user_state(&mut ctx.storage, USER, 1, 100, BTreeMap::new());
+        save_user_state(&mut ctx.storage, OTHER_USER, 1, 50, BTreeMap::new());
+
+        // USER cancels by cid=7 — only USER's order should disappear.
+        cancel_one_order_by_client_order_id(ctx.as_mutable(), Uint64::new(7)).should_succeed();
+
+        assert!(
+            BIDS.idx
+                .order_id
+                .may_load(&ctx.storage, Uint64::new(1))
+                .unwrap()
+                .is_none()
+        );
+        // OTHER_USER's order with the same cid is untouched.
+        assert!(
+            BIDS.idx
+                .order_id
+                .may_load(&ctx.storage, Uint64::new(2))
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            BIDS.idx
+                .client_order_id
+                .may_load_key(&ctx.storage, (OTHER_USER, Uint64::new(7)))
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/dango/perps/src/trade/cancel_order.rs
+++ b/dango/perps/src/trade/cancel_order.rs
@@ -280,7 +280,9 @@ mod tests {
             FundingPerUnit, Quantity, UsdPrice, UsdValue,
             perps::{LimitOrder, PairId, PairParam, Position, UserState},
         },
-        grug::{Addr, Coins, EventName, JsonDeExt, MockContext, ResultExt, Storage, Timestamp, Uint64},
+        grug::{
+            Addr, Coins, EventName, JsonDeExt, MockContext, ResultExt, Storage, Timestamp, Uint64,
+        },
         std::collections::{BTreeMap, VecDeque},
     };
 

--- a/dango/perps/src/trade/cancel_order.rs
+++ b/dango/perps/src/trade/cancel_order.rs
@@ -270,6 +270,7 @@ mod tests {
             created_at: Timestamp::from_nanos(0),
             tp: None,
             sl: None,
+            client_order_id: None,
         };
 
         BIDS.save(storage, key, &order).unwrap();
@@ -293,6 +294,7 @@ mod tests {
             created_at: Timestamp::from_nanos(0),
             tp: None,
             sl: None,
+            client_order_id: None,
         };
 
         ASKS.save(storage, key, &order).unwrap();

--- a/dango/perps/src/trade/cancel_order.rs
+++ b/dango/perps/src/trade/cancel_order.rs
@@ -118,27 +118,50 @@ where
 ///
 /// The `(sender, client_order_id)` index on `BIDS` / `ASKS` is consulted
 /// — that index is per-sender, so the lookup can only ever return orders
-/// owned by `ctx.sender`. The actual cancellation delegates to
-/// [`cancel_one_order`].
+/// owned by `ctx.sender`, which means no redundant ownership check is
+/// needed. The actual cancellation delegates to [`_cancel_one_order`]
+/// with the loaded `(order_key, order)` so we don't re-resolve through
+/// the `order_id` index.
 pub fn cancel_one_order_by_client_order_id(
     ctx: MutableCtx,
     client_order_id: ClientOrderId,
 ) -> anyhow::Result<Response> {
     let key = (ctx.sender, client_order_id);
 
-    let (_, _, order_id) = BIDS
+    // `or_else` is lazy: ASKS is only consulted on a BIDS miss.
+    let (order_key, order) = BIDS
         .idx
         .client_order_id
-        .may_load_key(ctx.storage, key)?
-        .or(ASKS.idx.client_order_id.may_load_key(ctx.storage, key)?)
+        .may_load(ctx.storage, key)
+        .transpose()
+        .or_else(|| {
+            ASKS.idx
+                .client_order_id
+                .may_load(ctx.storage, key)
+                .transpose()
+        })
         .ok_or_else(|| {
             anyhow!(
                 "order not found with user {} and client_order_id {client_order_id}",
                 ctx.sender
             )
-        })?;
+        })??;
 
-    cancel_one_order(ctx, order_id)
+    let mut events = EventBuilder::new();
+
+    update_user_state_with(ctx.storage, ctx.sender, |storage, user_state| {
+        _cancel_one_order(
+            storage,
+            user_state,
+            order_key,
+            order,
+            Some(&mut events),
+            ReasonForOrderRemoval::Canceled,
+            |storage, pair_id| PAIR_PARAMS.load(storage, pair_id),
+        )
+    })?;
+
+    Ok(Response::new().add_events(events)?)
 }
 
 pub fn cancel_all_orders(ctx: MutableCtx) -> anyhow::Result<Response> {

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -22,14 +22,15 @@ use {
         },
         volume::flush_volumes,
     },
-    anyhow::ensure,
+    anyhow::{bail, ensure},
     dango_oracle::OracleQuerier,
     dango_types::{
         Dimensionless, Quantity, UsdPrice, UsdValue,
         perps::{
-            ChildOrder, ConditionalOrder, ConditionalOrderPlaced, LimitOrder, OrderFilled, OrderId,
-            OrderKind, OrderPersisted, OrderRemoved, PairId, PairParam, PairState, Param,
-            ReasonForOrderRemoval, State, TimeInForce, TriggerDirection, UserState,
+            ChildOrder, ClientOrderId, ConditionalOrder, ConditionalOrderPlaced, LimitOrder,
+            OrderFilled, OrderId, OrderKind, OrderPersisted, OrderRemoved, PairId, PairParam,
+            PairState, Param, ReasonForOrderRemoval, State, TimeInForce, TriggerDirection,
+            UserState,
         },
     },
     grug::{
@@ -331,6 +332,18 @@ pub(crate) fn _submit_order(
         },
     }
 
+    // IOC limit orders never enter the book, so a `client_order_id` would
+    // never be reachable for cancellation — disallow it to surface the
+    // misconfiguration loudly instead of silently dropping the id.
+    if let OrderKind::Limit {
+        time_in_force: TimeInForce::ImmediateOrCancel,
+        client_order_id: Some(_),
+        ..
+    } = &kind
+    {
+        bail!("client_order_id is not allowed with TimeInForce::ImmediateOrCancel");
+    }
+
     for child_order in [&tp, &sl].into_iter().flatten() {
         ensure!(
             child_order.trigger_price.is_positive(),
@@ -377,7 +390,12 @@ pub(crate) fn _submit_order(
 
     // ---------------------- Step 4. Post-only fast path ----------------------
 
-    if let Some(limit_price) = kind.post_only_price() {
+    if let OrderKind::Limit {
+        limit_price,
+        time_in_force: TimeInForce::PostOnly,
+        client_order_id,
+    } = kind
+    {
         let StoreLimitOrderOutcome {
             user_state: updated_taker_state,
             stored_price,
@@ -398,6 +416,7 @@ pub(crate) fn _submit_order(
             taker_order_id,
             tp,
             sl,
+            client_order_id,
         )?;
 
         taker_state = updated_taker_state;
@@ -512,6 +531,7 @@ pub(crate) fn _submit_order(
             OrderKind::Limit {
                 limit_price,
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id,
             } => {
                 let StoreLimitOrderOutcome {
                     user_state: updated_taker_state,
@@ -532,6 +552,7 @@ pub(crate) fn _submit_order(
                     taker_order_id,
                     tp.clone(),
                     sl.clone(),
+                    client_order_id,
                 )?;
 
                 taker_state = updated_taker_state;
@@ -1175,6 +1196,7 @@ fn store_post_only_limit_order(
     order_id: OrderId,
     tp: Option<ChildOrder>,
     sl: Option<ChildOrder>,
+    client_order_id: Option<ClientOrderId>,
 ) -> anyhow::Result<StoreLimitOrderOutcome> {
     let taker_is_bid = size.is_positive();
     let maker_is_bid = !taker_is_bid;
@@ -1220,6 +1242,7 @@ fn store_post_only_limit_order(
         order_id,
         tp,
         sl,
+        client_order_id,
     )
 }
 
@@ -1257,6 +1280,7 @@ fn store_limit_order(
     order_id: OrderId,
     tp: Option<ChildOrder>,
     sl: Option<ChildOrder>,
+    client_order_id: Option<ClientOrderId>,
 ) -> anyhow::Result<StoreLimitOrderOutcome> {
     ensure!(
         user_state.open_order_count < param.max_open_orders,
@@ -1315,6 +1339,7 @@ fn store_limit_order(
             created_at: current_time,
             tp,
             sl,
+            client_order_id,
         },
     })
 }
@@ -1494,6 +1519,7 @@ mod tests {
             created_at: Timestamp::from_nanos(0),
             tp: None,
             sl: None,
+            client_order_id: None,
         };
         ASKS.save(storage, key, &order).unwrap();
 
@@ -1521,6 +1547,7 @@ mod tests {
             created_at: Timestamp::from_nanos(0),
             tp: None,
             sl: None,
+            client_order_id: None,
         };
         BIDS.save(storage, key, &order).unwrap();
 
@@ -1750,6 +1777,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: None,
             },
             false,
             None,
@@ -1806,6 +1834,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: None,
             },
             false,
             None,
@@ -1866,6 +1895,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: None,
             },
             false,
             None,
@@ -1924,6 +1954,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::ImmediateOrCancel,
+                client_order_id: None,
             },
             false,
             None,
@@ -1982,6 +2013,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::ImmediateOrCancel,
+                client_order_id: None,
             },
             false,
             None,
@@ -2336,6 +2368,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_100),
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: None,
             },
             false,
             None,
@@ -2385,6 +2418,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_050),
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: None,
             },
             false,
             None,
@@ -3530,6 +3564,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -3583,6 +3618,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -3629,6 +3665,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -3681,6 +3718,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -3733,6 +3771,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -3784,6 +3823,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -3846,6 +3886,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(51_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             true,
             None,
@@ -3905,6 +3946,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -4760,6 +4802,7 @@ mod tests {
                 OrderKind::Limit {
                     limit_price: UsdPrice::new_int(50_000),
                     time_in_force: TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
                 },
                 false,
                 None,
@@ -5050,6 +5093,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(50_000),
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: None,
             },
             false,
             make_tp(55_000),
@@ -5116,6 +5160,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(49_000),
                 time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: None,
             },
             false,
             make_tp(55_000),
@@ -5157,6 +5202,7 @@ mod tests {
             created_at: Timestamp::from_nanos(0),
             tp: make_tp(45_000),
             sl: make_sl(55_000),
+            client_order_id: None,
         };
         ASKS.save(&mut ctx.storage, key, &order).unwrap();
 
@@ -5460,6 +5506,7 @@ mod tests {
             created_at: Timestamp::from_nanos(0),
             tp: make_tp(55_000),
             sl: make_sl(45_000),
+            client_order_id: None,
         };
         BIDS.save(&mut ctx.storage, key, &order).unwrap();
 
@@ -5669,6 +5716,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::new_int(-1_000),
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -5716,6 +5764,7 @@ mod tests {
             OrderKind::Limit {
                 limit_price: UsdPrice::ZERO,
                 time_in_force: TimeInForce::PostOnly,
+                client_order_id: None,
             },
             false,
             None,
@@ -6115,5 +6164,278 @@ mod tests {
             ..Default::default()
         };
         USER_STATES.save(storage, TAKER, &ts).unwrap();
+    }
+
+    // ======================== client_order_id tests ==========================
+
+    /// A GTC limit order carrying a `client_order_id` is reachable via the
+    /// `(sender, cid)` index and the stored `LimitOrder.client_order_id`
+    /// matches the submitted value.
+    #[test]
+    fn submit_limit_with_client_order_id_indexes_it() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+        let cid = Uint64::new(7);
+
+        let SubmitOrderOutcome { order_to_store, .. } = _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Limit {
+                limit_price: UsdPrice::new_int(49_000),
+                time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: Some(cid),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .unwrap();
+
+        let (stored_price, order_id, order) = order_to_store.unwrap();
+        assert_eq!(order.client_order_id, Some(cid));
+
+        // Apply the outcome: persist the resting order. The new
+        // `client_order_id` index entry is written by `IndexedMap::save`.
+        BIDS.save(
+            &mut ctx.storage,
+            (pair_id(), stored_price, order_id),
+            &order,
+        )
+        .unwrap();
+
+        let key = BIDS
+            .idx
+            .client_order_id
+            .may_load_key(&ctx.storage, (TAKER, cid))
+            .unwrap();
+        assert_eq!(key, Some((pair_id(), stored_price, order_id)));
+    }
+
+    /// IOC limit orders never enter the book, so a `client_order_id` is
+    /// meaningless — `_submit_order` rejects with a clear error.
+    #[test]
+    fn submit_ioc_with_client_order_id_rejects() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Limit {
+                limit_price: UsdPrice::new_int(49_000),
+                time_in_force: TimeInForce::ImmediateOrCancel,
+                client_order_id: Some(Uint64::new(7)),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .should_fail_with_error("client_order_id is not allowed");
+    }
+
+    /// Submitting a second resting order with a `client_order_id` already
+    /// owned by the same sender is rejected by the `UniqueIndex` (returns
+    /// `StdError::duplicate_data`).
+    #[test]
+    fn submit_duplicate_client_order_id_rejects() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        let cid = Uint64::new(7);
+
+        let order_a = LimitOrder {
+            user: TAKER,
+            size: Quantity::new_int(5),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(12_500),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: Some(cid),
+        };
+        BIDS.save(
+            &mut ctx.storage,
+            (pair_id(), !UsdPrice::new_int(49_000), Uint64::new(1)),
+            &order_a,
+        )
+        .unwrap();
+
+        // A second order with the same (TAKER, cid) — different price/id, so
+        // the primary key differs, but the `client_order_id` index collides.
+        let order_b = LimitOrder {
+            user: TAKER,
+            size: Quantity::new_int(5),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(12_500),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: Some(cid),
+        };
+        let err = BIDS
+            .save(
+                &mut ctx.storage,
+                (pair_id(), !UsdPrice::new_int(48_000), Uint64::new(2)),
+                &order_b,
+            )
+            .unwrap_err();
+        assert!(
+            format!("{err:?}").to_lowercase().contains("duplicate"),
+            "expected duplicate_data error, got: {err:?}"
+        );
+    }
+
+    /// When a maker order with a `client_order_id` is fully filled and
+    /// removed from the book, the `(sender, cid)` index entry is cleared
+    /// automatically by `IndexedMap::remove`.
+    #[test]
+    fn client_order_id_alias_clears_on_fill() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        let cid = Uint64::new(7);
+
+        // Place a maker ask owned by MAKER_A with cid=Some(7).
+        let maker_order = LimitOrder {
+            user: MAKER_A,
+            size: Quantity::new_int(-10),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(25_000),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: Some(cid),
+        };
+        let maker_key = (pair_id(), UsdPrice::new_int(50_000), Uint64::new(100));
+        ASKS.save(&mut ctx.storage, maker_key, &maker_order).unwrap();
+        USER_STATES
+            .save(
+                &mut ctx.storage,
+                MAKER_A,
+                &UserState {
+                    margin: LARGE_COLLATERAL,
+                    open_order_count: 1,
+                    reserved_margin: UsdValue::new_int(25_000),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // Sanity: the alias is reachable before the fill.
+        assert!(
+            ASKS.idx
+                .client_order_id
+                .may_load_key(&ctx.storage, (MAKER_A, cid))
+                .unwrap()
+                .is_some()
+        );
+
+        // Taker fully fills the maker.
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        let SubmitOrderOutcome {
+            order_mutations, ..
+        } = _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_percent(10),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .unwrap();
+
+        // Apply the order mutation: a `None` mutation removes the maker.
+        for (stored_price, order_id, mutation, _) in order_mutations {
+            let key = (pair_id(), stored_price, order_id);
+            match mutation {
+                Some(o) => ASKS.save(&mut ctx.storage, key, &o).unwrap(),
+                None => ASKS.remove(&mut ctx.storage, key).unwrap(),
+            }
+        }
+
+        // After full fill, the alias is gone — same `cid` is reusable.
+        assert!(
+            ASKS.idx
+                .client_order_id
+                .may_load_key(&ctx.storage, (MAKER_A, cid))
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -501,7 +501,9 @@ pub(crate) fn _submit_order(
         // `OrderFilled` event so off-chain consumers can correlate fills
         // with the originally-submitted order.
         match kind {
-            OrderKind::Limit { client_order_id, .. } => client_order_id,
+            OrderKind::Limit {
+                client_order_id, ..
+            } => client_order_id,
             OrderKind::Market { .. } => None,
         },
         taker_fee_rate,
@@ -6385,16 +6387,12 @@ mod tests {
         )
         .unwrap();
         USER_STATES
-            .save(
-                &mut ctx.storage,
-                MAKER_A,
-                &UserState {
-                    margin: LARGE_COLLATERAL,
-                    open_order_count: 1,
-                    reserved_margin: UsdValue::new_int(25_000),
-                    ..Default::default()
-                },
-            )
+            .save(&mut ctx.storage, MAKER_A, &UserState {
+                margin: LARGE_COLLATERAL,
+                open_order_count: 1,
+                reserved_margin: UsdValue::new_int(25_000),
+                ..Default::default()
+            })
             .unwrap();
 
         let param = test_param();
@@ -6440,11 +6438,7 @@ mod tests {
             .map(|e| e.data.deserialize_json().unwrap())
             .collect();
 
-        assert_eq!(
-            order_filleds.len(),
-            2,
-            "expected one OrderFilled per side"
-        );
+        assert_eq!(order_filleds.len(), 2, "expected one OrderFilled per side");
 
         let taker_filled = order_filleds
             .iter()
@@ -6484,18 +6478,15 @@ mod tests {
             client_order_id: Some(cid),
         };
         let maker_key = (pair_id(), UsdPrice::new_int(50_000), Uint64::new(100));
-        ASKS.save(&mut ctx.storage, maker_key, &maker_order).unwrap();
+        ASKS.save(&mut ctx.storage, maker_key, &maker_order)
+            .unwrap();
         USER_STATES
-            .save(
-                &mut ctx.storage,
-                MAKER_A,
-                &UserState {
-                    margin: LARGE_COLLATERAL,
-                    open_order_count: 1,
-                    reserved_margin: UsdValue::new_int(25_000),
-                    ..Default::default()
-                },
-            )
+            .save(&mut ctx.storage, MAKER_A, &UserState {
+                margin: LARGE_COLLATERAL,
+                open_order_count: 1,
+                reserved_margin: UsdValue::new_int(25_000),
+                ..Default::default()
+            })
             .unwrap();
 
         // Sanity: the alias is reachable before the fill.

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -210,6 +210,7 @@ pub fn submit_order(
             user: ctx.sender,
             limit_price,
             size: order.size,
+            client_order_id: order.client_order_id,
         })?;
     }
 
@@ -496,6 +497,13 @@ pub(crate) fn _submit_order(
         &taker_state,
         taker_is_bid,
         taker_order_id,
+        // Surface the taker's `client_order_id` (if any) on the
+        // `OrderFilled` event so off-chain consumers can correlate fills
+        // with the originally-submitted order.
+        match kind {
+            OrderKind::Limit { client_order_id, .. } => client_order_id,
+            OrderKind::Market { .. } => None,
+        },
         taker_fee_rate,
         None, // no forced maker fee; respect per-user overrides and tier schedule
         &BTreeMap::new(),
@@ -667,6 +675,7 @@ pub fn match_order(
     taker_state: &UserState,
     taker_is_bid: bool,
     taker_order_id: OrderId,
+    taker_client_order_id: Option<ClientOrderId>,
     taker_fee_rate: Dimensionless,
     force_maker_fee_rate: Option<Dimensionless>,
     maker_states: &BTreeMap<Addr, UserState>,
@@ -738,6 +747,7 @@ pub fn match_order(
                 pair_id: pair_id.clone(),
                 user: taker,
                 reason: ReasonForOrderRemoval::SelfTradePrevention,
+                client_order_id: maker_order.client_order_id,
             })?;
 
             continue;
@@ -780,6 +790,7 @@ pub fn match_order(
                 pair_id: pair_id.clone(),
                 user: maker_order.user,
                 reason: ReasonForOrderRemoval::PriceBandViolation,
+                client_order_id: maker_order.client_order_id,
             })?;
 
             continue;
@@ -813,7 +824,7 @@ pub fn match_order(
             &mut pnls,
             &mut fees,
             &mut volumes,
-            Some((events, taker_order_id)),
+            Some((events, taker_order_id, taker_client_order_id)),
         )?;
 
         if let Some(diff) = compute_position_diff(
@@ -869,7 +880,7 @@ pub fn match_order(
             &mut pnls,
             &mut fees,
             &mut volumes,
-            Some((events, maker_order_id)),
+            Some((events, maker_order_id, maker_order.client_order_id)),
         )?;
 
         if let Some(diff) = compute_position_diff(
@@ -938,6 +949,7 @@ pub fn match_order(
                     pair_id: pair_id.clone(),
                     user: maker_order.user,
                     reason: ReasonForOrderRemoval::Filled,
+                    client_order_id: maker_order.client_order_id,
                 })?;
             }
 
@@ -994,7 +1006,7 @@ pub fn settle_fill(
     pnls: &mut BTreeMap<Addr, UsdValue>,
     fees: &mut BTreeMap<Addr, UsdValue>,
     volumes: &mut BTreeMap<Addr, UsdValue>,
-    events: Option<(&mut EventBuilder, OrderId)>,
+    events: Option<(&mut EventBuilder, OrderId, Option<ClientOrderId>)>,
 ) -> grug::StdResult<UsdValue> {
     let (closing, opening) = {
         let current_pos = user_state
@@ -1027,7 +1039,7 @@ pub fn settle_fill(
         .or_default()
         .checked_add_assign(volume)?;
 
-    if let Some((events, order_id)) = events {
+    if let Some((events, order_id, client_order_id)) = events {
         events.push(OrderFilled {
             order_id,
             pair_id: pair_id.clone(),
@@ -1038,6 +1050,7 @@ pub fn settle_fill(
             opening_size: opening,
             realized_pnl: pnl,
             fee,
+            client_order_id,
         })?;
     }
 
@@ -1446,7 +1459,10 @@ mod tests {
             oracle::PrecisionedPrice,
             perps::{Position, RateSchedule},
         },
-        grug::{Coins, MockContext, ResultExt, Timestamp, Udec128, Uint64, hash_map},
+        grug::{
+            Coins, EventName, JsonDeExt, MockContext, ResultExt, Timestamp, Udec128, Uint64,
+            hash_map,
+        },
     };
 
     const CONTRACT: Addr = Addr::mock(0);
@@ -6334,6 +6350,113 @@ mod tests {
             format!("{err:?}").to_lowercase().contains("duplicate"),
             "expected duplicate_data error, got: {err:?}"
         );
+    }
+
+    /// On a fill, both the taker's and maker's `OrderFilled` events
+    /// surface the respective `client_order_id` from the originally
+    /// submitted order, so off-chain consumers can correlate fills with
+    /// the cid the trader assigned.
+    #[test]
+    fn order_filled_events_carry_client_order_ids() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        let maker_cid = Uint64::new(11);
+        let taker_cid = Uint64::new(22);
+
+        // Maker ask carrying a cid.
+        let maker_order = LimitOrder {
+            user: MAKER_A,
+            size: Quantity::new_int(-10),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(25_000),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: Some(maker_cid),
+        };
+        ASKS.save(
+            &mut ctx.storage,
+            (pair_id(), UsdPrice::new_int(50_000), Uint64::new(100)),
+            &maker_order,
+        )
+        .unwrap();
+        USER_STATES
+            .save(
+                &mut ctx.storage,
+                MAKER_A,
+                &UserState {
+                    margin: LARGE_COLLATERAL,
+                    open_order_count: 1,
+                    reserved_margin: UsdValue::new_int(25_000),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+        let mut events = EventBuilder::new();
+
+        // Taker GTC limit buy carrying its own cid fully fills the maker.
+        _submit_order(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            UsdPrice::new_int(50_000),
+            Quantity::new_int(10),
+            OrderKind::Limit {
+                limit_price: UsdPrice::new_int(50_000),
+                time_in_force: TimeInForce::GoodTilCanceled,
+                client_order_id: Some(taker_cid),
+            },
+            false,
+            None,
+            None,
+            &mut events,
+        )
+        .unwrap();
+
+        let order_filleds: Vec<OrderFilled> = events
+            .into_iter()
+            .filter(|e| e.ty == OrderFilled::EVENT_NAME)
+            .map(|e| e.data.deserialize_json().unwrap())
+            .collect();
+
+        assert_eq!(
+            order_filleds.len(),
+            2,
+            "expected one OrderFilled per side"
+        );
+
+        let taker_filled = order_filleds
+            .iter()
+            .find(|f| f.user == TAKER)
+            .expect("taker OrderFilled missing");
+        assert_eq!(taker_filled.client_order_id, Some(taker_cid));
+
+        let maker_filled = order_filleds
+            .iter()
+            .find(|f| f.user == MAKER_A)
+            .expect("maker OrderFilled missing");
+        assert_eq!(maker_filled.client_order_id, Some(maker_cid));
     }
 
     /// When a maker order with a `client_order_id` is fully filled and

--- a/dango/perps/src/vault/refresh.rs
+++ b/dango/perps/src/vault/refresh.rs
@@ -164,6 +164,7 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
                 created_at: ctx.block.timestamp,
                 tp: None,
                 sl: None,
+                client_order_id: None,
             };
 
             BIDS.save(
@@ -195,6 +196,7 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
                 created_at: ctx.block.timestamp,
                 tp: None,
                 sl: None,
+                client_order_id: None,
             };
 
             ASKS.save(

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -75,6 +75,7 @@ pub fn create_perps_fill(
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(price as i128),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -47,6 +47,7 @@ fn place_limit_ask(
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(price as i128),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -123,6 +123,7 @@ fn adl_bug_absurd_book_price() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -215,6 +216,7 @@ fn adl_bug_absurd_book_price() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(3_900),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/client_order_id.rs
+++ b/dango/testing/tests/perps/client_order_id.rs
@@ -1,0 +1,142 @@
+use {
+    crate::register_oracle_prices,
+    dango_testing::{TestOption, perps::pair_id, setup_test_naive},
+    dango_types::{
+        Quantity, UsdPrice,
+        constants::usdc,
+        perps::{self, ClientOrderId},
+    },
+    grug::{Addressable, Coins, QuerierExt, ResultExt, Uint64, Uint128},
+    std::collections::BTreeMap,
+};
+
+/// End-to-end: submit a GTC limit order carrying a `client_order_id`,
+/// cancel it via `CancelOrderRequest::OneByClientOrderId`, and prove the
+/// same `client_order_id` is reusable after the cancel.
+///
+/// Covers the full execute-message round trip the algo-trader use case
+/// depends on.
+#[test]
+fn submit_cancel_resubmit_by_client_order_id() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+    let cid: ClientOrderId = Uint64::new(42);
+
+    // Deposit margin so the trader can place a resting order.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // Submit a resting GTC limit bid carrying `cid`. The price ($1,500) is
+    // well below the oracle ($2,000) so the order rests rather than crosses.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(1_500),
+                    time_in_force: perps::TimeInForce::GoodTilCanceled,
+                    client_order_id: Some(cid),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Sanity: exactly one resting order, carrying `cid`.
+    let orders: BTreeMap<perps::OrderId, perps::QueryOrdersByUserResponseItem> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+    assert_eq!(orders.len(), 1);
+
+    // Cancel it by the client order id — the trader doesn't need to know
+    // the system-assigned `OrderId`.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::CancelOrder(
+                perps::CancelOrderRequest::OneByClientOrderId(cid),
+            )),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // The order is gone.
+    let orders: BTreeMap<perps::OrderId, perps::QueryOrdersByUserResponseItem> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+    assert!(orders.is_empty(), "order should be removed after cancel");
+
+    // The same `cid` is reusable now that the prior order is no longer
+    // active. (If the alias hadn't been cleared, this would hit
+    // `StdError::duplicate_data` from the `client_order_id` UniqueIndex.)
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(1_400),
+                    time_in_force: perps::TimeInForce::GoodTilCanceled,
+                    client_order_id: Some(cid),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let orders: BTreeMap<perps::OrderId, perps::QueryOrdersByUserResponseItem> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+    assert_eq!(
+        orders.len(),
+        1,
+        "the re-submitted order should be on the book"
+    );
+}
+
+/// Cancelling a `client_order_id` that the sender never used (or has
+/// already cancelled / had filled) bails with a clear error message.
+#[test]
+fn cancel_by_unknown_client_order_id_fails() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::CancelOrder(
+                perps::CancelOrderRequest::OneByClientOrderId(Uint64::new(99)),
+            )),
+            Coins::new(),
+        )
+        .should_fail_with_error("order not found");
+}

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -49,6 +49,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -133,6 +134,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_500),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -217,6 +219,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -271,6 +274,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -375,6 +379,7 @@ fn conditional_orders_follow_price_time_priority() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -482,6 +487,7 @@ fn conditional_orders_follow_price_time_priority() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_790),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -501,6 +507,7 @@ fn conditional_orders_follow_price_time_priority() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_770),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -640,6 +647,7 @@ fn conditional_order_failure_does_not_block_others() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -681,6 +689,7 @@ fn conditional_order_failure_does_not_block_others() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -788,6 +797,7 @@ fn conditional_order_failure_does_not_block_others() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -914,6 +924,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -954,6 +965,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_950),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1127,6 +1139,7 @@ fn child_order_market_with_tp_triggers() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1185,6 +1198,7 @@ fn child_order_market_with_tp_triggers() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_500),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1245,6 +1259,7 @@ fn child_order_market_with_sl_triggers() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1303,6 +1318,7 @@ fn child_order_market_with_sl_triggers() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_800),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1360,6 +1376,7 @@ fn child_order_ignored_when_position_closed() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1398,6 +1415,7 @@ fn child_order_ignored_when_position_closed() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1476,6 +1494,7 @@ fn child_order_overwrites_existing() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1602,6 +1621,7 @@ fn conditional_order_overwrite_same_direction() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1715,6 +1735,7 @@ fn conditional_order_size_exceeds_position_allowed() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1834,6 +1855,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1908,6 +1930,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_500),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -115,6 +115,7 @@ fn liquidation_on_order_book() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -197,6 +198,7 @@ fn liquidation_on_order_book() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_450),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -401,6 +403,7 @@ fn liquidation_with_adl() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -466,6 +469,7 @@ fn liquidation_with_adl() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -659,6 +663,7 @@ fn liquidation_cancels_conditional_orders() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -758,6 +763,7 @@ fn liquidation_cancels_conditional_orders() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_450),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1030,6 +1036,7 @@ fn vault_liquidation_on_order_book() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_600),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -17,6 +17,7 @@ use {
 };
 
 mod adl_bug_reproduction;
+mod client_order_id;
 mod conditional_orders;
 mod liquidation;
 mod price_band;

--- a/dango/testing/tests/perps/price_band.rs
+++ b/dango/testing/tests/perps/price_band.rs
@@ -66,6 +66,7 @@ macro_rules! submit_limit {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int($price),
                     time_in_force: $tif,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -268,6 +269,7 @@ fn banding_drift_maker_cancelled_at_match_time() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_400),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -1402,6 +1402,7 @@ fn place_ask_order(
                 kind: perps::OrderKind::Limit {
                     limit_price: price,
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -75,6 +75,7 @@ fn trading_lifecycle() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -244,6 +245,7 @@ fn limit_order_partial_fill_and_cancel() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -269,6 +271,7 @@ fn limit_order_partial_fill_and_cancel() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -449,6 +452,7 @@ fn liquidity_depth_tracking() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -487,6 +491,7 @@ fn liquidity_depth_tracking() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -529,6 +534,7 @@ fn liquidity_depth_tracking() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -655,6 +661,7 @@ fn protocol_fee_accumulates_across_fills() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -706,6 +713,7 @@ fn protocol_fee_accumulates_across_fills() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -827,6 +835,7 @@ fn negative_maker_fee_rebate_lifecycle() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -965,6 +974,7 @@ fn ioc_limit_order_partial_fill() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -990,6 +1000,7 @@ fn ioc_limit_order_partial_fill() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::ImmediateOrCancel,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1076,6 +1087,7 @@ fn ioc_limit_order_no_fill_rejected() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(1_900),
                     time_in_force: perps::TimeInForce::ImmediateOrCancel,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,
@@ -1237,6 +1249,7 @@ fn slippage_cap_does_not_affect_limit_orders() {
                 kind: perps::OrderKind::Limit {
                     limit_price: UsdPrice::new_int(2_000),
                     time_in_force: perps::TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
                 },
                 reduce_only: false,
                 tp: None,

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1353,6 +1353,9 @@ pub struct OrderFilled {
     pub opening_size: Quantity,
     pub realized_pnl: UsdValue,
     pub fee: UsdValue,
+    /// Caller-assigned id from the originally-submitted order, or `None`
+    /// if the order was submitted without one.
+    pub client_order_id: Option<ClientOrderId>,
 }
 
 /// Event indicating an order have been inserted into the order book.
@@ -1364,6 +1367,9 @@ pub struct OrderPersisted {
     pub user: Addr,
     pub limit_price: UsdPrice,
     pub size: Quantity,
+    /// Caller-assigned id from the originally-submitted order, or `None`
+    /// if the order was submitted without one.
+    pub client_order_id: Option<ClientOrderId>,
 }
 
 /// Event indicating an order has been removed from the order book.
@@ -1374,6 +1380,9 @@ pub struct OrderRemoved {
     pub pair_id: PairId,
     pub user: Addr,
     pub reason: ReasonForOrderRemoval,
+    /// Caller-assigned id from the originally-submitted order, or `None`
+    /// if the order was submitted without one.
+    pub client_order_id: Option<ClientOrderId>,
 }
 
 /// Event indicating a conditional (TP/SL) order has been placed.

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -789,8 +789,13 @@ pub struct ChildOrder {
 
 #[grug::derive(Serde)]
 pub enum CancelOrderRequest {
-    /// Cancel a single order by ID.
+    /// Cancel a single order by its system-assigned `OrderId`.
     One(OrderId),
+
+    /// Cancel a single order by its caller-assigned `ClientOrderId`.
+    /// Resolves to the active order owned by the sender that carries this
+    /// client id; bails if no such order exists.
+    OneByClientOrderId(ClientOrderId),
 
     /// Cancel all orders associated with the sender.
     All,

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -48,6 +48,15 @@ pub type OrderId = Uint64;
 /// Shares the same ID space as `OrderId` (same `NEXT_ORDER_ID` counter).
 pub type ConditionalOrderId = OrderId;
 
+/// Client-assigned order id. Lets a trader cancel an order in the same block
+/// it was submitted, without round-tripping through the server response to
+/// learn the system-assigned `OrderId`.
+///
+/// Scope of uniqueness: per-sender, across the sender's *active* (resting)
+/// limit orders only. The contract does not remember client order ids of
+/// orders that have been canceled or filled, so they can be reused freely.
+pub type ClientOrderId = Uint64;
+
 /// Type alias for a referrer's user index.
 pub type Referrer = UserIndex;
 
@@ -102,21 +111,15 @@ pub enum OrderKind {
         ///   limit price crosses best offer).
         #[serde(default)]
         time_in_force: TimeInForce,
-    },
-}
 
-impl OrderKind {
-    /// If this is a post-only limit order, return the limit price.
-    /// Otherwise, return `None`.
-    pub fn post_only_price(self) -> Option<UsdPrice> {
-        match self {
-            OrderKind::Limit {
-                limit_price,
-                time_in_force: TimeInForce::PostOnly,
-            } => Some(limit_price),
-            _ => None,
-        }
-    }
+        /// Caller-assigned id used to cancel this order via
+        /// `CancelOrderRequest::OneByClientOrderId` before the system-assigned
+        /// `OrderId` is known. Must be unique across the sender's *active*
+        /// orders. Not allowed with `TimeInForce::ImmediateOrCancel`, which
+        /// never enters the book.
+        #[serde(default)]
+        client_order_id: Option<ClientOrderId>,
+    },
 }
 
 /// For a conditional (TP/SL) order, direction the oracle price must cross to
@@ -746,6 +749,10 @@ pub struct LimitOrder {
     pub tp: Option<ChildOrder>,
     /// Stop-loss child order to apply when this order fills.
     pub sl: Option<ChildOrder>,
+    /// Caller-assigned id used to look this order up via the
+    /// `client_order_id` index on `BIDS`/`ASKS`. `None` if the order was
+    /// submitted without one.
+    pub client_order_id: Option<ClientOrderId>,
 }
 
 /// A conditional order stored off-book until triggered.

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,9 +1,13 @@
 use {
+    dango_perps::state::OrderKey,
     dango_types::{
         Dimensionless, FundingRate, Quantity, UsdPrice, UsdValue,
-        perps::{self, PairId},
+        perps::{self, ChildOrder, OrderId, PairId},
     },
-    grug::{Addr, BlockInfo, Order as IterationOrder, StdResult, Storage, addr},
+    grug::{
+        Addr, BlockInfo, IndexedMap, MultiIndex, Order as IterationOrder, StdResult, Storage,
+        Timestamp, UniqueIndex, addr,
+    },
     grug_app::{AppResult, CHAIN_ID, CONTRACT_NAMESPACE, StorageProvider},
     std::collections::BTreeSet,
 };
@@ -34,8 +38,16 @@ const MIGRATION_MAX_MARKET_SLIPPAGE: Dimensionless = Dimensionless::new_percent(
 /// Legacy types matching the pre-upgrade Borsh layout.
 ///
 /// `PairParam` before this upgrade does not contain the
-/// `max_limit_price_deviation` or `max_market_slippage` fields —
-/// both are introduced by the price-banding / slippage-policy PR.
+/// `max_limit_price_deviation` or `max_market_slippage` fields — both
+/// are introduced by the price-banding / slippage-policy PR.
+///
+/// `LimitOrder` before this upgrade does not contain the
+/// `client_order_id` field, and `OrderIndexes` only had the `order_id`
+/// and `user` indexes (the `client_order_id` `UniqueIndex` is new).
+/// Both `BIDS` and `ASKS` mirror the pre-upgrade `IndexedMap` layout
+/// verbatim so `legacy::BIDS.clear_all` correctly wipes the legacy
+/// primary entries *and* the legacy index namespaces (`bid__id`,
+/// `bid__user`, etc.) before we re-save under the new shape.
 mod legacy {
     use super::*;
 
@@ -58,6 +70,46 @@ mod legacy {
         pub vault_max_skew_size: Quantity,
         pub bucket_sizes: BTreeSet<UsdPrice>,
     }
+
+    #[derive(borsh::BorshDeserialize, borsh::BorshSerialize)]
+    pub struct LimitOrder {
+        pub user: Addr,
+        pub size: Quantity,
+        pub reduce_only: bool,
+        pub reserved_margin: UsdValue,
+        pub created_at: Timestamp,
+        pub tp: Option<ChildOrder>,
+        pub sl: Option<ChildOrder>,
+    }
+
+    #[grug::index_list(OrderKey, LimitOrder)]
+    pub struct OrderIndexes<'a> {
+        pub order_id: UniqueIndex<'a, OrderKey, OrderId, LimitOrder>,
+        pub user: MultiIndex<'a, OrderKey, Addr, LimitOrder>,
+    }
+
+    impl OrderIndexes<'static> {
+        pub const fn new(
+            pk_namespace: &'static str,
+            order_id_namespace: &'static str,
+            user_namespace: &'static str,
+        ) -> Self {
+            OrderIndexes {
+                order_id: UniqueIndex::new(
+                    |(_, _, order_id), _| *order_id,
+                    pk_namespace,
+                    order_id_namespace,
+                ),
+                user: MultiIndex::new(|_, order| order.user, pk_namespace, user_namespace),
+            }
+        }
+    }
+
+    pub const BIDS: IndexedMap<OrderKey, LimitOrder, OrderIndexes> =
+        IndexedMap::new("bid", OrderIndexes::new("bid", "bid__id", "bid__user"));
+
+    pub const ASKS: IndexedMap<OrderKey, LimitOrder, OrderIndexes> =
+        IndexedMap::new("ask", OrderIndexes::new("ask", "ask__id", "ask__user"));
 }
 
 pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
@@ -71,10 +123,13 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
 
     let mut storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
 
-    Ok(_do_upgrade(&mut storage)?)
+    do_price_banding_upgrade(&mut storage)?;
+    do_client_order_id_upgrade(&mut storage)?;
+
+    Ok(())
 }
 
-fn _do_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
+fn do_price_banding_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
     let old_params: Vec<_> = legacy::PAIR_PARAMS
         .range(storage, None, None, IterationOrder::Ascending)
         .collect::<StdResult<_>>()?;
@@ -112,14 +167,79 @@ fn _do_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
     Ok(())
 }
 
+/// Rewrite every resting `LimitOrder` in `BIDS` / `ASKS` from the
+/// pre-`client_order_id` Borsh layout to the new layout, with
+/// `client_order_id: None` for all migrated orders. Existing orders
+/// were submitted before the feature shipped, so none of them carry a
+/// client id; the new `client_order_id` index stays empty for them.
+///
+/// The pattern is **read-via-legacy → clear-via-legacy → save-via-new**:
+///
+/// 1. `legacy_map.range` deserializes the on-disk bytes through the
+///    old Borsh schema.
+/// 2. `legacy_map.clear_all` wipes the primary namespace *and* the
+///    legacy index namespaces (`bid__id`, `bid__user`, …). Without
+///    this, `IndexedMap::save` below would hit
+///    `StdError::duplicate_data` on the `order_id` `UniqueIndex` while
+///    rebuilding it.
+/// 3. `new_map.save` re-populates the primary entry and rebuilds all
+///    three new indexes (`order_id`, `user`, `client_order_id`).
+fn do_client_order_id_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
+    let bid_count = migrate_book(storage, &legacy::BIDS, &dango_perps::state::BIDS)?;
+    let ask_count = migrate_book(storage, &legacy::ASKS, &dango_perps::state::ASKS)?;
+
+    tracing::info!(
+        "Migrated {bid_count} resting bids and {ask_count} resting asks (added client_order_id = None)"
+    );
+
+    Ok(())
+}
+
+fn migrate_book(
+    storage: &mut dyn Storage,
+    legacy_map: &IndexedMap<OrderKey, legacy::LimitOrder, legacy::OrderIndexes>,
+    new_map: &IndexedMap<
+        OrderKey,
+        dango_types::perps::LimitOrder,
+        dango_perps::state::OrderIndexes,
+    >,
+) -> StdResult<usize> {
+    let entries: Vec<_> = legacy_map
+        .range(storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<_>>()?;
+
+    let count = entries.len();
+
+    legacy_map.clear_all(storage);
+
+    for (key, old) in entries {
+        let new = dango_types::perps::LimitOrder {
+            user: old.user,
+            size: old.size,
+            reduce_only: old.reduce_only,
+            reserved_margin: old.reserved_margin,
+            created_at: old.created_at,
+            tp: old.tp,
+            sl: old.sl,
+            client_order_id: None,
+        };
+        new_map.save(storage, key, &new)?;
+    }
+
+    Ok(count)
+}
+
 // ----------------------------------- tests -----------------------------------
 
 #[cfg(test)]
 mod tests {
     use {
         super::*,
-        grug::{MockStorage, btree_set},
+        grug::{MockStorage, Uint64, addr, btree_set},
     };
+
+    const USER_A: Addr = addr!("000000000000000000000000000000000000aaaa");
+    const USER_B: Addr = addr!("000000000000000000000000000000000000bbbb");
 
     fn eth_pair() -> PairId {
         "perp/ethusd".parse().unwrap()
@@ -127,6 +247,18 @@ mod tests {
 
     fn btc_pair() -> PairId {
         "perp/btcusd".parse().unwrap()
+    }
+
+    fn legacy_limit_order(user: Addr, size: i128, reserved_margin: i128) -> legacy::LimitOrder {
+        legacy::LimitOrder {
+            user,
+            size: Quantity::new_int(size),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(reserved_margin),
+            created_at: Timestamp::from_nanos(123_000_000),
+            tp: None,
+            sl: None,
+        }
     }
 
     fn legacy_pair_param(tick_size_int: i128) -> legacy::PairParam {
@@ -162,7 +294,7 @@ mod tests {
             .save(&mut storage, &btc_pair(), &btc)
             .unwrap();
 
-        _do_upgrade(&mut storage).unwrap();
+        do_price_banding_upgrade(&mut storage).unwrap();
 
         let migrated_eth = dango_perps::state::PAIR_PARAMS
             .load(&storage, &eth_pair())
@@ -222,6 +354,144 @@ mod tests {
     #[test]
     fn migration_with_no_pairs_is_noop() {
         let mut storage = MockStorage::new();
-        _do_upgrade(&mut storage).unwrap();
+        do_price_banding_upgrade(&mut storage).unwrap();
+    }
+
+    /// `do_client_order_id_upgrade` rewrites every legacy resting order
+    /// into the new shape with `client_order_id == None`, preserves the
+    /// other fields verbatim, and leaves the `order_id` index pointing
+    /// at the new entry.
+    #[test]
+    fn client_order_id_migration_rewrites_legacy_orders() {
+        let mut storage = MockStorage::new();
+
+        // Two legacy bids and one legacy ask, spanning two users.
+        let bid_a = legacy_limit_order(USER_A, 10, 100);
+        let bid_b = legacy_limit_order(USER_B, 5, 50);
+        let ask_a = legacy_limit_order(USER_A, -7, 70);
+
+        legacy::BIDS
+            .save(
+                &mut storage,
+                (eth_pair(), UsdPrice::new_int(2_000), Uint64::new(1)),
+                &bid_a,
+            )
+            .unwrap();
+        legacy::BIDS
+            .save(
+                &mut storage,
+                (eth_pair(), UsdPrice::new_int(1_950), Uint64::new(2)),
+                &bid_b,
+            )
+            .unwrap();
+        legacy::ASKS
+            .save(
+                &mut storage,
+                (eth_pair(), UsdPrice::new_int(2_100), Uint64::new(3)),
+                &ask_a,
+            )
+            .unwrap();
+
+        do_client_order_id_upgrade(&mut storage).unwrap();
+
+        // All three orders are now reachable via the new `IndexedMap`.
+        for (book, order_id, expected_size, expected_user, expected_margin) in [
+            (
+                &dango_perps::state::BIDS,
+                Uint64::new(1),
+                Quantity::new_int(10),
+                USER_A,
+                UsdValue::new_int(100),
+            ),
+            (
+                &dango_perps::state::BIDS,
+                Uint64::new(2),
+                Quantity::new_int(5),
+                USER_B,
+                UsdValue::new_int(50),
+            ),
+        ] {
+            let (_key, order) = book
+                .idx
+                .order_id
+                .may_load(&storage, order_id)
+                .unwrap()
+                .expect("post-migration order missing from order_id index");
+            assert_eq!(order.user, expected_user);
+            assert_eq!(order.size, expected_size);
+            assert_eq!(order.reserved_margin, expected_margin);
+            assert_eq!(order.client_order_id, None);
+            assert_eq!(order.created_at, Timestamp::from_nanos(123_000_000));
+        }
+
+        let (_key, ask_order) = dango_perps::state::ASKS
+            .idx
+            .order_id
+            .may_load(&storage, Uint64::new(3))
+            .unwrap()
+            .unwrap();
+        assert_eq!(ask_order.user, USER_A);
+        assert_eq!(ask_order.size, Quantity::new_int(-7));
+        assert_eq!(ask_order.client_order_id, None);
+
+        // The new `client_order_id` index is empty for migrated orders.
+        let any_cid = dango_perps::state::BIDS
+            .idx
+            .client_order_id
+            .keys(
+                &storage,
+                None,
+                None,
+                grug::Order::Ascending,
+            )
+            .next();
+        assert!(any_cid.is_none(), "new client_order_id index should be empty");
+    }
+
+    #[test]
+    fn client_order_id_migration_no_orders_is_noop() {
+        let mut storage = MockStorage::new();
+        do_client_order_id_upgrade(&mut storage).unwrap();
+    }
+
+    /// `do_upgrade` chains both migrations: legacy `PairParam`s are
+    /// rewritten *and* legacy resting orders are rewritten, all under
+    /// one upgrade boundary.
+    #[test]
+    fn do_upgrade_runs_both_migrations() {
+        let mut storage = MockStorage::new();
+
+        // Seed legacy state for both migrations.
+        legacy::PAIR_PARAMS
+            .save(&mut storage, &eth_pair(), &legacy_pair_param(1))
+            .unwrap();
+        legacy::BIDS
+            .save(
+                &mut storage,
+                (eth_pair(), UsdPrice::new_int(2_000), Uint64::new(1)),
+                &legacy_limit_order(USER_A, 10, 100),
+            )
+            .unwrap();
+
+        // Run both migrations sequentially (mirrors `do_upgrade`).
+        do_price_banding_upgrade(&mut storage).unwrap();
+        do_client_order_id_upgrade(&mut storage).unwrap();
+
+        // PairParam migrated.
+        let pair = dango_perps::state::PAIR_PARAMS
+            .load(&storage, &eth_pair())
+            .unwrap();
+        assert_eq!(pair.max_limit_price_deviation, MIGRATION_MAX_LIMIT_PRICE_DEVIATION);
+        assert_eq!(pair.max_market_slippage, MIGRATION_MAX_MARKET_SLIPPAGE);
+
+        // Order migrated.
+        let (_key, order) = dango_perps::state::BIDS
+            .idx
+            .order_id
+            .may_load(&storage, Uint64::new(1))
+            .unwrap()
+            .unwrap();
+        assert_eq!(order.user, USER_A);
+        assert_eq!(order.client_order_id, None);
     }
 }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -438,14 +438,12 @@ mod tests {
         let any_cid = dango_perps::state::BIDS
             .idx
             .client_order_id
-            .keys(
-                &storage,
-                None,
-                None,
-                grug::Order::Ascending,
-            )
+            .keys(&storage, None, None, grug::Order::Ascending)
             .next();
-        assert!(any_cid.is_none(), "new client_order_id index should be empty");
+        assert!(
+            any_cid.is_none(),
+            "new client_order_id index should be empty"
+        );
     }
 
     #[test]
@@ -481,7 +479,10 @@ mod tests {
         let pair = dango_perps::state::PAIR_PARAMS
             .load(&storage, &eth_pair())
             .unwrap();
-        assert_eq!(pair.max_limit_price_deviation, MIGRATION_MAX_LIMIT_PRICE_DEVIATION);
+        assert_eq!(
+            pair.max_limit_price_deviation,
+            MIGRATION_MAX_LIMIT_PRICE_DEVIATION
+        );
         assert_eq!(pair.max_market_slippage, MIGRATION_MAX_MARKET_SLIPPAGE);
 
         // Order migrated.

--- a/sdk/dango/src/actions/perps/mutations/cancelOrder.ts
+++ b/sdk/dango/src/actions/perps/mutations/cancelOrder.ts
@@ -34,12 +34,21 @@ export async function cancelPerpsOrder<transport extends Transport>(
     },
   };
 
-  const cancelOrderTypedData =
-    request === "all"
-      ? { CancelOrder: [] }
-      : {
-          CancelOrder: [{ name: "one", type: "string" }],
-        };
+  const cancelOrderTypedData = (() => {
+    if (request === "all") {
+      return { CancelOrder: [] };
+    }
+    if ("one" in request) {
+      return { CancelOrder: [{ name: "one", type: "string" }] };
+    }
+    // `oneByClientOrderId` — the message is camelCase here; the
+    // outgoing JSON is snake_cased by `composeTxTypedData` via
+    // `recursiveTransform`, so the typed-data field name must be the
+    // snake_case form the contract sees.
+    return {
+      CancelOrder: [{ name: "one_by_client_order_id", type: "string" }],
+    };
+  })();
 
   const typedData: TypedDataParameter = {
     type: [{ name: "trade", type: "Trade" }],

--- a/sdk/dango/src/actions/perps/mutations/submitOrder.ts
+++ b/sdk/dango/src/actions/perps/mutations/submitOrder.ts
@@ -40,12 +40,28 @@ export async function submitPerpsOrder<transport extends Transport>(
     ...(child.size ? { size: child.size } : {}),
   });
 
+  // Strip a `null` / `undefined` `clientOrderId` from the limit body so
+  // the JSON message and the EIP-712 typed-data structure agree on
+  // whether the field is present. The typed-data builder below uses the
+  // same `!= null` check.
+  const limitHasClientOrderId = "limit" in kind && kind.limit.clientOrderId != null;
+  const normalizedKind: PerpsOrderKind =
+    "limit" in kind
+      ? {
+          limit: {
+            limitPrice: kind.limit.limitPrice,
+            timeInForce: kind.limit.timeInForce,
+            ...(limitHasClientOrderId ? { clientOrderId: kind.limit.clientOrderId as string } : {}),
+          },
+        }
+      : kind;
+
   const msg = {
     trade: {
       submitOrder: {
         pairId,
         size,
-        kind,
+        kind: normalizedKind,
         reduceOnly,
         ...(tp ? { tp: buildChildOrder(tp) } : {}),
         ...(sl ? { sl: buildChildOrder(sl) } : {}),
@@ -53,18 +69,20 @@ export async function submitPerpsOrder<transport extends Transport>(
     },
   };
 
-  const kindTypedData = "market" in kind
-    ? {
-        kind: [{ name: "market", type: "Market" }],
-        Market: [{ name: "max_slippage", type: "string" }],
-      }
-    : {
-        kind: [{ name: "limit", type: "Limit" }],
-        Limit: [
-          { name: "limit_price", type: "string" },
-          { name: "time_in_force", type: "string" },
-        ],
-      };
+  const kindTypedData =
+    "market" in kind
+      ? {
+          kind: [{ name: "market", type: "Market" }],
+          Market: [{ name: "max_slippage", type: "string" }],
+        }
+      : {
+          kind: [{ name: "limit", type: "Limit" }],
+          Limit: [
+            { name: "limit_price", type: "string" },
+            { name: "time_in_force", type: "string" },
+            ...(limitHasClientOrderId ? [{ name: "client_order_id", type: "string" }] : []),
+          ],
+        };
 
   const childOrderTypeFor = (child: ChildOrder) => [
     { name: "trigger_price", type: "string" },

--- a/sdk/dango/src/types/perps.ts
+++ b/sdk/dango/src/types/perps.ts
@@ -62,9 +62,27 @@ export type PerpsUserStateExtended = {
 
 export type PerpsTimeInForce = "GTC" | "IOC" | "POST";
 
+/**
+ * Caller-assigned id for a limit order, serialized as a `Uint64` string.
+ * Lets a trader cancel an order in the same block it was submitted, via
+ * `PerpsCancelOrderRequest.oneByClientOrderId`, without round-tripping
+ * through the server response to learn the system-assigned `OrderId`.
+ *
+ * Uniqueness is per-sender and applies only to the sender's *active*
+ * orders. Reusable once the prior order has been canceled or filled.
+ */
+export type PerpsClientOrderId = string;
+
 export type PerpsOrderKind =
   | { market: { maxSlippage: string } }
-  | { limit: { limitPrice: string; timeInForce: PerpsTimeInForce } };
+  | {
+      limit: {
+        limitPrice: string;
+        timeInForce: PerpsTimeInForce;
+        /** Optional. Not allowed with `timeInForce: "IOC"`. */
+        clientOrderId?: PerpsClientOrderId | null;
+      };
+    };
 
 export type PerpsPairParam = {
   tickSize: string;
@@ -161,7 +179,10 @@ export type PerpsLiquidityDepthResponse = {
   asks: Record<string, PerpsLiquidityDepth>;
 };
 
-export type PerpsCancelOrderRequest = { one: string } | "all";
+export type PerpsCancelOrderRequest =
+  | { one: string }
+  | { oneByClientOrderId: PerpsClientOrderId }
+  | "all";
 
 export type PerpsCancelConditionalOrderRequest =
   | { one: { pairId: string; triggerDirection: TriggerDirection } }


### PR DESCRIPTION
Adds an optional `client_order_id` to perps limit orders so algo traders can cancel an order in the same block it was submitted, without round-tripping through the server response to learn the system-assigned `OrderId`. Cancel via the new `CancelOrderRequest::OneByClientOrderId` variant; emitted on `OrderPersisted` / `OrderFilled` / `OrderRemoved` so off-chain consumers can correlate.                                                                                                            