### PR TITLE
feat(perps): assign FillId to order-book matches

### DIFF
--- a/book/perps/4-liquidation-and-adl.md
+++ b/book/perps/4-liquidation-and-adl.md
@@ -77,6 +77,8 @@ Since equity is typically negative for liquidatable users, the bankruptcy price 
 
 Liquidation fills (both order-book and ADL) carry **zero trading fees** for both taker and maker.
 
+Order-book fills during liquidation emit `order_filled` events with a `fill_id` just like regular matches (see the [events reference](8-api.md#9-events-reference)); ADL fills do _not_ — they use the separate `deleveraged` and `liquidated` events, which carry no `fill_id`, because ADL is a position transfer at the bankruptcy price rather than an order-book match.
+
 ## 4. Liquidation fee
 
 After all positions in the schedule are closed, a one-time liquidation fee is charged:

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -1442,7 +1442,9 @@ The `data` field contains the event-specific payload as JSON. For example, an `o
   "closing_size": "0.000000",
   "opening_size": "0.100000",
   "realized_pnl": "0.000000",
-  "fee": "6.500000"
+  "fee": "6.500000",
+  "client_order_id": "42",
+  "fill_id": "17"
 }
 ```
 
@@ -2126,13 +2128,15 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 ### Order events
 
-| Event             | Fields                                                                                                                              | Description                     |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `fee`, `client_order_id?` | Order partially or fully filled |
-| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                            | Limit order placed on book      |
-| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                         | Order removed from book         |
+| Event             | Fields                                                                                                                                          | Description                     |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `fee`, `client_order_id?`, `fill_id?` | Order partially or fully filled |
+| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                                        | Limit order placed on book      |
+| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                                     | Order removed from book         |
 
 `client_order_id` is `null` if the order was submitted without one. Off-chain consumers can use it to correlate fills, persistence, and removal with the originally-submitted client id.
+
+`fill_id` groups the two sides of a single order-book match. When a taker crosses a resting maker, two `order_filled` events are emitted — one for each side — and both carry the same `fill_id`. Successive matches use consecutive ids (strictly increasing), so a taker that crosses two makers in the same transaction produces four events with two distinct `fill_id` values. `fill_id` is `null` for trades executed before v0.15.0 — fill IDs were not assigned prior to that release. Not emitted for ADL fills, which use the [`deleveraged` and `liquidated` events](#liquidation-events) instead.
 
 ### Conditional order events
 
@@ -2197,6 +2201,7 @@ Additional integer types:
 | `OrderId`            | `Uint64` (string)               | `"42"`                           |
 | `ConditionalOrderId` | `Uint64` (shared counter)       | `"43"`                           |
 | `ClientOrderId`      | `Uint64` (caller-assigned)      | `"42"`                           |
+| `FillId`             | `Uint64` (per-match identifier) | `"17"`                           |
 | `Addr`               | Hex address                     | `"0x1234...abcd"`                |
 | `Hash256`            | 64-char hex                     | `"a1b2c3d4e5f6..."`              |
 | `UserIndex`          | `u32`                           | `0`                              |

--- a/dango/indexer/sql/src/entity/perps_trade.rs
+++ b/dango/indexer/sql/src/entity/perps_trade.rs
@@ -41,4 +41,10 @@ pub struct PerpsTrade {
 
     #[cfg_attr(feature = "async-graphql", graphql(name = "tradeIdx"))]
     pub trade_idx: u32,
+
+    /// Identifier shared between the two `OrderFilled` events of a single
+    /// order-book match. `None` for trades executed before v0.15.0 — fill
+    /// IDs were not assigned prior to that release.
+    #[cfg_attr(feature = "async-graphql", graphql(name = "fillId"))]
+    pub fill_id: Option<String>,
 }

--- a/dango/indexer/sql/src/indexer/perps_events.rs
+++ b/dango/indexer/sql/src/indexer/perps_events.rs
@@ -232,6 +232,7 @@ fn try_build_perps_trade(
         created_at: created_at.to_string(),
         block_height,
         trade_idx,
+        fill_id: order_filled.fill_id.as_ref().map(ToString::to_string),
     })
 }
 

--- a/dango/indexer/sql/src/indexer/perps_trades/cache.rs
+++ b/dango/indexer/sql/src/indexer/perps_trades/cache.rs
@@ -72,6 +72,7 @@ impl PerpsTradeCache {
                 created_at: Timestamp::from(row.created_at).to_rfc3339_string(),
                 block_height: row.block_height as u64,
                 trade_idx: trade_idx as u32,
+                fill_id: order_filled.fill_id.as_ref().map(ToString::to_string),
             };
 
             trades

--- a/dango/perps/src/cron/process_conditional_orders.rs
+++ b/dango/perps/src/cron/process_conditional_orders.rs
@@ -5,8 +5,8 @@ use {
         price::may_invert_price,
         referral::{FeeCommissionsOutcome, apply_fee_commissions},
         state::{
-            ASKS, BIDS, NEXT_ORDER_ID, PAIR_IDS, PAIR_PARAMS, PAIR_STATES, PARAM, STATE,
-            USER_STATES,
+            ASKS, BIDS, NEXT_FILL_ID, NEXT_ORDER_ID, PAIR_IDS, PAIR_PARAMS, PAIR_STATES, PARAM,
+            STATE, USER_STATES,
         },
         trade::{_submit_order, SubmitOrderOutcome},
         volume::flush_volumes,
@@ -367,6 +367,7 @@ fn process_triggered_order(
         order_mutations,
         order_to_store: _order_to_store,
         next_order_id,
+        next_fill_id,
         index_updates,
         volumes,
         fee_breakdowns,
@@ -447,6 +448,7 @@ fn process_triggered_order(
     maker_states = updated_maker_states;
 
     NEXT_ORDER_ID.save(storage, &next_order_id)?;
+    NEXT_FILL_ID.save(storage, &next_fill_id)?;
 
     for (addr, user_state) in &maker_states {
         USER_STATES.save(storage, *addr, user_state)?;

--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -16,14 +16,15 @@ pub mod volume;
 
 use {
     crate::state::{
-        FEE_RATE_OVERRIDES, NEXT_ORDER_ID, PAIR_PARAMS, PAIR_STATES, PARAM, STATE, USER_STATES,
+        FEE_RATE_OVERRIDES, NEXT_FILL_ID, NEXT_ORDER_ID, PAIR_PARAMS, PAIR_STATES, PARAM, STATE,
+        USER_STATES,
     },
     anyhow::ensure,
     dango_oracle::OracleQuerier,
     dango_types::{
         DangoQuerier, UsdValue,
         perps::{
-            CancelConditionalOrderRequest, CancelOrderRequest, ExecuteMsg, InstantiateMsg,
+            CancelConditionalOrderRequest, CancelOrderRequest, ExecuteMsg, FillId, InstantiateMsg,
             MaintainerMsg, OrderId, QueryMsg, ReferralMsg, State, TraderMsg, VaultMsg,
         },
     },
@@ -90,6 +91,7 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
     })?;
 
     NEXT_ORDER_ID.save(ctx.storage, &OrderId::ONE)?;
+    NEXT_FILL_ID.save(ctx.storage, &FillId::ONE)?;
 
     maintain::configure(ctx, msg.param, msg.pair_params)
 }

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -13,8 +13,8 @@ use {
         price::may_invert_price,
         querier::NoCachePerpQuerier,
         state::{
-            ASKS, BIDS, LONGS, NEXT_ORDER_ID, PAIR_PARAMS, PAIR_STATES, PARAM, SHORTS, STATE,
-            USER_STATES,
+            ASKS, BIDS, LONGS, NEXT_FILL_ID, NEXT_ORDER_ID, PAIR_PARAMS, PAIR_STATES, PARAM,
+            SHORTS, STATE, USER_STATES,
         },
         trade::{
             _cancel_all_orders, CancelAllOrdersOutcome, MatchOrderOutcome, match_order,
@@ -27,9 +27,9 @@ use {
     dango_types::{
         Dimensionless, Quantity, UsdPrice, UsdValue,
         perps::{
-            BadDebtCovered, ConditionalOrderRemoved, Deleveraged, LimitOrder, Liquidated, OrderId,
-            PairId, PairParam, PairState, Param, RateSchedule, ReasonForOrderRemoval, State,
-            TriggerDirection, UserState,
+            BadDebtCovered, ConditionalOrderRemoved, Deleveraged, FillId, LimitOrder, Liquidated,
+            OrderId, PairId, PairParam, PairState, Param, RateSchedule, ReasonForOrderRemoval,
+            State, TriggerDirection, UserState,
         },
     },
     grug::{
@@ -133,6 +133,7 @@ pub fn liquidate(ctx: MutableCtx, user: Addr) -> anyhow::Result<Response> {
         index_updates,
         volumes,
         next_order_id,
+        next_fill_id,
     } = _liquidate(
         ctx.storage,
         user,
@@ -155,6 +156,7 @@ pub fn liquidate(ctx: MutableCtx, user: Addr) -> anyhow::Result<Response> {
     STATE.save(ctx.storage, &state)?;
 
     NEXT_ORDER_ID.save(ctx.storage, &next_order_id)?;
+    NEXT_FILL_ID.save(ctx.storage, &next_fill_id)?;
 
     for (pair_id, pair_state) in &pair_states {
         PAIR_STATES.save(ctx.storage, pair_id, pair_state)?;
@@ -286,6 +288,7 @@ pub struct LiquidateOutcome {
     pub index_updates: Vec<PositionIndexUpdate>,
     pub volumes: BTreeMap<Addr, UsdValue>,
     pub next_order_id: OrderId,
+    pub next_fill_id: FillId,
 }
 
 /// Pure liquidation core: takes the dense state structs by `&` and
@@ -363,6 +366,7 @@ fn _liquidate(
         all_index_updates,
         all_volumes,
         next_order_id,
+        next_fill_id,
     ) = execute_close_schedule(
         storage,
         user,
@@ -466,6 +470,7 @@ fn _liquidate(
         index_updates: all_index_updates,
         volumes: all_volumes,
         next_order_id,
+        next_fill_id,
     })
 }
 
@@ -505,8 +510,10 @@ fn execute_close_schedule(
     Vec<PositionIndexUpdate>,
     BTreeMap<Addr, UsdValue>,
     OrderId,
+    FillId,
 )> {
     let mut next_order_id = NEXT_ORDER_ID.load(storage)?;
+    let mut next_fill_id = NEXT_FILL_ID.load(storage)?;
 
     // Zero-fee param for liquidation fills.
     let liq_param = Param {
@@ -580,6 +587,7 @@ fn execute_close_schedule(
             order_mutations,
             index_updates,
             next_order_id: updated_next_order_id,
+            next_fill_id: updated_next_fill_id,
         } = match_order(
             storage,
             user,
@@ -600,6 +608,7 @@ fn execute_close_schedule(
             pair_params.get(pair_id).unwrap().max_limit_price_deviation,
             *close_size,
             next_order_id,
+            next_fill_id,
             events,
         )?;
 
@@ -607,6 +616,7 @@ fn execute_close_schedule(
         *user_state = updated_user_state;
         *maker_states = updated_maker_states;
         next_order_id = updated_next_order_id;
+        next_fill_id = updated_next_fill_id;
 
         // Merge PnLs.
         for (addr, pnl) in pnls {
@@ -711,6 +721,7 @@ fn execute_close_schedule(
         all_index_updates,
         all_volumes,
         next_order_id,
+        next_fill_id,
     ))
 }
 
@@ -938,6 +949,7 @@ mod tests {
         PARAM.save(storage, param).unwrap();
         STATE.save(storage, &State::default()).unwrap();
         NEXT_ORDER_ID.save(storage, &OrderId::ONE).unwrap();
+        NEXT_FILL_ID.save(storage, &FillId::ONE).unwrap();
 
         for (pair_id, pair_param, pair_state) in pairs {
             PAIR_PARAMS.save(storage, pair_id, pair_param).unwrap();

--- a/dango/perps/src/state.rs
+++ b/dango/perps/src/state.rs
@@ -3,8 +3,8 @@ use {
         Dimensionless, Quantity, UsdPrice, UsdValue,
         account_factory::UserIndex,
         perps::{
-            ClientOrderId, CommissionRate, ConditionalOrderId, FeeShareRatio, LimitOrder, OrderId,
-            PairId, PairParam, PairState, Param, Referee, RefereeStats, Referrer, State,
+            ClientOrderId, CommissionRate, ConditionalOrderId, FeeShareRatio, FillId, LimitOrder,
+            OrderId, PairId, PairParam, PairState, Param, Referee, RefereeStats, Referrer, State,
             TriggerDirection, UserReferralData, UserState,
         },
     },
@@ -15,6 +15,8 @@ use {
 // --------------------------------- constants ---------------------------------
 
 pub const NEXT_ORDER_ID: Item<OrderId> = Item::new("next_order_id");
+
+pub const NEXT_FILL_ID: Item<FillId> = Item::new("next_fill_id");
 
 pub const LAST_VAULT_ORDERS_UPDATE: Item<u64> = Item::new("last_vault_orders_update");
 

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -17,8 +17,8 @@ use {
         query::query_volume,
         referral::{FeeCommissionsOutcome, apply_fee_commissions},
         state::{
-            ASKS, BIDS, FEE_RATE_OVERRIDES, NEXT_ORDER_ID, PAIR_PARAMS, PAIR_STATES, PARAM, STATE,
-            USER_STATES,
+            ASKS, BIDS, FEE_RATE_OVERRIDES, NEXT_FILL_ID, NEXT_ORDER_ID, PAIR_PARAMS, PAIR_STATES,
+            PARAM, STATE, USER_STATES,
         },
         volume::flush_volumes,
     },
@@ -27,10 +27,10 @@ use {
     dango_types::{
         Dimensionless, Quantity, UsdPrice, UsdValue,
         perps::{
-            ChildOrder, ClientOrderId, ConditionalOrder, ConditionalOrderPlaced, LimitOrder,
-            OrderFilled, OrderId, OrderKind, OrderPersisted, OrderRemoved, PairId, PairParam,
-            PairState, Param, ReasonForOrderRemoval, State, TimeInForce, TriggerDirection,
-            UserState,
+            ChildOrder, ClientOrderId, ConditionalOrder, ConditionalOrderPlaced, FillId,
+            LimitOrder, OrderFilled, OrderId, OrderKind, OrderPersisted, OrderRemoved, PairId,
+            PairParam, PairState, Param, ReasonForOrderRemoval, State, TimeInForce,
+            TriggerDirection, UserState,
         },
     },
     grug::{
@@ -81,6 +81,7 @@ pub fn submit_order(
         order_mutations,
         order_to_store,
         next_order_id,
+        next_fill_id,
         index_updates,
         volumes,
         fee_breakdowns,
@@ -128,6 +129,7 @@ pub fn submit_order(
     maker_states = updated_maker_states;
 
     NEXT_ORDER_ID.save(ctx.storage, &next_order_id)?;
+    NEXT_FILL_ID.save(ctx.storage, &next_fill_id)?;
 
     STATE.save(ctx.storage, &state)?;
 
@@ -272,6 +274,7 @@ pub struct SubmitOrderOutcome {
     pub order_mutations: Vec<(UsdPrice, OrderId, Option<LimitOrder>, Quantity)>,
     pub order_to_store: Option<(UsdPrice, OrderId, LimitOrder)>,
     pub next_order_id: OrderId,
+    pub next_fill_id: FillId,
     pub index_updates: Vec<PositionIndexUpdate>,
     pub volumes: BTreeMap<Addr, UsdValue>,
     pub fee_breakdowns: BTreeMap<Addr, FeeBreakdown>,
@@ -388,6 +391,7 @@ pub(crate) fn _submit_order(
 
     let taker_order_id = NEXT_ORDER_ID.load(storage)?;
     let mut next_order_id = taker_order_id + OrderId::ONE;
+    let next_fill_id = NEXT_FILL_ID.load(storage)?;
 
     // ---------------------- Step 4. Post-only fast path ----------------------
 
@@ -430,6 +434,8 @@ pub(crate) fn _submit_order(
             order_mutations: Vec::new(),
             order_to_store: Some((stored_price, order_id, order)),
             next_order_id: taker_order_id + OrderId::ONE,
+            // Post-only orders cannot match, so no fill id is allocated.
+            next_fill_id,
             index_updates: Vec::new(),
             volumes: BTreeMap::new(),
             fee_breakdowns: BTreeMap::new(),
@@ -486,6 +492,7 @@ pub(crate) fn _submit_order(
         order_mutations,
         index_updates,
         next_order_id: updated_next_order_id,
+        next_fill_id: updated_next_fill_id,
     } = match_order(
         storage,
         taker,
@@ -514,12 +521,14 @@ pub(crate) fn _submit_order(
         pair_param.max_limit_price_deviation,
         fillable_size,
         next_order_id,
+        next_fill_id,
         events,
     )?;
 
     pair_state = updated_pair_state;
     taker_state = updated_taker_state;
     next_order_id = updated_next_order_id;
+    let next_fill_id = updated_next_fill_id;
 
     // ------------------- Step 8. Handle unfilled remainder -------------------
 
@@ -628,6 +637,7 @@ pub(crate) fn _submit_order(
         order_mutations,
         order_to_store,
         next_order_id,
+        next_fill_id,
         index_updates,
         volumes,
         fee_breakdowns,
@@ -651,6 +661,7 @@ pub struct MatchOrderOutcome {
     pub order_mutations: Vec<(UsdPrice, OrderId, Option<LimitOrder>, Quantity)>,
     pub index_updates: Vec<PositionIndexUpdate>,
     pub next_order_id: OrderId,
+    pub next_fill_id: FillId,
 }
 
 /// Iterate the opposite-side order book in price-time priority and match
@@ -686,6 +697,7 @@ pub fn match_order(
     max_limit_price_deviation: Dimensionless,
     mut remaining_size: Quantity,
     mut next_order_id: OrderId,
+    mut next_fill_id: FillId,
     events: &mut EventBuilder,
 ) -> anyhow::Result<MatchOrderOutcome> {
     // Clone at entry and mutate locals freely. `events` is the one
@@ -810,6 +822,13 @@ pub fn match_order(
 
         let maker_fill_size = taker_fill_size.checked_neg()?;
 
+        // -------------------- Allocate a shared fill id ----------------------
+
+        // Both `OrderFilled` events below carry this `fill_id`, so downstream
+        // consumers can group the two sides of the match.
+        let fill_id = next_fill_id;
+        next_fill_id = next_fill_id.checked_add(FillId::ONE)?;
+
         // ------------------------ Settle taker's PnL -------------------------
 
         let old_taker_pos = taker_state.positions.get(pair_id).cloned();
@@ -826,7 +845,7 @@ pub fn match_order(
             &mut pnls,
             &mut fees,
             &mut volumes,
-            Some((events, taker_order_id, taker_client_order_id)),
+            Some((events, taker_order_id, taker_client_order_id, fill_id)),
         )?;
 
         if let Some(diff) = compute_position_diff(
@@ -882,7 +901,7 @@ pub fn match_order(
             &mut pnls,
             &mut fees,
             &mut volumes,
-            Some((events, maker_order_id, maker_order.client_order_id)),
+            Some((events, maker_order_id, maker_order.client_order_id, fill_id)),
         )?;
 
         if let Some(diff) = compute_position_diff(
@@ -986,6 +1005,7 @@ pub fn match_order(
         order_mutations,
         index_updates,
         next_order_id,
+        next_fill_id,
     })
 }
 
@@ -1008,7 +1028,7 @@ pub fn settle_fill(
     pnls: &mut BTreeMap<Addr, UsdValue>,
     fees: &mut BTreeMap<Addr, UsdValue>,
     volumes: &mut BTreeMap<Addr, UsdValue>,
-    events: Option<(&mut EventBuilder, OrderId, Option<ClientOrderId>)>,
+    events: Option<(&mut EventBuilder, OrderId, Option<ClientOrderId>, FillId)>,
 ) -> grug::StdResult<UsdValue> {
     let (closing, opening) = {
         let current_pos = user_state
@@ -1041,7 +1061,7 @@ pub fn settle_fill(
         .or_default()
         .checked_add_assign(volume)?;
 
-    if let Some((events, order_id, client_order_id)) = events {
+    if let Some((events, order_id, client_order_id, fill_id)) = events {
         events.push(OrderFilled {
             order_id,
             pair_id: pair_id.clone(),
@@ -1053,6 +1073,7 @@ pub fn settle_fill(
             realized_pnl: pnl,
             fee,
             client_order_id,
+            fill_id: Some(fill_id),
         })?;
     }
 
@@ -1524,6 +1545,7 @@ mod tests {
             .save(storage, &pair_id(), &PairState::default())
             .unwrap();
         NEXT_ORDER_ID.save(storage, &Uint64::new(1)).unwrap();
+        NEXT_FILL_ID.save(storage, &FillId::ONE).unwrap();
     }
 
     /// Place a resting ask (sell) order on the book.
@@ -3142,6 +3164,7 @@ mod tests {
         NEXT_ORDER_ID
             .save(&mut ctx.storage, &Uint64::new(1))
             .unwrap();
+        NEXT_FILL_ID.save(&mut ctx.storage, &FillId::ONE).unwrap();
 
         place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 100);
 
@@ -3250,6 +3273,7 @@ mod tests {
         NEXT_ORDER_ID
             .save(&mut ctx.storage, &Uint64::new(1))
             .unwrap();
+        NEXT_FILL_ID.save(&mut ctx.storage, &FillId::ONE).unwrap();
 
         // Two resting asks — one per phase.
         place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 100);
@@ -3416,6 +3440,7 @@ mod tests {
         NEXT_ORDER_ID
             .save(&mut ctx.storage, &Uint64::new(1))
             .unwrap();
+        NEXT_FILL_ID.save(&mut ctx.storage, &FillId::ONE).unwrap();
 
         place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 100);
         place_ask(&mut ctx.storage, MAKER_A, 50_000, 10, 101);

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -391,7 +391,7 @@ pub(crate) fn _submit_order(
 
     let taker_order_id = NEXT_ORDER_ID.load(storage)?;
     let mut next_order_id = taker_order_id + OrderId::ONE;
-    let next_fill_id = NEXT_FILL_ID.load(storage)?;
+    let mut next_fill_id = NEXT_FILL_ID.load(storage)?;
 
     // ---------------------- Step 4. Post-only fast path ----------------------
 
@@ -528,7 +528,7 @@ pub(crate) fn _submit_order(
     pair_state = updated_pair_state;
     taker_state = updated_taker_state;
     next_order_id = updated_next_order_id;
-    let next_fill_id = updated_next_fill_id;
+    next_fill_id = updated_next_fill_id;
 
     // ------------------- Step 8. Handle unfilled remainder -------------------
 

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -2266,7 +2266,9 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
     // events each, and the two values must be consecutive.
     let mut by_fill_id = BTreeMap::<_, usize>::new();
     for filled in &fills {
-        let id = filled.fill_id.expect("cron-triggered fill must carry a fill_id");
+        let id = filled
+            .fill_id
+            .expect("cron-triggered fill must carry a fill_id");
         *by_fill_id.entry(id).or_default() += 1;
     }
 

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -4,9 +4,13 @@ use {
     dango_types::{
         Dimensionless, Quantity, UsdPrice, UsdValue,
         constants::usdc,
-        perps::{self, PairParam, UserState},
+        perps::{self, OrderFilled, PairParam, UserState},
     },
-    grug::{Addressable, Coins, Duration, QuerierExt, ResultExt, Uint128, btree_map},
+    grug::{
+        Addressable, CheckedContractEvent, Coins, Duration, Inner, JsonDeExt, QuerierExt,
+        ResultExt, SearchEvent, Uint128, btree_map,
+    },
+    std::collections::BTreeMap,
 };
 
 /// Full lifecycle: deposit → open position → place TP → oracle rises →
@@ -1963,5 +1967,328 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
     assert!(
         pos.conditional_order_above.is_none(),
         "conditional order should have been removed by the cap-tightened cancel"
+    );
+}
+
+/// A TP that fires from cron and crosses a resting maker produces
+/// `OrderFilled` events carrying `Some(fill_id)` on both sides of the
+/// match. Verifies the cron path of `_submit_order` → `match_order` →
+/// `settle_fill` correctly threads `next_fill_id` the same way the
+/// user-submitted path does.
+#[test]
+fn conditional_order_trigger_fills_carry_fill_id() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+
+    // Trader deposits, buys 5 ETH long, attaches a TP at $2,500.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(50_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitConditionalOrder {
+                pair_id: pair.clone(),
+                size: Some(Quantity::new_int(-5)),
+                trigger_price: UsdPrice::new_int(2_500),
+                trigger_direction: perps::TriggerDirection::Above,
+                max_slippage: Dimensionless::new_percent(5),
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Resting bid that the TP will cross when triggered.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_500),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Move oracle above the TP trigger and advance time to fire cron.
+    // `increase_time` discards the block outcome, so inline its body to
+    // keep access to the cron-emitted events.
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+
+    let old_block_time = suite.block_time;
+    suite.block_time = Duration::from_minutes(2);
+    let outcome = suite.make_empty_block();
+    suite.block_time = old_block_time;
+
+    let fills = outcome
+        .block_outcome
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_filled")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderFilled>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        fills.len(),
+        2,
+        "one TP crossing one maker should emit two OrderFilled events"
+    );
+
+    for filled in &fills {
+        assert!(
+            filled.fill_id.is_some(),
+            "cron-triggered TP fills must carry a fill_id"
+        );
+    }
+    assert_eq!(
+        fills[0].fill_id, fills[1].fill_id,
+        "the taker and maker sides of a single match must share one fill_id"
+    );
+}
+
+/// Two TP orders that fire in the same `process_conditional_orders`
+/// invocation must produce consecutive fill ids. This pins the storage
+/// round-trip at `dango/perps/src/cron/process_conditional_orders.rs`:
+/// after the first triggered order saves its advanced `NEXT_FILL_ID`,
+/// the second triggered order must load the updated value rather than
+/// the pre-cron one.
+#[test]
+fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+
+    // Two traders each open a long position and attach a TP.
+    for trader in [&mut accounts.user1, &mut accounts.user3] {
+        suite
+            .execute(
+                trader,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+                Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+            )
+            .should_succeed();
+    }
+
+    // Maker deposits and seeds the book with asks so both traders can
+    // open their longs, then later provides bids to fill the TPs.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // Two opening asks, one per trader.
+    for _ in 0..2 {
+        suite
+            .execute(
+                &mut accounts.user2,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                    pair_id: pair.clone(),
+                    size: Quantity::new_int(-5),
+                    kind: perps::OrderKind::Limit {
+                        limit_price: UsdPrice::new_int(2_000),
+                        time_in_force: perps::TimeInForce::PostOnly,
+                        client_order_id: None,
+                    },
+                    reduce_only: false,
+                    tp: None,
+                    sl: None,
+                }),
+                Coins::new(),
+            )
+            .should_succeed();
+    }
+
+    for trader in [&mut accounts.user1, &mut accounts.user3] {
+        suite
+            .execute(
+                trader,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                    pair_id: pair.clone(),
+                    size: Quantity::new_int(5),
+                    kind: perps::OrderKind::Market {
+                        max_slippage: Dimensionless::new_percent(50),
+                    },
+                    reduce_only: false,
+                    tp: None,
+                    sl: None,
+                }),
+                Coins::new(),
+            )
+            .should_succeed();
+    }
+
+    // Both traders submit TPs at the same trigger price so both fire in
+    // the same cron tick. Using slightly different trigger prices is
+    // not required — the cron handler processes every triggered order
+    // in a single invocation regardless of relative trigger prices.
+    for trader in [&mut accounts.user1, &mut accounts.user3] {
+        suite
+            .execute(
+                trader,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitConditionalOrder {
+                    pair_id: pair.clone(),
+                    size: Some(Quantity::new_int(-5)),
+                    trigger_price: UsdPrice::new_int(2_500),
+                    trigger_direction: perps::TriggerDirection::Above,
+                    max_slippage: Dimensionless::new_percent(5),
+                }),
+                Coins::new(),
+            )
+            .should_succeed();
+    }
+
+    // Two resting bids — one per TP — priced generously enough to fill.
+    for _ in 0..2 {
+        suite
+            .execute(
+                &mut accounts.user2,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                    pair_id: pair.clone(),
+                    size: Quantity::new_int(5),
+                    kind: perps::OrderKind::Limit {
+                        limit_price: UsdPrice::new_int(2_500),
+                        time_in_force: perps::TimeInForce::PostOnly,
+                        client_order_id: None,
+                    },
+                    reduce_only: false,
+                    tp: None,
+                    sl: None,
+                }),
+                Coins::new(),
+            )
+            .should_succeed();
+    }
+
+    // Move the oracle so both TPs trigger, then fire cron.
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+
+    let old_block_time = suite.block_time;
+    suite.block_time = Duration::from_minutes(2);
+    let outcome = suite.make_empty_block();
+    suite.block_time = old_block_time;
+
+    let fills = outcome
+        .block_outcome
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_filled")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderFilled>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        fills.len(),
+        4,
+        "two TPs × two sides per match = four OrderFilled events"
+    );
+
+    // Group by fill_id. Must be exactly two distinct values with two
+    // events each, and the two values must be consecutive.
+    let mut by_fill_id = BTreeMap::<_, usize>::new();
+    for filled in &fills {
+        let id = filled.fill_id.expect("cron-triggered fill must carry a fill_id");
+        *by_fill_id.entry(id).or_default() += 1;
+    }
+
+    assert_eq!(
+        by_fill_id.len(),
+        2,
+        "two independent matches should produce two distinct fill_ids"
+    );
+    for (id, count) in &by_fill_id {
+        assert_eq!(
+            *count, 2,
+            "fill_id {} should appear on exactly two events (taker + maker); got {}",
+            id, count,
+        );
+    }
+
+    let mut ids = by_fill_id.keys().copied().collect::<Vec<_>>();
+    ids.sort();
+    assert_eq!(
+        *ids[1].inner(),
+        ids[0].inner() + 1,
+        "the second cron-triggered match's fill_id must be the first's + 1 \
+         (pins the NEXT_FILL_ID storage round-trip between triggers)"
     );
 }

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -4,9 +4,15 @@ use {
     dango_types::{
         Dimensionless, Quantity, UsdPrice, UsdValue,
         constants::usdc,
-        perps::{self, PairParam, Param, QueryOrdersByUserResponseItem, UserState},
+        perps::{
+            self, Deleveraged, OrderFilled, PairParam, Param, QueryOrdersByUserResponseItem,
+            UserState,
+        },
     },
-    grug::{Addressable, Coins, Duration, QuerierExt, ResultExt, Uint128, btree_map},
+    grug::{
+        Addressable, CheckedContractEvent, Coins, Duration, JsonDeExt, QuerierExt, ResultExt,
+        SearchEvent, Uint128, btree_map,
+    },
     std::collections::BTreeMap,
 };
 
@@ -1152,5 +1158,234 @@ fn vault_liquidation_on_order_book() {
     assert!(
         user3_pos.size.is_positive(),
         "user3 should be long (absorbed vault's sell)"
+    );
+}
+
+/// A liquidation that partially fills on the order book and ADLs the
+/// remainder must:
+///
+/// - emit `OrderFilled` events for every book-matching fill, each with
+///   `fill_id: Some(_)`;
+/// - pair those fills two-to-one per `fill_id` (taker + maker);
+/// - emit `Deleveraged` events for the ADL leg, whose event payload has
+///   no `fill_id` field (enforced at compile time by the `Deleveraged`
+///   struct definition, re-confirmed at runtime by the successful
+///   `deserialize_json::<Deleveraged>`).
+///
+/// This pins the BitMEX-style separation: order-book matches get a
+/// `fill_id`, position transfers at the bankruptcy price do not.
+#[test]
+fn liquidation_book_fills_have_fill_id_adl_does_not() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+
+    // Trader A (user1) opens a long that will later become liquidatable.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(1_100_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // Maker (user2) deposits enough to seed the book with plenty of asks,
+    // and later partial-bid for the liquidation.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(20_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // Maker places ask: 5 ETH @ $2,000. Trader A fills it, ending long 5 ETH.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Trader B (user3) will be the ADL counter-party: short 5 ETH @ $2,000.
+    // Large margin so that ADL finds them and they stay solvent.
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // Maker places a bid so Trader B can short into it.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(5),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-5),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Oracle drops to $1,450. Trader A is deeply underwater and forced
+    // to close the full position; equity is negative so target_price for
+    // book matching is the oracle ($1,450).
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450);
+
+    // Partial book liquidity for the liquidation: Maker places a bid for
+    // 2 ETH @ $1,450. Trader A's liquidation will fill this, then ADL
+    // the remaining 3 ETH against Trader B at the bankruptcy price.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(2),
+                kind: perps::OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(1_450),
+                    time_in_force: perps::TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Liquidate Trader A. Expect book fills + ADL remainder.
+    let events = suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Liquidate {
+                user: accounts.user1.address(),
+            }),
+            Coins::new(),
+        )
+        .should_succeed()
+        .events;
+
+    // Book-matching leg: every OrderFilled event must carry a fill_id,
+    // and the events must pair two-to-one per fill_id (taker + maker).
+    let order_filled_events = events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_filled")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderFilled>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert!(
+        !order_filled_events.is_empty(),
+        "liquidation should have produced at least one book fill"
+    );
+
+    for filled in &order_filled_events {
+        assert!(
+            filled.fill_id.is_some(),
+            "every OrderFilled emitted during liquidation book matching must carry a fill_id"
+        );
+    }
+
+    let mut by_fill_id = BTreeMap::<_, usize>::new();
+    for filled in &order_filled_events {
+        *by_fill_id.entry(filled.fill_id.unwrap()).or_default() += 1;
+    }
+    for (fill_id, count) in &by_fill_id {
+        assert_eq!(
+            *count, 2,
+            "fill_id {} should appear on exactly two OrderFilled events \
+             (taker side + maker side); got {}",
+            fill_id, count,
+        );
+    }
+
+    // ADL leg: Deleveraged events must exist and deserialize cleanly into
+    // the `Deleveraged` struct, which has no fill_id field — if the
+    // runtime JSON ever gained one, downstream consumers would still
+    // deserialize fine (extra fields ignored) but this assertion
+    // documents the intended shape.
+    let deleveraged_events = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "deleveraged")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Deleveraged>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert!(
+        !deleveraged_events.is_empty(),
+        "liquidation should have ADL'd the remainder against a counter-party"
     );
 }

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -4,9 +4,12 @@ use {
     dango_types::{
         Dimensionless, Quantity, UsdPrice, UsdValue,
         constants::usdc,
-        perps::{self, LiquidityDepthResponse, PairParam, Param, UserState},
+        perps::{self, LiquidityDepthResponse, OrderFilled, PairParam, Param, UserState},
     },
-    grug::{Addressable, Coins, QuerierExt, ResultExt, Uint128, btree_map, btree_set},
+    grug::{
+        Addressable, CheckedContractEvent, Coins, Inner, JsonDeExt, QuerierExt, ResultExt,
+        SearchEvent, Uint128, btree_map, btree_set,
+    },
     std::collections::BTreeMap,
 };
 
@@ -1258,4 +1261,124 @@ fn slippage_cap_does_not_affect_limit_orders() {
             Coins::new(),
         )
         .should_succeed();
+}
+
+/// A taker that crosses two resting maker orders emits four `OrderFilled`
+/// events — two per match — and the two events of a given match share a
+/// `fill_id`. Successive matches use consecutive fill ids, and
+/// `NEXT_FILL_ID` in storage advances by one per match.
+#[test]
+fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+
+    // Two different maker users so we also exercise the maker-states map.
+    for user in [&mut accounts.user1, &mut accounts.user2] {
+        suite
+            .execute(
+                user,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+                Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+            )
+            .should_succeed();
+    }
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .should_succeed();
+
+    // Two resting asks at different prices. The taker's market buy will
+    // sweep the cheaper one first, then fill the rest at the higher price —
+    // two distinct matches, four `OrderFilled` events total.
+    for (maker, price) in [(&mut accounts.user1, 2_000), (&mut accounts.user2, 2_010)] {
+        suite
+            .execute(
+                maker,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                    pair_id: pair.clone(),
+                    size: Quantity::new_int(-2), // ask
+                    kind: perps::OrderKind::Limit {
+                        limit_price: UsdPrice::new_int(price),
+                        time_in_force: perps::TimeInForce::PostOnly,
+                        client_order_id: None,
+                    },
+                    reduce_only: false,
+                    tp: None,
+                    sl: None,
+                }),
+                Coins::new(),
+            )
+            .should_succeed();
+    }
+
+    // Taker market buy crosses both asks.
+    let events = suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(4),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            }),
+            Coins::new(),
+        )
+        .should_succeed()
+        .events;
+
+    let fills = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_filled")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderFilled>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(fills.len(), 4, "two matches × two sides = four fills");
+
+    for fill in &fills {
+        assert!(
+            fill.fill_id.is_some(),
+            "every matched fill must carry a fill id"
+        );
+    }
+
+    // Matching iterates makers in price-time priority (best price first).
+    // Given the current iteration order, the event stream pairs are
+    // (fills[0] taker, fills[1] maker) and (fills[2] taker, fills[3] maker).
+    let match1 = fills[0].fill_id.unwrap();
+    assert_eq!(
+        fills[1].fill_id.unwrap(),
+        match1,
+        "the two sides of a match share one fill id"
+    );
+
+    let match2 = fills[2].fill_id.unwrap();
+    assert_eq!(
+        fills[3].fill_id.unwrap(),
+        match2,
+        "the two sides of a match share one fill id"
+    );
+
+    assert_ne!(match1, match2, "distinct matches have distinct fill ids");
+    assert_eq!(
+        match2.into_inner(),
+        match1.into_inner() + 1,
+        "fill ids increment by one per match"
+    );
 }

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -48,6 +48,15 @@ pub type OrderId = Uint64;
 /// Shares the same ID space as `OrderId` (same `NEXT_ORDER_ID` counter).
 pub type ConditionalOrderId = OrderId;
 
+/// Identifier for an order-book match. Both `OrderFilled` events emitted
+/// for a single match (taker side + maker side) carry the same `FillId`,
+/// so consumers can group the two sides by this field. Strictly
+/// increasing across matches.
+///
+/// Not assigned to ADL fills — those are emitted via the `Deleveraged`
+/// and `Liquidated` events, which have no `fill_id` field.
+pub type FillId = Uint64;
+
 /// Client-assigned order id. Lets a trader cancel an order in the same block
 /// it was submitted, without round-tripping through the server response to
 /// learn the system-assigned `OrderId`.
@@ -1356,6 +1365,11 @@ pub struct OrderFilled {
     /// Caller-assigned id from the originally-submitted order, or `None`
     /// if the order was submitted without one.
     pub client_order_id: Option<ClientOrderId>,
+    /// Identifier shared between the two `OrderFilled` events of a single
+    /// order-book match (taker + maker). Strictly increasing across
+    /// matches. `None` for trades executed before v0.15.0 — fill IDs
+    /// were not assigned prior to that release.
+    pub fill_id: Option<FillId>,
 }
 
 /// Event indicating an order have been inserted into the order book.

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1369,6 +1369,18 @@ pub struct OrderFilled {
     /// order-book match (taker + maker). Strictly increasing across
     /// matches. `None` for trades executed before v0.15.0 — fill IDs
     /// were not assigned prior to that release.
+    ///
+    /// Equivalents at other venues:
+    ///
+    /// - BitMEX — `trdMatchID`, shared across the two executions of a
+    ///   match; non-match `execType`s use an all-zeros placeholder:
+    ///   <https://support.bitmex.com/hc/en-gb/articles/6205689858077--execution-field-definitions>
+    /// - Hyperliquid — `tid`, a 50-bit hash of `(buyer_oid, seller_oid)`
+    ///   that both sides of a match emit:
+    ///   <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions>
+    /// - Binance USD-M Futures — trade `id` on `GET /fapi/v1/userTrades`;
+    ///   each side sees the same `id` per match:
+    ///   <https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Account-Trade-List>
     pub fill_id: Option<FillId>,
 }
 

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -2,11 +2,11 @@ use {
     dango_perps::state::OrderKey,
     dango_types::{
         Dimensionless, FundingRate, Quantity, UsdPrice, UsdValue,
-        perps::{self, ChildOrder, OrderId, PairId},
+        perps::{self, ChildOrder, FillId, OrderId, PairId},
     },
     grug::{
-        Addr, BlockInfo, IndexedMap, MultiIndex, Order as IterationOrder, StdResult, Storage,
-        Timestamp, UniqueIndex, addr,
+        Addr, BlockInfo, IndexedMap, MultiIndex, NumberConst, Order as IterationOrder, StdResult,
+        Storage, Timestamp, UniqueIndex, addr,
     },
     grug_app::{AppResult, CHAIN_ID, CONTRACT_NAMESPACE, StorageProvider},
     std::collections::BTreeSet,
@@ -125,6 +125,7 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
 
     do_price_banding_upgrade(&mut storage)?;
     do_client_order_id_upgrade(&mut storage)?;
+    do_fill_id_upgrade(&mut storage)?;
 
     Ok(())
 }
@@ -192,6 +193,16 @@ fn do_client_order_id_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
         "Migrated {bid_count} resting bids and {ask_count} resting asks (added client_order_id = None)"
     );
 
+    Ok(())
+}
+
+/// Seed `NEXT_FILL_ID` with `FillId::ONE` so that the counter exists for
+/// post-upgrade `load` calls. Fills executed before the upgrade have no
+/// `fill_id` in their emitted `OrderFilled` events and are not backfilled —
+/// downstream consumers treat a missing field as "pre-v0.15.0".
+fn do_fill_id_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
+    dango_perps::state::NEXT_FILL_ID.save(storage, &FillId::ONE)?;
+    tracing::info!("Initialized NEXT_FILL_ID to 1");
     Ok(())
 }
 
@@ -452,11 +463,33 @@ mod tests {
         do_client_order_id_upgrade(&mut storage).unwrap();
     }
 
-    /// `do_upgrade` chains both migrations: legacy `PairParam`s are
-    /// rewritten *and* legacy resting orders are rewritten, all under
-    /// one upgrade boundary.
+    /// `do_fill_id_upgrade` seeds `NEXT_FILL_ID` to 1 so post-upgrade
+    /// `load` calls in the matching engine succeed.
     #[test]
-    fn do_upgrade_runs_both_migrations() {
+    fn fill_id_upgrade_initializes_counter_to_one() {
+        let mut storage = MockStorage::new();
+
+        // Before the upgrade, the counter does not exist.
+        assert!(
+            dango_perps::state::NEXT_FILL_ID
+                .may_load(&storage)
+                .unwrap()
+                .is_none()
+        );
+
+        do_fill_id_upgrade(&mut storage).unwrap();
+
+        assert_eq!(
+            dango_perps::state::NEXT_FILL_ID.load(&storage).unwrap(),
+            FillId::ONE
+        );
+    }
+
+    /// `do_upgrade` chains all three migrations: legacy `PairParam`s are
+    /// rewritten, legacy resting orders are rewritten, and the
+    /// `NEXT_FILL_ID` counter is seeded — all under one upgrade boundary.
+    #[test]
+    fn do_upgrade_runs_all_migrations() {
         let mut storage = MockStorage::new();
 
         // Seed legacy state for both migrations.
@@ -471,9 +504,10 @@ mod tests {
             )
             .unwrap();
 
-        // Run both migrations sequentially (mirrors `do_upgrade`).
+        // Run all migrations sequentially (mirrors `do_upgrade`).
         do_price_banding_upgrade(&mut storage).unwrap();
         do_client_order_id_upgrade(&mut storage).unwrap();
+        do_fill_id_upgrade(&mut storage).unwrap();
 
         // PairParam migrated.
         let pair = dango_perps::state::PAIR_PARAMS
@@ -494,5 +528,11 @@ mod tests {
             .unwrap();
         assert_eq!(order.user, USER_A);
         assert_eq!(order.client_order_id, None);
+
+        // NEXT_FILL_ID seeded.
+        assert_eq!(
+            dango_perps::state::NEXT_FILL_ID.load(&storage).unwrap(),
+            FillId::ONE
+        );
     }
 }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -200,7 +200,20 @@ fn do_client_order_id_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
 /// post-upgrade `load` calls. Fills executed before the upgrade have no
 /// `fill_id` in their emitted `OrderFilled` events and are not backfilled —
 /// downstream consumers treat a missing field as "pre-v0.15.0".
+///
+/// Idempotency: this handler seeds a fresh counter. If it were ever rerun
+/// on a chain that already has `NEXT_FILL_ID` populated, blindly saving
+/// `FillId::ONE` would reset a live counter and cause duplicate fill ids
+/// to be emitted. The assertion below makes the invariant explicit —
+/// `assert!` is deliberate: the upgrade framework has no recovery path,
+/// and silently skipping would hide a serious control-flow bug.
 fn do_fill_id_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
+    assert!(
+        dango_perps::state::NEXT_FILL_ID
+            .may_load(storage)?
+            .is_none(),
+        "NEXT_FILL_ID already initialized — do_fill_id_upgrade must not run twice",
+    );
     dango_perps::state::NEXT_FILL_ID.save(storage, &FillId::ONE)?;
     tracing::info!("Initialized NEXT_FILL_ID to 1");
     Ok(())
@@ -483,6 +496,24 @@ mod tests {
             dango_perps::state::NEXT_FILL_ID.load(&storage).unwrap(),
             FillId::ONE
         );
+    }
+
+    /// Running `do_fill_id_upgrade` a second time on a chain that already
+    /// has a live `NEXT_FILL_ID` must panic rather than reset the counter.
+    /// A silent overwrite would cause the matching engine to emit fill
+    /// ids that collide with previously-emitted ones.
+    #[test]
+    #[should_panic(expected = "NEXT_FILL_ID already initialized")]
+    fn fill_id_upgrade_rejects_rerun() {
+        let mut storage = MockStorage::new();
+
+        // Simulate a chain that already has the counter advanced past 1.
+        dango_perps::state::NEXT_FILL_ID
+            .save(&mut storage, &Uint64::new(42))
+            .unwrap();
+
+        // A rerun must panic.
+        do_fill_id_upgrade(&mut storage).unwrap();
     }
 
     /// `do_upgrade` chains all three migrations: legacy `PairParam`s are

--- a/indexer/client/src/schemas/schema.graphql
+++ b/indexer/client/src/schemas/schema.graphql
@@ -562,6 +562,12 @@ type PerpsTrade {
 	createdAt: String!
 	blockHeight: Int!
 	tradeIdx: Int!
+	"""
+	Identifier shared between the two `OrderFilled` events of a single
+	order-book match. `None` for trades executed before v0.15.0 — fill
+	IDs were not assigned prior to that release.
+	"""
+	fillId: String
 }
 
 type PublicKey {

--- a/sdk/dango/src/types/indexer.ts
+++ b/sdk/dango/src/types/indexer.ts
@@ -78,6 +78,12 @@ export type PerpsTrade = {
   createdAt: string;
   blockHeight: number;
   tradeIdx: number;
+  /**
+   * Identifier shared between the two `OrderFilled` events of a single
+   * order-book match. `null` for trades executed before v0.15.0 — fill IDs
+   * were not assigned prior to that release.
+   */
+  fillId?: string | null;
 };
 
 export type PerpsEventType = "order_filled" | "liquidated" | "deleveraged";
@@ -92,6 +98,12 @@ export type OrderFilledData = {
   opening_size: string;
   realized_pnl: string;
   fee: string;
+  /**
+   * Identifier shared between the two `OrderFilled` events of a single
+   * order-book match. `null` for trades executed before v0.15.0 — fill IDs
+   * were not assigned prior to that release.
+   */
+  fill_id?: string | null;
 };
 
 export type LiquidatedData = {


### PR DESCRIPTION
Add a new `FillId` identifier that groups the two sides of a single
order-book match — the taker's `OrderFilled` and the maker's
`OrderFilled` emitted within the same match-loop iteration share a
`fill_id`, and the id strictly increases across matches. This is the
BitMEX `trdMatchID` / Hyperliquid `tid` pattern: it gives off-chain
consumers (indexer, UI, analytics) a first-class join key for
correlating the two sides without having to infer the pairing from
timestamp + price + complementary sizes.