### PR TITLE
chore: increase-ws-keep-alive

### DIFF
--- a/grug/httpd/src/routes/graphql.rs
+++ b/grug/httpd/src/routes/graphql.rs
@@ -3,6 +3,7 @@ use {
     actix_web::{HttpRequest, HttpResponse, Resource, http::header, web},
     async_graphql::{Schema, http::GraphiQLSource},
     async_graphql_actix_web::{GraphQLBatchRequest, GraphQLResponse, GraphQLSubscription},
+    std::time::Duration,
 };
 
 pub fn graphql_route<Q, M, S>() -> Resource
@@ -67,5 +68,7 @@ where
     M: async_graphql::ObjectType + 'static,
     S: async_graphql::SubscriptionType + 'static,
 {
-    GraphQLSubscription::new(Schema::clone(&*schema)).start(&req, payload)
+    GraphQLSubscription::new(Schema::clone(&*schema))
+        .keepalive_timeout(Duration::from_secs(30))
+        .start(&req, payload)
 }


### PR DESCRIPTION
Add 30-second WebSocket keepalive ping to the GraphQL subscription handler.                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                        
Without keepalive, idle WebSocket connections (e.g., fills subscriptions with no activity) are silently killed by intermediaries (CloudFlare, proxies). This causes constant reconnection churn. Each reconnect re-subscribes to ~20 subscriptions, wasting bandwidth and causing data gaps.
                                                                                                                                                                             
- CloudFlare WebSocket upgrade expect significant drop
- Bots users no longer see 35s timeout disconnects  