### PR TITLE
fix(perps): reserved margin rounding

### DIFF
--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -978,10 +978,20 @@ pub fn match_order(
 
         let pre_fill_abs_size = maker_order.size.checked_abs()?;
 
-        // Release reserved margin proportionally to the filled portion.
-        let margin_to_release = (maker_order.reserved_margin)
-            .checked_mul(maker_fill_size)?
-            .checked_div(maker_order.size)?;
+        // Compute the new size first so we can detect a full fill below.
+        let new_maker_size = maker_order.size.checked_sub(maker_fill_size)?;
+
+        // Release reserved margin. On a full fill, release everything that's
+        // left in the order: the proportional formula truncates toward zero
+        // and would otherwise orphan the residual in `maker_state` when the
+        // order is removed from storage a few lines below.
+        let margin_to_release = if new_maker_size.is_zero() {
+            maker_order.reserved_margin
+        } else {
+            (maker_order.reserved_margin)
+                .checked_mul(maker_fill_size)?
+                .checked_div(maker_order.size)?
+        };
 
         maker_state
             .reserved_margin
@@ -991,7 +1001,7 @@ pub fn match_order(
             .reserved_margin
             .checked_sub_assign(margin_to_release)?;
 
-        maker_order.size.checked_sub_assign(maker_fill_size)?;
+        maker_order.size = new_maker_size;
 
         if maker_order.size.is_zero() {
             maker_state.open_order_count -= 1;

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -2801,6 +2801,390 @@ mod tests {
         assert_eq!(maker_states[&MAKER_A].open_order_count, 0);
     }
 
+    /// Regression test: a maker ask is consumed by two back-to-back partial
+    /// fills that together equal its full size. The final fill lands on the
+    /// `new_maker_size.is_zero()` branch and must release every remaining
+    /// ULP of `reserved_margin`.
+    ///
+    /// Pre-fix, each of the two fills truncates via the proportional
+    /// formula: the first leaves the order and user state consistent at the
+    /// mid-point (both drifted by the same amount), but the second fill
+    /// applies the proportional formula again on the residual R, truncates
+    /// once more, and drops a ≥1-ULP orphan into `maker_state.reserved_margin`
+    /// when the order is removed. Post-fix the final fill releases the full
+    /// remainder unconditionally.
+    #[test]
+    fn maker_reserved_margin_no_orphan_on_full_fill_via_two_partial_fills() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        // Same truncation-prone plant values as the single-shot test above,
+        // split into two equal-sized taker fills (2 × 91_473 = 182_946).
+        let price = UsdPrice::new_int(50_000);
+        let size_inner: i128 = 182_946;
+        let half_size_inner: i128 = 91_473;
+        let reserved_inner: i128 = 21_406_601;
+        let order_id = Uint64::new(100);
+        let key = (pair_id(), price, order_id);
+        let ask = LimitOrder {
+            user: MAKER_A,
+            size: Quantity::new_raw(-size_inner),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_raw(reserved_inner),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        };
+        ASKS.save(&mut ctx.storage, key, &ask).unwrap();
+        USER_STATES
+            .save(&mut ctx.storage, MAKER_A, &UserState {
+                margin: LARGE_COLLATERAL,
+                open_order_count: 1,
+                reserved_margin: ask.reserved_margin,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+
+        // ---------- Phase 1: first half-fill (partial) ----------
+        {
+            let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+            let taker_state = UserState {
+                margin: LARGE_COLLATERAL,
+                ..Default::default()
+            };
+            let mut oq = test_oracle_querier();
+
+            let SubmitOrderOutcome {
+                pair_state,
+                taker_state,
+                maker_states,
+                order_mutations,
+                ..
+            } = compute_submit_order_outcome(
+                &ctx.storage,
+                TAKER,
+                CONTRACT,
+                Timestamp::ZERO,
+                &mut oq,
+                &param,
+                &State::default(),
+                &pair_id(),
+                &pair_param,
+                &pair_state,
+                &taker_state,
+                price,
+                Quantity::new_raw(half_size_inner),
+                OrderKind::Market {
+                    max_slippage: Dimensionless::new_permille(100),
+                },
+                false,
+                None,
+                None,
+                &mut EventBuilder::new(),
+            )
+            .unwrap();
+
+            // Partial fill: the order must still exist with the residual size.
+            assert_eq!(order_mutations.len(), 1);
+            assert!(
+                order_mutations[0].2.is_some(),
+                "order should remain on the book after partial fill"
+            );
+            assert_eq!(maker_states[&MAKER_A].open_order_count, 1);
+
+            // Persist phase-1 side effects so phase-2 sees the post-partial state.
+            PAIR_STATES
+                .save(&mut ctx.storage, &pair_id(), &pair_state)
+                .unwrap();
+            USER_STATES
+                .save(&mut ctx.storage, TAKER, &taker_state)
+                .unwrap();
+            for (addr, ms) in &maker_states {
+                USER_STATES.save(&mut ctx.storage, *addr, ms).unwrap();
+            }
+            for (stored_price, mutated_order_id, mutation, _) in order_mutations {
+                let key = (pair_id(), stored_price, mutated_order_id);
+                match mutation {
+                    Some(order) => ASKS.save(&mut ctx.storage, key, &order).unwrap(),
+                    None => ASKS.remove(&mut ctx.storage, key).unwrap(),
+                }
+            }
+        }
+
+        // ---------- Phase 2: consume the remainder (triggers full-fill branch) ----------
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = USER_STATES.load(&ctx.storage, TAKER).unwrap();
+        let mut oq = test_oracle_querier();
+
+        let SubmitOrderOutcome {
+            maker_states,
+            order_mutations,
+            ..
+        } = compute_submit_order_outcome(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            price,
+            Quantity::new_raw(half_size_inner),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_permille(100),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .unwrap();
+
+        // Second fill fully consumes the order.
+        assert_eq!(order_mutations.len(), 1);
+        assert!(
+            order_mutations[0].2.is_none(),
+            "order should be removed after full consumption"
+        );
+        // The invariant: no ULP is orphaned in the maker's reserved_margin
+        // even though the two fills both touched the truncating formula.
+        assert_eq!(maker_states[&MAKER_A].reserved_margin, UsdValue::ZERO);
+        assert_eq!(maker_states[&MAKER_A].open_order_count, 0);
+    }
+
+    /// Defensive test for the cancel-after-partial-fill pathway. Partial
+    /// fills decrement `order.reserved_margin` and `user_state.reserved_margin`
+    /// by the same truncated amount, so the mid-life invariant holds by
+    /// construction. On cancel, `cancel_order.rs` subtracts the full residual
+    /// `order.reserved_margin` from the user's reserved margin; this test
+    /// locks in that pairing with fractional-ULP values so a future refactor
+    /// cannot silently desynchronize either half.
+    ///
+    /// Passes both pre- and post-matcher-fix — the matcher bug only manifests
+    /// on a *full fill*, which removes the order and bypasses cancel.
+    #[test]
+    fn reserved_margin_zero_after_cancel_following_partial_fill() {
+        use crate::trade::cancel_order::_cancel_one_order;
+
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        let price = UsdPrice::new_int(50_000);
+        let size_inner: i128 = 182_946;
+        let half_size_inner: i128 = 91_473;
+        let reserved_inner: i128 = 21_406_601;
+        let order_id = Uint64::new(100);
+        let key = (pair_id(), price, order_id);
+        let ask = LimitOrder {
+            user: MAKER_A,
+            size: Quantity::new_raw(-size_inner),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_raw(reserved_inner),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        };
+        ASKS.save(&mut ctx.storage, key, &ask).unwrap();
+        USER_STATES
+            .save(&mut ctx.storage, MAKER_A, &UserState {
+                margin: LARGE_COLLATERAL,
+                open_order_count: 1,
+                reserved_margin: ask.reserved_margin,
+                ..Default::default()
+            })
+            .unwrap();
+
+        // Partial fill consuming half the order.
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        let SubmitOrderOutcome {
+            pair_state,
+            taker_state,
+            maker_states,
+            order_mutations,
+            ..
+        } = compute_submit_order_outcome(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            price,
+            Quantity::new_raw(half_size_inner),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_permille(100),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .unwrap();
+
+        // Persist the partial-fill outcome so cancel operates on the correct
+        // post-fill state.
+        PAIR_STATES
+            .save(&mut ctx.storage, &pair_id(), &pair_state)
+            .unwrap();
+        USER_STATES
+            .save(&mut ctx.storage, TAKER, &taker_state)
+            .unwrap();
+        for (addr, ms) in &maker_states {
+            USER_STATES.save(&mut ctx.storage, *addr, ms).unwrap();
+        }
+        for (stored_price, mutated_order_id, mutation, _) in order_mutations {
+            let key = (pair_id(), stored_price, mutated_order_id);
+            match mutation {
+                Some(order) => ASKS.save(&mut ctx.storage, key, &order).unwrap(),
+                None => ASKS.remove(&mut ctx.storage, key).unwrap(),
+            }
+        }
+
+        // Sanity: after a partial fill the maker still holds some reserved
+        // margin — otherwise the cancel path isn't being exercised.
+        let mid_state = USER_STATES.load(&ctx.storage, MAKER_A).unwrap();
+        assert!(
+            mid_state.reserved_margin.is_non_zero(),
+            "partial fill must leave non-zero residual reserved_margin"
+        );
+        assert_eq!(mid_state.open_order_count, 1);
+
+        // Cancel the remaining order.
+        let mut events = EventBuilder::new();
+        _cancel_one_order(&mut ctx.storage, MAKER_A, order_id, &mut events).unwrap();
+
+        let after = USER_STATES.load(&ctx.storage, MAKER_A).unwrap();
+        assert_eq!(after.reserved_margin, UsdValue::ZERO);
+        assert_eq!(after.open_order_count, 0);
+    }
+
+    /// Defensive test for the self-trade prevention (STP) pathway. When a
+    /// taker crosses their own maker, the STP branch releases the full
+    /// `maker_order.reserved_margin` in one step (no truncating formula),
+    /// so the taker's `reserved_margin` must land at exactly zero — even
+    /// when the original reservation uses fractional-ULP values. This
+    /// tightens the existing `self_trade_prevention_expire_maker` test,
+    /// which only asserts `taker_state.reserved_margin < taker_reserved_before`.
+    ///
+    /// Passes both pre- and post-matcher-fix — the STP branch is untouched
+    /// by the fix.
+    #[test]
+    fn reserved_margin_zero_after_self_trade_prevention_with_fractional_values() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        // TAKER owns a resting ask planted with fractional reserved_margin.
+        let takers_price = UsdPrice::new_int(50_000);
+        let size_inner: i128 = 182_946;
+        let reserved_inner: i128 = 21_406_601;
+        let takers_order_id = Uint64::new(100);
+        let takers_key = (pair_id(), takers_price, takers_order_id);
+        let takers_ask = LimitOrder {
+            user: TAKER,
+            size: Quantity::new_raw(-size_inner),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_raw(reserved_inner),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        };
+        ASKS.save(&mut ctx.storage, takers_key, &takers_ask)
+            .unwrap();
+
+        // A second, higher-priced maker ask so the taker's market buy can
+        // find liquidity after STP cancels the taker's own ask (otherwise
+        // `compute_submit_order_outcome` rejects the order as "no liquidity
+        // at acceptable price" when `unfilled == fillable_size`).
+        place_ask(&mut ctx.storage, MAKER_A, 50_100, 10, 101);
+
+        let taker_state_before = UserState {
+            margin: LARGE_COLLATERAL,
+            open_order_count: 1,
+            reserved_margin: takers_ask.reserved_margin,
+            ..Default::default()
+        };
+        USER_STATES
+            .save(&mut ctx.storage, TAKER, &taker_state_before)
+            .unwrap();
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let mut oq = test_oracle_querier();
+
+        let SubmitOrderOutcome {
+            taker_state,
+            order_mutations,
+            ..
+        } = compute_submit_order_outcome(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state_before,
+            UsdPrice::new_int(50_100),
+            Quantity::new_int(10),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_permille(100),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .unwrap();
+
+        // First mutation is the taker's own ask, removed by STP.
+        assert_eq!(order_mutations.len(), 2);
+        assert!(
+            order_mutations[0].2.is_none(),
+            "taker's own ask should be STP-cancelled (mutation = None)"
+        );
+
+        // The STP branch releases the full fractional reservation in one
+        // step — no truncation, no orphan.
+        assert_eq!(taker_state.reserved_margin, UsdValue::ZERO);
+        assert_eq!(taker_state.open_order_count, 0);
+    }
+
     // ======= Market buy: price beyond slippage ===============================
 
     #[test]

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -2690,6 +2690,107 @@ mod tests {
         );
     }
 
+    // ======= Maker reserved margin release: full fill, truncation-prone =====
+
+    /// Regression test for a rounding leak in the proportional
+    /// margin-release formula on a full fill.
+    ///
+    /// The maker's order is planted directly with values chosen so that
+    /// `R * S` is not a multiple of `PRECISION` (1e6):
+    ///
+    /// - `R` (reserved_margin) = 21.406601 USD → inner = 21_406_601
+    /// - `S` (|size|)          = 0.182946 qty  → inner =    182_946
+    /// - `R.inner * S.inner mod 1_000_000 = 26_546 ≠ 0`
+    ///
+    /// On a single full fill, the proportional formula
+    /// `floor(floor(R·S / 1e6) · 1e6 / S)` yields 21_406_600 — one ULP
+    /// short of `R`. The order is removed with a residual ULP still in
+    /// `maker_order.reserved_margin`; that residual is dropped from the
+    /// order but orphaned in `maker_state.reserved_margin`, breaking the
+    /// invariant `user_state.reserved_margin == sum(open orders'
+    /// reserved_margin)`.
+    ///
+    /// After the fix this test must pass: on a full fill, everything
+    /// left in the order's reserved_margin is released to the user, so
+    /// the user's reserved_margin goes to zero once the only order is
+    /// removed.
+    #[test]
+    fn maker_reserved_margin_no_orphan_on_full_fill_with_truncation() {
+        let mut ctx = MockContext::new()
+            .with_sender(TAKER)
+            .with_funds(Coins::default());
+
+        setup_storage(&mut ctx.storage);
+
+        // Plant a resting ask directly (can't reuse `place_ask` because it
+        // hardcodes integer price/size and computes reserved_margin as
+        // `size * price / 20`; we need fractional inner values).
+        let price = UsdPrice::new_int(50_000);
+        let size_inner: i128 = 182_946; // 0.182946
+        let reserved_inner: i128 = 21_406_601; // 21.406601
+        let order_id = Uint64::new(100);
+        let key = (pair_id(), price, order_id);
+        let ask = LimitOrder {
+            user: MAKER_A,
+            size: Quantity::new_raw(-size_inner),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_raw(reserved_inner),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        };
+        ASKS.save(&mut ctx.storage, key, &ask).unwrap();
+
+        let maker_state_before = UserState {
+            margin: LARGE_COLLATERAL,
+            open_order_count: 1,
+            reserved_margin: ask.reserved_margin,
+            ..Default::default()
+        };
+        USER_STATES
+            .save(&mut ctx.storage, MAKER_A, &maker_state_before)
+            .unwrap();
+
+        let param = test_param();
+        let pair_param = test_pair_param();
+        let pair_state = PAIR_STATES.load(&ctx.storage, &pair_id()).unwrap();
+        let taker_state = UserState {
+            margin: LARGE_COLLATERAL,
+            ..Default::default()
+        };
+        let mut oq = test_oracle_querier();
+
+        let SubmitOrderOutcome { maker_states, .. } = compute_submit_order_outcome(
+            &ctx.storage,
+            TAKER,
+            CONTRACT,
+            Timestamp::ZERO,
+            &mut oq,
+            &param,
+            &State::default(),
+            &pair_id(),
+            &pair_param,
+            &pair_state,
+            &taker_state,
+            price,
+            Quantity::new_raw(size_inner),
+            OrderKind::Market {
+                max_slippage: Dimensionless::new_permille(100),
+            },
+            false,
+            None,
+            None,
+            &mut EventBuilder::new(),
+        )
+        .unwrap();
+
+        // Order is fully consumed, so the user's reserved_margin must be
+        // zero. Pre-fix this is `UsdValue::new_raw(1)` — one ULP orphan.
+        assert_eq!(maker_states[&MAKER_A].reserved_margin, UsdValue::ZERO);
+        assert_eq!(maker_states[&MAKER_A].open_order_count, 0);
+    }
+
     // ======= Market buy: price beyond slippage ===============================
 
     #[test]

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -156,6 +156,7 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
     do_price_banding_and_batch_action_upgrades(&mut storage)?;
     do_client_order_id_upgrade(&mut storage)?;
     do_fill_id_upgrade(&mut storage)?;
+    do_reserved_margin_rounding_error_fix(&mut storage)?;
 
     Ok(())
 }
@@ -286,6 +287,72 @@ fn do_fill_id_upgrade(storage: &mut dyn Storage) -> StdResult<()> {
     Ok(())
 }
 
+/// Repair `UserState::reserved_margin` drift caused by a rounding bug in
+/// the proportional margin-release formula in `submit_order::match_order`
+/// (fixed in the same release). Pre-fix, each fully-filled maker order
+/// could orphan up to a few ULPs of reserved margin on the user side.
+/// A mainnet survey (Apr 2026) found hundreds of users with residuals
+/// ≤ ~0.04 USD.
+///
+/// For every user we recompute `reserved_margin` as the sum of
+/// `LimitOrder::reserved_margin` across their resting bids and asks,
+/// overwriting the field if it disagrees. This restores the invariant
+/// `user_state.reserved_margin == sum(open orders' reserved_margin)` at
+/// the upgrade boundary; from there the fixed matcher keeps it intact.
+///
+/// Must run *after* `do_client_order_id_upgrade` so that the books are
+/// already in the new `dango_perps::state::{BIDS, ASKS}` layout — the
+/// per-user `MultiIndex` used below reads through the new shape.
+fn do_reserved_margin_rounding_error_fix(storage: &mut dyn Storage) -> StdResult<()> {
+    // Snapshot users first — we cannot iterate `USER_STATES` and mutate
+    // it in the same pass.
+    let users: Vec<_> = dango_perps::state::USER_STATES
+        .range(storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<_>>()?;
+
+    let mut fixed = 0usize;
+
+    for (user, mut user_state) in users {
+        let mut actual = UsdValue::ZERO;
+
+        for res in dango_perps::state::BIDS.idx.user.prefix(user).range(
+            storage,
+            None,
+            None,
+            IterationOrder::Ascending,
+        ) {
+            let (_, order) = res?;
+            actual.checked_add_assign(order.reserved_margin)?;
+        }
+
+        for res in dango_perps::state::ASKS.idx.user.prefix(user).range(
+            storage,
+            None,
+            None,
+            IterationOrder::Ascending,
+        ) {
+            let (_, order) = res?;
+            actual.checked_add_assign(order.reserved_margin)?;
+        }
+
+        if actual != user_state.reserved_margin {
+            tracing::info!(
+                %user,
+                old = %user_state.reserved_margin,
+                new = %actual,
+                "Fixed reserved_margin rounding drift",
+            );
+            user_state.reserved_margin = actual;
+            dango_perps::state::USER_STATES.save(storage, user, &user_state)?;
+            fixed += 1;
+        }
+    }
+
+    tracing::info!("Reserved_margin rounding-error fix complete: {fixed} user(s) updated");
+
+    Ok(())
+}
+
 fn migrate_book(
     storage: &mut dyn Storage,
     legacy_map: &IndexedMap<OrderKey, legacy::LimitOrder, legacy::OrderIndexes>,
@@ -388,6 +455,71 @@ mod tests {
             vault_max_skew_size: Quantity::new_int(500),
             bucket_sizes: btree_set! { UsdPrice::new_int(1), UsdPrice::new_int(10) },
         }
+    }
+
+    /// Build a current-shape `LimitOrder` with `reserved_margin` given
+    /// directly in inner (Dec128_6) units — useful for exercising the
+    /// rounding-error fix with fractional values.
+    fn limit_order_with_reserved_raw(
+        user: Addr,
+        size: i128,
+        reserved_margin_raw: i128,
+    ) -> dango_types::perps::LimitOrder {
+        dango_types::perps::LimitOrder {
+            user,
+            size: Quantity::new_int(size),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_raw(reserved_margin_raw),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        }
+    }
+
+    fn plant_bid(
+        storage: &mut dyn Storage,
+        pair: PairId,
+        price: i128,
+        id: u64,
+        order: &dango_types::perps::LimitOrder,
+    ) {
+        // Buy-side orders are stored under the inverted price so iteration
+        // yields the highest-priced bids first.
+        let stored_price = !UsdPrice::new_int(price);
+        dango_perps::state::BIDS
+            .save(storage, (pair, stored_price, Uint64::new(id)), order)
+            .unwrap();
+    }
+
+    fn plant_ask(
+        storage: &mut dyn Storage,
+        pair: PairId,
+        price: i128,
+        id: u64,
+        order: &dango_types::perps::LimitOrder,
+    ) {
+        dango_perps::state::ASKS
+            .save(
+                storage,
+                (pair, UsdPrice::new_int(price), Uint64::new(id)),
+                order,
+            )
+            .unwrap();
+    }
+
+    fn plant_user_state_with_reserved_raw(
+        storage: &mut dyn Storage,
+        user: Addr,
+        reserved_raw: i128,
+    ) {
+        let state = dango_types::perps::UserState {
+            reserved_margin: UsdValue::new_raw(reserved_raw),
+            ..Default::default()
+        };
+        dango_perps::state::USER_STATES
+            .save(storage, user, &state)
+            .unwrap();
     }
 
     #[test]
@@ -660,10 +792,82 @@ mod tests {
         do_fill_id_upgrade(&mut storage).unwrap();
     }
 
+    /// With a drifted `USER_A` (reserved_margin strictly greater than the
+    /// sum of their order's reserved_margin) and a consistent `USER_B`,
+    /// the fix rewrites `USER_A`'s field to the true sum and leaves
+    /// `USER_B` untouched.
+    #[test]
+    fn reserved_margin_fix_repairs_drift() {
+        let mut storage = MockStorage::new();
+
+        // USER_A: one ask with reserved_margin = 21.405596 USD, but
+        // user_state says 21.406601 USD — a 1005-ULP orphan.
+        let ask_a = limit_order_with_reserved_raw(USER_A, -1, 21_405_596);
+        plant_ask(&mut storage, eth_pair(), 2_340, 1, &ask_a);
+        plant_user_state_with_reserved_raw(&mut storage, USER_A, 21_406_601);
+
+        // USER_B: a bid + an ask summing to 10 USD, user_state matches.
+        let bid_b = limit_order_with_reserved_raw(USER_B, 1, 6_000_000);
+        let ask_b = limit_order_with_reserved_raw(USER_B, -1, 4_000_000);
+        plant_bid(&mut storage, btc_pair(), 50_000, 2, &bid_b);
+        plant_ask(&mut storage, btc_pair(), 51_000, 3, &ask_b);
+        plant_user_state_with_reserved_raw(&mut storage, USER_B, 10_000_000);
+
+        do_reserved_margin_rounding_error_fix(&mut storage).unwrap();
+
+        let after_a = dango_perps::state::USER_STATES
+            .load(&storage, USER_A)
+            .unwrap();
+        assert_eq!(after_a.reserved_margin, UsdValue::new_raw(21_405_596));
+
+        let after_b = dango_perps::state::USER_STATES
+            .load(&storage, USER_B)
+            .unwrap();
+        assert_eq!(after_b.reserved_margin, UsdValue::new_raw(10_000_000));
+    }
+
+    /// Users whose orders have all been fully filled can still carry a
+    /// residual reserved_margin. With no orders left, the fix resets
+    /// the field to zero.
+    #[test]
+    fn reserved_margin_fix_resets_to_zero_when_no_orders() {
+        let mut storage = MockStorage::new();
+
+        // User with 0.034211 USD reserved but no open orders — matches
+        // the shape of several mainnet inconsistencies from the survey.
+        plant_user_state_with_reserved_raw(&mut storage, USER_A, 34_211);
+
+        do_reserved_margin_rounding_error_fix(&mut storage).unwrap();
+
+        let after = dango_perps::state::USER_STATES
+            .load(&storage, USER_A)
+            .unwrap();
+        assert_eq!(after.reserved_margin, UsdValue::ZERO);
+    }
+
+    /// When every user's reserved_margin already matches the sum of
+    /// their orders' reserved_margin, the fix is a no-op.
+    #[test]
+    fn reserved_margin_fix_noop_when_consistent() {
+        let mut storage = MockStorage::new();
+
+        let bid = limit_order_with_reserved_raw(USER_A, 1, 5_000_000);
+        plant_bid(&mut storage, eth_pair(), 2_000, 1, &bid);
+        plant_user_state_with_reserved_raw(&mut storage, USER_A, 5_000_000);
+
+        do_reserved_margin_rounding_error_fix(&mut storage).unwrap();
+
+        let after = dango_perps::state::USER_STATES
+            .load(&storage, USER_A)
+            .unwrap();
+        assert_eq!(after.reserved_margin, UsdValue::new_raw(5_000_000));
+    }
+
     /// `do_upgrade` chains all migrations: legacy `PairParam`s are
     /// rewritten, the global `Param` gains `max_action_batch_size`,
-    /// legacy resting orders are rewritten, and the `NEXT_FILL_ID`
-    /// counter is seeded — all under one upgrade boundary.
+    /// legacy resting orders are rewritten, `NEXT_FILL_ID` is seeded,
+    /// and drifted `reserved_margin` entries are repaired — all under
+    /// one upgrade boundary.
     #[test]
     fn do_upgrade_runs_all_migrations() {
         let mut storage = MockStorage::new();
@@ -681,10 +885,15 @@ mod tests {
             )
             .unwrap();
 
+        // USER_A has one bid with reserved_margin = 100, but their
+        // user_state claims 105 — a 5 USD orphan to be corrected.
+        plant_user_state_with_reserved_raw(&mut storage, USER_A, 105_000_000);
+
         // Run all migrations sequentially (mirrors `do_upgrade`).
         do_price_banding_and_batch_action_upgrades(&mut storage).unwrap();
         do_client_order_id_upgrade(&mut storage).unwrap();
         do_fill_id_upgrade(&mut storage).unwrap();
+        do_reserved_margin_rounding_error_fix(&mut storage).unwrap();
 
         // PairParam migrated.
         let pair = dango_perps::state::PAIR_PARAMS
@@ -720,5 +929,12 @@ mod tests {
             dango_perps::state::NEXT_FILL_ID.load(&storage).unwrap(),
             FillId::ONE
         );
+
+        // `reserved_margin` repaired: user_state now matches the sum of
+        // the user's open orders (the one bid with reserved_margin = 100).
+        let user_a_state = dango_perps::state::USER_STATES
+            .load(&storage, USER_A)
+            .unwrap();
+        assert_eq!(user_a_state.reserved_margin, UsdValue::new_int(100));
     }
 }


### PR DESCRIPTION
Fix a rounding leak when releasing the reserved margin of a partially filled limit order.