### PR TITLE
feat(perps): funding rate multiplier

### DIFF
--- a/book/perps/3-funding.md
+++ b/book/perps/3-funding.md
@@ -83,11 +83,12 @@ $$
 
 ## 5. Parameters
 
-| Field                  | Type          | Description                                                                                                                                                                                                     |
-| ---------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `funding_period`       | `Duration`    | Minimum time between funding collections.                                                                                                                                                                       |
-| `impact_size`          | `UsdValue`    | Notional depth walked on each side of the book to compute impact prices. A larger value dilutes the influence of any single resting order on the premium in proportion to the fraction of the walk it occupies. |
-| `max_abs_funding_rate` | `FundingRate` | Symmetric clamp applied to the average premium before scaling to a delta. Prevents runaway rates during prolonged skew.                                                                                         |
+| Field                      | Type            | Description                                                                                                                                                                                                     |
+| -------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `funding_period`           | `Duration`      | Minimum time between funding collections.                                                                                                                                                                       |
+| `impact_size`              | `UsdValue`      | Notional depth walked on each side of the book to compute impact prices. A larger value dilutes the influence of any single resting order on the premium in proportion to the fraction of the walk it occupies. |
+| `max_abs_funding_rate`     | `FundingRate`   | Symmetric clamp applied to the average premium before scaling to a delta. Prevents runaway rates during prolonged skew.                                                                                         |
+| `funding_rate_multiplier`  | `Dimensionless` | Scalar applied to the vault-driven premium so governance can tune funding independently of the vault's quoting (see §6). Bounds: $\geq 0$. $1$ is identity; $0$ disables funding for the pair.                  |
 
 ## 6. Discussions
 
@@ -112,10 +113,12 @@ $$
 and therefore
 
 $$
-\mathtt{premium} = -\mathtt{halfSpread} \cdot \mathtt{skew} \cdot \mathtt{spreadSkewFactor}
+\mathtt{premium} = -\mathtt{halfSpread} \cdot \mathtt{skew} \cdot \mathtt{spreadSkewFactor} \cdot \mathtt{fundingRateMultiplier}
 $$
 
 Positive skew (vault long, because sell flow has dominated) produces a negative premium, so longs receive funding from shorts — which credits the vault-as-long for absorbed inventory. Symmetric when short. The sign is economically correct by construction.
+
+The closed-form also tethers funding to the vault's quoting parameters: tightening spreads to compete for flow would otherwise shrink funding by the same factor. $\mathtt{fundingRateMultiplier}$ is a per-pair governance knob that decouples these two — admins can dial funding up or down (e.g. in response to persistent one-sided skew) without touching $\mathtt{halfSpread}$ or $\mathtt{spreadSkewFactor}$ and therefore without changing the vault's quoted prices. $\mathtt{fundingRateMultiplier} = 1$ is the identity and matches the pre-multiplier formulation; $0$ disables funding entirely.
 
 ### Comparison with other exchanges
 

--- a/dango/perps/src/core/vault_premium.rs
+++ b/dango/perps/src/core/vault_premium.rs
@@ -10,10 +10,12 @@ use {
 /// premium formula yields:
 ///
 /// ```text
-/// premium = -halfSpread × skew × spreadSkewFactor
+/// premium = -halfSpread × skew × spreadSkewFactor × fundingRateMultiplier
 /// ```
 ///
-/// where `skew = clamp(positionSize / maxSkewSize, -1, 1)`.
+/// where `skew = clamp(positionSize / maxSkewSize, -1, 1)`. The
+/// `fundingRateMultiplier` is a governance-tunable scale that lets admins
+/// dial funding up or down without altering the vault's quoting.
 ///
 /// **Sign convention:** a positive vault position (long) produces a negative
 /// premium, meaning shorts pay longs — crediting the vault for absorbed
@@ -30,11 +32,12 @@ pub fn compute_vault_premium(
             .clamp(Dimensionless::new_int(-1), Dimensionless::new_int(1))
     };
 
-    // premium = -(halfSpread * skew * spreadSkewFactor)
+    // premium = -(halfSpread * skew * spreadSkewFactor * fundingRateMultiplier)
     pair_param
         .vault_half_spread
         .checked_mul(skew)?
         .checked_mul(pair_param.vault_spread_skew_factor)?
+        .checked_mul(pair_param.funding_rate_multiplier)?
         .checked_neg()
 }
 
@@ -49,12 +52,14 @@ mod tests {
 
     /// Default pair param with vault skew enabled.
     ///
-    /// half_spread = 1% (0.01), spread_skew_factor = 0.3, max_skew_size = 100.
+    /// half_spread = 1% (0.01), spread_skew_factor = 0.3, max_skew_size = 100,
+    /// funding_rate_multiplier = 1 (identity).
     fn default_pair_param() -> PairParam {
         PairParam {
             vault_half_spread: Dimensionless::new_permille(10), // 1%
             vault_spread_skew_factor: Dimensionless::new_permille(300), // 0.3
             vault_max_skew_size: Quantity::new_int(100),
+            funding_rate_multiplier: Dimensionless::ONE,
             ..Default::default()
         }
     }
@@ -134,5 +139,57 @@ mod tests {
         };
         let premium = compute_vault_premium(Quantity::new_int(50), &param).unwrap();
         assert_eq!(premium, Dimensionless::ZERO);
+    }
+
+    #[test]
+    fn multiplier_two_doubles_premium() {
+        // Baseline premium with multiplier = 1 is -0.0015 (see
+        // `long_position_gives_negative_premium`). Doubling the multiplier
+        // should double the magnitude.
+        let param = PairParam {
+            funding_rate_multiplier: Dimensionless::new_int(2),
+            ..default_pair_param()
+        };
+        let premium = compute_vault_premium(Quantity::new_int(50), &param).unwrap();
+        // premium = -(0.01 * 0.5 * 0.3 * 2) = -0.003
+        assert_eq!(premium, Dimensionless::new_raw(-3_000));
+    }
+
+    #[test]
+    fn multiplier_half_halves_premium() {
+        let param = PairParam {
+            funding_rate_multiplier: Dimensionless::new_permille(500), // 0.5
+            ..default_pair_param()
+        };
+        let premium = compute_vault_premium(Quantity::new_int(50), &param).unwrap();
+        // premium = -(0.01 * 0.5 * 0.3 * 0.5) = -0.00075
+        assert_eq!(premium, Dimensionless::new_raw(-750));
+    }
+
+    #[test]
+    fn zero_funding_rate_multiplier_gives_zero_premium() {
+        // With the multiplier at zero, the premium is zero regardless of skew
+        // or spread. Lets governance disable funding without touching the
+        // vault's quoting parameters.
+        let param = PairParam {
+            funding_rate_multiplier: Dimensionless::ZERO,
+            ..default_pair_param()
+        };
+        let premium = compute_vault_premium(Quantity::new_int(50), &param).unwrap();
+        assert_eq!(premium, Dimensionless::ZERO);
+    }
+
+    #[test]
+    fn large_multiplier_amplifies_premium() {
+        // Multipliers above 1 amplify funding. Upstream clamping by
+        // `max_abs_funding_rate` happens in `compute_funding_delta`, so
+        // `compute_vault_premium` is free to return large magnitudes.
+        let param = PairParam {
+            funding_rate_multiplier: Dimensionless::new_int(100),
+            ..default_pair_param()
+        };
+        let premium = compute_vault_premium(Quantity::new_int(50), &param).unwrap();
+        // premium = -(0.01 * 0.5 * 0.3 * 100) = -0.15
+        assert_eq!(premium, Dimensionless::new_raw(-150_000));
     }
 }

--- a/dango/perps/src/cron/process_funding.rs
+++ b/dango/perps/src/cron/process_funding.rs
@@ -216,6 +216,7 @@ mod tests {
             vault_half_spread: Dimensionless::new_permille(10), // 1%
             vault_spread_skew_factor: Dimensionless::new_permille(300), // 0.3
             vault_max_skew_size: Quantity::new_int(100),
+            funding_rate_multiplier: Dimensionless::ONE,
             ..Default::default()
         }
     }

--- a/dango/perps/src/maintain/configure.rs
+++ b/dango/perps/src/maintain/configure.rs
@@ -290,6 +290,13 @@ fn validate_pair_param(pair_id: &PairId, pair_param: &PairParam) -> anyhow::Resu
     );
 
     ensure!(
+        !pair_param.funding_rate_multiplier.is_negative(),
+        "invalid `funding_rate_multiplier`! pair id: {}, bounds: >= 0, found: {}",
+        pair_id,
+        pair_param.funding_rate_multiplier,
+    );
+
+    ensure!(
         pair_param.max_limit_price_deviation > Dimensionless::ZERO
             && pair_param.max_limit_price_deviation < Dimensionless::ONE,
         "invalid `max_limit_price_deviation`! pair id: {}, bounds: (0, 1), found: {}",
@@ -438,6 +445,7 @@ mod tests {
             vault_size_skew_factor: Dimensionless::ZERO,
             vault_spread_skew_factor: Dimensionless::ZERO,
             vault_max_skew_size: Quantity::ZERO,
+            funding_rate_multiplier: Dimensionless::ONE,
             bucket_sizes: btree_set! {},
         }
     }
@@ -755,6 +763,38 @@ mod tests {
         };
         let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
         assert!(err.contains("`vault_max_skew_size`"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_negative_funding_rate_multiplier_rejected() {
+        let p = PairParam {
+            funding_rate_multiplier: Dimensionless::new_raw(-1),
+            ..valid_pair_param()
+        };
+        let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
+        assert!(err.contains("`funding_rate_multiplier`"), "{err}");
+        assert!(err.contains(">= 0"), "{err}");
+    }
+
+    #[test]
+    fn pair_param_zero_funding_rate_multiplier_accepted() {
+        // Zero is in range — lets governance disable funding for a pair
+        // without touching the vault's quoting.
+        let p = PairParam {
+            funding_rate_multiplier: Dimensionless::ZERO,
+            ..valid_pair_param()
+        };
+        validate_pair_param(&pair(), &p).unwrap();
+    }
+
+    #[test]
+    fn pair_param_large_funding_rate_multiplier_accepted() {
+        // No upper bound on the multiplier.
+        let p = PairParam {
+            funding_rate_multiplier: Dimensionless::new_int(1_000),
+            ..valid_pair_param()
+        };
+        validate_pair_param(&pair(), &p).unwrap();
     }
 
     #[test]

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -489,6 +489,21 @@ pub struct PairParam {
     /// Bounds: `>= 0`. Zero disables inventory skew (skew always 0).
     pub vault_max_skew_size: Quantity,
 
+    /// Multiplier applied to the funding-rate premium so governance can tune
+    /// funding independently of the vault's quoting parameters. The full
+    /// formula is:
+    ///
+    /// ```plain
+    /// premium = -halfSpread × skew × spreadSkewFactor × fundingRateMultiplier
+    /// ```
+    ///
+    /// `1` reproduces the pre-multiplier behavior; `0` disables funding
+    /// without touching the vault's quoting; values `> 1` amplify funding.
+    ///
+    /// Bounds: `>= 0`. Negative values would flip the funding sign and
+    /// invert the economic incentive.
+    pub funding_rate_multiplier: Dimensionless,
+
     /// Price bucket sizes for which aggregated order book depth is maintained.
     /// Each entry defines a granularity level for the depth query.
     ///
@@ -506,6 +521,7 @@ impl PairParam {
             vault_max_quote_size: Quantity::new_int(100),
             max_limit_price_deviation: Dimensionless::new_permille(500), // 50%
             max_market_slippage: Dimensionless::new_permille(500),       // 50%
+            funding_rate_multiplier: Dimensionless::ONE,
             ..Default::default()
         }
     }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -41,6 +41,14 @@ const MIGRATION_MAX_MARKET_SLIPPAGE: Dimensionless = Dimensionless::new_percent(
 /// `Configure` once traffic patterns are understood.
 const MIGRATION_MAX_ACTION_BATCH_SIZE: usize = 5;
 
+/// Default `funding_rate_multiplier` applied to every pair during the
+/// migration. `1` reproduces the pre-multiplier funding behavior —
+/// funding continues to be computed as `-halfSpread × skew ×
+/// spreadSkewFactor` at the upgrade boundary, so there is no
+/// discontinuity for positions active across the upgrade. Governance
+/// tunes per-pair via `Configure` after the upgrade completes.
+const MIGRATION_FUNDING_RATE_MULTIPLIER: Dimensionless = Dimensionless::ONE;
+
 /// Legacy types matching the pre-upgrade Borsh layout.
 ///
 /// `PairParam` before this upgrade does not contain the
@@ -153,7 +161,7 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
 
     let mut storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
 
-    do_price_banding_and_batch_action_upgrades(&mut storage)?;
+    do_pair_param_and_param_upgrades(&mut storage)?;
     do_client_order_id_upgrade(&mut storage)?;
     do_fill_id_upgrade(&mut storage)?;
     do_reserved_margin_rounding_error_fix(&mut storage)?;
@@ -161,17 +169,21 @@ pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> 
     Ok(())
 }
 
-/// Two Borsh-layout-breaking migrations bundled into one upgrade event:
+/// Borsh-layout-breaking migrations to `PairParam` and the global
+/// `Param`, bundled into one upgrade event:
 ///
 /// 1. Price banding — adds `max_limit_price_deviation` and
 ///    `max_market_slippage` to every `PairParam`.
-/// 2. Batch action size cap — adds `max_action_batch_size` to the
+/// 2. Funding rate multiplier — adds `funding_rate_multiplier` to
+///    every `PairParam`, seeded at `1` so funding behavior is
+///    unchanged at the upgrade boundary.
+/// 3. Batch action size cap — adds `max_action_batch_size` to the
 ///    global `Param`.
 ///
-/// Both are pure additions at the end of their respective struct
-/// layouts, so the migration is a straightforward read-legacy /
-/// write-new roundtrip.
-fn do_price_banding_and_batch_action_upgrades(storage: &mut dyn Storage) -> StdResult<()> {
+/// All three are pure additions to their respective struct layouts, so
+/// the migration is a straightforward read-legacy / write-new
+/// roundtrip.
+fn do_pair_param_and_param_upgrades(storage: &mut dyn Storage) -> StdResult<()> {
     // 1. PairParam: add price-banding fields.
     let old_pair_params: Vec<_> = legacy::PAIR_PARAMS
         .range(storage, None, None, IterationOrder::Ascending)
@@ -197,6 +209,8 @@ fn do_price_banding_and_batch_action_upgrades(storage: &mut dyn Storage) -> StdR
             vault_size_skew_factor: old.vault_size_skew_factor,
             vault_spread_skew_factor: old.vault_spread_skew_factor,
             vault_max_skew_size: old.vault_max_skew_size,
+            // Identity multiplier preserves pre-upgrade funding behavior.
+            funding_rate_multiplier: MIGRATION_FUNDING_RATE_MULTIPLIER,
             bucket_sizes: old.bucket_sizes,
         };
 
@@ -204,7 +218,7 @@ fn do_price_banding_and_batch_action_upgrades(storage: &mut dyn Storage) -> StdR
     }
 
     tracing::info!(
-        "Migrated {pair_count} PairParam entries (added max_limit_price_deviation = {MIGRATION_MAX_LIMIT_PRICE_DEVIATION}, max_market_slippage = {MIGRATION_MAX_MARKET_SLIPPAGE})"
+        "Migrated {pair_count} PairParam entries (added max_limit_price_deviation = {MIGRATION_MAX_LIMIT_PRICE_DEVIATION}, max_market_slippage = {MIGRATION_MAX_MARKET_SLIPPAGE}, funding_rate_multiplier = {MIGRATION_FUNDING_RATE_MULTIPLIER})"
     );
 
     // 2. Param: add `max_action_batch_size`.
@@ -538,7 +552,7 @@ mod tests {
             .unwrap();
         legacy::PARAM.save(&mut storage, &old_param).unwrap();
 
-        do_price_banding_and_batch_action_upgrades(&mut storage).unwrap();
+        do_pair_param_and_param_upgrades(&mut storage).unwrap();
 
         let migrated_eth = dango_perps::state::PAIR_PARAMS
             .load(&storage, &eth_pair())
@@ -591,6 +605,14 @@ mod tests {
         assert_eq!(
             migrated_btc.max_market_slippage,
             MIGRATION_MAX_MARKET_SLIPPAGE
+        );
+        assert_eq!(
+            migrated_eth.funding_rate_multiplier,
+            MIGRATION_FUNDING_RATE_MULTIPLIER
+        );
+        assert_eq!(
+            migrated_btc.funding_rate_multiplier,
+            MIGRATION_FUNDING_RATE_MULTIPLIER
         );
         assert_eq!(migrated_btc.tick_size, btc.tick_size);
 
@@ -647,7 +669,7 @@ mod tests {
     fn migration_with_no_pairs_still_migrates_param() {
         let mut storage = MockStorage::new();
         legacy::PARAM.save(&mut storage, &legacy_param()).unwrap();
-        do_price_banding_and_batch_action_upgrades(&mut storage).unwrap();
+        do_pair_param_and_param_upgrades(&mut storage).unwrap();
         assert_eq!(
             dango_perps::state::PARAM
                 .load(&storage)
@@ -655,6 +677,36 @@ mod tests {
                 .max_action_batch_size,
             MIGRATION_MAX_ACTION_BATCH_SIZE
         );
+    }
+
+    /// Focused regression: every migrated pair gets
+    /// `funding_rate_multiplier = 1` so funding behavior is unchanged at
+    /// the upgrade boundary. Decoupled from
+    /// `migration_copies_fields_and_sets_new_default` so a constant
+    /// drift fails with a targeted message.
+    #[test]
+    fn migration_sets_funding_rate_multiplier_to_one() {
+        let mut storage = MockStorage::new();
+
+        legacy::PAIR_PARAMS
+            .save(&mut storage, &eth_pair(), &legacy_pair_param(1))
+            .unwrap();
+        legacy::PAIR_PARAMS
+            .save(&mut storage, &btc_pair(), &legacy_pair_param(2))
+            .unwrap();
+        legacy::PARAM.save(&mut storage, &legacy_param()).unwrap();
+
+        do_pair_param_and_param_upgrades(&mut storage).unwrap();
+
+        let eth = dango_perps::state::PAIR_PARAMS
+            .load(&storage, &eth_pair())
+            .unwrap();
+        let btc = dango_perps::state::PAIR_PARAMS
+            .load(&storage, &btc_pair())
+            .unwrap();
+
+        assert_eq!(eth.funding_rate_multiplier, Dimensionless::ONE);
+        assert_eq!(btc.funding_rate_multiplier, Dimensionless::ONE);
     }
 
     /// `do_client_order_id_upgrade` rewrites every legacy resting order
@@ -890,7 +942,7 @@ mod tests {
         plant_user_state_with_reserved_raw(&mut storage, USER_A, 105_000_000);
 
         // Run all migrations sequentially (mirrors `do_upgrade`).
-        do_price_banding_and_batch_action_upgrades(&mut storage).unwrap();
+        do_pair_param_and_param_upgrades(&mut storage).unwrap();
         do_client_order_id_upgrade(&mut storage).unwrap();
         do_fill_id_upgrade(&mut storage).unwrap();
         do_reserved_margin_rounding_error_fix(&mut storage).unwrap();
@@ -904,6 +956,10 @@ mod tests {
             MIGRATION_MAX_LIMIT_PRICE_DEVIATION
         );
         assert_eq!(pair.max_market_slippage, MIGRATION_MAX_MARKET_SLIPPAGE);
+        assert_eq!(
+            pair.funding_rate_multiplier,
+            MIGRATION_FUNDING_RATE_MULTIPLIER
+        );
 
         // Param migrated.
         assert_eq!(

--- a/deploy/roles/full-app/templates/config/cometbft/genesis.json
+++ b/deploy/roles/full-app/templates/config/cometbft/genesis.json
@@ -883,6 +883,7 @@
                   "10",
                   "100"
                 ],
+                "funding_rate_multiplier": "1",
                 "impact_size": "50000",
                 "initial_margin_ratio": "0.05",
                 "maintenance_margin_ratio": "0.025",
@@ -905,6 +906,7 @@
                   "10",
                   "100"
                 ],
+                "funding_rate_multiplier": "1",
                 "impact_size": "10000",
                 "initial_margin_ratio": "0.1",
                 "maintenance_margin_ratio": "0.05",

--- a/localdango/configs/cometbft/config/genesis.json
+++ b/localdango/configs/cometbft/config/genesis.json
@@ -872,6 +872,7 @@
             "pair_params": {
               "perp/ethusd": {
                 "bucket_sizes": [],
+                "funding_rate_multiplier": "1",
                 "impact_size": "10000",
                 "initial_margin_ratio": "0.1",
                 "maintenance_margin_ratio": "0.05",


### PR DESCRIPTION
Introduces a per-pair governance knob so admins can tune the funding
rate independently of the vault's quoting parameters. The premium
formula becomes:

    premium = -halfSpread × skew × spreadSkewFactor × fundingRateMultiplier

`1` reproduces the pre-multiplier behavior, `0` disables funding for the
pair, values `> 1` amplify funding. Bounds: `>= 0`.