### PR TITLE
chore: add repo-level Claude Code settings to deny .env access

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(.env*)",
+      "Edit(.env*)",
+      "Bash(cat *.env*)",
+      "Bash(head *.env*)",
+      "Bash(tail *.env*)",
+      "Bash(less *.env*)",
+      "Bash(more *.env*)",
+      "Bash(grep *.env*)"
+    ]
+  }
+}


### PR DESCRIPTION
Prevent Claude Code from reading secrets stored in `.env` files via `Read`, `Edit`, or common bash commands (`cat`, `head`, `tail`, `less`, `more`, `grep`).