### PR TITLE
feat(perps): add `is_maker` to OrderFilled event

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -1446,7 +1446,8 @@ The `data` field contains the event-specific payload as JSON. For example, an `o
   "realized_pnl": "0.000000",
   "fee": "6.500000",
   "client_order_id": "42",
-  "fill_id": "17"
+  "fill_id": "17",
+  "is_maker": false
 }
 ```
 
@@ -2065,26 +2066,28 @@ subscription {
     createdAt
     blockHeight
     tradeIdx
+    isMaker
   }
 }
 ```
 
 **Behavior:** On connection, cached recent trades are replayed first, then new trades stream in real-time.
 
-| Field         | Type     | Description                                   |
-| ------------- | -------- | --------------------------------------------- |
-| `orderId`     | `String` | Order ID that produced this fill              |
-| `pairId`      | `String` | Trading pair                                  |
-| `user`        | `String` | Account address                               |
-| `fillPrice`   | `String` | Execution price                               |
-| `fillSize`    | `String` | Filled size (positive = buy, negative = sell) |
-| `closingSize` | `String` | Portion that closed existing position         |
-| `openingSize` | `String` | Portion that opened new position              |
-| `realizedPnl` | `String` | PnL realized from the closing portion         |
-| `fee`         | `String` | Trading fee charged                           |
-| `createdAt`   | `String` | Timestamp (ISO 8601)                          |
-| `blockHeight` | `Int`    | Block in which the trade occurred             |
-| `tradeIdx`    | `Int`    | Index within the block                        |
+| Field         | Type       | Description                                                                                                              |
+| ------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `orderId`     | `String`   | Order ID that produced this fill                                                                                         |
+| `pairId`      | `String`   | Trading pair                                                                                                             |
+| `user`        | `String`   | Account address                                                                                                          |
+| `fillPrice`   | `String`   | Execution price                                                                                                          |
+| `fillSize`    | `String`   | Filled size (positive = buy, negative = sell)                                                                            |
+| `closingSize` | `String`   | Portion that closed existing position                                                                                    |
+| `openingSize` | `String`   | Portion that opened new position                                                                                         |
+| `realizedPnl` | `String`   | PnL realized on this fill, including funding settled on the pre-existing position; excludes trading fees                 |
+| `fee`         | `String`   | Trading fee charged                                                                                                      |
+| `createdAt`   | `String`   | Timestamp (ISO 8601)                                                                                                     |
+| `blockHeight` | `Int`      | Block in which the trade occurred                                                                                        |
+| `tradeIdx`    | `Int`      | Index within the block                                                                                                   |
+| `isMaker`     | `Boolean?` | True for the maker side of a match, false for the taker side; null for trades executed before v0.16.0                    |
 
 ### 8.3 Contract query polling
 
@@ -2199,13 +2202,17 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 | Event             | Fields                                                                                                                                          | Description                     |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `fee`, `client_order_id?`, `fill_id?` | Order partially or fully filled |
+| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `fee`, `client_order_id?`, `fill_id?`, `is_maker?` | Order partially or fully filled |
 | `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                                        | Limit order placed on book      |
 | `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                                     | Order removed from book         |
 
 `client_order_id` is `null` if the order was submitted without one. Off-chain consumers can use it to correlate fills, persistence, and removal with the originally-submitted client id.
 
 `fill_id` groups the two sides of a single order-book match. When a taker crosses a resting maker, two `order_filled` events are emitted — one for each side — and both carry the same `fill_id`. Successive matches use consecutive ids (strictly increasing), so a taker that crosses two makers in the same transaction produces four events with two distinct `fill_id` values. `fill_id` is `null` for trades executed before v0.15.0 — fill IDs were not assigned prior to that release. Not emitted for ADL fills, which use the [`deleveraged` and `liquidated` events](#liquidation-events) instead.
+
+`is_maker` is `true` for the maker side of a match and `false` for the taker side. Within a single match's pair of `order_filled` events (sharing one `fill_id`), exactly one carries `is_maker = true` and one carries `is_maker = false`. `is_maker` is `null` for trades executed before v0.16.0 — the maker/taker flag was not recorded prior to that release.
+
+`realized_pnl` on `order_filled`, `deleveraged`, and `liquidated` (as `adl_realized_pnl`) includes both the closing PnL on the fill and the funding settled on the user's pre-existing position immediately before the fill is applied. Trading fees are reported separately in the `fee` field on `order_filled`; ADL and deleverage fills incur no trading fees.
 
 ### Conditional order events
 

--- a/dango/indexer/sql/src/entity/perps_trade.rs
+++ b/dango/indexer/sql/src/entity/perps_trade.rs
@@ -47,4 +47,10 @@ pub struct PerpsTrade {
     /// IDs were not assigned prior to that release.
     #[cfg_attr(feature = "async-graphql", graphql(name = "fillId"))]
     pub fill_id: Option<String>,
+
+    /// `Some(true)` for the maker side of a match, `Some(false)` for the
+    /// taker side. `None` for trades executed before v0.16.0 — the
+    /// maker/taker flag was not recorded prior to that release.
+    #[cfg_attr(feature = "async-graphql", graphql(name = "isMaker"))]
+    pub is_maker: Option<bool>,
 }

--- a/dango/indexer/sql/src/indexer/perps_events.rs
+++ b/dango/indexer/sql/src/indexer/perps_events.rs
@@ -233,6 +233,7 @@ fn try_build_perps_trade(
         block_height,
         trade_idx,
         fill_id: order_filled.fill_id.as_ref().map(ToString::to_string),
+        is_maker: order_filled.is_maker,
     })
 }
 

--- a/dango/indexer/sql/src/indexer/perps_trades/cache.rs
+++ b/dango/indexer/sql/src/indexer/perps_trades/cache.rs
@@ -73,6 +73,7 @@ impl PerpsTradeCache {
                 block_height: row.block_height as u64,
                 trade_idx: trade_idx as u32,
                 fill_id: order_filled.fill_id.as_ref().map(ToString::to_string),
+                is_maker: order_filled.is_maker,
             };
 
             trades

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -880,7 +880,13 @@ pub fn match_order(
             &mut pnls,
             &mut fees,
             &mut volumes,
-            Some((events, taker_order_id, taker_client_order_id, fill_id)),
+            Some((
+                events,
+                taker_order_id,
+                taker_client_order_id,
+                fill_id,
+                false,
+            )),
         )?;
 
         if let Some(diff) = compute_position_diff(
@@ -936,7 +942,13 @@ pub fn match_order(
             &mut pnls,
             &mut fees,
             &mut volumes,
-            Some((events, maker_order_id, maker_order.client_order_id, fill_id)),
+            Some((
+                events,
+                maker_order_id,
+                maker_order.client_order_id,
+                fill_id,
+                true,
+            )),
         )?;
 
         if let Some(diff) = compute_position_diff(
@@ -1073,7 +1085,13 @@ pub fn settle_fill(
     pnls: &mut BTreeMap<Addr, UsdValue>,
     fees: &mut BTreeMap<Addr, UsdValue>,
     volumes: &mut BTreeMap<Addr, UsdValue>,
-    events: Option<(&mut EventBuilder, OrderId, Option<ClientOrderId>, FillId)>,
+    events: Option<(
+        &mut EventBuilder,
+        OrderId,
+        Option<ClientOrderId>,
+        FillId,
+        bool,
+    )>,
 ) -> grug::StdResult<UsdValue> {
     let (closing, opening) = {
         let current_pos = user_state
@@ -1106,7 +1124,7 @@ pub fn settle_fill(
         .or_default()
         .checked_add_assign(volume)?;
 
-    if let Some((events, order_id, client_order_id, fill_id)) = events {
+    if let Some((events, order_id, client_order_id, fill_id, is_maker)) = events {
         events.push(OrderFilled {
             order_id,
             pair_id: pair_id.clone(),
@@ -1119,6 +1137,7 @@ pub fn settle_fill(
             fee,
             client_order_id,
             fill_id: Some(fill_id),
+            is_maker: Some(is_maker),
         })?;
     }
 

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -2112,6 +2112,15 @@ fn conditional_order_trigger_fills_carry_fill_id() {
         fills[0].fill_id, fills[1].fill_id,
         "the taker and maker sides of a single match must share one fill_id"
     );
+
+    let mut is_makers = fills.iter().map(|f| f.is_maker).collect::<Vec<_>>();
+    is_makers.sort();
+    assert_eq!(
+        is_makers,
+        vec![Some(false), Some(true)],
+        "the two OrderFilled events of a match must have one is_maker=Some(false) (taker) \
+         and one is_maker=Some(true) (maker)"
+    );
 }
 
 /// Two TP orders that fire in the same `process_conditional_orders`
@@ -2288,6 +2297,28 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
             *count, 2,
             "fill_id {} should appear on exactly two events (taker + maker); got {}",
             id, count,
+        );
+    }
+
+    // Each fill_id pair must contain exactly one taker (is_maker=false)
+    // and one maker (is_maker=true).
+    let mut by_fill_id_makers = BTreeMap::<_, Vec<_>>::new();
+    for filled in &fills {
+        let id = filled.fill_id.unwrap();
+        by_fill_id_makers
+            .entry(id)
+            .or_default()
+            .push(filled.is_maker);
+    }
+    for (id, mut makers) in by_fill_id_makers {
+        makers.sort();
+        assert_eq!(
+            makers,
+            vec![Some(false), Some(true)],
+            "fill_id {} must pair one is_maker=Some(false) (taker) with one is_maker=Some(true) \
+             (maker); got {:?}",
+            id,
+            makers,
         );
     }
 

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1413,11 +1413,28 @@ pub struct OrderFilled {
     pub fill_size: Quantity,
     pub closing_size: Quantity,
     pub opening_size: Quantity,
+
+    /// PnL realized by the user on this fill. Includes both:
+    ///
+    /// 1. Closing PnL: `|closing_size| * (fill_price - entry_price)` for
+    ///    longs, mirrored for shorts. Zero on pure-opening fills.
+    /// 2. Funding settled on the user's pre-existing position immediately
+    ///    before this fill is applied. Can be non-zero even on
+    ///    pure-opening fills if the user already held a position.
+    ///
+    /// Does not include trading fees (see `fee`).
     pub realized_pnl: UsdValue,
+
+    /// Trading fee charged on this fill, in USD. Always non-negative.
+    /// Already deducted from the user's margin in the same transaction;
+    /// reported here for transparency. Vault fills are exempt and report
+    /// zero.
     pub fee: UsdValue,
+
     /// Caller-assigned id from the originally-submitted order, or `None`
     /// if the order was submitted without one.
     pub client_order_id: Option<ClientOrderId>,
+
     /// Identifier shared between the two `OrderFilled` events of a single
     /// order-book match (taker + maker). Strictly increasing across
     /// matches. `None` for trades executed before v0.15.0 — fill IDs
@@ -1435,6 +1452,15 @@ pub struct OrderFilled {
     ///   each side sees the same `id` per match:
     ///   <https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Account-Trade-List>
     pub fill_id: Option<FillId>,
+
+    /// `Some(true)` for the maker side of a match, `Some(false)` for the
+    /// taker side. Each order-book match emits two `OrderFilled` events
+    /// sharing one `fill_id` — exactly one with `is_maker = Some(true)`
+    /// and one with `is_maker = Some(false)`.
+    ///
+    /// `None` for trades executed before v0.16.0 — the maker/taker flag was not
+    /// recorded prior to that release.
+    pub is_maker: Option<bool>,
 }
 
 /// Event indicating an order have been inserted into the order book.
@@ -1556,7 +1582,11 @@ pub struct Liquidated {
     /// Bankruptcy price used for ADL fills, or `None` if no ADL happened.
     pub adl_price: Option<UsdPrice>,
 
-    /// PnL realized by the liquidated user from ADL fills (zero if no ADL).
+    /// PnL realized by the liquidated user from ADL fills, accumulated
+    /// across all counter-party fills for this pair. Includes both the
+    /// closing PnL on each ADL fill and the funding settled on the user's
+    /// position immediately before each fill. Zero if no ADL happened.
+    /// ADL fills incur no trading fees.
     pub adl_realized_pnl: UsdValue,
 }
 
@@ -1575,7 +1605,10 @@ pub struct Deleveraged {
     /// Fill price (the liquidated user's bankruptcy price).
     pub fill_price: UsdPrice,
 
-    /// PnL realized by the counter-party from this ADL fill.
+    /// PnL realized by the counter-party from this ADL fill. Includes
+    /// both the closing PnL on the ADL fill and the funding settled on
+    /// the counter-party's pre-existing position immediately before the
+    /// fill is applied. ADL fills incur no trading fees.
     pub realized_pnl: UsdValue,
 }
 

--- a/indexer/client/src/schemas/schema.graphql
+++ b/indexer/client/src/schemas/schema.graphql
@@ -568,6 +568,12 @@ type PerpsTrade {
 	IDs were not assigned prior to that release.
 	"""
 	fillId: String
+	"""
+	`Some(true)` for the maker side of a match, `Some(false)` for the
+	taker side. `None` for trades executed before v0.16.0 — the
+	maker/taker flag was not recorded prior to that release.
+	"""
+	isMaker: Boolean
 }
 
 type PublicKey {

--- a/sdk/dango/src/types/indexer.ts
+++ b/sdk/dango/src/types/indexer.ts
@@ -84,6 +84,12 @@ export type PerpsTrade = {
    * were not assigned prior to that release.
    */
   fillId?: string | null;
+  /**
+   * `true` for the maker side of a match, `false` for the taker side.
+   * `null` for trades executed before v0.16.0 — the maker/taker flag was
+   * not recorded prior to that release.
+   */
+  isMaker?: boolean | null;
 };
 
 export type PerpsEventType = "order_filled" | "liquidated" | "deleveraged";
@@ -104,6 +110,12 @@ export type OrderFilledData = {
    * were not assigned prior to that release.
    */
   fill_id?: string | null;
+  /**
+   * `true` for the maker side of a match, `false` for the taker side.
+   * `null` for trades executed before v0.16.0 — the maker/taker flag was
+   * not recorded prior to that release.
+   */
+  is_maker?: boolean | null;
 };
 
 export type LiquidatedData = {

--- a/ui/portal/web/src/components/activities/PerpOrderFilled.tsx
+++ b/ui/portal/web/src/components/activities/PerpOrderFilled.tsx
@@ -14,7 +14,7 @@ type ActivityPerpOrderFilledProps = {
 
 export const ActivityPerpOrderFilled = forwardRef<ActivityRef, ActivityPerpOrderFilledProps>(
   ({ activity }, ref) => {
-    const { pair_id, fill_price, fill_size, realized_pnl, fee } = activity.data;
+    const { pair_id, fill_price, fill_size, realized_pnl, fee, is_maker } = activity.data;
 
     const isBuy = !fill_size.startsWith("-");
     const absSize = fill_size.startsWith("-") ? fill_size.slice(1) : fill_size;
@@ -46,6 +46,11 @@ export const ActivityPerpOrderFilled = forwardRef<ActivityRef, ActivityPerpOrder
               <span className="diatype-m-bold">
                 <FormattedNumber number={absSize} as="span" /> {baseSymbol}
               </span>
+              {is_maker != null && (
+                <span className="uppercase diatype-m-bold text-ink-tertiary-500">
+                  {is_maker ? "Maker" : "Taker"}
+                </span>
+              )}
             </div>
 
             <div className="flex w-full gap-1">


### PR DESCRIPTION
Add an `is_maker: Option<bool>` field on `OrderFilled` so consumers can distinguish the maker and taker sides of a match without having to pair the two events on `fill_id`. The field is `Option` for backward compatibility with events emitted before this release.

Also tighten the docstrings on `OrderFilled.realized_pnl`, `fee`, `Deleveraged.realized_pnl`, and `Liquidated.adl_realized_pnl` so the semantics are explicit: `realized_pnl` includes both the closing PnL and the funding settled on the pre-existing position at fill time, and excludes trading fees (which live in the separate `fee` field on `OrderFilled`; ADL fills are fee-free).

Plumbed through the indexer entity + builders, regenerated the GraphQL schema, updated the TS SDK types, the PerpOrderFilled UI activity, and the API book. Extended the existing `fill_id` pairing assertions in `conditional_orders` to also assert each pair contains exactly one `is_maker = Some(true)` and one `is_maker = Some(false)`.