### PR TITLE
feat(perps): lift upper bound on vault_spread_skew_factor

### DIFF
--- a/book/perps/5-vault.md
+++ b/book/perps/5-vault.md
@@ -181,7 +181,7 @@ The mirror applies when short.
 | `vault_max_quote_size`     | Maximum base size per side                   |
 | `vault_max_skew_size`      | Position size at which skew saturates        |
 | `vault_size_skew_factor`   | Size skew intensity ($[0, 1]$)               |
-| `vault_spread_skew_factor` | Spread skew intensity ($[0, 1)$)             |
+| `vault_spread_skew_factor` | Spread skew intensity ($\ge 0$)              |
 
 If any of `vault_half_spread`, `vault_max_quote_size`, `vault_liquidity_weight`, `tick_size`, or the allocated margin is zero, the vault skips quoting for that pair.
 
@@ -191,6 +191,6 @@ If any of `vault_half_spread`, `vault_max_quote_size`, `vault_liquidity_weight`,
 
 **`vault_size_skew_factor`** — how aggressively to tilt order sizes. Start with **0.5**: at maximum skew, the heavier side quotes 1.5x and the lighter side 0.5x. A value of 1.0 fully shuts off quoting on one side at max position, which may be too aggressive for a vault that should always provide some liquidity. Range **0.5 to 0.8** is recommended.
 
-**`vault_spread_skew_factor`** — how aggressively to tilt spreads. Start with **0.3**: at maximum skew, the tightened side has 70% of normal spread and the widened side has 130%. Keep this below `vault_size_skew_factor` — size adjustment is the primary lever, spread adjustment is the fine-tuning. Must stay below 1.0 to avoid a negative spread. Range **0.3 to 0.5** is recommended.
+**`vault_spread_skew_factor`** — how aggressively to tilt spreads. Start with **0.3**: at maximum skew, the tightened side has 70% of normal spread and the widened side has 130%. Keep this below `vault_size_skew_factor` — size adjustment is the primary lever, spread adjustment is the fine-tuning. Range **0.3 to 0.5** is recommended. Values above 1.0 are permitted and cause the tightened side to cross the oracle price at maximum skew (an aggressive-unwind posture, useful for quickly deleveraging a large directional position); the invariant `bid < ask` still holds since `ask - bid = 2 × oracle × vault_half_spread`. The effective upper bound is governed by the cross-field invariant `vault_half_spread × (1 + vault_spread_skew_factor) < 1`, which ensures the bid stays positive at max skew.
 
 **General tuning principle:** start conservative (size 0.5, spread 0.3), observe PnL and position behavior, increase if the vault still accumulates too much directional exposure.

--- a/dango/perps/src/core/vault.rs
+++ b/dango/perps/src/core/vault.rs
@@ -659,4 +659,48 @@ mod tests {
         // Ask side still active.
         assert!(ask.is_some());
     }
+
+    /// `vault_spread_skew_factor > 1` causes the tightened side to cross
+    /// the oracle price at maximum skew, while `bid < ask` still holds.
+    ///
+    /// Setup: oracle = $1000, half_spread = 1%, spread_factor = 2.0,
+    /// max_skew = 50, position = 50 (long) → skew = 1.
+    ///
+    /// Expected math:
+    ///   bid = 1000 * (1 - 0.01 * (1 + 1*2)) = 1000 * 0.97 = 970
+    ///   ask = 1000 * (1 + 0.01 * (1 - 1*2)) = 1000 * 0.99 = 990
+    ///
+    /// Note: ask < oracle (the vault is willing to sell below oracle to
+    /// aggressively unwind its long), but bid < ask is preserved.
+    #[test]
+    fn spread_skew_factor_above_one_crosses_oracle_on_tightened_side() {
+        let pair_param = PairParam {
+            vault_spread_skew_factor: Dimensionless::new_int(2),
+            vault_size_skew_factor: Dimensionless::ZERO,
+            vault_max_skew_size: Quantity::new_int(50),
+            ..default_pair_param()
+        };
+        let oracle = UsdPrice::new_int(1000);
+        let margin = UsdValue::new_int(10_000);
+
+        let (bid, ask) = compute_vault_quotes(
+            oracle,
+            &pair_param,
+            None,
+            None,
+            margin,
+            Quantity::new_int(50), // skew = 1 (max long)
+        )
+        .unwrap();
+
+        let bid = bid.unwrap();
+        let ask = ask.unwrap();
+
+        assert_eq!(bid.price, UsdPrice::new_int(970));
+        assert_eq!(ask.price, UsdPrice::new_int(990));
+
+        assert!(ask.price < oracle, "ask should cross below oracle");
+        assert!(bid.price > UsdPrice::ZERO, "bid must stay positive");
+        assert!(bid.price < ask.price, "bid < ask invariant must hold");
+    }
 }

--- a/dango/perps/src/core/vault_premium.rs
+++ b/dango/perps/src/core/vault_premium.rs
@@ -192,4 +192,18 @@ mod tests {
         // premium = -(0.01 * 0.5 * 0.3 * 100) = -0.15
         assert_eq!(premium, Dimensionless::new_raw(-150_000));
     }
+
+    #[test]
+    fn spread_skew_factor_above_one_scales_linearly() {
+        // `vault_spread_skew_factor > 1` is now permitted; the premium
+        // formula scales linearly in the factor. Downstream clamping by
+        // `max_abs_funding_rate` handles magnitude, so no upper bound here.
+        let param = PairParam {
+            vault_spread_skew_factor: Dimensionless::new_int(5),
+            ..default_pair_param()
+        };
+        let premium = compute_vault_premium(Quantity::new_int(50), &param).unwrap();
+        // premium = -(0.01 * 0.5 * 5 * 1) = -0.025
+        assert_eq!(premium, Dimensionless::new_raw(-25_000));
+    }
 }

--- a/dango/perps/src/maintain/configure.rs
+++ b/dango/perps/src/maintain/configure.rs
@@ -261,8 +261,8 @@ fn validate_pair_param(pair_id: &PairId, pair_param: &PairParam) -> anyhow::Resu
     );
 
     ensure!(
-        (Dimensionless::ZERO..Dimensionless::ONE).contains(&pair_param.vault_spread_skew_factor),
-        "invalid `vault_spread_skew_factor`! pair id: {}, bounds: [0, 1), found: {}",
+        !pair_param.vault_spread_skew_factor.is_negative(),
+        "invalid `vault_spread_skew_factor`! pair id: {}, bounds: >= 0, found: {}",
         pair_id,
         pair_param.vault_spread_skew_factor,
     );
@@ -745,14 +745,51 @@ mod tests {
     }
 
     #[test]
-    fn pair_param_spread_skew_factor_one_rejected() {
+    fn pair_param_spread_skew_factor_one_accepted() {
+        // `vault_spread_skew_factor = 1` is now accepted as long as the
+        // cross-field invariant `vault_half_spread * (1 + factor) < 1` holds.
+        // Here: 0.01 * 2 = 0.02 < 1.
         let p = PairParam {
+            vault_half_spread: Dimensionless::new_permille(10), // 1%
             vault_spread_skew_factor: Dimensionless::ONE,
             ..valid_pair_param()
         };
+        validate_pair_param(&pair(), &p).unwrap();
+    }
+
+    #[test]
+    fn pair_param_spread_skew_factor_above_one_accepted() {
+        // `vault_spread_skew_factor = 5` is accepted when paired with a small
+        // `vault_half_spread`: 0.1 * (1 + 5) = 0.6 < 1. At max positive skew,
+        // the vault's ask drops below the oracle — the intended aggressive
+        // unwind semantic.
+        let p = PairParam {
+            vault_half_spread: Dimensionless::new_permille(100), // 10%
+            vault_spread_skew_factor: Dimensionless::new_int(5),
+            // Band must accommodate the vault's widest quote deviation
+            // (`vault_half_spread * (1 + factor)` = 60%).
+            max_limit_price_deviation: Dimensionless::new_permille(700),
+            ..valid_pair_param()
+        };
+        validate_pair_param(&pair(), &p).unwrap();
+    }
+
+    #[test]
+    fn pair_param_spread_skew_factor_above_one_rejected_by_cross_invariant() {
+        // `vault_spread_skew_factor = 5` with `vault_half_spread = 0.2` violates
+        // the cross-field invariant (0.2 * 6 = 1.2 >= 1). This proves the
+        // cross-field invariant — not any per-field cap — is the sole gatekeeper
+        // for large factors.
+        let p = PairParam {
+            vault_half_spread: Dimensionless::new_permille(200), // 20%
+            vault_spread_skew_factor: Dimensionless::new_int(5),
+            ..valid_pair_param()
+        };
         let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
-        assert!(err.contains("`vault_spread_skew_factor`"), "{err}");
-        assert!(err.contains("[0, 1)"), "{err}");
+        assert!(
+            err.contains("vault_half_spread * (1 + vault_spread_skew_factor) < 1"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -1206,6 +1243,7 @@ mod tests {
         };
         let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();
         assert!(err.contains("`vault_spread_skew_factor`"), "{err}");
+        assert!(err.contains(">= 0"), "{err}");
     }
 
     #[test]
@@ -1283,18 +1321,11 @@ mod tests {
 
     #[test]
     fn pair_param_half_spread_times_skew_factor_exactly_one_rejected() {
-        // 0.5 * (1 + 1) = 1.0 — boundary is strict (< 1, not <= 1).
-        // (vault_spread_skew_factor must be < 1 so use 0.5 * (1 + 0.999...)
-        //  — close enough; we pick 1/2 and factor that still tops out at 1.)
-        // Simpler: 0.5 * (1 + 1) is not reachable because skew_factor < 1.
-        // Instead pick half_spread = 0.5 and skew_factor just below 1:
-        // 0.5 * (1 + 0.999999) ≈ 0.9999995 — accepted. So we use half_spread
-        // slightly above 0.5 and skew_factor close to 1 to get >= 1:
-        // half_spread = 501 permille, skew_factor = 999 permille
-        //   → 0.501 * 1.999 = 1.001499 → rejected.
+        // Boundary: 0.5 * (1 + 1) = 1.0 — the cross-field invariant is
+        // strict (< 1, not <= 1), so this must be rejected.
         let p = PairParam {
-            vault_half_spread: Dimensionless::new_permille(501),
-            vault_spread_skew_factor: Dimensionless::new_permille(999),
+            vault_half_spread: Dimensionless::new_permille(500),
+            vault_spread_skew_factor: Dimensionless::ONE,
             ..valid_pair_param()
         };
         let err = validate_pair_param(&pair(), &p).unwrap_err().to_string();

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -479,8 +479,18 @@ pub struct PairParam {
     /// How aggressively to tilt spreads based on inventory.
     /// 0 = no skew (symmetric spreads on both sides).
     ///
-    /// Bounds: `[0, 1)`. At 1, the effective spread on the tightened side
-    /// reaches zero; > 1 would produce a negative spread.
+    /// Bounds: `>= 0`. Values > 1 cause the tightened side's quote to
+    /// cross the oracle price at maximum skew — e.g. when the vault is
+    /// fully long, the ask drops below the oracle. This is an aggressive
+    /// unwind posture, useful when the vault needs to rapidly deleverage
+    /// a large directional position. The invariant `bid < ask` always
+    /// holds because `ask - bid = 2 * oracle_price * vault_half_spread`,
+    /// independent of this factor.
+    ///
+    /// The effective upper bound is enforced via the cross-field invariant
+    /// `vault_half_spread * (1 + vault_spread_skew_factor) < 1` documented
+    /// on `vault_half_spread`, which prevents the bid price from collapsing
+    /// to zero at maximum positive skew.
     pub vault_spread_skew_factor: Dimensionless,
 
     /// Position size at which inventory skew saturates.


### PR DESCRIPTION
The existing `[0, 1)` bound was justified in the docstring as preventing a "negative spread" at values >= 1. This is incorrect: the gross spread `ask - bid = 2 * oracle * vault_half_spread` is independent of the skew factor, so `bid < ask` holds for any vault_spread_skew_factor >= 0 as long as vault_half_spread > 0. What values > 1 actually do is let the tightened side cross the oracle price at max skew (e.g. when the vault is long, the ask drops below oracle) — an aggressive unwind posture that governance may legitimately want when the vault has accumulated a large directional position.

The cross-field invariant `vault_half_spread * (1 + vault_spread_skew_factor) < 1` (already enforced in validate_pair_param) remains the real protection: it ensures the bid stays positive at max positive skew, and implicitly also covers ask-positivity since `h * (f - 1) < h * (f + 1) < 1`. Drop the per-field upper cap; keep the non-negativity check. Docstrings and the book spec are corrected. Tests adjusted and new ones added to lock in the semantic.