### PR TITLE
[codex] log and rate limit GraphQL requester IPs

### DIFF
--- a/dango/indexer/httpd/src/graphql.rs
+++ b/dango/indexer/httpd/src/graphql.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "tracing")]
 use async_graphql::extensions;
+#[cfg(feature = "tracing")]
+use grug_httpd::graphql::extensions::RequestLoggingExtension;
 #[cfg(feature = "metrics")]
 use indexer_httpd::graphql::extensions::metrics::{MetricsExtension, init_graphql_metrics};
 use {
@@ -93,6 +95,7 @@ pub fn build_schema(dango_httpd_context: crate::context::Context) -> AppSchema {
     #[cfg(feature = "tracing")]
     {
         schema_builder = schema_builder
+            .extension(RequestLoggingExtension)
             .extension(extensions::Tracing)
             .extension(extensions::Logger);
     }

--- a/dango/indexer/httpd/src/server.rs
+++ b/dango/indexer/httpd/src/server.rs
@@ -4,10 +4,11 @@ use {
     actix_files::Files,
     actix_web::{
         App, HttpResponse, HttpServer, http,
-        middleware::{Compress, Logger},
+        middleware::Compress,
         web::{self, ServiceConfig},
     },
     grug_httpd::{
+        access_logger,
         middlewares::shutdown::ShutdownMiddleware,
         routes::{graphql::graphql_route, index::index},
     },
@@ -76,6 +77,13 @@ where
             .app_data(web::Data::new(
                 dango_httpd_context.indexer_httpd_context.base.clone(),
             ))
+            .app_data(web::Data::new(
+                dango_httpd_context
+                    .indexer_httpd_context
+                    .base
+                    .graphql_rate_limiter
+                    .clone(),
+            ))
             .app_data(web::Data::new(graphql_schema.clone()));
     })
 }
@@ -132,7 +140,7 @@ pub async fn run_server(
         let app = App::new()
             .wrap(ShutdownMiddleware::new(shutdown_flag_clone.clone()))
             .wrap(Sentry::new())
-            .wrap(Logger::default())
+            .wrap(access_logger())
             .wrap(Compress::default())
             .wrap(cors);
 

--- a/grug/httpd/src/context.rs
+++ b/grug/httpd/src/context.rs
@@ -1,12 +1,38 @@
-use {crate::traits::QueryApp, std::sync::Arc};
+use {
+    crate::{rate_limit::GraphqlIpRateLimiter, traits::QueryApp},
+    std::sync::Arc,
+};
 
 #[derive(Clone)]
 pub struct Context {
     pub grug_app: Arc<dyn QueryApp + Send + Sync>,
+    pub graphql_rate_limiter: Arc<GraphqlIpRateLimiter>,
 }
 
 impl Context {
     pub fn new(grug_app: Arc<dyn QueryApp + Send + Sync>) -> Self {
-        Self { grug_app }
+        Self::new_with_graphql_rate_limiter(grug_app, Arc::new(GraphqlIpRateLimiter::default()))
+    }
+
+    pub fn new_with_graphql_rate_limiter(
+        grug_app: Arc<dyn QueryApp + Send + Sync>,
+        graphql_rate_limiter: Arc<GraphqlIpRateLimiter>,
+    ) -> Self {
+        Self {
+            grug_app,
+            graphql_rate_limiter,
+        }
+    }
+
+    pub fn ban_graphql_ip(&self, ip: impl Into<String>) {
+        self.graphql_rate_limiter.ban_ip(ip);
+    }
+
+    pub fn unban_graphql_ip(&self, ip: &str) {
+        self.graphql_rate_limiter.unban_ip(ip);
+    }
+
+    pub fn banned_graphql_ips(&self) -> Vec<String> {
+        self.graphql_rate_limiter.banned_ips()
     }
 }

--- a/grug/httpd/src/graphql.rs
+++ b/grug/httpd/src/graphql.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "tracing")]
+use crate::graphql::extensions::RequestLoggingExtension;
 #[cfg(feature = "metrics")]
 use crate::metrics::init_graphql_metrics;
 use {crate::context::Context, async_graphql::Schema};
 
+pub mod extensions;
 pub mod query;
 // pub mod subscription;
 pub mod types;
@@ -13,11 +16,17 @@ pub fn build_schema(app_ctx: Context) -> AppSchema {
     #[cfg(feature = "metrics")]
     init_graphql_metrics();
 
-    Schema::build(
+    #[allow(unused_mut)]
+    let mut schema_builder = Schema::build(
         query::Query::default(),
         async_graphql::EmptyMutation,
         async_graphql::EmptySubscription,
-    )
-    .data(app_ctx)
-    .finish()
+    );
+
+    #[cfg(feature = "tracing")]
+    {
+        schema_builder = schema_builder.extension(RequestLoggingExtension);
+    }
+
+    schema_builder.data(app_ctx).finish()
 }

--- a/grug/httpd/src/graphql/extensions.rs
+++ b/grug/httpd/src/graphql/extensions.rs
@@ -1,0 +1,116 @@
+#[cfg(feature = "tracing")]
+use {
+    crate::request_ip::RequesterIp,
+    async_graphql::{
+        Request, Response, ServerResult,
+        extensions::{
+            Extension, ExtensionContext, ExtensionFactory, NextExecute, NextPrepareRequest,
+        },
+        parser::types::{DocumentOperations, OperationType},
+    },
+    std::{sync::Arc, time::Instant},
+};
+
+#[cfg(feature = "tracing")]
+pub struct RequestLoggingExtension;
+
+#[cfg(feature = "tracing")]
+impl ExtensionFactory for RequestLoggingExtension {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(RequestLoggingExtension)
+    }
+}
+
+#[cfg(feature = "tracing")]
+#[async_trait::async_trait]
+impl Extension for RequestLoggingExtension {
+    async fn prepare_request(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        mut request: Request,
+        next: NextPrepareRequest<'_>,
+    ) -> ServerResult<Request> {
+        let operation_name = request.operation_name.clone();
+
+        if let Ok(doc) = request.parsed_query()
+            && let Some(operation_type) =
+                pick_operation_type(&doc.operations, operation_name.as_deref())
+        {
+            request = request.data(operation_type);
+        }
+
+        next.run(ctx, request).await
+    }
+
+    async fn execute(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        operation_name: Option<&str>,
+        next: NextExecute<'_>,
+    ) -> Response {
+        let start = Instant::now();
+        let response = next.run(ctx, operation_name).await;
+        let requester_ip = ctx.data::<RequesterIp>().ok();
+
+        let operation_type = match ctx.data::<OperationType>() {
+            Ok(OperationType::Query) => "query",
+            Ok(OperationType::Mutation) => "mutation",
+            Ok(OperationType::Subscription) => "subscription",
+            Err(_) => "unknown",
+        };
+
+        tracing::info!(
+            operation_name = operation_name.unwrap_or("anonymous"),
+            operation_type,
+            duration_ms = start.elapsed().as_secs_f64() * 1000.0,
+            error_count = response.errors.len(),
+            remote_ip = requester_ip
+                .and_then(|ip| ip.remote_ip.as_deref())
+                .unwrap_or("-"),
+            peer_ip = requester_ip
+                .and_then(|ip| ip.peer_ip.as_deref())
+                .unwrap_or("-"),
+            x_forwarded_for = requester_ip
+                .and_then(|ip| ip.x_forwarded_for.as_deref())
+                .unwrap_or("-"),
+            forwarded = requester_ip
+                .and_then(|ip| ip.forwarded.as_deref())
+                .unwrap_or("-"),
+            cf_connecting_ip = requester_ip
+                .and_then(|ip| ip.cf_connecting_ip.as_deref())
+                .unwrap_or("-"),
+            true_client_ip = requester_ip
+                .and_then(|ip| ip.true_client_ip.as_deref())
+                .unwrap_or("-"),
+            x_real_ip = requester_ip
+                .and_then(|ip| ip.x_real_ip.as_deref())
+                .unwrap_or("-"),
+            "graphql request completed"
+        );
+
+        response
+    }
+}
+
+#[cfg(feature = "tracing")]
+fn pick_operation_type(
+    operations: &DocumentOperations,
+    operation_name: Option<&str>,
+) -> Option<OperationType> {
+    match operations {
+        DocumentOperations::Single(operation) => Some(operation.node.ty),
+        DocumentOperations::Multiple(operations) if !operations.is_empty() => {
+            if let Some(name) = operation_name
+                && let Some(operation) = operations.get(name)
+            {
+                return Some(operation.node.ty);
+            }
+
+            operations
+                .values()
+                .next()
+                .map(|operation| operation.node.ty)
+        },
+        _ => None,
+    }
+}

--- a/grug/httpd/src/lib.rs
+++ b/grug/httpd/src/lib.rs
@@ -4,7 +4,10 @@ pub mod graphql;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod middlewares;
+pub mod rate_limit;
 mod request_ip;
 pub mod routes;
 pub mod server;
 pub mod traits;
+
+pub use request_ip::access_logger;

--- a/grug/httpd/src/rate_limit.rs
+++ b/grug/httpd/src/rate_limit.rs
@@ -1,0 +1,288 @@
+use {
+    async_graphql::{
+        BatchRequest,
+        parser::types::{DocumentOperations, OperationType},
+    },
+    std::{
+        collections::{HashMap, HashSet},
+        sync::Mutex,
+        time::{Duration, Instant},
+    },
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GraphqlOperationCounts {
+    pub queries: u32,
+    pub subscriptions: u32,
+}
+
+impl GraphqlOperationCounts {
+    pub fn from_batch_request(request: &mut BatchRequest) -> Self {
+        let mut counts = Self {
+            queries: 0,
+            subscriptions: 0,
+        };
+
+        for request in request.iter_mut() {
+            let operation_name = request.operation_name.clone();
+
+            match request
+                .parsed_query()
+                .ok()
+                .and_then(|doc| pick_operation_type(&doc.operations, operation_name.as_deref()))
+            {
+                Some(OperationType::Subscription) => counts.subscriptions += 1,
+                Some(OperationType::Mutation) => {},
+                Some(OperationType::Query) | None => counts.queries += 1,
+            }
+        }
+
+        counts
+    }
+
+    pub const fn subscription() -> Self {
+        Self {
+            queries: 0,
+            subscriptions: 1,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GraphqlIpRateLimiterConfig {
+    pub window: Duration,
+    pub max_queries_per_window: u32,
+    pub max_subscriptions_per_window: u32,
+}
+
+impl Default for GraphqlIpRateLimiterConfig {
+    fn default() -> Self {
+        Self {
+            window: Duration::from_secs(60),
+            max_queries_per_window: 300,
+            max_subscriptions_per_window: 30,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum GraphqlIpRateLimitRejection {
+    Banned,
+    TooManyQueries { limit: u32, attempted: u32 },
+    TooManySubscriptions { limit: u32, attempted: u32 },
+}
+
+#[derive(Debug)]
+pub struct GraphqlIpRateLimiter {
+    config: GraphqlIpRateLimiterConfig,
+    state: Mutex<GraphqlIpRateLimiterState>,
+}
+
+#[derive(Debug, Default)]
+struct GraphqlIpRateLimiterState {
+    banned_ips: HashSet<String>,
+    activity_by_ip: HashMap<String, IpActivity>,
+}
+
+#[derive(Debug)]
+struct IpActivity {
+    window_started_at: Instant,
+    queries: u32,
+    subscriptions: u32,
+}
+
+impl GraphqlIpRateLimiter {
+    pub fn new(config: GraphqlIpRateLimiterConfig) -> Self {
+        Self {
+            config,
+            state: Mutex::new(GraphqlIpRateLimiterState::default()),
+        }
+    }
+
+    pub fn ban_ip(&self, ip: impl Into<String>) {
+        if let Ok(mut state) = self.state.lock() {
+            state.banned_ips.insert(ip.into());
+        }
+    }
+
+    pub fn unban_ip(&self, ip: &str) {
+        if let Ok(mut state) = self.state.lock() {
+            state.banned_ips.remove(ip);
+        }
+    }
+
+    pub fn banned_ips(&self) -> Vec<String> {
+        self.state
+            .lock()
+            .map(|state| state.banned_ips.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn check(
+        &self,
+        ip: Option<&str>,
+        counts: GraphqlOperationCounts,
+    ) -> Result<(), GraphqlIpRateLimitRejection> {
+        let ip = ip.unwrap_or("unknown");
+        let now = Instant::now();
+        let mut state =
+            self.state
+                .lock()
+                .map_err(|_| GraphqlIpRateLimitRejection::TooManyQueries {
+                    limit: 0,
+                    attempted: counts.queries,
+                })?;
+
+        if state.banned_ips.contains(ip) {
+            return Err(GraphqlIpRateLimitRejection::Banned);
+        }
+
+        state.activity_by_ip.retain(|_, activity| {
+            now.duration_since(activity.window_started_at) <= self.config.window
+        });
+
+        let activity = state
+            .activity_by_ip
+            .entry(ip.to_string())
+            .or_insert_with(|| IpActivity {
+                window_started_at: now,
+                queries: 0,
+                subscriptions: 0,
+            });
+
+        if now.duration_since(activity.window_started_at) > self.config.window {
+            *activity = IpActivity {
+                window_started_at: now,
+                queries: 0,
+                subscriptions: 0,
+            };
+        }
+
+        let attempted_queries = activity.queries.saturating_add(counts.queries);
+        if attempted_queries > self.config.max_queries_per_window {
+            return Err(GraphqlIpRateLimitRejection::TooManyQueries {
+                limit: self.config.max_queries_per_window,
+                attempted: attempted_queries,
+            });
+        }
+
+        let attempted_subscriptions = activity.subscriptions.saturating_add(counts.subscriptions);
+        if attempted_subscriptions > self.config.max_subscriptions_per_window {
+            return Err(GraphqlIpRateLimitRejection::TooManySubscriptions {
+                limit: self.config.max_subscriptions_per_window,
+                attempted: attempted_subscriptions,
+            });
+        }
+
+        activity.queries = attempted_queries;
+        activity.subscriptions = attempted_subscriptions;
+
+        Ok(())
+    }
+}
+
+impl Default for GraphqlIpRateLimiter {
+    fn default() -> Self {
+        Self::new(GraphqlIpRateLimiterConfig::default())
+    }
+}
+
+fn pick_operation_type(
+    operations: &DocumentOperations,
+    operation_name: Option<&str>,
+) -> Option<OperationType> {
+    match operations {
+        DocumentOperations::Single(operation) => Some(operation.node.ty),
+        DocumentOperations::Multiple(operations) if !operations.is_empty() => {
+            if let Some(name) = operation_name
+                && let Some(operation) = operations.get(name)
+            {
+                return Some(operation.node.ty);
+            }
+
+            operations
+                .values()
+                .next()
+                .map(|operation| operation.node.ty)
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {crate::rate_limit::*, std::time::Duration};
+
+    #[test]
+    fn rejects_manually_banned_ip() {
+        let limiter = GraphqlIpRateLimiter::new(GraphqlIpRateLimiterConfig {
+            window: Duration::from_secs(60),
+            max_queries_per_window: 100,
+            max_subscriptions_per_window: 100,
+        });
+
+        limiter.ban_ip("198.51.100.10");
+
+        assert_eq!(
+            limiter.check(Some("198.51.100.10"), GraphqlOperationCounts {
+                queries: 1,
+                subscriptions: 0
+            }),
+            Err(GraphqlIpRateLimitRejection::Banned)
+        );
+    }
+
+    #[test]
+    fn rejects_queries_over_limit() {
+        let limiter = GraphqlIpRateLimiter::new(GraphqlIpRateLimiterConfig {
+            window: Duration::from_secs(60),
+            max_queries_per_window: 1,
+            max_subscriptions_per_window: 100,
+        });
+
+        assert_eq!(
+            limiter.check(Some("198.51.100.10"), GraphqlOperationCounts {
+                queries: 1,
+                subscriptions: 0
+            }),
+            Ok(())
+        );
+        assert_eq!(
+            limiter.check(Some("198.51.100.10"), GraphqlOperationCounts {
+                queries: 1,
+                subscriptions: 0
+            }),
+            Err(GraphqlIpRateLimitRejection::TooManyQueries {
+                limit: 1,
+                attempted: 2
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_subscriptions_over_limit() {
+        let limiter = GraphqlIpRateLimiter::new(GraphqlIpRateLimiterConfig {
+            window: Duration::from_secs(60),
+            max_queries_per_window: 100,
+            max_subscriptions_per_window: 1,
+        });
+
+        assert_eq!(
+            limiter.check(
+                Some("198.51.100.10"),
+                GraphqlOperationCounts::subscription()
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            limiter.check(
+                Some("198.51.100.10"),
+                GraphqlOperationCounts::subscription()
+            ),
+            Err(GraphqlIpRateLimitRejection::TooManySubscriptions {
+                limit: 1,
+                attempted: 2
+            })
+        );
+    }
+}

--- a/grug/httpd/src/request_ip.rs
+++ b/grug/httpd/src/request_ip.rs
@@ -1,10 +1,17 @@
 use {
-    actix_web::{HttpRequest, http::header::HeaderMap},
+    actix_web::{
+        HttpRequest,
+        dev::{ConnectionInfo, ServiceRequest},
+        http::header::HeaderMap,
+        middleware::Logger,
+    },
     async_graphql::SimpleObject,
     grug_types::HttpRequestDetails,
     serde::Serialize,
     std::net::{IpAddr, SocketAddr},
 };
+
+const ACCESS_LOG_FORMAT: &str = r#"%{remote_ip}xi "%r" %s %b "%{Referer}i" "%{User-Agent}i" %T"#;
 
 #[derive(Clone, Debug, Serialize, SimpleObject)]
 #[serde(rename_all = "camelCase")]
@@ -20,39 +27,61 @@ pub struct RequesterIp {
 
 impl RequesterIp {
     pub(crate) fn from_request(req: &HttpRequest) -> Self {
-        let x_forwarded_for = header_value(req.headers(), "x-forwarded-for").map(ToOwned::to_owned);
-        let forwarded = header_value(req.headers(), "forwarded").map(ToOwned::to_owned);
-        let cf_connecting_ip =
-            header_value(req.headers(), "cf-connecting-ip").map(ToOwned::to_owned);
-        let true_client_ip = header_value(req.headers(), "true-client-ip").map(ToOwned::to_owned);
-        let x_real_ip = header_value(req.headers(), "x-real-ip").map(ToOwned::to_owned);
-        #[cfg(feature = "tracing")]
-        let cf_ray = header_value(req.headers(), "cf-ray").map(ToOwned::to_owned);
+        let connection_info = req.connection_info();
 
-        let real_ip = req
-            .connection_info()
+        Self::from_parts(
+            req.headers(),
+            &connection_info,
+            req.method().as_str(),
+            req.path(),
+        )
+    }
+
+    fn from_service_request(req: &ServiceRequest) -> Self {
+        let connection_info = req.connection_info();
+
+        Self::from_parts(
+            req.headers(),
+            &connection_info,
+            req.method().as_str(),
+            req.path(),
+        )
+    }
+
+    fn from_parts(
+        headers: &HeaderMap,
+        connection_info: &ConnectionInfo,
+        _method: &str,
+        _path: &str,
+    ) -> Self {
+        let x_forwarded_for = header_value(headers, "x-forwarded-for").map(ToOwned::to_owned);
+        let forwarded = header_value(headers, "forwarded").map(ToOwned::to_owned);
+        let cf_connecting_ip = header_value(headers, "cf-connecting-ip").map(ToOwned::to_owned);
+        let true_client_ip = header_value(headers, "true-client-ip").map(ToOwned::to_owned);
+        let x_real_ip = header_value(headers, "x-real-ip").map(ToOwned::to_owned);
+        #[cfg(feature = "tracing")]
+        let cf_ray = header_value(headers, "cf-ray").map(ToOwned::to_owned);
+
+        let real_ip = connection_info
             .realip_remote_addr()
             .and_then(parse_ip_candidate);
-        let peer_ip = req
-            .connection_info()
-            .peer_addr()
-            .and_then(parse_ip_candidate);
+        let peer_ip = connection_info.peer_addr().and_then(parse_ip_candidate);
 
         let remote_ip = if real_ip.as_ref().is_some_and(|ip| !is_proxy_hop_ip(ip)) {
             real_ip
         } else {
-            original_client_ip_from_headers(req.headers())
+            original_client_ip_from_headers(headers)
                 .or(real_ip)
                 .or_else(|| peer_ip.clone())
         };
 
         #[cfg(feature = "tracing")]
         tracing::info!(
-            method = %req.method(),
-            path = %req.path(),
+            method = %_method,
+            path = %_path,
             remote_ip = remote_ip.as_deref().unwrap_or("unknown"),
             peer_ip = peer_ip.as_deref().unwrap_or("unknown"),
-            real_ip = req.connection_info().realip_remote_addr().unwrap_or("unknown"),
+            real_ip = connection_info.realip_remote_addr().unwrap_or("unknown"),
             x_forwarded_for = x_forwarded_for.as_deref().unwrap_or("-"),
             forwarded = forwarded.as_deref().unwrap_or("-"),
             cf_connecting_ip = cf_connecting_ip.as_deref().unwrap_or("-"),
@@ -76,6 +105,16 @@ impl RequesterIp {
     pub(crate) fn into_http_request_details(self) -> HttpRequestDetails {
         HttpRequestDetails::new(self.remote_ip, self.peer_ip)
     }
+}
+
+pub fn access_logger() -> Logger {
+    Logger::new(ACCESS_LOG_FORMAT).custom_request_replace("remote_ip", access_log_remote_ip)
+}
+
+fn access_log_remote_ip(req: &ServiceRequest) -> String {
+    RequesterIp::from_service_request(req)
+        .remote_ip
+        .unwrap_or_else(|| "-".to_string())
 }
 
 fn original_client_ip_from_headers(headers: &HeaderMap) -> Option<String> {
@@ -242,6 +281,17 @@ mod tests {
 
         assert_eq!(requester_ip.remote_ip, Some("198.51.100.10".to_string()));
         assert_eq!(requester_ip.peer_ip, Some("172.22.0.2".to_string()));
+    }
+
+    #[test]
+    fn access_log_remote_ip_uses_resolved_requester_ip() {
+        let req = TestRequest::default()
+            .insert_header(("x-forwarded-for", "172.23.0.2"))
+            .insert_header(("cf-connecting-ip", "203.0.113.9"))
+            .peer_addr("172.22.0.2:1234".parse().unwrap())
+            .to_srv_request();
+
+        assert_eq!(access_log_remote_ip(&req), "203.0.113.9");
     }
 
     #[test]

--- a/grug/httpd/src/routes/graphql.rs
+++ b/grug/httpd/src/routes/graphql.rs
@@ -1,9 +1,16 @@
 use {
-    crate::request_ip::RequesterIp,
-    actix_web::{HttpRequest, HttpResponse, Resource, web},
-    async_graphql::Schema,
+    crate::{
+        rate_limit::{GraphqlIpRateLimitRejection, GraphqlIpRateLimiter, GraphqlOperationCounts},
+        request_ip::RequesterIp,
+    },
+    actix_web::{
+        HttpRequest, HttpResponse, Resource, Responder,
+        http::StatusCode,
+        web::{self, Data},
+    },
+    async_graphql::{BatchRequest, Data as GraphqlData, Schema},
     async_graphql_actix_web::{GraphQLBatchRequest, GraphQLResponse, GraphQLSubscription},
-    std::time::Duration,
+    std::{sync::Arc, time::Duration},
 };
 
 pub fn graphql_route<Q, M, S>() -> Resource
@@ -26,18 +33,25 @@ pub async fn graphql_index<Q, M, S>(
     schema: web::Data<Schema<Q, M, S>>,
     req: HttpRequest,
     gql_request: GraphQLBatchRequest,
-) -> GraphQLResponse
+) -> HttpResponse
 where
     Q: async_graphql::ObjectType + 'static,
     M: async_graphql::ObjectType + 'static,
     S: async_graphql::SubscriptionType + 'static,
 {
     let requester_ip = RequesterIp::from_request(&req);
-    let details = requester_ip.clone().into_http_request_details();
+    let mut request = gql_request.into_inner();
 
-    let request = gql_request.into_inner().data(details).data(requester_ip);
+    if let Some(response) = rate_limit_response(
+        &req,
+        requester_ip.remote_ip.as_deref(),
+        GraphqlOperationCounts::from_batch_request(&mut request),
+    ) {
+        return response;
+    }
 
-    schema.execute_batch(request).await.into()
+    let request = add_requester_ip_data(request, requester_ip);
+    GraphQLResponse::from(schema.execute_batch(request).await).respond_to(&req)
 }
 
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
@@ -51,7 +65,55 @@ where
     M: async_graphql::ObjectType + 'static,
     S: async_graphql::SubscriptionType + 'static,
 {
+    let requester_ip = RequesterIp::from_request(&req);
+
+    if let Some(response) = rate_limit_response(
+        &req,
+        requester_ip.remote_ip.as_deref(),
+        GraphqlOperationCounts::subscription(),
+    ) {
+        return Ok(response);
+    }
+
     GraphQLSubscription::new(Schema::clone(&*schema))
+        .with_data(requester_ip_data(requester_ip))
         .keepalive_timeout(Duration::from_secs(30))
         .start(&req, payload)
+}
+
+fn add_requester_ip_data(request: BatchRequest, requester_ip: RequesterIp) -> BatchRequest {
+    request
+        .data(requester_ip.clone().into_http_request_details())
+        .data(requester_ip)
+}
+
+fn requester_ip_data(requester_ip: RequesterIp) -> GraphqlData {
+    let mut data = GraphqlData::default();
+    data.insert(requester_ip.clone().into_http_request_details());
+    data.insert(requester_ip);
+    data
+}
+
+fn rate_limit_response(
+    req: &HttpRequest,
+    ip: Option<&str>,
+    counts: GraphqlOperationCounts,
+) -> Option<HttpResponse> {
+    let limiter = req
+        .app_data::<Data<Arc<GraphqlIpRateLimiter>>>()
+        .map(Data::get_ref)?;
+
+    limiter
+        .check(ip, counts)
+        .err()
+        .map(graphql_rate_limit_response)
+}
+
+fn graphql_rate_limit_response(_rejection: GraphqlIpRateLimitRejection) -> HttpResponse {
+    let status = StatusCode::from_u16(420).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
+
+    #[cfg(feature = "tracing")]
+    tracing::warn!(rejection = ?_rejection, "graphql request rejected by IP rate limiter");
+
+    HttpResponse::build(status).body("graphql request rejected by IP rate limiter")
 }

--- a/grug/httpd/src/server.rs
+++ b/grug/httpd/src/server.rs
@@ -1,10 +1,13 @@
 use {
     super::error::Error,
-    crate::{context::Context, middlewares::shutdown::ShutdownMiddleware, routes},
+    crate::{
+        context::Context, middlewares::shutdown::ShutdownMiddleware, request_ip::access_logger,
+        routes,
+    },
     actix_cors::Cors,
     actix_web::{
         App, HttpResponse, HttpServer, http,
-        middleware::{Compress, Logger},
+        middleware::Compress,
         web::{self, ServiceConfig},
     },
     grug_types::HttpdConfig,
@@ -65,7 +68,7 @@ where
         let app = App::new()
             .wrap(ShutdownMiddleware::new(shutdown_flag_clone.clone()))
             .wrap(Sentry::new())
-            .wrap(Logger::default())
+            .wrap(access_logger())
             .wrap(Compress::default())
             .wrap(cors);
 
@@ -118,7 +121,7 @@ where
         App::new()
             .wrap(metrics.clone())
             .wrap(Sentry::new())
-            .wrap(Logger::default())
+            .wrap(access_logger())
             .wrap(Compress::default())
             .route(
                 "/health",
@@ -169,6 +172,7 @@ where
             >())
             .default_service(web::to(HttpResponse::NotFound))
             .app_data(web::Data::new(app_ctx.clone()))
+            .app_data(web::Data::new(app_ctx.graphql_rate_limiter.clone()))
             .app_data(web::Data::new(graphql_schema.clone()));
     })
 }

--- a/indexer/httpd/Cargo.toml
+++ b/indexer/httpd/Cargo.toml
@@ -20,7 +20,12 @@ metrics = [
   "dep:metrics-exporter-prometheus",
   "grug-httpd/metrics",
 ]
-tracing = ["dep:tracing", "grug-app/tracing", "indexer-sql/tracing"]
+tracing = [
+  "dep:tracing",
+  "grug-app/tracing",
+  "grug-httpd/tracing",
+  "indexer-sql/tracing",
+]
 
 [dependencies]
 actix                       = { workspace = true }

--- a/indexer/httpd/src/graphql.rs
+++ b/indexer/httpd/src/graphql.rs
@@ -2,6 +2,8 @@
 use crate::graphql::extensions::metrics::{MetricsExtension, init_graphql_metrics};
 #[cfg(feature = "tracing")]
 use async_graphql::extensions as AsyncGraphqlExtensions;
+#[cfg(feature = "tracing")]
+use grug_httpd::graphql::extensions::RequestLoggingExtension;
 use {
     crate::context::Context,
     async_graphql::{Schema, dataloader::DataLoader},
@@ -88,6 +90,7 @@ pub fn build_schema(app_ctx: Context) -> AppSchema {
     #[cfg(feature = "tracing")]
     {
         schema_builder = schema_builder
+            .extension(RequestLoggingExtension)
             .extension(AsyncGraphqlExtensions::Tracing)
             .extension(AsyncGraphqlExtensions::Logger);
     }

--- a/indexer/httpd/src/server.rs
+++ b/indexer/httpd/src/server.rs
@@ -4,10 +4,13 @@ use {
     actix_cors::Cors,
     actix_web::{
         App, HttpResponse, HttpServer, http,
-        middleware::{Compress, Logger},
+        middleware::Compress,
         web::{self, ServiceConfig},
     },
-    grug_httpd::routes::{graphql::graphql_route, index::index},
+    grug_httpd::{
+        access_logger,
+        routes::{graphql::graphql_route, index::index},
+    },
     grug_types::HttpdConfig,
     sentry_actix::Sentry,
 };
@@ -68,7 +71,7 @@ where
 
         let app = App::new()
             .wrap(Sentry::new())
-            .wrap(Logger::default())
+            .wrap(access_logger())
             .wrap(Compress::default())
             .wrap(cors);
 
@@ -121,7 +124,7 @@ where
         App::new()
             .wrap(metrics.clone())
             .wrap(Sentry::new())
-            .wrap(Logger::default())
+            .wrap(access_logger())
             .wrap(Compress::default())
             .route(
                 "/health",
@@ -173,6 +176,7 @@ where
             >())
             .default_service(web::to(HttpResponse::NotFound))
             .app_data(web::Data::new(app_ctx.clone()))
+            .app_data(web::Data::new(app_ctx.base.graphql_rate_limiter.clone()))
             .app_data(web::Data::new(graphql_schema.clone()));
     })
 }


### PR DESCRIPTION
## Summary

Use the existing Cloudflare-aware requester IP resolver for Actix access logs and GraphQL operation logs so queries, mutations, and subscriptions include the original client IP fields instead of only the proxy hop address.

Add a shared in-memory GraphQL IP limiter in `grug-httpd` that rejects banned or over-limit IPs with HTTP 420. The limiter tracks query and subscription activity per resolved `remote_ip`, is attached through the base HTTP context, and can be manually updated in memory with `ban_graphql_ip`, `unban_graphql_ip`, or a custom injected limiter.

Merged latest `main` and integrated the incoming active subscription limiter with the requester-IP limiter wiring, so both protections remain in place.

## Validation

### Completed

- [x] `just fmt`
- [x] `cargo fetch`
- [x] `cargo fetch --locked`
- [x] `cargo test -p grug-httpd access_log_remote_ip_uses_resolved_requester_ip`
- [x] `cargo test -p grug-httpd request_ip::tests`
- [x] `cargo test -p grug-httpd rate_limit::tests`
- [x] `cargo test -p grug-httpd subscription_limiter::tests`
- [x] `cargo check -p grug-httpd --features tracing`
- [x] `cargo check -p indexer-httpd`
- [x] `cargo check -p indexer-httpd --features tracing`
- [x] `cargo check -p dango-httpd`
- [x] `cargo check -p dango-httpd --features tracing`
- [x] `just lint`

### Remaining

- [x] None

## Manual QA

None. The behavior is covered by unit tests and compile/lint checks.

## Testing TODOs

- [x] Verify access-log IP resolution prefers `cf-connecting-ip` when forwarded headers only contain proxy hops.
- [x] Verify manually banned IPs are rejected by the in-memory GraphQL limiter.
- [x] Verify over-limit queries and subscription handshakes are rejected by the in-memory GraphQL limiter.
- [x] Verify the merged active subscription limiter still enforces per-connection and global subscription caps.