### PR TITLE
feat(upgrade): graceful shutdown on version mismatch instead of panic

### DIFF
--- a/dango/cli/src/start.rs
+++ b/dango/cli/src/start.rs
@@ -9,7 +9,9 @@ use {
     config_parser::parse_config,
     dango_genesis::GenesisCodes,
     dango_proposal_preparer::ProposalPreparer,
-    grug_app::{App, Db, Indexer, NaiveProposalPreparer, NullIndexer, SimpleCommitment},
+    grug_app::{
+        App, Db, HaltReason, Indexer, NaiveProposalPreparer, NullIndexer, SimpleCommitment,
+    },
     grug_client::TendermintRpcClient,
     grug_db_disk::DiskDb,
     grug_httpd::context::Context as HttpdContext,
@@ -18,7 +20,10 @@ use {
     indexer_hooked::HookedIndexer,
     metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle},
     std::sync::{Arc, atomic::AtomicBool},
-    tokio::signal::unix::{SignalKind, signal},
+    tokio::{
+        signal::unix::{SignalKind, signal},
+        sync::watch,
+    },
     tower_abci::v038::{Server, split},
 };
 
@@ -104,7 +109,12 @@ impl StartCmd {
         let httpd_shutdown_flags = vec![httpd_shutdown_flag.clone()];
 
         // Run ABCI server, optionally with indexer and httpd server.
-        match (
+        //
+        // Capture the result instead of `?`-propagating so we can *always*
+        // wait for the indexer's pending post-indexing tasks to drain before
+        // returning, even if one of the servers errored out (e.g. planned
+        // halt propagated as an ABCI error).
+        let run_result: anyhow::Result<()> = match (
             cfg.indexer.enabled,
             cfg.httpd.enabled,
             cfg.metrics_httpd.enabled,
@@ -128,7 +138,8 @@ impl StartCmd {
                         hooked_indexer,
                         httpd_shutdown_flags
                     )
-                )?;
+                )
+                .map(|_| ())
             },
             (true, true, false) => {
                 // Indexer and HTTP server enabled, metrics disabled
@@ -148,7 +159,8 @@ impl StartCmd {
                         hooked_indexer,
                         httpd_shutdown_flags
                     )
-                )?;
+                )
+                .map(|_| ())
             },
             (true, false, true) => {
                 // Indexer and metrics enabled, HTTP server disabled
@@ -164,7 +176,8 @@ impl StartCmd {
                         hooked_indexer,
                         vec![] // No HTTP server shutdown flags
                     )
-                )?;
+                )
+                .map(|_| ())
             },
             (true, false, false) => {
                 // Only indexer enabled
@@ -178,7 +191,7 @@ impl StartCmd {
                     hooked_indexer,
                     vec![], // No HTTP server shutdown flags
                 )
-                .await?;
+                .await
             },
             (false, true, false) => {
                 // No indexer, but HTTP server enabled (minimal mode), metrics disabled
@@ -200,7 +213,8 @@ impl StartCmd {
                         NullIndexer,
                         httpd_shutdown_flags
                     )
-                )?;
+                )
+                .map(|_| ())
             },
             (false, true, true) => {
                 // No indexer, but HTTP server enabled (minimal mode), metrics enabled
@@ -223,7 +237,8 @@ impl StartCmd {
                         httpd_shutdown_flags
                     ),
                     Self::run_metrics_httpd_server(&cfg.metrics_httpd, metrics_handler)
-                )?;
+                )
+                .map(|_| ())
             },
             (false, false, _) => {
                 // No indexer, no HTTP server
@@ -237,13 +252,17 @@ impl StartCmd {
                     NullIndexer,
                     vec![], // No HTTP server shutdown flags
                 )
-                .await?;
+                .await
             },
+        };
+
+        // Always drain the indexer's in-flight post-indexing tasks before
+        // returning, even if `run_result` is `Err`.
+        if let Err(err) = indexer_clone.wait_for_finish().await {
+            tracing::error!(%err, "Error waiting for indexer to finish");
         }
 
-        indexer_clone.wait_for_finish().await?;
-
-        Ok(())
+        run_result
     }
 
     /// Setup the hooked indexer with both SQL and Dango indexers, and prepare contexts for HTTP servers
@@ -449,6 +468,12 @@ impl StartCmd {
     where
         ID: Indexer + Send + 'static,
     {
+        // Channel used by the app to request a graceful shutdown from inside
+        // `finalize_block` (see `grug_app::HaltReason`). Initial value is
+        // `None`; a `Some(reason)` means the app has requested a halt.
+        let (halt_tx, mut halt_rx) = watch::channel::<Option<HaltReason>>(None);
+        let halt_tx = Arc::new(halt_tx);
+
         let app = App::new(
             db,
             vm,
@@ -457,7 +482,8 @@ impl StartCmd {
             grug_cfg.query_gas_limit,
             Some(dango_upgrade::do_upgrade), // Important: set the upgrade handler.
             env!("CARGO_PKG_VERSION"),
-        );
+        )
+        .with_shutdown_trigger(halt_tx);
 
         let (consensus, mempool, snapshot, info) = split::service(app, 1);
 
@@ -477,7 +503,7 @@ impl StartCmd {
         let mut sigint = signal(SignalKind::interrupt())?;
         let mut sigterm = signal(SignalKind::terminate())?;
 
-        let mut shutdown = async || {
+        let shutdown = async |indexer_for_shutdown: &mut ID| -> anyhow::Result<()> {
             // Set shutdown flags to return 503 for new HTTP requests
             for flag in &httpd_shutdown_flags {
                 flag.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -496,18 +522,42 @@ impl StartCmd {
             Ok(())
         };
 
-        tokio::select! {
+        // Wait for the ABCI server to exit, a signal, or an app-initiated halt
+        // (e.g. scheduled upgrade with the wrong binary). We *always* run the
+        // shutdown sequence afterwards, regardless of which arm fires.
+        let select_result: anyhow::Result<()> = tokio::select! {
             result = async { abci_server.listen_tcp(tendermint_cfg.abci_addr).await } => {
                 result.map_err(|err| anyhow!("failed to start ABCI server: {err:?}"))
             },
             _ = sigint.recv() => {
                 tracing::info!("Received SIGINT, shutting down");
-                shutdown().await
+                Ok(())
             },
             _ = sigterm.recv() => {
                 tracing::info!("Received SIGTERM, shutting down");
-                shutdown().await
+                Ok(())
             },
+            _ = halt_rx.changed() => {
+                tracing::warn!(reason = ?halt_rx.borrow(), "App requested graceful shutdown");
+                Ok(())
+            },
+        };
+
+        // Always run the shutdown sequence, even if the ABCI server exited
+        // with an error, so indexer writes and telemetry are flushed.
+        if let Err(err) = shutdown(&mut indexer_for_shutdown).await {
+            tracing::error!(%err, "Graceful shutdown failed");
         }
+
+        // If the app itself requested the halt, treat it as a clean exit so
+        // systemd doesn't restart us — the operator must deploy the correct
+        // binary before the chain resumes. The ABCI server very likely
+        // returned an error too (CometBFT disconnected after we rejected
+        // `finalize_block`), but that error is *expected* in this case.
+        if halt_rx.borrow().is_some() {
+            return Ok(());
+        }
+
+        select_result
     }
 }

--- a/grug/app/src/abci.rs
+++ b/grug/app/src/abci.rs
@@ -226,6 +226,18 @@ where
                     consensus_param_updates: None,
                 })
             },
+            // A *planned* halt (e.g. upgrade height reached with the wrong
+            // binary) is reported to the host via `App::shutdown_trigger`
+            // inside `do_finalize_block`. Propagate the error instead of
+            // panicking so the CLI's main loop can run its graceful
+            // shutdown path (flush indexer, close HTTP, flush telemetry)
+            // and exit with code 0.
+            Err(err) if err.is_planned_halt() => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(%err, "planned chain halt — yielding to graceful shutdown");
+
+                Err(err)
+            },
             Err(err) => panic!("failed to finalize block: {err}"),
         }
     }

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -25,9 +25,30 @@ use {
         StdResult, Storage, Timestamp, Tx, TxEvents, TxOutcome, UnsignedTx,
     },
     prost::bytes::Bytes,
+    std::sync::Arc,
+    tokio::sync::watch,
 };
 
 pub type UpgradeHandler<VM> = fn(Box<dyn Storage>, VM, BlockInfo) -> AppResult<()>;
+
+/// Reason why the app requested a graceful halt of the process.
+///
+/// Sent over a `watch` channel so the binary's main loop can stop the ABCI
+/// server, flush the indexer, and exit cleanly with code `0` — in contrast
+/// with `panic!`, which leaves async background work unfinished.
+#[derive(Clone, Debug)]
+pub enum HaltReason {
+    /// The chain reached a scheduled upgrade height but the running binary's
+    /// cargo version does not match the one declared in the upgrade plan.
+    /// The operator must deploy the correct binary before the chain resumes.
+    UpgradeIncorrectVersion { current: String, expected: String },
+}
+
+/// Handle used by [`App`] to request a graceful shutdown of the host process.
+///
+/// Cloneable so the `App` (which is itself `Clone`) can carry it across the
+/// `split::service` fan-out; all clones drive the same underlying channel.
+pub type ShutdownTrigger = Arc<watch::Sender<Option<HaltReason>>>;
 
 /// The ABCI application.
 ///
@@ -56,6 +77,13 @@ pub struct App<DB, VM, PP = NaiveProposalPreparer, ID = NullIndexer> {
     upgrade_handler: Option<UpgradeHandler<VM>>,
     /// Current cargo version of the app. Used in chain upgrades.
     cargo_version: String,
+    /// If set, the app can request a graceful shutdown of the host process
+    /// by sending a [`HaltReason`] through this channel (e.g. when
+    /// `finalize_block` hits an upgrade height with the wrong binary).
+    ///
+    /// `None` in tests and in the read-only `App` instance used by the HTTP
+    /// server, which never finalize blocks and therefore never halt.
+    shutdown_trigger: Option<ShutdownTrigger>,
 }
 
 impl<DB, VM, PP, ID> App<DB, VM, PP, ID> {
@@ -84,7 +112,19 @@ impl<DB, VM, PP, ID> App<DB, VM, PP, ID> {
             query_gas_limit,
             upgrade_handler,
             cargo_version: cargo_version.into(),
+            shutdown_trigger: None,
         }
+    }
+
+    /// Attach a shutdown trigger so the app can request a graceful halt of
+    /// the host process (see [`HaltReason`]).
+    ///
+    /// Intended to be called by the binary's `start` command right after
+    /// `App::new`; tests and the HTTP-only `App` instance leave this unset.
+    #[must_use]
+    pub fn with_shutdown_trigger(mut self, trigger: ShutdownTrigger) -> Self {
+        self.shutdown_trigger = Some(trigger);
+        self
     }
 }
 
@@ -99,6 +139,10 @@ impl<DB, VM, PP, ID> App<DB, VM, PP, ID> {
     {
         self.cargo_version = cargo_version.into();
         self.upgrade_handler = upgrade_handler;
+    }
+
+    pub fn set_shutdown_trigger(&mut self, trigger: ShutdownTrigger) {
+        self.shutdown_trigger = Some(trigger);
     }
 }
 
@@ -117,6 +161,7 @@ where
             query_gas_limit: self.query_gas_limit,
             upgrade_handler: self.upgrade_handler,
             cargo_version: self.cargo_version.clone(),
+            shutdown_trigger: self.shutdown_trigger.clone(),
         }
     }
 }
@@ -369,6 +414,19 @@ where
                         upgrade_version = upgrade.cargo_version,
                         "!!! PRE-PLANNED CHAIN HALT !!!"
                     );
+                }
+
+                // Signal the host binary to shut down gracefully (flush the
+                // indexer, close HTTP servers, flush telemetry) instead of
+                // leaving the main loop to `panic!` in the ABCI layer.
+                // Safe to ignore the send result: if there are no receivers,
+                // we are running in a test or in an embedded context that
+                // does not own the process lifecycle.
+                if let Some(trigger) = &self.shutdown_trigger {
+                    let _ = trigger.send(Some(HaltReason::UpgradeIncorrectVersion {
+                        current: self.cargo_version.clone(),
+                        expected: upgrade.cargo_version.clone(),
+                    }));
                 }
 
                 return Err(AppError::upgrade_incorrect_version(

--- a/grug/app/src/error.rs
+++ b/grug/app/src/error.rs
@@ -72,6 +72,20 @@ pub enum AppError {
     ExceedMaxMessageDepth,
 }
 
+impl AppError {
+    /// Whether this error represents a *planned* chain halt — i.e. a condition
+    /// the node operator is expected to resolve by intervening (e.g. deploying
+    /// the correct binary for a scheduled upgrade), rather than an
+    /// implementation bug.
+    ///
+    /// The ABCI layer uses this to decide whether to `panic!` (bug, force a
+    /// crash so it is visible) or return the error normally so the host binary
+    /// can shut down gracefully.
+    pub fn is_planned_halt(&self) -> bool {
+        matches!(self, AppError::UpgradeIncorrectVersion { .. })
+    }
+}
+
 /// Dedicated error type for indexer operations
 #[error_backtrace::backtrace]
 #[derive(Debug, Clone, thiserror::Error)]

--- a/grug/testing/tests/upgrade.rs
+++ b/grug/testing/tests/upgrade.rs
@@ -1,5 +1,5 @@
 use {
-    grug_app::{AppError, CHAIN_ID, CONFIG, CONTRACTS, GasTracker, TraceOption},
+    grug_app::{AppError, CHAIN_ID, CONFIG, CONTRACTS, GasTracker, HaltReason, TraceOption},
     grug_math::{Bytable, NextNumber, Uint128, Uint256},
     grug_testing::TestBuilder,
     grug_types::{
@@ -7,7 +7,7 @@ use {
         PastUpgrade, QuerierExt, ResultExt, StdError, Timestamp, btree_map, coins,
     },
     grug_vm_rust::ContractBuilder,
-    std::str::FromStr,
+    std::{str::FromStr, sync::Arc},
 };
 
 #[test]
@@ -281,4 +281,64 @@ fn upgrading_with_calling_contract() {
             bytes.len() == Uint256::BYTE_LEN
                 && bytes.as_ref() == Uint128::new(123).into_next().to_borsh_vec().unwrap()
         });
+}
+
+/// When the chain reaches a scheduled upgrade height but the running binary's
+/// cargo version doesn't match the planned one, the app must:
+///   1. return `AppError::UpgradeIncorrectVersion` (existing behavior), and
+///   2. fire the shutdown trigger so the host binary can flush the indexer
+///      and telemetry before exiting, instead of panicking inside the ABCI
+///      layer.
+///
+/// This test exercises (2): we attach a `watch` channel, drive the chain
+/// through the halt block, and assert the trigger fired with the expected
+/// halt reason.
+#[test]
+fn upgrade_incorrect_version_fires_shutdown_trigger() {
+    let (mut suite, mut accounts) = TestBuilder::new()
+        .set_genesis_time(Timestamp::from_nanos(0))
+        .set_block_time(Duration::from_seconds(1))
+        .add_account("owner", Coins::new())
+        .set_owner("owner")
+        .build();
+
+    let (halt_tx, halt_rx) = tokio::sync::watch::channel::<Option<HaltReason>>(None);
+    suite.app.set_shutdown_trigger(Arc::new(halt_tx));
+
+    // -------------------------------- Block 1 --------------------------------
+    suite
+        .upgrade(
+            &mut accounts["owner"],
+            3,
+            "0.1.0",
+            None::<String>,
+            None::<String>,
+        )
+        .should_succeed();
+
+    // -------------------------------- Block 2 --------------------------------
+    // Upgrade height not yet reached: trigger must stay silent.
+    suite.make_empty_block();
+    assert!(
+        halt_rx.borrow().is_none(),
+        "shutdown trigger fired before upgrade height",
+    );
+
+    // -------------------------------- Block 3 --------------------------------
+    // Halt height reached with wrong cargo version: error returned AND
+    // trigger fires with the mismatched versions.
+    suite
+        .try_make_empty_block()
+        .should_fail_with_error(AppError::upgrade_incorrect_version(
+            "0.0.0".to_string(),
+            "0.1.0".to_string(),
+        ));
+
+    match halt_rx.borrow().clone() {
+        Some(HaltReason::UpgradeIncorrectVersion { current, expected }) => {
+            assert_eq!(current, "0.0.0");
+            assert_eq!(expected, "0.1.0");
+        },
+        other => panic!("expected UpgradeIncorrectVersion halt reason, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

- When a scheduled chain upgrade hits a cargo-version mismatch, the ABCI layer used to `panic!("failed to finalize block: …")` inside `tower_finalize_block`, which left the indexer's `wait_for_finish`, the OTLP tracer provider and the Sentry client un-flushed — background work silently lost.
- Introduce `grug_app::HaltReason` + a `ShutdownTrigger` (a `watch::Sender<Option<HaltReason>>` wrapped in `Arc` so `App: Clone` still holds). `App::with_shutdown_trigger(…)` attaches it; `do_finalize_block` fires it on `UpgradeIncorrectVersion` before returning the error.
- ABCI `tower_finalize_block` now discriminates: `err.is_planned_halt() ⇒ log + return Err(err)`; other errors keep panicking (bugs must stay loud).
- `dango-cli`'s `run_with_indexer` gets a fourth `tokio::select!` branch on the halt receiver. The shutdown closure (HTTP 503 flags → indexer shutdown → telemetry/sentry flush) now runs **unconditionally** after the select. On a planned halt the CLI returns `Ok(())` → exit code 0 → systemd won't restart the node until the operator swaps in the correct binary.
- `StartCmd::run` also stops short-circuiting on `?`; `indexer.wait_for_finish()` now runs on every exit path, even when `try_join!` errored.

**Operator note:** exit code is now `0` on planned halts. If the systemd unit uses `Restart=always` it will still bounce the service — it should be `Restart=on-failure` for this mechanism to keep the node down.

## Validation

### Completed
- [x] `cargo check --workspace --all-targets`
- [x] `just fmt` (rustfmt; only reformatted import blocks touched by this PR)
- [x] `just lint` (workspace clippy with `-D warnings`)
- [x] `cargo test -p grug-testing --test upgrade` — 4/4 pass (3 pre-existing + 1 new regression test `upgrade_incorrect_version_fires_shutdown_trigger` asserting the trigger fires with the mismatched versions and stays silent before the halt height)

### Remaining
- [ ] End-to-end validation on a devnet: schedule an upgrade at height `N`, run the node with the wrong `cargo_version`, observe that at block `N` the process exits with code `0`, indexer post-indexing tasks have drained, OTLP spans have flushed, and systemd does **not** restart the service.

## Manual QA

Did not exercise the full start command locally (requires a devnet with CometBFT + Postgres + ClickHouse) — see `Remaining` above. Unit-level behavior is covered by the new regression test in `grug/testing/tests/upgrade.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)