### PR TITLE
fix(indexer): validate graphql subscription and query inputs

### DIFF
--- a/dango/indexer/httpd/src/graphql/query/user.rs
+++ b/dango/indexer/httpd/src/graphql/query/user.rs
@@ -92,7 +92,11 @@ impl UserQuery {
 
                         query = query.limit(limit + 1);
                     },
-                    _ => unreachable!(),
+                    _ => {
+                        return Err(async_graphql::Error::new(
+                            "unexpected combination of pagination parameters; should use `first` with `after`, or `last` with `before`",
+                        ));
+                    },
                 }
 
                 if let Some(block_height) = block_height {

--- a/dango/testing/tests/httpd/users.rs
+++ b/dango/testing/tests/httpd/users.rs
@@ -173,3 +173,44 @@ async fn query_public_keys_by_user_index() -> anyhow::Result<()> {
         })
         .await?
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn query_users_rejects_conflicting_pagination_args() -> anyhow::Result<()> {
+    let (
+        _suite,
+        _accounts,
+        _codes,
+        _contracts,
+        _validator_sets,
+        _,
+        dango_httpd_context,
+        _,
+        _db_guard,
+    ) = setup_test_with_indexer(TestOption::default()).await;
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let response = call_graphql_query::<_, users::ResponseData>(
+                    dango_httpd_context,
+                    Users::build_query(users::Variables {
+                        first: Some(1),
+                        last: Some(1),
+                        ..Default::default()
+                    }),
+                )
+                .await?;
+
+                let errors = response.errors.unwrap_or_default();
+                assert_that!(errors).is_not_empty();
+                assert_that!(errors[0].message.as_str())
+                    .contains("unexpected combination of pagination parameters");
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}

--- a/indexer/httpd/src/graphql/subscription/grug.rs
+++ b/indexer/httpd/src/graphql/subscription/grug.rs
@@ -28,6 +28,11 @@ impl GrugSubscription {
         block_interval: u64,
     ) -> Result<impl Stream<Item = Result<QueryResponseWithBlockHeight, Error>> + 'a> {
         let sub_guard = acquire_subscription(ctx)?;
+
+        if block_interval == 0 {
+            return Err(Error::new("blockInterval must be >= 1"));
+        }
+
         let app_ctx = ctx.data::<crate::context::Context>()?;
 
         #[cfg(feature = "metrics")]
@@ -86,6 +91,11 @@ impl GrugSubscription {
         block_interval: u64,
     ) -> Result<impl Stream<Item = Result<Store, Error>> + 'a> {
         let sub_guard = acquire_subscription(ctx)?;
+
+        if block_interval == 0 {
+            return Err(Error::new("blockInterval must be >= 1"));
+        }
+
         let app_ctx = ctx.data::<crate::context::Context>()?;
 
         #[cfg(feature = "metrics")]
@@ -140,6 +150,11 @@ impl GrugSubscription {
         block_interval: u64,
     ) -> Result<impl Stream<Item = Result<Status, Error>> + 'a> {
         let sub_guard = acquire_subscription(ctx)?;
+
+        if block_interval == 0 {
+            return Err(Error::new("blockInterval must be >= 1"));
+        }
+
         let app_ctx = ctx.data::<crate::context::Context>()?;
 
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
Reject degenerate `blockInterval` in the `queryApp/queryStore/queryStatus` subscription resolvers, and reject disallowed pagination combinations in the `users` query. All four paths now surface a GraphQL error to the caller instead of reaching an arithmetic/match panic.