### PR TITLE
fix(indexer): use fromUnixTimestamp64Micro in pair_prices since query

### DIFF
--- a/dango/indexer/clickhouse/src/entities/pair_price.rs
+++ b/dango/indexer/clickhouse/src/entities/pair_price.rs
@@ -102,6 +102,11 @@ impl PairPrice {
     /// in-progress candle after an ungraceful shutdown (e.g. a panic triggered
     /// by a chain upgrade block) when the in-memory aggregation was lost
     /// before it could be flushed.
+    ///
+    /// Uses `fromUnixTimestamp64Micro` rather than `toDateTime64(?, 6)`:
+    /// ClickHouse's `toDateTime64` treats integer inputs as seconds
+    /// regardless of scale, so a microsecond-valued bind saturates to the
+    /// DateTime64 max (year 2299) and silently matches nothing.
     pub async fn since(
         clickhouse_client: &clickhouse::Client,
         base_denom: &str,
@@ -112,7 +117,7 @@ impl PairPrice {
             SELECT quote_denom, base_denom, clearing_price, volume_base, volume_quote,
                    created_at, block_height
             FROM pair_prices
-            WHERE quote_denom = ? AND base_denom = ? AND created_at >= toDateTime64(?, 6)
+            WHERE quote_denom = ? AND base_denom = ? AND created_at >= fromUnixTimestamp64Micro(?)
             ORDER BY block_height ASC
         "#;
 

--- a/dango/indexer/clickhouse/src/entities/perps_pair_price.rs
+++ b/dango/indexer/clickhouse/src/entities/perps_pair_price.rs
@@ -85,6 +85,11 @@ impl PerpsPairPrice {
     /// in-progress candle after an ungraceful shutdown (e.g. a panic triggered
     /// by a chain upgrade block) when the in-memory aggregation was lost
     /// before it could be flushed.
+    ///
+    /// Uses `fromUnixTimestamp64Micro` rather than `toDateTime64(?, 6)`:
+    /// ClickHouse's `toDateTime64` treats integer inputs as seconds
+    /// regardless of scale, so a microsecond-valued bind saturates to the
+    /// DateTime64 max (year 2299) and silently matches nothing.
     pub async fn since(
         clickhouse_client: &clickhouse::Client,
         pair_id: &str,
@@ -93,7 +98,7 @@ impl PerpsPairPrice {
         let query = r#"
             SELECT pair_id, high, low, close, volume, volume_usd, created_at, block_height
             FROM perps_pair_prices
-            WHERE pair_id = ? AND created_at >= toDateTime64(?, 6)
+            WHERE pair_id = ? AND created_at >= fromUnixTimestamp64Micro(?)
             ORDER BY block_height ASC
         "#;
 

--- a/dango/testing/tests/indexing/candles.rs
+++ b/dango/testing/tests/indexing/candles.rs
@@ -2,9 +2,12 @@ use {
     assertor::*,
     chrono::{DateTime, TimeDelta},
     dango_genesis::{Contracts, DexOption, GenesisOption},
-    dango_indexer_clickhouse::entities::{
-        CandleInterval, candle::Candle, candle_query::CandleQueryBuilder, pair_price::PairPrice,
-        pair_price_query::PairPriceQueryBuilder,
+    dango_indexer_clickhouse::{
+        entities::{
+            CandleInterval, candle::Candle, candle_query::CandleQueryBuilder,
+            pair_price::PairPrice, pair_price_query::PairPriceQueryBuilder,
+        },
+        indexer::candles::cache::{CandleCache, CandleCacheKey},
     },
     dango_testing::{
         Preset, TestAccounts, TestOption, TestSuite, TestSuiteWithIndexer,
@@ -752,6 +755,86 @@ async fn create_pair_prices(
         .for_each(|outcome| {
             outcome.should_succeed();
         });
+
+    Ok(())
+}
+
+/// Regression test: `CandleCache::preload_pairs` must rebuild the
+/// in-progress candle from `pair_prices` in ClickHouse end-to-end.
+/// A prior bug in `PairPrice::since` bound `timestamp_micros()` into
+/// `toDateTime64(?, 6)`; ClickHouse treats integer inputs to
+/// `toDateTime64` as seconds regardless of scale, so the bind saturated
+/// to the DateTime64 max (year 2299) and the predicate silently matched
+/// nothing — the rebuild ran on an empty prices vec (`replayed=0`) and
+/// the in-progress candle was lost on every restart.
+///
+/// Uses a recent genesis timestamp so block `created_at` values fall
+/// inside the current `earliest_current_bucket_start` window; with the
+/// 1971-based default (`MOCK_GENESIS_TIMESTAMP`) the per-interval
+/// `created_at >= start` filter in `rebuild_in_progress_from_prices`
+/// drops every row even when `since` is fixed, masking the regression.
+#[tokio::test(flavor = "multi_thread")]
+async fn index_candles_preload_rebuilds_current_bucket_from_clickhouse() -> anyhow::Result<()> {
+    let genesis_secs = chrono::Utc::now().timestamp() as u128 - 3_600;
+
+    let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
+        setup_test_with_indexer_and_custom_genesis(
+            TestOption {
+                genesis_block: BlockInfo {
+                    height: 0,
+                    timestamp: Timestamp::from_seconds(genesis_secs),
+                    hash: Hash256::ZERO,
+                },
+                ..Default::default()
+            },
+            GenesisOption::preset_test(),
+        )
+        .await;
+
+    create_pair_prices(&mut suite, &mut accounts, &contracts).await?;
+    suite.app.indexer.wait_for_finish().await?;
+
+    let ch = clickhouse_context.clickhouse_client();
+    let pairs = PairPrice::all_pairs(ch).await?;
+    assert_that!(pairs.is_empty()).is_false();
+
+    // Exactly the path `Context::preload_cache` takes at node startup.
+    let mut fresh_cache = CandleCache::default();
+    fresh_cache.preload_pairs(&pairs, ch).await?;
+
+    // With the broken `since` binding every interval's in-progress
+    // candle was missing after rebuild. Assert every active pair has
+    // produced 1h / 4h / 1d candles whose volume survived the replay.
+    for pair in &pairs {
+        for interval in [
+            CandleInterval::OneHour,
+            CandleInterval::FourHours,
+            CandleInterval::OneDay,
+        ] {
+            let key = CandleCacheKey::new(
+                pair.base_denom.to_string(),
+                pair.quote_denom.to_string(),
+                interval,
+            );
+            let candle = fresh_cache
+                .get_last_candle(&key)
+                .cloned()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "preload_pairs produced no {interval} candle for {}/{}",
+                        pair.base_denom, pair.quote_denom
+                    )
+                });
+
+            assert!(
+                candle.volume_base > Udec128_6::ZERO,
+                "{}/{} {interval} rebuilt with zero volume_base — the \
+                 `since` query did not return the day's rows",
+                pair.base_denom,
+                pair.quote_denom,
+            );
+        }
+    }
 
     Ok(())
 }

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -8,7 +8,7 @@ use {
             perps_candle_query::{PerpsCandleQueryBuilder, PerpsCandleResult},
             perps_pair_price::PerpsPairPrice,
         },
-        indexer::perps_candles::cache::PerpsCandleCache,
+        indexer::perps_candles::cache::{PerpsCandleCache, PerpsCandleCacheKey},
     },
     dango_testing::{
         Preset, TestAccounts, TestOption, TestSuiteWithIndexer,
@@ -705,6 +705,92 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
     assert_that!(btc_candle.volume).is_equal_to(Udec128_6::new(1));
     // volume_usd = 1 * 60000 = 60000
     assert_that!(btc_candle.volume_usd).is_equal_to(Udec128_6::new(60_000));
+
+    Ok(())
+}
+
+/// Regression test: `preload_pairs` must rebuild the in-progress candle
+/// from `perps_pair_prices` in ClickHouse end-to-end. A prior bug in
+/// `PerpsPairPrice::since` bound `timestamp_micros()` into
+/// `toDateTime64(?, 6)`; ClickHouse treats integer inputs as seconds
+/// regardless of scale, so the bind saturated to the DateTime64 max
+/// (year 2299) and the predicate silently matched nothing — the rebuild
+/// ran on an empty prices vec (`replayed=0`) and the in-progress candle
+/// was lost on every restart.
+///
+/// The test uses a recent genesis timestamp so that block `created_at`
+/// values fall inside the current `earliest_current_bucket_start`
+/// window; with the 1970-based genesis used by the other tests the
+/// `since` filter would drop every row anyway, masking the regression.
+#[tokio::test(flavor = "multi_thread")]
+async fn index_perps_candles_preload_rebuilds_current_bucket_from_clickhouse() -> anyhow::Result<()>
+{
+    // One hour ago — comfortably inside every current-bucket window,
+    // including the 1d and 1h intervals exercised below.
+    let genesis_secs = chrono::Utc::now().timestamp() as u128 - 3_600;
+
+    let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
+        setup_test_with_indexer_and_custom_genesis(
+            TestOption {
+                genesis_block: BlockInfo {
+                    height: 0,
+                    timestamp: Timestamp::from_seconds(genesis_secs),
+                    hash: Hash256::ZERO,
+                },
+                ..Default::default()
+            },
+            dango_genesis::GenesisOption::preset_test(),
+        )
+        .await;
+
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+
+    for _ in 0..5 {
+        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
+    }
+
+    suite.app.indexer.wait_for_finish().await?;
+
+    let ch = clickhouse_context.clickhouse_client();
+    let pair_ids = PerpsPairPrice::all_pair_ids(ch).await?;
+    assert_that!(pair_ids.is_empty()).is_false();
+
+    // Exactly the path `Context::preload_cache` takes at node startup.
+    let mut fresh_cache = PerpsCandleCache::default();
+    fresh_cache.preload_pairs(&pair_ids, ch).await?;
+
+    // With the broken `since` binding the 1d in-progress candle was never
+    // rebuilt: `replayed=0`, cache empty for the current bucket, and
+    // `get_last_candle` would return `None` (or a stale candle from a
+    // previous bucket). Assert the rebuild actually populated it.
+    for interval in [
+        CandleInterval::OneHour,
+        CandleInterval::FourHours,
+        CandleInterval::OneDay,
+    ] {
+        let key = PerpsCandleCacheKey::new(pair_id().to_string(), interval);
+        let candle = fresh_cache
+            .get_last_candle(&key)
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "preload_pairs produced no {interval} candle for {}",
+                    pair_id()
+                )
+            });
+
+        // 5 fills * 1 event (positive side) * 1 ETH each.
+        assert_eq!(
+            candle.volume,
+            Udec128_6::new(5),
+            "{interval} candle volume mismatch after rebuild",
+        );
+        assert_eq!(
+            candle.volume_usd,
+            Udec128_6::new(10_000),
+            "{interval} candle volume_usd mismatch after rebuild",
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- `PairPrice::since` and `PerpsPairPrice::since` bound `since.timestamp_micros()` into `toDateTime64(?, 6)`. ClickHouse treats integer inputs to `toDateTime64` as Unix timestamps in **seconds** regardless of scale, so a microsecond-valued bind overflows and saturates to the `DateTime64` max (`2299-12-31 23:59:59`). The predicate `created_at >= <year 2299>` silently matches nothing.
- The rebuild path added in #1896 — the safety net for an ungraceful shutdown like the panic that happens at a scheduled upgrade block — was therefore running on an empty prices vec (`replayed=0`) on every restart. The in-progress candle was never reconstructed, which is why mainnet saw a \"new empty candle\" on 1h / 4h / 1d after the v0.15.1 → v0.16.0 upgrade window this morning even though downtime was only 10 minutes (still within every bucket).

### Repro on mainnet ClickHouse

\`\`\`sql
SELECT toDateTime64(1776556800000000, 6) AS as_micros,
       toDateTime64(1776556800, 6)       AS as_secs;
-- as_micros = 2299-12-31 23:59:59.000000  (saturated)
-- as_secs   = 2026-04-19 00:00:00.000000  (correct)

SELECT count() FROM perps_pair_prices WHERE created_at >= toDateTime64(1776556800000000, 6);  -- 0
SELECT count() FROM perps_pair_prices WHERE created_at >= toDateTime64(1776556800, 6);         -- 93554
\`\`\`

## Fix

Switch to `fromUnixTimestamp64Micro(?)`, which interprets the integer as microseconds by design. The Rust-side bind stays `since.timestamp_micros()`, matching the `DateTime64(6)` column precision with zero ambiguity and zero precision loss.

## Regression coverage

Two new integration tests (`candles.rs::index_candles_preload_rebuilds_current_bucket_from_clickhouse`, `perps_candles.rs::index_perps_candles_preload_rebuilds_current_bucket_from_clickhouse`) drive `preload_pairs` end-to-end through ClickHouse with a **recent** genesis timestamp (1 hour ago). They assert the rebuilt 1h / 4h / 1d in-progress candles carry the expected non-zero volume.

Why the existing `index_perps_candles_cache_consistency` test did not catch the bug: it relies on `MOCK_GENESIS_TIMESTAMP` (1971-01-01). `earliest_current_bucket_start(Utc::now())` then filters every row out in the per-interval replay loop regardless of whether `since` returned them, so the broken and fixed behaviour produced identical empty caches.

## Validation

### Completed
- [x] `cargo check -p dango-indexer-clickhouse --all-features`
- [x] `cargo check -p dango-testing --tests --all-features`
- [x] `cargo clippy -p dango-indexer-clickhouse -p dango-testing --all-features --tests -- -D warnings`
- [x] `just fmt`

### Remaining
- [ ] Run the two new integration tests against a local ClickHouse (`cargo test -p dango-testing --test indexing -- preload_rebuilds_current_bucket_from_clickhouse`) — requires the usual CI ClickHouse fixture.

## Manual QA

None — the bug is database-side query interpretation; the new integration tests are the only reliable check. On the live mainnet the smoking gun was the `replayed=0` trace combined with a direct ClickHouse query that showed 93,554 rows present for the same window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)