### PR TITLE
fix(ui): align referral data fields with renamed contract type

### DIFF
--- a/ui/portal/web/src/components/points/referral/MyCommission.tsx
+++ b/ui/portal/web/src/components/points/referral/MyCommission.tsx
@@ -70,12 +70,12 @@ function diffReferralData(
   wider: {
     commissionEarnedFromReferees?: string;
     refereesVolume?: string;
-    cumulativeActiveReferees?: number;
+    cumulativeDailyActiveReferees?: number;
   },
   narrower: {
     commissionEarnedFromReferees?: string;
     refereesVolume?: string;
-    cumulativeActiveReferees?: number;
+    cumulativeDailyActiveReferees?: number;
   },
 ) {
   return {
@@ -83,7 +83,7 @@ function diffReferralData(
       Number(wider.commissionEarnedFromReferees ?? "0") -
       Number(narrower.commissionEarnedFromReferees ?? "0"),
     volume: Number(wider.refereesVolume ?? "0") - Number(narrower.refereesVolume ?? "0"),
-    activeUsers: (wider.cumulativeActiveReferees ?? 0) - (narrower.cumulativeActiveReferees ?? 0),
+    activeUsers: (wider.cumulativeDailyActiveReferees ?? 0) - (narrower.cumulativeDailyActiveReferees ?? 0),
   };
 }
 

--- a/ui/portal/web/src/components/points/referral/ReferralStats.tsx
+++ b/ui/portal/web/src/components/points/referral/ReferralStats.tsx
@@ -276,7 +276,7 @@ export const AffiliateStats: React.FC = () => {
   const totalCommission = referralData?.commissionEarnedFromReferees ?? "0";
   const totalRefereesVolume = referralData?.refereesVolume ?? "0";
   const totalReferees = referralData?.refereeCount ?? 0;
-  const activeReferees = referralData?.cumulativeActiveReferees ?? 0;
+  const activeReferees = referralData?.cumulativeGlobalActiveReferees ?? 0;
 
   const nextTierLabel = `Tier ${currentTier + 1}`;
   const progressLeftLabel = isConnected

--- a/ui/store/src/types/referral.ts
+++ b/ui/store/src/types/referral.ts
@@ -21,7 +21,9 @@ export type UserReferralData = {
   /** Total commission distributed from this user's referees (cumulative). */
   commissionEarnedFromReferees: string;
   /** Cumulative count of daily active direct referees. */
-  cumulativeActiveReferees: number;
+  cumulativeDailyActiveReferees: number;
+  /** Number of direct referees that have made at least one trade. */
+  cumulativeGlobalActiveReferees: number;
 };
 
 /**


### PR DESCRIPTION
Update frontend UserReferralData to match the contract rename from cumulative_active_referees to cumulative_daily_active_referees, and add the new cumulative_global_active_referees field.