### PR TITLE
feat(perps): always emit FeeDistributed event

### DIFF
--- a/dango/perps/src/referral/apply_fee_commissions.rs
+++ b/dango/perps/src/referral/apply_fee_commissions.rs
@@ -64,13 +64,16 @@ pub fn apply_fee_commissions(
     // `&BTreeMap<Addr, UserState>` is never touched.
     let mut user_states = user_states.clone();
 
-    let mut total_vault_deduction = UsdValue::ZERO;
     let mut referrer_settings_cache = BTreeMap::<UserIndex, ReferrerSettings>::new();
     let mut addr_to_user_index_cache = BTreeMap::<Addr, Option<UserIndex>>::new();
 
     let account_factory = account_factory(querier);
 
     for (payer, fee_breakdown) in fee_breakdowns {
+        // The USD value credited to the referee and referrer that need to be subtracted
+        // from the vault balance. We can't change the vault value during the referral calculation.
+        let mut vault_deduction = UsdValue::ZERO;
+
         let vault_fee = fee_breakdown.vault_fee;
         if payer == perps_contract {
             continue;
@@ -136,7 +139,7 @@ pub fn apply_fee_commissions(
         // Credit the referee.
         if referee_share.is_non_zero() {
             credit_commission(storage, &mut user_states, payer, referee_share)?;
-            total_vault_deduction.checked_add_assign(referee_share)?;
+            vault_deduction.checked_add_assign(referee_share)?;
         }
 
         // Credit the first referrer.
@@ -150,7 +153,7 @@ pub fn apply_fee_commissions(
                 referrer_addr,
                 referrer_commission,
             )?;
-            total_vault_deduction.checked_add_assign(referrer_commission)?;
+            vault_deduction.checked_add_assign(referrer_commission)?;
         }
 
         // Payer's trade volume for this fill.
@@ -219,7 +222,7 @@ pub fn apply_fee_commissions(
                         super::retrieve_master_account(querier, next_referrer, account_factory)
                     {
                         credit_commission(storage, &mut user_states, addr, upstream_commission)?;
-                        total_vault_deduction.checked_add_assign(upstream_commission)?;
+                        vault_deduction.checked_add_assign(upstream_commission)?;
                     }
 
                     // Update upstream referrer's referral data: commission_earned_from_referees only.
@@ -242,22 +245,22 @@ pub fn apply_fee_commissions(
             current_user = next_referrer;
         }
 
+        // Deduct the total commission from the vault margin.
+        if vault_deduction.is_non_zero() {
+            user_states
+                .get_mut(&perps_contract)
+                .expect("vault must be in user_states for fee commission settlement")
+                .margin
+                .checked_sub_assign(vault_deduction)?;
+        }
+
         events.push(FeeDistributed {
             payer: payer_index,
             payer_addr: payer,
             protocol_fee: fee_breakdown.protocol_fee,
-            vault_fee,
+            vault_fee: vault_fee.checked_sub(vault_deduction)?,
             commissions,
         })?;
-    }
-
-    // Deduct the total commission from the vault margin.
-    if total_vault_deduction.is_non_zero() {
-        user_states
-            .get_mut(&perps_contract)
-            .expect("vault must be in user_states for fee commission settlement")
-            .margin
-            .checked_sub_assign(total_vault_deduction)?;
     }
 
     Ok(FeeCommissionsOutcome { user_states })

--- a/dango/perps/src/referral/apply_fee_commissions.rs
+++ b/dango/perps/src/referral/apply_fee_commissions.rs
@@ -31,7 +31,8 @@ pub struct FeeCommissionsOutcome {
 }
 
 /// Calculate and apply fee commissions for all fee-paying users based on the
-/// referral chain.
+/// referral chain. Emits a [`FeeDistributed`] event for every fee-paying user,
+/// regardless of whether they have a referrer.
 ///
 /// Commissions are funded from the post-protocol-cut fee.
 /// The protocol treasury is unaffected.
@@ -63,10 +64,6 @@ pub fn apply_fee_commissions(
     // `&BTreeMap<Addr, UserState>` is never touched.
     let mut user_states = user_states.clone();
 
-    if !param.referral_active {
-        return Ok(FeeCommissionsOutcome { user_states });
-    }
-
     let mut total_vault_deduction = UsdValue::ZERO;
     let mut referrer_settings_cache = BTreeMap::<UserIndex, ReferrerSettings>::new();
     let mut addr_to_user_index_cache = BTreeMap::<Addr, Option<UserIndex>>::new();
@@ -94,8 +91,22 @@ pub fn apply_fee_commissions(
             continue;
         };
 
-        // Look up the first referrer.
-        let Some(first_referrer) = REFEREE_TO_REFERRER.may_load(storage, payer_index)? else {
+        // If referrals are inactive or the payer has no referrer, emit the
+        // event with empty commissions and skip chain processing.
+        let first_referrer = if param.referral_active {
+            REFEREE_TO_REFERRER.may_load(storage, payer_index)?
+        } else {
+            None
+        };
+
+        let Some(first_referrer) = first_referrer else {
+            events.push(FeeDistributed {
+                payer: payer_index,
+                payer_addr: payer,
+                protocol_fee: fee_breakdown.protocol_fee,
+                vault_fee,
+                commissions: vec![],
+            })?;
             continue;
         };
 

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -7,13 +7,14 @@ use {
         constants::usdc,
         oracle::{self, PriceSource},
         perps::{
-            self, CommissionRate, FeeShareRatio, QueryParamRequest, Referee, ReferrerSettings,
-            ReferrerStatsOrderBy, ReferrerStatsOrderIndex, UserReferralData,
+            self, CommissionRate, FeeDistributed, FeeShareRatio, QueryParamRequest, Referee,
+            ReferrerSettings, ReferrerStatsOrderBy, ReferrerStatsOrderIndex, UserReferralData,
         },
     },
     grug::{
-        Addr, Addressable, Coins, HashExt, NumberConst, Op, Order as IterationOrder, QuerierExt,
-        ResultExt, Signer, Timestamp, TxOutcome, Udec128, Uint128, btree_map,
+        Addr, Addressable, CheckedContractEvent, Coins, HashExt, JsonDeExt, NumberConst, Op,
+        Order as IterationOrder, QuerierExt, ResultExt, SearchEvent, Signer, Timestamp, TxOutcome,
+        Udec128, Uint128, btree_map,
     },
     grug_app::NaiveProposalPreparer,
 };
@@ -1516,6 +1517,205 @@ fn negative_maker_fee_does_not_debit_referrers() {
     );
 }
 
+/// A payer without a referrer still gets a `FeeDistributed` event with
+/// correct protocol_fee, vault_fee, and empty commissions.
+#[test]
+fn fee_distributed_event_without_referrer() {
+    let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
+
+    // Set protocol fee to 50%.
+    let mut param: perps::Param = suite
+        .query_wasm_smart(contracts.perps, perps::QueryParamRequest {})
+        .should_succeed();
+
+    param.protocol_fee_rate = Dimensionless::new_percent(50);
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param,
+                pair_params: Default::default(),
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
+
+    // Trade without any referral relationship.
+    place_ask_order(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user1,
+        UsdPrice::new_int(2_000),
+        1,
+    );
+    let events = place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1);
+
+    let fee_events: Vec<FeeDistributed> = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "fee_distributed")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json().unwrap())
+        .collect();
+
+    // Maker fee is zero, so only the taker gets a FeeDistributed event.
+    assert_eq!(
+        fee_events.len(),
+        1,
+        "One FeeDistributed event must be emitted for the taker"
+    );
+
+    // Notional = 1 × $2,000 = $2,000. Taker fee = 0.1% = $2. Protocol fee = 50%.
+    // With no commissions: protocol_fee = $1, vault_fee = $1.
+    let expected_vault_fee = UsdValue::new_int(1);
+    let expected_protocol_fee = UsdValue::new_int(1);
+
+    let total_vault_fee: UsdValue = fee_events
+        .iter()
+        .map(|e| e.vault_fee)
+        .try_fold(UsdValue::ZERO, |acc, v| acc.checked_add(v))
+        .unwrap();
+    let total_protocol_fee: UsdValue = fee_events
+        .iter()
+        .map(|e| e.protocol_fee)
+        .try_fold(UsdValue::ZERO, |acc, v| acc.checked_add(v))
+        .unwrap();
+
+    assert_eq!(total_vault_fee, expected_vault_fee);
+    assert_eq!(total_protocol_fee, expected_protocol_fee);
+
+    for event in &fee_events {
+        assert!(event.commissions.is_empty());
+    }
+}
+
+/// A payer with a referrer gets a `FeeDistributed` event with correct
+/// protocol_fee, vault_fee (reduced by commissions), and commissions.
+#[test]
+fn fee_distributed_event_with_referrer() {
+    let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
+
+    // Set protocol fee to 50%.
+    let mut param: perps::Param = suite
+        .query_wasm_smart(contracts.perps, perps::QueryParamRequest {})
+        .should_succeed();
+
+    param.protocol_fee_rate = Dimensionless::new_percent(50);
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param,
+                pair_params: Default::default(),
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000);
+
+    // User1 becomes a referrer with 20% share ratio.
+    set_fee_share_ratio(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user1,
+        Dimensionless::new_percent(20),
+    )
+    .should_succeed();
+
+    // User2 sets User1 as referrer.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetReferral {
+                referrer: 1,
+                referee: 2,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Set a known commission rate override for deterministic math.
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetCommissionRateOverride {
+                user: 1,
+                commission_rate: Op::Insert(CommissionRate::new_percent(50)),
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // User8 places ask (maker), User2 (referee) buys (taker).
+    // Notional = 1 × $2,000 = $2,000. Taker fee = 0.1% = $2.
+    place_ask_order(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user8,
+        UsdPrice::new_int(2_000),
+        1,
+    );
+    let events = place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1);
+
+    let fee_events: Vec<FeeDistributed> = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "fee_distributed")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json().unwrap())
+        .collect();
+
+    // The taker (user2) has a referrer → non-empty commissions.
+    let taker_event = fee_events
+        .iter()
+        .find(|e| e.payer_addr == accounts.user2.address())
+        .expect("taker must have a FeeDistributed event");
+
+    // Notional = $2,000. Taker fee = 0.1% = $2.
+    // protocol_fee = $2 × 50% = $1. vault_fee (before commissions) = $1.
+    // commission_rate = 50%, share_ratio = 20%.
+    // total_commission = $1 × 50% = $0.50
+    // referee_share    = $0.50 × 20% = $0.10
+    // referrer_share   = $0.50 × 80% = $0.40
+    // vault_fee (after) = $1 − $0.50 = $0.50
+    let expected_protocol_fee = UsdValue::new_int(1);
+    let expected_vault_fee_before = UsdValue::new_int(1);
+    let expected_total_commission = expected_vault_fee_before
+        .checked_mul(CommissionRate::new_percent(50))
+        .unwrap();
+    let expected_referee_share = expected_total_commission
+        .checked_mul(Dimensionless::new_percent(20))
+        .unwrap();
+    let expected_referrer_share = expected_total_commission
+        .checked_sub(expected_referee_share)
+        .unwrap();
+    let expected_vault_fee = expected_vault_fee_before
+        .checked_sub(expected_total_commission)
+        .unwrap();
+
+    assert_eq!(taker_event.protocol_fee, expected_protocol_fee);
+    assert_eq!(taker_event.vault_fee, expected_vault_fee);
+    assert_eq!(taker_event.commissions.len(), 2);
+    assert_eq!(taker_event.commissions[0], expected_referee_share);
+    assert_eq!(taker_event.commissions[1], expected_referrer_share);
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1647,6 +1847,32 @@ fn create_perps_fill(
         size,
     );
     place_market_buy(suite, perps, &mut accounts.user2, size);
+}
+
+fn place_market_buy_with_events(
+    suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
+    perps: Addr,
+    user: &mut dyn Signer,
+    size: u128,
+) -> grug::TxEvents {
+    suite
+        .execute(
+            user,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: dango_testing::perps::pair_id(),
+                size: Quantity::new_int(size as i128),
+                kind: perps::OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .should_succeed()
+        .events
 }
 
 fn query_referral_settings(

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1654,7 +1654,7 @@ pub struct FeeDistributed {
     /// Protocol treasury portion of the fee.
     pub protocol_fee: UsdValue,
 
-    /// Vault portion of the fee (before commissions).
+    /// Vault portion of the fee.
     pub vault_fee: UsdValue,
 
     /// Commission amounts per chain level: [payer, 1st referrer, 2nd, ...].


### PR DESCRIPTION
Emit the FeeDistributed event for every fee-paying user, not just those with a referrer. Previously the event was skipped when the payer had no referral or when referrals were globally inactive. Now, non-referred payers and inactive-referral scenarios emit the event with an empty commissions vec.