### PR TITLE
feat(indexer-client): rewrite WsClient with multiplexed subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,12 +5489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5652,25 +5646,6 @@ checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
 dependencies = [
  "combine",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "graphql-ws-client"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4855443d93653e3b7a0378cf65eb680098600dfd2319a663ea45e49240084ec6"
-dependencies = [
- "async-channel 2.5.0",
- "futures-lite",
- "futures-sink",
- "futures-timer",
- "graphql_client",
- "log",
- "pin-project 1.1.11",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -6861,7 +6836,6 @@ dependencies = [
  "dango-types",
  "error-backtrace",
  "futures",
- "graphql-ws-client",
  "graphql_client",
  "grug",
  "grug-testing",
@@ -6872,6 +6846,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint-rpc",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,7 @@ ed25519-dalek               = "2"
 elsa                        = "1"
 futures                     = "0.3"
 futures-util                = "0.3"
-graphql-ws-client           = { version = "0.12", features = ["client-graphql-client", "tungstenite-0.28"] }
-graphql_client              = "0.14" # FIXME: can't bump to 0.16 because graphql-ws-client requires 0.12
+graphql_client              = "0.14"
 hex                         = "0.4"
 hex-literal                 = "1"
 home                        = "0.5"
@@ -188,7 +187,7 @@ test-case                   = "3"
 thiserror                   = "2"
 tokio                       = { version = "1", features = ["full"] }
 tokio-stream                = { version = "0.1", features = ["sync"] }
-tokio-tungstenite           = { version = "0.28", features = ["native-tls"] } # FIXME: can't bump to 0.29 because graphql-ws-client requires 0.28
+tokio-tungstenite           = { version = "0.28", features = ["native-tls"] }
 toml                        = "0.9"
 tower                       = "0.5"
 tower-abci                  = "0.19"

--- a/indexer/client/Cargo.toml
+++ b/indexer/client/Cargo.toml
@@ -19,13 +19,14 @@ async-trait       = { workspace = true }
 error-backtrace   = { workspace = true }
 futures           = { workspace = true }
 graphql_client    = { workspace = true }
-graphql-ws-client = { workspace = true }
 grug-types        = { workspace = true, features = ["tendermint"] }
 paste             = { workspace = true }
 reqwest           = { workspace = true, features = ["json"] }
 serde             = { workspace = true }
 serde_json        = { workspace = true }
 tendermint-rpc    = { workspace = true }
+thiserror         = { workspace = true }
+tokio             = { workspace = true }
 tokio-tungstenite = { workspace = true }
 tracing           = { workspace = true, optional = true }
 url               = { workspace = true }

--- a/indexer/client/src/subscription.rs
+++ b/indexer/client/src/subscription.rs
@@ -3,9 +3,14 @@ use {
     anyhow::bail,
     graphql_client::{GraphQLQuery, Response},
     graphql_ws_client::{Client, graphql::StreamingOperation},
+    std::time::Duration,
     tokio_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue},
     url::Url,
 };
+
+/// Must stay below the server's `GraphQLSubscription::keepalive_timeout` (30s)
+/// or idle subscriptions are dropped with close code 3008.
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
 
 /// A WebSocket client for GraphQL subscriptions.
 #[derive(Debug, Clone)]
@@ -122,6 +127,7 @@ impl WsClient {
         tracing::debug!("WebSocket connected, building client");
 
         let subscription = Client::build(connection)
+            .keep_alive_interval(KEEP_ALIVE_INTERVAL)
             .subscribe(StreamingOperation::<Q>::new(variables))
             .await
             .map_err(|e| anyhow::anyhow!("Subscription failed: {e}"))?;

--- a/indexer/client/src/subscription.rs
+++ b/indexer/client/src/subscription.rs
@@ -1,12 +1,26 @@
 use {
     crate::Variables,
     anyhow::bail,
-    futures::{SinkExt, Stream, StreamExt, channel::mpsc},
+    futures::{
+        SinkExt, Stream, StreamExt,
+        channel::mpsc,
+        stream::{SplitSink, SplitStream},
+    },
     graphql_client::{GraphQLQuery, Response},
-    serde::{Deserialize, Serialize},
-    std::{pin::Pin, time::Duration},
+    serde::{Deserialize, Serialize, de::DeserializeOwned},
+    std::{
+        collections::HashMap,
+        marker::PhantomData,
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        task::{Context, Poll},
+        time::Duration,
+    },
     tokio_tungstenite::{
-        connect_async,
+        MaybeTlsStream, WebSocketStream, connect_async,
         tungstenite::{Message, client::IntoClientRequest, http::HeaderValue},
     },
     url::Url,
@@ -16,11 +30,12 @@ use {
 /// or idle subscriptions are dropped with close code 3008.
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
 
-const SUBSCRIPTION_ID: &str = "1";
-const CHANNEL_CAPACITY: usize = 32;
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type ResponseSender = mpsc::UnboundedSender<Result<serde_json::Value, WsError>>;
+type ResponseReceiver = mpsc::UnboundedReceiver<Result<serde_json::Value, WsError>>;
 
 /// Errors surfaced on a [`SubscriptionStream`].
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum WsError {
     #[error("WebSocket connection closed: {0}")]
     Closed(String),
@@ -34,13 +49,36 @@ pub enum WsError {
 
 /// A WebSocket client for GraphQL subscriptions.
 ///
-/// Implements the `graphql-transport-ws` protocol directly on top of
+/// Speaks the `graphql-transport-ws` protocol directly on top of
 /// [`tokio_tungstenite`] so that `ping` messages are sent on a fixed schedule
 /// regardless of inbound traffic — required because `async-graphql` only
 /// resets its `keepalive_timeout` when it receives a client protocol message.
 #[derive(Debug, Clone)]
 pub struct WsClient {
     url: Url,
+}
+
+/// A live WebSocket session that can host multiple concurrent subscriptions
+/// over a single connection.
+///
+/// `Session` is cheap to clone (backed by an [`Arc`]); the underlying
+/// connection is closed when the last clone is dropped and every outstanding
+/// subscription stream has also been dropped.
+#[derive(Debug, Clone)]
+pub struct Session {
+    inner: Arc<SessionInner>,
+}
+
+#[derive(Debug)]
+struct SessionInner {
+    commands: mpsc::UnboundedSender<Command>,
+    next_id: AtomicU64,
+}
+
+impl Drop for SessionInner {
+    fn drop(&mut self) {
+        let _ = self.commands.unbounded_send(Command::Close);
+    }
 }
 
 /// Type alias for the subscription stream returned by the client.
@@ -78,6 +116,18 @@ enum ServerMessage {
     Complete {
         id: String,
     },
+}
+
+enum Command {
+    Subscribe {
+        id: String,
+        payload: serde_json::Value,
+        tx: ResponseSender,
+    },
+    Unsubscribe {
+        id: String,
+    },
+    Close,
 }
 
 impl WsClient {
@@ -119,45 +169,13 @@ impl WsClient {
         Ok(Self { url })
     }
 
-    /// Subscribe to a GraphQL subscription.
+    /// Open a new WebSocket connection and return a [`Session`] that can host
+    /// multiple concurrent subscriptions over the same connection.
     ///
-    /// Returns a stream of subscription responses wrapped in `graphql_client::Response`.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use futures::StreamExt;
-    /// use indexer_client::{WsClient, SubscribeTrades, subscribe_trades};
-    ///
-    /// let client = WsClient::new("ws://localhost:8080/graphql")?;
-    ///
-    /// let variables = subscribe_trades::Variables {
-    ///     base_denom: "dango".to_string(),
-    ///     quote_denom: "bridge/usdc".to_string(),
-    /// };
-    ///
-    /// let mut stream = client.subscribe::<SubscribeTrades>(variables).await?;
-    ///
-    /// while let Some(response) = stream.next().await {
-    ///     match response {
-    ///         Ok(resp) => {
-    ///             if let Some(data) = resp.data {
-    ///                 println!("{:?}", data);
-    ///             }
-    ///         }
-    ///         Err(e) => eprintln!("Error: {e}"),
-    ///     }
-    /// }
-    /// ```
-    pub async fn subscribe<Q>(
-        &self,
-        variables: Q::Variables,
-    ) -> Result<SubscriptionStream<Q::ResponseData>, anyhow::Error>
-    where
-        Q: GraphQLQuery + Unpin + Send + Sync + 'static,
-        Q::Variables: Unpin + Send + Sync + 'static,
-        Q::ResponseData: Unpin + Send + Sync + 'static,
-    {
+    /// The handshake (`connection_init`/`connection_ack`) is performed before
+    /// returning. The connection stays open as long as the `Session` (or a
+    /// clone) or any subscription stream derived from it is alive.
+    pub async fn connect(&self) -> Result<Session, anyhow::Error> {
         let mut request = self.url.as_str().into_client_request()?;
 
         request.headers_mut().insert(
@@ -202,6 +220,85 @@ impl WsClient {
             }
         }
 
+        #[cfg(feature = "tracing")]
+        tracing::debug!("WebSocket handshake complete");
+
+        let (cmd_tx, cmd_rx) = mpsc::unbounded::<Command>();
+        tokio::spawn(run_session(sink, stream, cmd_rx));
+
+        Ok(Session {
+            inner: Arc::new(SessionInner {
+                commands: cmd_tx,
+                next_id: AtomicU64::new(1),
+            }),
+        })
+    }
+
+    /// Open a new WebSocket connection and start a single subscription.
+    ///
+    /// Convenience wrapper around [`WsClient::connect`] followed by
+    /// [`Session::subscribe`]; the underlying connection is dedicated to this
+    /// subscription and closes automatically when the returned stream is
+    /// dropped.
+    ///
+    /// Use [`WsClient::connect`] directly if you want to multiplex multiple
+    /// subscriptions over a single WebSocket.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use futures::StreamExt;
+    /// use indexer_client::{WsClient, SubscribeTrades, subscribe_trades};
+    ///
+    /// let client = WsClient::new("ws://localhost:8080/graphql")?;
+    ///
+    /// let variables = subscribe_trades::Variables {
+    ///     base_denom: "dango".to_string(),
+    ///     quote_denom: "bridge/usdc".to_string(),
+    /// };
+    ///
+    /// let mut stream = client.subscribe::<SubscribeTrades>(variables).await?;
+    ///
+    /// while let Some(response) = stream.next().await {
+    ///     match response {
+    ///         Ok(resp) => {
+    ///             if let Some(data) = resp.data {
+    ///                 println!("{:?}", data);
+    ///             }
+    ///         }
+    ///         Err(e) => eprintln!("Error: {e}"),
+    ///     }
+    /// }
+    /// ```
+    pub async fn subscribe<Q>(
+        &self,
+        variables: Q::Variables,
+    ) -> Result<SubscriptionStream<Q::ResponseData>, anyhow::Error>
+    where
+        Q: GraphQLQuery + Unpin + Send + Sync + 'static,
+        Q::Variables: Unpin + Send + Sync + 'static,
+        Q::ResponseData: DeserializeOwned + Unpin + Send + Sync + 'static,
+    {
+        let session = self.connect().await?;
+        session.subscribe::<Q>(variables).await
+    }
+}
+
+impl Session {
+    /// Start a new subscription on this session.
+    ///
+    /// Multiple subscriptions can run concurrently on the same session; each
+    /// is tagged with a unique id at the protocol level and routed back to
+    /// its own stream.
+    pub async fn subscribe<Q>(
+        &self,
+        variables: Q::Variables,
+    ) -> Result<SubscriptionStream<Q::ResponseData>, anyhow::Error>
+    where
+        Q: GraphQLQuery + Unpin + Send + Sync + 'static,
+        Q::Variables: Unpin + Send + Sync + 'static,
+        Q::ResponseData: DeserializeOwned + Unpin + Send + Sync + 'static,
+    {
         let body = Q::build_query(variables);
         let payload = serde_json::json!({
             "query": body.query,
@@ -209,141 +306,190 @@ impl WsClient {
             "operationName": body.operation_name,
         });
 
-        sink.send(Message::text(serde_json::to_string(
-            &ClientMessage::Subscribe {
-                id: SUBSCRIPTION_ID,
+        let id = self
+            .inner
+            .next_id
+            .fetch_add(1, Ordering::Relaxed)
+            .to_string();
+
+        let (tx, rx) = mpsc::unbounded::<Result<serde_json::Value, WsError>>();
+
+        self.inner
+            .commands
+            .unbounded_send(Command::Subscribe {
+                id: id.clone(),
                 payload,
-            },
-        )?))
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send subscribe: {e}"))?;
+                tx,
+            })
+            .map_err(|_| anyhow::anyhow!("session is closed"))?;
 
         #[cfg(feature = "tracing")]
-        tracing::debug!("Subscription established");
+        tracing::debug!(subscription_id = %id, "Subscription registered");
 
-        let (tx, rx) =
-            mpsc::channel::<Result<Response<Q::ResponseData>, WsError>>(CHANNEL_CAPACITY);
-
-        tokio::spawn(run_subscription::<Q>(sink, stream, tx));
-
-        Ok(Box::pin(rx))
+        Ok(Box::pin(SubscriptionStreamInner::<Q::ResponseData> {
+            rx,
+            id: Some(id),
+            commands: self.inner.commands.clone(),
+            _session: self.clone(),
+            _phantom: PhantomData,
+        }))
     }
 }
 
-async fn run_subscription<Q>(
-    mut sink: futures::stream::SplitSink<
-        tokio_tungstenite::WebSocketStream<
-            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-        >,
-        Message,
-    >,
-    mut stream: futures::stream::SplitStream<
-        tokio_tungstenite::WebSocketStream<
-            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-        >,
-    >,
-    mut tx: mpsc::Sender<Result<Response<Q::ResponseData>, WsError>>,
-) where
-    Q: GraphQLQuery + Unpin + Send + Sync + 'static,
-    Q::ResponseData: Unpin + Send + Sync + 'static,
+struct SubscriptionStreamInner<T> {
+    rx: ResponseReceiver,
+    id: Option<String>,
+    commands: mpsc::UnboundedSender<Command>,
+    _session: Session,
+    _phantom: PhantomData<fn() -> T>,
+}
+
+impl<T> Stream for SubscriptionStreamInner<T>
+where
+    T: DeserializeOwned + Unpin + Send + 'static,
 {
+    type Item = Result<Response<T>, WsError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.rx).poll_next(cx) {
+            Poll::Ready(Some(Ok(payload))) => Poll::Ready(Some(
+                serde_json::from_value::<Response<T>>(payload)
+                    .map_err(|e| WsError::Decode(e.to_string())),
+            )),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T> Drop for SubscriptionStreamInner<T> {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            let _ = self.commands.unbounded_send(Command::Unsubscribe { id });
+        }
+    }
+}
+
+async fn run_session(
+    mut sink: SplitSink<WsStream, Message>,
+    mut stream: SplitStream<WsStream>,
+    mut commands: mpsc::UnboundedReceiver<Command>,
+) {
+    let mut senders: HashMap<String, ResponseSender> = HashMap::new();
     let mut ping_interval = tokio::time::interval(KEEP_ALIVE_INTERVAL);
-    // First tick fires immediately; skip it so we don't ping right after subscribe.
+    // First tick fires immediately; skip it so we don't ping right after the ack.
     ping_interval.tick().await;
 
-    let ping_payload = serde_json::to_string(&ClientMessage::Ping)
+    let ping_msg = serde_json::to_string(&ClientMessage::Ping)
         .expect("serializing unit enum variant never fails");
-    let pong_payload = serde_json::to_string(&ClientMessage::Pong)
+    let pong_msg = serde_json::to_string(&ClientMessage::Pong)
         .expect("serializing unit enum variant never fails");
-    let complete_payload = serde_json::to_string(&ClientMessage::Complete {
-        id: SUBSCRIPTION_ID,
-    })
-    .expect("serializing Complete never fails");
 
-    loop {
+    let exit_error = loop {
         tokio::select! {
             _ = ping_interval.tick() => {
-                if sink.send(Message::text(ping_payload.clone())).await.is_err() {
-                    break;
+                if sink.send(Message::text(ping_msg.clone())).await.is_err() {
+                    break Some(WsError::Transport("failed to send ping".into()));
                 }
             }
+            cmd = commands.next() => match cmd {
+                Some(Command::Subscribe { id, payload, tx }) => {
+                    let msg = serde_json::to_string(&ClientMessage::Subscribe {
+                        id: &id,
+                        payload,
+                    })
+                    .expect("serializing subscribe never fails");
+                    senders.insert(id, tx);
+                    if sink.send(Message::text(msg)).await.is_err() {
+                        break Some(WsError::Transport("failed to send subscribe".into()));
+                    }
+                }
+                Some(Command::Unsubscribe { id }) => {
+                    if senders.remove(&id).is_some() {
+                        let msg = serde_json::to_string(&ClientMessage::Complete { id: &id })
+                            .expect("serializing complete never fails");
+                        if sink.send(Message::text(msg)).await.is_err() {
+                            break Some(WsError::Transport("failed to send complete".into()));
+                        }
+                    }
+                }
+                Some(Command::Close) | None => break None,
+            },
             msg = stream.next() => {
                 match msg {
                     Some(Ok(Message::Text(txt))) => {
                         let decoded: ServerMessage = match serde_json::from_str(&txt) {
                             Ok(m) => m,
-                            Err(e) => {
-                                let _ = tx.send(Err(WsError::Decode(e.to_string()))).await;
-                                break;
-                            },
+                            Err(e) => break Some(WsError::Decode(e.to_string())),
                         };
 
                         match decoded {
                             ServerMessage::Next { id, payload } => {
-                                if id != SUBSCRIPTION_ID {
-                                    continue;
-                                }
-                                match serde_json::from_value::<Response<Q::ResponseData>>(payload) {
-                                    Ok(resp) => {
-                                        if tx.send(Ok(resp)).await.is_err() {
-                                            break;
-                                        }
-                                    },
-                                    Err(e) => {
-                                        let _ =
-                                            tx.send(Err(WsError::Decode(e.to_string()))).await;
-                                        break;
-                                    },
-                                }
-                            },
-                            ServerMessage::Error { id, payload } => {
-                                if id != SUBSCRIPTION_ID {
-                                    continue;
-                                }
-                                let _ = tx.send(Err(WsError::Subscription(payload))).await;
-                                break;
-                            },
-                            ServerMessage::Complete { id } => {
-                                if id == SUBSCRIPTION_ID {
-                                    break;
-                                }
-                            },
-                            ServerMessage::Ping => {
-                                if sink
-                                    .send(Message::text(pong_payload.clone()))
-                                    .await
-                                    .is_err()
+                                if let Some(tx) = senders.get(&id)
+                                    && tx.unbounded_send(Ok(payload)).is_err()
                                 {
-                                    break;
+                                    // Consumer dropped its stream without sending
+                                    // Unsubscribe yet; drop the sender and tell the server.
+                                    senders.remove(&id);
+                                    let msg =
+                                        serde_json::to_string(&ClientMessage::Complete { id: &id })
+                                            .expect("serializing complete never fails");
+                                    if sink.send(Message::text(msg)).await.is_err() {
+                                        break Some(WsError::Transport(
+                                            "failed to send complete".into(),
+                                        ));
+                                    }
                                 }
-                            },
+                            }
+                            ServerMessage::Error { id, payload } => {
+                                if let Some(tx) = senders.remove(&id) {
+                                    let _ = tx.unbounded_send(Err(WsError::Subscription(payload)));
+                                }
+                            }
+                            ServerMessage::Complete { id } => {
+                                // Dropping the sender closes the consumer's stream.
+                                senders.remove(&id);
+                            }
+                            ServerMessage::Ping => {
+                                if sink.send(Message::text(pong_msg.clone())).await.is_err() {
+                                    break Some(WsError::Transport("failed to send pong".into()));
+                                }
+                            }
                             ServerMessage::Pong | ServerMessage::ConnectionAck => {},
                         }
-                    },
+                    }
                     Some(Ok(Message::Ping(data))) => {
                         if sink.send(Message::Pong(data)).await.is_err() {
-                            break;
+                            break Some(WsError::Transport("failed to send pong".into()));
                         }
-                    },
+                    }
                     Some(Ok(Message::Close(frame))) => {
                         let reason = frame
                             .map(|f| format!("{} (code {})", f.reason, u16::from(f.code)))
                             .unwrap_or_else(|| "no close frame".to_string());
-                        let _ = tx.send(Err(WsError::Closed(reason))).await;
-                        break;
-                    },
-                    Some(Ok(_)) => {},
-                    Some(Err(e)) => {
-                        let _ = tx.send(Err(WsError::Transport(e.to_string()))).await;
-                        break;
-                    },
-                    None => break,
+                        break Some(WsError::Closed(reason));
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => break Some(WsError::Transport(e.to_string())),
+                    None => break Some(WsError::Closed("stream ended".into())),
                 }
             }
         }
-    }
+    };
 
-    let _ = sink.send(Message::text(complete_payload)).await;
+    // Best-effort graceful shutdown.
+    if let Some(err) = &exit_error {
+        for tx in senders.values() {
+            let _ = tx.unbounded_send(Err(err.clone()));
+        }
+    }
+    for id in senders.keys() {
+        let msg = serde_json::to_string(&ClientMessage::Complete { id })
+            .expect("serializing complete never fails");
+        let _ = sink.send(Message::text(msg)).await;
+    }
+    drop(senders);
     let _ = sink.close().await;
 }
 
@@ -362,7 +508,8 @@ pub trait SubscriptionVariables: Variables {
     where
         Self: Sized + Unpin + Send + Sync + 'static,
         <Self as Variables>::Query: Unpin + Send + Sync + 'static,
-        <<Self as Variables>::Query as GraphQLQuery>::ResponseData: Unpin + Send + Sync + 'static,
+        <<Self as Variables>::Query as GraphQLQuery>::ResponseData:
+            DeserializeOwned + Unpin + Send + Sync + 'static,
     {
         client.subscribe::<Self::Query>(self)
     }

--- a/indexer/client/src/subscription.rs
+++ b/indexer/client/src/subscription.rs
@@ -1,10 +1,14 @@
 use {
     crate::Variables,
     anyhow::bail,
+    futures::{SinkExt, Stream, StreamExt, channel::mpsc},
     graphql_client::{GraphQLQuery, Response},
-    graphql_ws_client::{Client, graphql::StreamingOperation},
-    std::time::Duration,
-    tokio_tungstenite::tungstenite::{client::IntoClientRequest, http::HeaderValue},
+    serde::{Deserialize, Serialize},
+    std::{pin::Pin, time::Duration},
+    tokio_tungstenite::{
+        connect_async,
+        tungstenite::{Message, client::IntoClientRequest, http::HeaderValue},
+    },
     url::Url,
 };
 
@@ -12,16 +16,69 @@ use {
 /// or idle subscriptions are dropped with close code 3008.
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
 
+const SUBSCRIPTION_ID: &str = "1";
+const CHANNEL_CAPACITY: usize = 32;
+
+/// Errors surfaced on a [`SubscriptionStream`].
+#[derive(Debug, thiserror::Error)]
+pub enum WsError {
+    #[error("WebSocket connection closed: {0}")]
+    Closed(String),
+    #[error("WebSocket transport error: {0}")]
+    Transport(String),
+    #[error("subscription returned error: {0}")]
+    Subscription(serde_json::Value),
+    #[error("failed to decode message: {0}")]
+    Decode(String),
+}
+
 /// A WebSocket client for GraphQL subscriptions.
+///
+/// Implements the `graphql-transport-ws` protocol directly on top of
+/// [`tokio_tungstenite`] so that `ping` messages are sent on a fixed schedule
+/// regardless of inbound traffic — required because `async-graphql` only
+/// resets its `keepalive_timeout` when it receives a client protocol message.
 #[derive(Debug, Clone)]
 pub struct WsClient {
     url: Url,
 }
 
 /// Type alias for the subscription stream returned by the client.
-pub type SubscriptionStream<T> = std::pin::Pin<
-    Box<dyn futures::Stream<Item = Result<Response<T>, graphql_ws_client::Error>> + Send>,
->;
+pub type SubscriptionStream<T> = Pin<Box<dyn Stream<Item = Result<Response<T>, WsError>> + Send>>;
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClientMessage<'a> {
+    ConnectionInit,
+    Subscribe {
+        id: &'a str,
+        payload: serde_json::Value,
+    },
+    Ping,
+    Pong,
+    Complete {
+        id: &'a str,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ServerMessage {
+    ConnectionAck,
+    Ping,
+    Pong,
+    Next {
+        id: String,
+        payload: serde_json::Value,
+    },
+    Error {
+        id: String,
+        payload: serde_json::Value,
+    },
+    Complete {
+        id: String,
+    },
+}
 
 impl WsClient {
     /// Create a new WebSocket client.
@@ -31,7 +88,6 @@ impl WsClient {
         let url_str = url.into();
         let url = Url::parse(&url_str)?;
 
-        // Validate the URL scheme
         match url.scheme() {
             "ws" | "wss" => {},
             scheme => bail!("Invalid URL scheme: {scheme}. Expected ws:// or wss://"),
@@ -47,7 +103,6 @@ impl WsClient {
         let url_str = url.into();
         let mut url = Url::parse(&url_str)?;
 
-        // Convert HTTP scheme to WebSocket scheme
         match url.scheme() {
             "http" => url
                 .set_scheme("ws")
@@ -105,7 +160,6 @@ impl WsClient {
     {
         let mut request = self.url.as_str().into_client_request()?;
 
-        // Set the required WebSocket protocol header for GraphQL
         request.headers_mut().insert(
             "Sec-WebSocket-Protocol",
             HeaderValue::from_static("graphql-transport-ws"),
@@ -114,29 +168,183 @@ impl WsClient {
         #[cfg(feature = "tracing")]
         tracing::debug!("Connecting to WebSocket: {}", self.url);
 
-        let (connection, _response) =
-            tokio_tungstenite::connect_async(request)
-                .await
-                .map_err(|e| {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!("WebSocket connection failed: {e}");
-                    anyhow::anyhow!("WebSocket connection failed: {e}")
-                })?;
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!("WebSocket connected, building client");
-
-        let subscription = Client::build(connection)
-            .keep_alive_interval(KEEP_ALIVE_INTERVAL)
-            .subscribe(StreamingOperation::<Q>::new(variables))
+        let (ws, _response) = connect_async(request)
             .await
-            .map_err(|e| anyhow::anyhow!("Subscription failed: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("WebSocket connection failed: {e}"))?;
+
+        let (mut sink, mut stream) = ws.split();
+
+        sink.send(Message::text(serde_json::to_string(
+            &ClientMessage::ConnectionInit,
+        )?))
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to send connection_init: {e}"))?;
+
+        // Wait for `connection_ack`, responding to any `ping` in between.
+        loop {
+            match stream.next().await {
+                Some(Ok(Message::Text(txt))) => {
+                    match serde_json::from_str::<ServerMessage>(&txt)? {
+                        ServerMessage::ConnectionAck => break,
+                        ServerMessage::Ping => {
+                            sink.send(Message::text(serde_json::to_string(&ClientMessage::Pong)?))
+                                .await?;
+                        },
+                        _ => bail!("unexpected message before connection_ack: {txt}"),
+                    }
+                },
+                Some(Ok(Message::Ping(data))) => {
+                    sink.send(Message::Pong(data)).await?;
+                },
+                Some(Ok(_)) => {},
+                Some(Err(e)) => bail!("WebSocket error before connection_ack: {e}"),
+                None => bail!("WebSocket closed before connection_ack"),
+            }
+        }
+
+        let body = Q::build_query(variables);
+        let payload = serde_json::json!({
+            "query": body.query,
+            "variables": body.variables,
+            "operationName": body.operation_name,
+        });
+
+        sink.send(Message::text(serde_json::to_string(
+            &ClientMessage::Subscribe {
+                id: SUBSCRIPTION_ID,
+                payload,
+            },
+        )?))
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to send subscribe: {e}"))?;
 
         #[cfg(feature = "tracing")]
         tracing::debug!("Subscription established");
 
-        Ok(Box::pin(subscription))
+        let (tx, rx) =
+            mpsc::channel::<Result<Response<Q::ResponseData>, WsError>>(CHANNEL_CAPACITY);
+
+        tokio::spawn(run_subscription::<Q>(sink, stream, tx));
+
+        Ok(Box::pin(rx))
     }
+}
+
+async fn run_subscription<Q>(
+    mut sink: futures::stream::SplitSink<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        Message,
+    >,
+    mut stream: futures::stream::SplitStream<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    >,
+    mut tx: mpsc::Sender<Result<Response<Q::ResponseData>, WsError>>,
+) where
+    Q: GraphQLQuery + Unpin + Send + Sync + 'static,
+    Q::ResponseData: Unpin + Send + Sync + 'static,
+{
+    let mut ping_interval = tokio::time::interval(KEEP_ALIVE_INTERVAL);
+    // First tick fires immediately; skip it so we don't ping right after subscribe.
+    ping_interval.tick().await;
+
+    let ping_payload = serde_json::to_string(&ClientMessage::Ping)
+        .expect("serializing unit enum variant never fails");
+    let pong_payload = serde_json::to_string(&ClientMessage::Pong)
+        .expect("serializing unit enum variant never fails");
+    let complete_payload = serde_json::to_string(&ClientMessage::Complete {
+        id: SUBSCRIPTION_ID,
+    })
+    .expect("serializing Complete never fails");
+
+    loop {
+        tokio::select! {
+            _ = ping_interval.tick() => {
+                if sink.send(Message::text(ping_payload.clone())).await.is_err() {
+                    break;
+                }
+            }
+            msg = stream.next() => {
+                match msg {
+                    Some(Ok(Message::Text(txt))) => {
+                        let decoded: ServerMessage = match serde_json::from_str(&txt) {
+                            Ok(m) => m,
+                            Err(e) => {
+                                let _ = tx.send(Err(WsError::Decode(e.to_string()))).await;
+                                break;
+                            },
+                        };
+
+                        match decoded {
+                            ServerMessage::Next { id, payload } => {
+                                if id != SUBSCRIPTION_ID {
+                                    continue;
+                                }
+                                match serde_json::from_value::<Response<Q::ResponseData>>(payload) {
+                                    Ok(resp) => {
+                                        if tx.send(Ok(resp)).await.is_err() {
+                                            break;
+                                        }
+                                    },
+                                    Err(e) => {
+                                        let _ =
+                                            tx.send(Err(WsError::Decode(e.to_string()))).await;
+                                        break;
+                                    },
+                                }
+                            },
+                            ServerMessage::Error { id, payload } => {
+                                if id != SUBSCRIPTION_ID {
+                                    continue;
+                                }
+                                let _ = tx.send(Err(WsError::Subscription(payload))).await;
+                                break;
+                            },
+                            ServerMessage::Complete { id } => {
+                                if id == SUBSCRIPTION_ID {
+                                    break;
+                                }
+                            },
+                            ServerMessage::Ping => {
+                                if sink
+                                    .send(Message::text(pong_payload.clone()))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            },
+                            ServerMessage::Pong | ServerMessage::ConnectionAck => {},
+                        }
+                    },
+                    Some(Ok(Message::Ping(data))) => {
+                        if sink.send(Message::Pong(data)).await.is_err() {
+                            break;
+                        }
+                    },
+                    Some(Ok(Message::Close(frame))) => {
+                        let reason = frame
+                            .map(|f| format!("{} (code {})", f.reason, u16::from(f.code)))
+                            .unwrap_or_else(|| "no close frame".to_string());
+                        let _ = tx.send(Err(WsError::Closed(reason))).await;
+                        break;
+                    },
+                    Some(Ok(_)) => {},
+                    Some(Err(e)) => {
+                        let _ = tx.send(Err(WsError::Transport(e.to_string()))).await;
+                        break;
+                    },
+                    None => break,
+                }
+            }
+        }
+    }
+
+    let _ = sink.send(Message::text(complete_payload)).await;
+    let _ = sink.close().await;
 }
 
 /// Helper trait for subscription variables with an associated subscription type.
@@ -174,6 +382,3 @@ impl SubscriptionVariables for crate::subscribe_trades::Variables {}
 impl SubscriptionVariables for crate::subscribe_query_app::Variables {}
 impl SubscriptionVariables for crate::subscribe_query_store::Variables {}
 impl SubscriptionVariables for crate::subscribe_query_status::Variables {}
-
-// Re-export graphql_ws_client types that users might need
-pub use graphql_ws_client::Error as WsError;

--- a/indexer/client/tests/client.rs
+++ b/indexer/client/tests/client.rs
@@ -1,9 +1,12 @@
 use {
-    crate::utils::setup_client_test,
+    crate::utils::{setup_client_test, setup_client_test_with_port},
     dango_types::constants::usdc,
+    futures::StreamExt,
     grug::{
         BroadcastClient, Coins, MOCK_CHAIN_ID, Message, NonEmpty, ResultExt, SearchTxClient, Signer,
     },
+    indexer_client::{SubscribeBlock, WsClient, subscribe_block},
+    std::time::Duration,
 };
 
 mod utils;
@@ -28,6 +31,74 @@ async fn broadcast() -> anyhow::Result<()> {
     let tx_hash = res.tx_hash;
 
     client.search_tx(tx_hash).await?.outcome.should_succeed();
+
+    Ok(())
+}
+
+/// Verify that a single [`indexer_client::Session`] can host multiple
+/// subscriptions over one WebSocket: each stream is routed independently and
+/// dropping one does not disturb the others.
+///
+/// The mock server is configured with `BlockCreation::OnBroadcast`, so blocks
+/// only appear when we broadcast a transaction — each broadcast drives one
+/// round of deliveries to every active subscription.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_multiplex() -> anyhow::Result<()> {
+    let (http_client, mut accounts, port) = setup_client_test_with_port().await?;
+
+    let ws = WsClient::new(format!("ws://localhost:{port}/graphql"))?;
+    let session = ws.connect().await?;
+
+    let mut blocks_a = session
+        .subscribe::<SubscribeBlock>(subscribe_block::Variables {})
+        .await?;
+    let mut blocks_b = session
+        .subscribe::<SubscribeBlock>(subscribe_block::Variables {})
+        .await?;
+
+    // Give the server a moment to register both subscriptions before producing
+    // the first block — graphql-transport-ws has no "subscribed" ack.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let tx1 = accounts.user1.sign_transaction(
+        NonEmpty::new_unchecked(vec![Message::transfer(
+            accounts.user2.address.into_inner(),
+            Coins::one(usdc::DENOM.clone(), 100)?,
+        )?]),
+        MOCK_CHAIN_ID,
+        1_000_000,
+    )?;
+    http_client.broadcast_tx(tx1).await?;
+
+    let b_a = tokio::time::timeout(Duration::from_secs(10), blocks_a.next())
+        .await?
+        .expect("blocks_a stream ended")
+        .expect("blocks_a transport error");
+    let b_b = tokio::time::timeout(Duration::from_secs(10), blocks_b.next())
+        .await?
+        .expect("blocks_b stream ended")
+        .expect("blocks_b transport error");
+    assert!(b_a.data.is_some(), "expected block payload on stream a");
+    assert!(b_b.data.is_some(), "expected block payload on stream b");
+
+    // Drop one stream; the other must keep flowing on the same connection.
+    drop(blocks_b);
+
+    let tx2 = accounts.user1.sign_transaction(
+        NonEmpty::new_unchecked(vec![Message::transfer(
+            accounts.user2.address.into_inner(),
+            Coins::one(usdc::DENOM.clone(), 100)?,
+        )?]),
+        MOCK_CHAIN_ID,
+        1_000_000,
+    )?;
+    http_client.broadcast_tx(tx2).await?;
+
+    let b_a2 = tokio::time::timeout(Duration::from_secs(10), blocks_a.next())
+        .await?
+        .expect("blocks_a ended after sibling drop")
+        .expect("blocks_a transport error after sibling drop");
+    assert!(b_a2.data.is_some());
 
     Ok(())
 }

--- a/indexer/client/tests/utils.rs
+++ b/indexer/client/tests/utils.rs
@@ -7,6 +7,11 @@ use {
 };
 
 pub async fn setup_client_test() -> anyhow::Result<(HttpClient, TestAccounts)> {
+    let (client, accounts, _port) = setup_client_test_with_port().await?;
+    Ok((client, accounts))
+}
+
+pub async fn setup_client_test_with_port() -> anyhow::Result<(HttpClient, TestAccounts, u16)> {
     let port = get_mock_socket_addr();
 
     let (sx, rx) = tokio::sync::oneshot::channel();
@@ -43,5 +48,6 @@ pub async fn setup_client_test() -> anyhow::Result<(HttpClient, TestAccounts)> {
     Ok((
         HttpClient::new(format!("http://localhost:{port}"))?,
         accounts,
+        port,
     ))
 }


### PR DESCRIPTION
## Summary

Rewrites `indexer/client/src/subscription.rs` (the Rust `WsClient`) directly on `tokio-tungstenite`, speaking the `graphql-transport-ws` protocol by hand, and adds first-class multi-subscription support via a new `Session` handle.

### Why the previous fix (99837439e) did not work

`graphql-ws-client` 0.12's `.keep_alive_interval(Duration)` is **reactive**: in `client/actor.rs:188-191` every inbound `Message` rebuilds the keep-alive actor, which restarts its internal `futures_timer::Delay` from zero:

```rust
Select::Message(message) => {
    self.keep_alive_actor = Box::pin(self.keep_alive.run());
    Some(Next::Message(message?))
}
```

On a noisy subscription (e.g. `SubscribeBlock` emitting every ~460 ms), the 15 s `Delay` is reset ~32 times before it can tick, so no `Ping` is ever sent. Server-side, `async-graphql`'s `keepalive_timeout(Duration::from_secs(30))` at `grug/httpd/src/routes/graphql.rs:58` only resets on inbound `ClientMessage`s — not on outbound data — so it fires at 30 s and closes with close code 3008 (`timeout`). Reproduced against mainnet on branch SHA `99837439e`: stream ended at exactly `30.089 s` after 65 inbound messages, last one 128 ms earlier.

The JS `graphql-ws` (v6) client does **not** hit this bug because its `enqueuePing()` is triggered only on `onopen` and on receipt of a server `pong` (see `dist/client.js:187,207`) — never rearmed by `next` messages — so `keepAlive: 10_000` actually ticks every ~10 s against the same server.

### Core fix

- Reimplements `WsClient` on `tokio-tungstenite` + `futures::channel::mpsc`, handling `connection_init`/`ack`, `subscribe`, `next`, `error`, `complete`, and `ping`/`pong` by hand.
- Emits a protocol-level `ping` every 15 s via `tokio::time::interval`, **independent of inbound traffic** — resets server's keepalive timer reliably on noisy subscriptions.
- Sends a best-effort `complete` + close when the consumer drops the stream or the server closes the connection.
- Introduces a typed `WsError` (replacing the re-exported `graphql_ws_client::Error`).
- Removes `graphql-ws-client` from the workspace and drops the two FIXME pins on `graphql_client` / `tokio-tungstenite` versions.

### New feature: multiplexed subscriptions

`WsClient::connect() -> Session` opens one WebSocket and returns a cloneable handle on which multiple subscriptions can run concurrently:

```rust
let session = client.connect().await?;
let blocks   = session.subscribe::<SubscribeBlock>(subscribe_block::Variables {}).await?;
let candles  = session.subscribe::<SubscribeCandles>(candles_vars).await?;
let trades   = session.subscribe::<SubscribeTrades>(trades_vars).await?;
// all three streams live on a single underlying WebSocket
```

Each subscription gets a unique protocol id (monotonic `AtomicU64`). A background task owns the sink + stream and routes inbound `next`/`error`/`complete` messages to the right per-subscription channel via an `id -> Sender` map. Dropping a single stream sends `complete` for that id only — siblings keep flowing. The connection closes automatically when the last `Session` clone **and** every derived stream have been dropped.

`WsClient::subscribe::<Q>` is preserved as a thin wrapper (`connect + subscribe`) so existing callers (`dango-testing`, `dango-scripts`, `indexer-testing`) are unchanged and still get a dedicated WebSocket per subscription.

## Validation

### Completed

- [x] `cargo check -p indexer-client`
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo fetch --locked`
- [x] `cargo test -p indexer-client --lib --all-features` — all 16 `subscription_tests::test_subscribe_*` pass against the real `dango-mock-httpd` server (block, accounts, transfers, transactions, messages, events, event_by_addresses, candles, perps_candles, trades, query_app, query_store, query_status).
- [x] `cargo test -p indexer-client --test client --all-features` — `broadcast` and `session_multiplex` (new) pass. The multiplex test opens a single session with two concurrent `SubscribeBlock` streams, broadcasts a tx to produce a block, verifies both streams receive it, drops one stream, broadcasts again, and verifies the surviving stream still receives data on the same connection.

### Remaining

- [ ] End-to-end repro: against mainnet (`api-mainnet.dango.zone/graphql`), run a `SubscribeBlock` subscription on this branch for >60 s and confirm the stream does **not** close at 30 s. Previously closed at exactly 30.089 s.

## Manual QA

None performed locally. The lib subscription tests + the new `session_multiplex` integration test exercise the real `async-graphql` + `actix-web` stack end-to-end via `dango-mock-httpd`; the remaining item above is the one observational check against mainnet.