### PR TITLE
fix(indexer): use fromUnixTimestamp64Micro for perps fees range bounds

### DIFF
--- a/dango/indexer/clickhouse/src/entities/perps_fees.rs
+++ b/dango/indexer/clickhouse/src/entities/perps_fees.rs
@@ -99,6 +99,11 @@ impl PerpsFeesAndRevenue {
         // Short ranges hit the per-block table for precise bounds. Long ranges
         // hit `perps_fees_hourly` (a SummingMergeTree MV) whose buckets make
         // a year-long scan a few thousand rows instead of tens of millions.
+        //
+        // Bounds use `fromUnixTimestamp64Micro` rather than `toDateTime64(?, 6)`:
+        // ClickHouse's `toDateTime64` treats integer inputs as seconds regardless
+        // of scale, so a microsecond-valued bind saturates to the DateTime64 max
+        // (year 2299) and silently matches nothing.
         let query = if (to - from) < Self::HOURLY_THRESHOLD {
             r#"
                 SELECT
@@ -108,8 +113,8 @@ impl PerpsFeesAndRevenue {
                     toUInt128(sum(referrer_payout)) AS referrer_payout,
                     toUInt64(sum(fee_events_count)) AS fee_events_count
                 FROM perps_fees
-                WHERE created_at >= toDateTime64(?, 6)
-                  AND created_at <= toDateTime64(?, 6)
+                WHERE created_at >= fromUnixTimestamp64Micro(?)
+                  AND created_at <= fromUnixTimestamp64Micro(?)
             "#
         } else {
             r#"
@@ -120,8 +125,8 @@ impl PerpsFeesAndRevenue {
                     toUInt128(sum(referrer_payout)) AS referrer_payout,
                     toUInt64(sum(fee_events_count)) AS fee_events_count
                 FROM perps_fees_hourly
-                WHERE hour >= toStartOfHour(toDateTime64(?, 6))
-                  AND hour <= toStartOfHour(toDateTime64(?, 6))
+                WHERE hour >= toStartOfHour(fromUnixTimestamp64Micro(?))
+                  AND hour <= toStartOfHour(fromUnixTimestamp64Micro(?))
             "#
         };
 


### PR DESCRIPTION
## Summary

`perpsFeesAndRevenue` was silently returning zero for every time window despite rows being ingested correctly. The bug was in the query resolver: the range filter used `toDateTime64(?, 6)` while binding `timestamp_micros()`.

ClickHouse's `toDateTime64` treats integer inputs as **seconds regardless of scale** — the scale only controls the fractional precision of the resulting type, not the unit of the input. Binding a microsecond value (e.g. `1_745_712_000_000_000`) makes ClickHouse interpret it as `~1.7e15` seconds since epoch, which saturates to the `DateTime64` max (year 2299). The WHERE clause then matches nothing.

The fix swaps `toDateTime64(?, 6)` for `fromUnixTimestamp64Micro(?)` in both the per-block branch and the hourly MV branch (inside `toStartOfHour`). Binds stay as `timestamp_micros()`.

The exact same pitfall is already documented in `dango/indexer/clickhouse/src/entities/perps_pair_price.rs:89-92` — this PR applies the same pattern here and leaves an inline comment so the next reader sees it.

### Diagnosis

- Metric `indexer_clickhouse_perps_fees_rows_inserted_total` was incrementing on devnet → ingestion path OK.
- GraphQL query returned `feeEventsCount: 0` for every window from 2026-03-01 onward → read path broken.
- TX `4D653028177FED1F32F2C46A70A3DB5A9897BFBD144F382894CD9304105A1B79` on devnet (block 1363820, 2026-04-24T11:41:35Z) emits a valid `fee_distributed` event from the perps contract but never surfaces in the aggregate.
- Other resolvers that hit `toDateTime64(?, 6)` (`pairStats`, `perpsPairStats`) bind `.timestamp()` (seconds), which is why only `perpsFeesAndRevenue` was affected.

## Validation

### Completed
- [x] `cargo check -p dango-indexer-clickhouse` passes
- [x] `cargo clippy -p dango-indexer-clickhouse --all-features -- -D warnings` passes
- [x] `cargo +nightly fmt --all` clean

### Remaining
- [ ] Deploy to devnet and re-run the query against a window covering block 1363820 (2026-04-24T11:41Z) — expect `feeEventsCount > 0` and `vaultFee > 0`
- [ ] Verify both short-range (< 3d, `perps_fees` table) and long-range (≥ 3d, `perps_fees_hourly` MV) paths

## Manual QA

Reproduce on devnet before fix:

```bash
curl -sS -X POST https://api-devnet.dango.zone/graphql \
  -H 'content-type: application/json' \
  -d '{"query":"query F { perpsFeesAndRevenue(from:\"2026-04-24T00:00:00Z\", to:\"2026-04-24T23:59:59Z\"){ feeEventsCount vaultFee } }"}'
# => { "feeEventsCount": 0, "vaultFee": "0" }   ❌ table has rows but filter matches none
```

After deploy of this fix, the same call should return the aggregated non-zero totals for that day.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>