### PR TITLE
fix(deploy): append `/mint` to frontend faucet URL

### DIFF
--- a/deploy/roles/full-app/tasks/deploy_configs.yml
+++ b/deploy/roles/full-app/tasks/deploy_configs.yml
@@ -1,6 +1,6 @@
 - set_fact:
     indexer_url: "https://api-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}"
-    faucet_url: "https://faucet-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}"
+    faucet_url: "https://faucet-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}/mint"
     quest_url: "https://quest-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}/to_fix"
     up_url: "https://api-{{ dango_network }}-{{ hostname }}.{{ dango_domain }}/up"
     points_url: "https://points-{{ dango_network }}.{{ dango_domain }}"
@@ -8,7 +8,7 @@
 
 - set_fact:
     indexer_url: "https://api-{{ dango_network }}.{{ dango_domain }}"
-    faucet_url: "https://faucet-{{ dango_network }}.{{ dango_domain }}"
+    faucet_url: "https://faucet-{{ dango_network }}.{{ dango_domain }}/mint"
     quest_url: "https://quest-{{ dango_network }}.{{ dango_domain }}/to_fix"
     up_url: "https://api-{{ dango_network }}.{{ dango_domain }}/up"
     points_url: "https://points-{{ dango_network }}.{{ dango_domain }}"


### PR DESCRIPTION
The frontend appends `/<address>?skip_check=true` to `window.dango.urls.faucetUrl`, which expects the URL to already point at the faucet bot's `/mint` endpoint (matching the build-time defaults in `ui/portal/web/rsbuild.config.ts` and `docker/dango-frontend/20-config.sh`). The Ansible-supplied value was missing the suffix, causing 404s when claiming test tokens on PR previews.