### PR TITLE
refactor(proposal-preparer): maker priority block building rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ dependencies = [
  "pyth-client",
  "pyth-types",
  "reqwest 0.13.2",
+ "test-case",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/dango/proposal-preparer/Cargo.toml
+++ b/dango/proposal-preparer/Cargo.toml
@@ -25,3 +25,6 @@ reqwest      = { workspace = true }
 tokio        = { workspace = true }
 tokio-stream = { workspace = true }
 tracing      = { workspace = true }
+
+[dev-dependencies]
+test-case = { workspace = true }

--- a/dango/proposal-preparer/src/lib.rs
+++ b/dango/proposal-preparer/src/lib.rs
@@ -1,4 +1,5 @@
+mod maker_priority_handler;
 mod proposal_preparer;
 mod pyth_handler;
 
-pub use {proposal_preparer::*, pyth_handler::*};
+pub use {maker_priority_handler::*, proposal_preparer::*, pyth_handler::*};

--- a/dango/proposal-preparer/src/maker_priority_handler.rs
+++ b/dango/proposal-preparer/src/maker_priority_handler.rs
@@ -1,0 +1,458 @@
+use {
+    dango_types::{
+        config::AppConfig,
+        perps::{self, SubmitOrCancelOrderRequest, TraderMsg},
+    },
+    grug::{Addr, JsonDeExt, Message, QuerierExt, QuerierWrapper, StdError, Tx},
+    prost::bytes::Bytes,
+};
+
+/// `ProposalPreparer` implementation that promotes "maker-priority"
+/// transactions to the front of the block.
+///
+/// A transaction qualifies as priority if every one of its messages is a
+/// perps trade message that is either a cancel or a post-only submit.
+/// Inspired by Hyperliquid's protection of market makers from toxic flow:
+/// <https://hyperliquid.medium.com/latency-and-transaction-ordering-on-hyperliquid-cf28df3648eb>
+#[derive(Default, Clone, Copy)]
+pub struct MakerPriorityHandler;
+
+impl grug_app::ProposalPreparer for MakerPriorityHandler {
+    type Error = StdError;
+
+    fn prepare_proposal(
+        &self,
+        querier: QuerierWrapper,
+        txs: Vec<Bytes>,
+        _max_tx_bytes: usize,
+    ) -> Result<Vec<Bytes>, Self::Error> {
+        let cfg: AppConfig = querier.query_app_config()?;
+        Ok(promote_priority_txs(txs, &cfg.addresses.perps))
+    }
+}
+
+/// Move all priority transactions to the front of the vector, preserving
+/// relative order within each group.
+fn promote_priority_txs(mut txs: Vec<Bytes>, perps: &Addr) -> Vec<Bytes> {
+    let (priority, other): (Vec<_>, Vec<_>) = txs
+        .drain(..)
+        .partition(|raw| is_priority_tx(raw.as_ref(), perps));
+
+    txs.extend(priority);
+    txs.extend(other);
+    txs
+}
+
+/// Returns `true` iff every message in the transaction is a perps trade
+/// message that is either a cancel or a post-only submit.
+///
+/// Malformed bytes, non-perps targets, non-trade execute messages, and any
+/// disqualifying message all return `false`.
+pub fn is_priority_tx(raw_tx: &[u8], perps: &Addr) -> bool {
+    let Ok(tx) = raw_tx.deserialize_json::<Tx>() else {
+        return false;
+    };
+
+    for msg in tx.msgs.iter() {
+        let Message::Execute(exec) = msg else {
+            return false;
+        };
+
+        if exec.contract != *perps {
+            return false;
+        }
+
+        let Ok(execute_msg) = exec.msg.clone().deserialize_json::<perps::ExecuteMsg>() else {
+            return false;
+        };
+
+        let perps::ExecuteMsg::Trade(trader_msg) = execute_msg else {
+            return false;
+        };
+
+        if !is_priority_trader_msg(&trader_msg) {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn is_priority_trader_msg(msg: &perps::TraderMsg) -> bool {
+    match msg {
+        TraderMsg::CancelOrder(_) | TraderMsg::CancelConditionalOrder(_) => true,
+        TraderMsg::SubmitOrder(req) => is_post_only(&req.kind),
+        TraderMsg::BatchUpdateOrders(batch) => {
+            batch.iter().all(is_priority_submit_or_cancel_order_request)
+        },
+        // Explicit non-priority arms — no `_` wildcard, so adding a new
+        // `TraderMsg` variant forces an explicit decision at compile time.
+        TraderMsg::Deposit { .. }
+        | TraderMsg::Withdraw { .. }
+        | TraderMsg::SubmitConditionalOrder { .. } => false,
+    }
+}
+
+fn is_priority_submit_or_cancel_order_request(req: &SubmitOrCancelOrderRequest) -> bool {
+    match req {
+        SubmitOrCancelOrderRequest::Cancel(_) => true,
+        SubmitOrCancelOrderRequest::Submit(req) => is_post_only(&req.kind),
+    }
+}
+
+fn is_post_only(kind: &perps::OrderKind) -> bool {
+    matches!(kind, perps::OrderKind::Limit {
+        time_in_force: perps::TimeInForce::PostOnly,
+        ..
+    },)
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        dango_types::{
+            Dimensionless, Quantity, UsdPrice, UsdValue,
+            constants::btc,
+            perps::{
+                CancelConditionalOrderRequest, CancelOrderRequest, ExecuteMsg, MaintainerMsg,
+                OrderKind, SubmitOrCancelOrderRequest, SubmitOrderRequest, TimeInForce, TraderMsg,
+                TriggerDirection,
+            },
+        },
+        grug::{Coins, Json, JsonSerExt, MsgExecute, NonEmpty, Uint64},
+        test_case::test_case,
+    };
+
+    fn perps() -> Addr {
+        Addr::mock(1)
+    }
+
+    fn other_contract() -> Addr {
+        Addr::mock(2)
+    }
+
+    // --- OrderKind constructors -------------------------------------------
+
+    fn limit(tif: TimeInForce) -> OrderKind {
+        OrderKind::Limit {
+            limit_price: UsdPrice::new_int(100),
+            time_in_force: tif,
+            client_order_id: None,
+        }
+    }
+
+    fn post_only_limit() -> OrderKind {
+        limit(TimeInForce::PostOnly)
+    }
+
+    fn gtc_limit() -> OrderKind {
+        limit(TimeInForce::GoodTilCanceled)
+    }
+
+    fn ioc_limit() -> OrderKind {
+        limit(TimeInForce::ImmediateOrCancel)
+    }
+
+    fn market() -> OrderKind {
+        OrderKind::Market {
+            max_slippage: Dimensionless::new_int(0),
+        }
+    }
+
+    // --- SubmitOrderRequest ------------------------------------------------
+
+    fn submit(kind: OrderKind) -> SubmitOrderRequest {
+        SubmitOrderRequest {
+            pair_id: btc::DENOM.clone(),
+            size: Quantity::new_int(1),
+            kind,
+            reduce_only: false,
+            tp: None,
+            sl: None,
+        }
+    }
+
+    // --- TraderMsg constructors --------------------------------------------
+
+    fn cancel_one() -> TraderMsg {
+        TraderMsg::CancelOrder(CancelOrderRequest::One(Uint64::new(0)))
+    }
+
+    fn cancel_one_by_client_id() -> TraderMsg {
+        TraderMsg::CancelOrder(CancelOrderRequest::OneByClientOrderId(Uint64::new(7)))
+    }
+
+    fn cancel_all() -> TraderMsg {
+        TraderMsg::CancelOrder(CancelOrderRequest::All)
+    }
+
+    fn cancel_cond_one() -> TraderMsg {
+        TraderMsg::CancelConditionalOrder(CancelConditionalOrderRequest::One {
+            pair_id: btc::DENOM.clone(),
+            trigger_direction: TriggerDirection::Above,
+        })
+    }
+
+    fn cancel_cond_all_for_pair() -> TraderMsg {
+        TraderMsg::CancelConditionalOrder(CancelConditionalOrderRequest::AllForPair {
+            pair_id: btc::DENOM.clone(),
+        })
+    }
+
+    fn cancel_cond_all() -> TraderMsg {
+        TraderMsg::CancelConditionalOrder(CancelConditionalOrderRequest::All)
+    }
+
+    fn submit_post_only() -> TraderMsg {
+        TraderMsg::SubmitOrder(submit(post_only_limit()))
+    }
+
+    fn submit_market() -> TraderMsg {
+        TraderMsg::SubmitOrder(submit(market()))
+    }
+
+    fn submit_gtc() -> TraderMsg {
+        TraderMsg::SubmitOrder(submit(gtc_limit()))
+    }
+
+    fn submit_ioc() -> TraderMsg {
+        TraderMsg::SubmitOrder(submit(ioc_limit()))
+    }
+
+    fn batch_all_cancel() -> TraderMsg {
+        TraderMsg::BatchUpdateOrders(NonEmpty::new_unchecked(vec![
+            SubmitOrCancelOrderRequest::Cancel(CancelOrderRequest::All),
+            SubmitOrCancelOrderRequest::Cancel(CancelOrderRequest::One(Uint64::new(1))),
+        ]))
+    }
+
+    fn batch_all_post_only() -> TraderMsg {
+        TraderMsg::BatchUpdateOrders(NonEmpty::new_unchecked(vec![
+            SubmitOrCancelOrderRequest::Submit(submit(post_only_limit())),
+            SubmitOrCancelOrderRequest::Submit(submit(post_only_limit())),
+        ]))
+    }
+
+    fn batch_mixed_priority() -> TraderMsg {
+        TraderMsg::BatchUpdateOrders(NonEmpty::new_unchecked(vec![
+            SubmitOrCancelOrderRequest::Cancel(CancelOrderRequest::All),
+            SubmitOrCancelOrderRequest::Submit(submit(post_only_limit())),
+        ]))
+    }
+
+    fn batch_with_market() -> TraderMsg {
+        TraderMsg::BatchUpdateOrders(NonEmpty::new_unchecked(vec![
+            SubmitOrCancelOrderRequest::Cancel(CancelOrderRequest::All),
+            SubmitOrCancelOrderRequest::Submit(submit(market())),
+        ]))
+    }
+
+    fn batch_with_gtc() -> TraderMsg {
+        TraderMsg::BatchUpdateOrders(NonEmpty::new_unchecked(vec![
+            SubmitOrCancelOrderRequest::Submit(submit(post_only_limit())),
+            SubmitOrCancelOrderRequest::Submit(submit(gtc_limit())),
+        ]))
+    }
+
+    fn batch_with_ioc() -> TraderMsg {
+        TraderMsg::BatchUpdateOrders(NonEmpty::new_unchecked(vec![
+            SubmitOrCancelOrderRequest::Submit(submit(ioc_limit())),
+        ]))
+    }
+
+    fn deposit() -> TraderMsg {
+        TraderMsg::Deposit { to: None }
+    }
+
+    fn withdraw() -> TraderMsg {
+        TraderMsg::Withdraw {
+            amount: UsdValue::new_int(1),
+        }
+    }
+
+    fn submit_conditional() -> TraderMsg {
+        TraderMsg::SubmitConditionalOrder {
+            pair_id: btc::DENOM.clone(),
+            size: None,
+            trigger_price: UsdPrice::new_int(100),
+            trigger_direction: TriggerDirection::Above,
+            max_slippage: Dimensionless::new_int(0),
+        }
+    }
+
+    // --- Tx builders -------------------------------------------------------
+
+    /// Build a perps trade tx with the given trader messages.
+    fn perps_tx(msgs: Vec<TraderMsg>) -> Bytes {
+        tx_with_messages(
+            msgs.into_iter()
+                .map(|tm| Message::execute(perps(), &ExecuteMsg::Trade(tm), Coins::new()).unwrap())
+                .collect(),
+        )
+    }
+
+    fn tx_with_messages(messages: Vec<Message>) -> Bytes {
+        let tx = Tx {
+            sender: Addr::mock(99),
+            gas_limit: 100_000,
+            msgs: NonEmpty::new_unchecked(messages),
+            data: Json::null(),
+            credential: Json::null(),
+        };
+        tx.to_json_vec().unwrap().into()
+    }
+
+    // --- is_priority_trader_msg --------------------------------------------
+
+    #[test_case(cancel_one() => true; "case_cancel_order_one")]
+    #[test_case(cancel_one_by_client_id() => true; "case_cancel_order_by_client_id")]
+    #[test_case(cancel_all() => true; "case_cancel_order_all")]
+    #[test_case(cancel_cond_one() => true; "case_cancel_conditional_one")]
+    #[test_case(cancel_cond_all_for_pair() => true; "case_cancel_conditional_all_for_pair")]
+    #[test_case(cancel_cond_all() => true; "case_cancel_conditional_all")]
+    #[test_case(submit_post_only() => true; "case_submit_post_only")]
+    #[test_case(batch_all_cancel() => true; "case_batch_all_cancel")]
+    #[test_case(batch_all_post_only() => true; "case_batch_all_post_only")]
+    #[test_case(batch_mixed_priority() => true; "case_batch_mixed")]
+    #[test_case(submit_market() => false; "case_submit_market")]
+    #[test_case(submit_gtc() => false; "case_submit_gtc")]
+    #[test_case(submit_ioc() => false; "case_submit_ioc")]
+    #[test_case(batch_with_market() => false; "case_batch_with_market")]
+    #[test_case(batch_with_gtc() => false; "case_batch_with_gtc")]
+    #[test_case(batch_with_ioc() => false; "case_batch_with_ioc")]
+    #[test_case(deposit() => false; "case_deposit")]
+    #[test_case(withdraw() => false; "case_withdraw")]
+    #[test_case(submit_conditional() => false; "case_submit_conditional")]
+    fn priority_trader_msg(msg: TraderMsg) -> bool {
+        is_priority_trader_msg(&msg)
+    }
+
+    // --- is_priority_tx ----------------------------------------------------
+
+    #[test_case(perps_tx(vec![cancel_all()])                              => true  ; "single_cancel")]
+    #[test_case(perps_tx(vec![submit_post_only()])                        => true  ; "single_post_only")]
+    #[test_case(perps_tx(vec![batch_all_cancel()])                        => true  ; "single_batch_all_cancel")]
+    #[test_case(perps_tx(vec![cancel_all(), submit_post_only()])          => true  ; "multi_msg_all_priority")]
+    #[test_case(perps_tx(vec![cancel_all(), cancel_one(), cancel_cond_all()]) => true ; "multi_cancel_only")]
+    #[test_case(perps_tx(vec![submit_market()])                           => false ; "single_market")]
+    #[test_case(perps_tx(vec![cancel_all(), submit_market()])             => false ; "multi_msg_one_disqualifies")]
+    #[test_case(perps_tx(vec![cancel_all(), deposit()])                   => false ; "multi_msg_deposit_disqualifies")]
+    #[test_case(perps_tx(vec![submit_conditional()])                      => false ; "single_conditional_submit")]
+    fn priority_tx_perps(tx: Bytes) -> bool {
+        is_priority_tx(tx.as_ref(), &perps())
+    }
+
+    #[test]
+    fn priority_tx_wrong_contract() {
+        // A cancel-only tx targeting a different contract is not priority.
+        let tx = tx_with_messages(vec![
+            Message::execute(
+                other_contract(),
+                &ExecuteMsg::Trade(cancel_all()),
+                Coins::new(),
+            )
+            .unwrap(),
+        ]);
+        assert!(!is_priority_tx(tx.as_ref(), &perps()));
+    }
+
+    #[test]
+    fn priority_tx_non_execute_message() {
+        // Token transfer is not an Execute message.
+        let tx = tx_with_messages(vec![Message::transfer(perps(), Coins::new()).unwrap()]);
+        assert!(!is_priority_tx(tx.as_ref(), &perps()));
+    }
+
+    #[test]
+    fn priority_tx_non_trade_execute_msg() {
+        // A perps Execute message that isn't `Trade(...)` is not priority.
+        let tx = tx_with_messages(vec![
+            Message::execute(
+                perps(),
+                &ExecuteMsg::Maintain(MaintainerMsg::Donate {}),
+                Coins::new(),
+            )
+            .unwrap(),
+        ]);
+        assert!(!is_priority_tx(tx.as_ref(), &perps()));
+    }
+
+    #[test]
+    fn priority_tx_malformed_bytes() {
+        let raw: &[u8] = b"not a tx";
+        assert!(!is_priority_tx(raw, &perps()));
+    }
+
+    #[test]
+    fn priority_tx_valid_tx_bad_inner_msg() {
+        // Valid `Tx`, but `MsgExecute.msg` payload (here, JSON null) isn't a
+        // valid perps `ExecuteMsg`.
+        let tx = Tx {
+            sender: Addr::mock(99),
+            gas_limit: 100_000,
+            msgs: NonEmpty::new_unchecked(vec![Message::Execute(MsgExecute {
+                contract: perps(),
+                msg: Json::null(),
+                funds: Coins::new(),
+            })]),
+            data: Json::null(),
+            credential: Json::null(),
+        };
+        let raw: Bytes = tx.to_json_vec().unwrap().into();
+        assert!(!is_priority_tx(raw.as_ref(), &perps()));
+    }
+
+    // --- promote_priority_txs ----------------------------------------------
+
+    #[test]
+    fn promote_empty_input() {
+        let txs = promote_priority_txs(vec![], &perps());
+        assert!(txs.is_empty());
+    }
+
+    #[test]
+    fn promote_all_priority_unchanged() {
+        let a = perps_tx(vec![cancel_all()]);
+        let b = perps_tx(vec![submit_post_only()]);
+        let c = perps_tx(vec![batch_all_cancel()]);
+        let txs = promote_priority_txs(vec![a.clone(), b.clone(), c.clone()], &perps());
+        assert_eq!(txs, vec![a, b, c]);
+    }
+
+    #[test]
+    fn promote_all_non_priority_unchanged() {
+        let a = perps_tx(vec![submit_market()]);
+        let b = perps_tx(vec![submit_gtc()]);
+        let c = perps_tx(vec![deposit()]);
+        let txs = promote_priority_txs(vec![a.clone(), b.clone(), c.clone()], &perps());
+        assert_eq!(txs, vec![a, b, c]);
+    }
+
+    #[test]
+    fn promote_mixed_preserves_relative_order() {
+        // Input order: P1, N1, P2, N2, P3
+        // Expected output: P1, P2, P3, N1, N2
+        let p1 = perps_tx(vec![cancel_all()]);
+        let n1 = perps_tx(vec![submit_market()]);
+        let p2 = perps_tx(vec![submit_post_only()]);
+        let n2 = perps_tx(vec![deposit()]);
+        let p3 = perps_tx(vec![cancel_one()]);
+        let txs = promote_priority_txs(
+            vec![p1.clone(), n1.clone(), p2.clone(), n2.clone(), p3.clone()],
+            &perps(),
+        );
+        assert_eq!(txs, vec![p1, p2, p3, n1, n2]);
+    }
+
+    #[test]
+    fn promote_single_priority_among_non_priority() {
+        let n1 = perps_tx(vec![submit_market()]);
+        let p = perps_tx(vec![cancel_all()]);
+        let n2 = perps_tx(vec![withdraw()]);
+        let txs = promote_priority_txs(vec![n1.clone(), p.clone(), n2.clone()], &perps());
+        assert_eq!(txs, vec![p, n1, n2]);
+    }
+}

--- a/dango/proposal-preparer/src/maker_priority_handler.rs
+++ b/dango/proposal-preparer/src/maker_priority_handler.rs
@@ -117,9 +117,9 @@ mod tests {
             Dimensionless, Quantity, UsdPrice, UsdValue,
             constants::btc,
             perps::{
-                CancelConditionalOrderRequest, CancelOrderRequest, ExecuteMsg, MaintainerMsg,
-                OrderKind, SubmitOrCancelOrderRequest, SubmitOrderRequest, TimeInForce, TraderMsg,
-                TriggerDirection,
+                CancelConditionalOrderRequest, CancelOrderRequest, ChildOrder, ExecuteMsg,
+                MaintainerMsg, OrderKind, ReferralMsg, SubmitOrCancelOrderRequest,
+                SubmitOrderRequest, TimeInForce, TraderMsg, TriggerDirection, VaultMsg,
             },
         },
         grug::{Coins, Json, JsonSerExt, MsgExecute, NonEmpty, Uint64},
@@ -148,6 +148,14 @@ mod tests {
         limit(TimeInForce::PostOnly)
     }
 
+    fn post_only_limit_with_client_id() -> OrderKind {
+        OrderKind::Limit {
+            limit_price: UsdPrice::new_int(100),
+            time_in_force: TimeInForce::PostOnly,
+            client_order_id: Some(Uint64::new(42)),
+        }
+    }
+
     fn gtc_limit() -> OrderKind {
         limit(TimeInForce::GoodTilCanceled)
     }
@@ -172,6 +180,25 @@ mod tests {
             reduce_only: false,
             tp: None,
             sl: None,
+        }
+    }
+
+    fn child_order() -> ChildOrder {
+        ChildOrder {
+            trigger_price: UsdPrice::new_int(120),
+            max_slippage: Dimensionless::new_int(0),
+            size: None,
+        }
+    }
+
+    fn submit_with_tp_sl(kind: OrderKind) -> SubmitOrderRequest {
+        SubmitOrderRequest {
+            pair_id: btc::DENOM.clone(),
+            size: Quantity::new_int(1),
+            kind,
+            reduce_only: false,
+            tp: Some(child_order()),
+            sl: Some(child_order()),
         }
     }
 
@@ -208,6 +235,14 @@ mod tests {
 
     fn submit_post_only() -> TraderMsg {
         TraderMsg::SubmitOrder(submit(post_only_limit()))
+    }
+
+    fn submit_post_only_with_tp_sl() -> TraderMsg {
+        TraderMsg::SubmitOrder(submit_with_tp_sl(post_only_limit()))
+    }
+
+    fn submit_post_only_with_client_id() -> TraderMsg {
+        TraderMsg::SubmitOrder(submit(post_only_limit_with_client_id()))
     }
 
     fn submit_market() -> TraderMsg {
@@ -314,6 +349,8 @@ mod tests {
     #[test_case(cancel_cond_all_for_pair() => true; "case_cancel_conditional_all_for_pair")]
     #[test_case(cancel_cond_all() => true; "case_cancel_conditional_all")]
     #[test_case(submit_post_only() => true; "case_submit_post_only")]
+    #[test_case(submit_post_only_with_tp_sl() => true; "case_submit_post_only_with_tp_sl")]
+    #[test_case(submit_post_only_with_client_id() => true; "case_submit_post_only_with_client_id")]
     #[test_case(batch_all_cancel() => true; "case_batch_all_cancel")]
     #[test_case(batch_all_post_only() => true; "case_batch_all_post_only")]
     #[test_case(batch_mixed_priority() => true; "case_batch_mixed")]
@@ -359,25 +396,27 @@ mod tests {
         assert!(!is_priority_tx(tx.as_ref(), &perps()));
     }
 
-    #[test]
-    fn priority_tx_non_execute_message() {
-        // Token transfer is not an Execute message.
-        let tx = tx_with_messages(vec![Message::transfer(perps(), Coins::new()).unwrap()]);
-        assert!(!is_priority_tx(tx.as_ref(), &perps()));
+    // Top-level `Message` variants other than `Execute` are never priority.
+    #[test_case(Message::transfer(perps(), Coins::new()).unwrap() => false ; "case_non_execute_transfer")]
+    #[test_case(Message::upload(vec![0u8; 8])                     => false ; "case_non_execute_upload")]
+    fn priority_tx_non_execute_message(message: Message) -> bool {
+        let tx = tx_with_messages(vec![message]);
+        is_priority_tx(tx.as_ref(), &perps())
     }
 
-    #[test]
-    fn priority_tx_non_trade_execute_msg() {
-        // A perps Execute message that isn't `Trade(...)` is not priority.
+    // A perps Execute message whose payload is not `Trade(...)` is never
+    // priority — covers all sibling variants of `ExecuteMsg`.
+    #[test_case(ExecuteMsg::Maintain(MaintainerMsg::Donate {})              => false ; "case_non_trade_maintain")]
+    #[test_case(ExecuteMsg::Vault(VaultMsg::Refresh {})                     => false ; "case_non_trade_vault")]
+    #[test_case(ExecuteMsg::Referral(ReferralMsg::SetReferral {
+        referrer: 1,
+        referee: 2,
+    })                                                                       => false ; "case_non_trade_referral")]
+    fn priority_tx_non_trade_execute_msg(execute_msg: ExecuteMsg) -> bool {
         let tx = tx_with_messages(vec![
-            Message::execute(
-                perps(),
-                &ExecuteMsg::Maintain(MaintainerMsg::Donate {}),
-                Coins::new(),
-            )
-            .unwrap(),
+            Message::execute(perps(), &execute_msg, Coins::new()).unwrap(),
         ]);
-        assert!(!is_priority_tx(tx.as_ref(), &perps()));
+        is_priority_tx(tx.as_ref(), &perps())
     }
 
     #[test]

--- a/dango/proposal-preparer/src/maker_priority_handler.rs
+++ b/dango/proposal-preparer/src/maker_priority_handler.rs
@@ -3,7 +3,7 @@ use {
         config::AppConfig,
         perps::{self, SubmitOrCancelOrderRequest, TraderMsg},
     },
-    grug::{Addr, JsonDeExt, Message, QuerierExt, QuerierWrapper, StdError, Tx},
+    grug::{Addr, Inner, JsonDeExt, Message, QuerierExt, QuerierWrapper, StdError, Tx},
     prost::bytes::Bytes,
 };
 
@@ -53,7 +53,7 @@ pub fn is_priority_tx(raw_tx: &[u8], perps: &Addr) -> bool {
         return false;
     };
 
-    for msg in tx.msgs.iter() {
+    for msg in tx.msgs.into_inner() {
         let Message::Execute(exec) = msg else {
             return false;
         };
@@ -62,7 +62,7 @@ pub fn is_priority_tx(raw_tx: &[u8], perps: &Addr) -> bool {
             return false;
         }
 
-        let Ok(execute_msg) = exec.msg.clone().deserialize_json::<perps::ExecuteMsg>() else {
+        let Ok(execute_msg) = exec.msg.deserialize_json::<perps::ExecuteMsg>() else {
             return false;
         };
 

--- a/dango/proposal-preparer/src/proposal_preparer.rs
+++ b/dango/proposal-preparer/src/proposal_preparer.rs
@@ -1,5 +1,8 @@
 use {
-    crate::pyth_handler::{PythHandler, QueryPythId},
+    crate::{
+        maker_priority_handler::MakerPriorityHandler,
+        pyth_handler::{PythHandler, QueryPythId},
+    },
     grug::{Lengthy, NonEmpty, QuerierWrapper, StdError},
     prost::bytes::Bytes,
     pyth_client::{PythClient, PythClientCache, PythClientTrait},
@@ -12,6 +15,7 @@ pub struct ProposalPreparer<P>
 where
     P: PythClientTrait + QueryPythId,
 {
+    maker_priority: MakerPriorityHandler,
     pyth: PythHandler<P>,
 }
 
@@ -21,6 +25,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
+            maker_priority: self.maker_priority,
             pyth: self.pyth.clone(),
         }
     }
@@ -34,6 +39,7 @@ impl ProposalPreparer<PythClient> {
         T: ToString,
     {
         Self {
+            maker_priority: MakerPriorityHandler,
             pyth: PythHandler::new(endpoints, access_token),
         }
     }
@@ -43,6 +49,7 @@ impl ProposalPreparer<PythClientCache> {
     pub fn new_with_cache() -> Self {
         // `LAZER_ENDPOINTS_TEST` is a static non-empty array.
         Self {
+            maker_priority: MakerPriorityHandler,
             pyth: PythHandler::new_with_cache(
                 NonEmpty::new_unchecked(LAZER_ENDPOINTS_TEST),
                 "lazer_token",
@@ -64,6 +71,12 @@ where
         txs: Vec<Bytes>,
         max_tx_bytes: usize,
     ) -> Result<Vec<Bytes>, Self::Error> {
+        // Maker-priority promotion runs first; Pyth runs second so the
+        // oracle-update tx ends up at index 0, ahead of the priority maker
+        // traffic. Final layout: `[oracle, priority_makers..., others...]`.
+        let txs = self
+            .maker_priority
+            .prepare_proposal(querier, txs, max_tx_bytes)?;
         self.pyth.prepare_proposal(querier, txs, max_tx_bytes)
     }
 }

--- a/dango/proposal-preparer/src/proposal_preparer.rs
+++ b/dango/proposal-preparer/src/proposal_preparer.rs
@@ -1,31 +1,18 @@
 use {
-    crate::{QueryPythId, pyth_handler::PythHandler},
-    dango_types::{config::AppConfig, oracle::ExecuteMsg},
-    grug::{
-        Coins, Json, JsonSerExt, Lengthy, Message, NonEmpty, QuerierExt, QuerierWrapper, StdError,
-        Tx,
-    },
+    crate::pyth_handler::{PythHandler, QueryPythId},
+    grug::{Lengthy, NonEmpty, QuerierWrapper, StdError},
     prost::bytes::Bytes,
     pyth_client::{PythClient, PythClientCache, PythClientTrait},
     pyth_types::constants::LAZER_ENDPOINTS_TEST,
     reqwest::IntoUrl,
-    std::{fmt::Debug, sync::Mutex},
-    tracing::{error, warn},
+    std::fmt::Debug,
 };
-#[cfg(feature = "metrics")]
-use {
-    metrics::{describe_histogram, histogram},
-    std::time::Instant,
-};
-
-const GAS_LIMIT: u64 = 50_000_000;
 
 pub struct ProposalPreparer<P>
 where
     P: PythClientTrait + QueryPythId,
 {
-    // `Option` to be able to not clone the `PythHandler`.
-    pyth_handler: Option<Mutex<PythHandler<P>>>,
+    pyth: PythHandler<P>,
 }
 
 impl<P> Clone for ProposalPreparer<P>
@@ -33,7 +20,9 @@ where
     P: PythClientTrait + QueryPythId,
 {
     fn clone(&self) -> Self {
-        Self { pyth_handler: None }
+        Self {
+            pyth: self.pyth.clone(),
+        }
     }
 }
 
@@ -44,54 +33,20 @@ impl ProposalPreparer<PythClient> {
         U: IntoUrl,
         T: ToString,
     {
-        #[cfg(feature = "metrics")]
-        init_metrics();
-
-        let mut client = None;
-
-        if access_token.to_string().is_empty() {
-            warn!("Pyth Lazer access token is empty! Oracle feeding is disabled");
-        } else if endpoints.length() == 0 {
-            warn!("Pyth Lazer endpoints not provided! Oracle feeding is disabled");
-        } else {
-            client = Some(Mutex::new(PythHandler::new(
-                NonEmpty::new(endpoints).unwrap(),
-                access_token,
-            )));
-        }
-
         Self {
-            pyth_handler: client,
+            pyth: PythHandler::new(endpoints, access_token),
         }
     }
 }
 
 impl ProposalPreparer<PythClientCache> {
     pub fn new_with_cache() -> Self {
-        #[cfg(feature = "metrics")]
-        init_metrics();
-
-        let client = PythHandler::new_with_cache(
-            NonEmpty::new(LAZER_ENDPOINTS_TEST).unwrap(),
-            "lazer_token",
-        );
-
+        // `LAZER_ENDPOINTS_TEST` is a static non-empty array.
         Self {
-            pyth_handler: Some(Mutex::new(client)),
-        }
-    }
-}
-
-// Ensure background streaming threads are stopped when the preparer is dropped.
-impl<P> Drop for ProposalPreparer<P>
-where
-    P: PythClientTrait + QueryPythId,
-{
-    fn drop(&mut self) {
-        if let Some(handler) = &self.pyth_handler
-            && let Ok(mut h) = handler.lock()
-        {
-            h.close_stream();
+            pyth: PythHandler::new_with_cache(
+                NonEmpty::new_unchecked(LAZER_ENDPOINTS_TEST),
+                "lazer_token",
+            ),
         }
     }
 }
@@ -106,63 +61,9 @@ where
     fn prepare_proposal(
         &self,
         querier: QuerierWrapper,
-        mut txs: Vec<Bytes>,
-        _max_tx_bytes: usize,
+        txs: Vec<Bytes>,
+        max_tx_bytes: usize,
     ) -> Result<Vec<Bytes>, Self::Error> {
-        #[cfg(feature = "metrics")]
-        let start = Instant::now();
-
-        let cfg: AppConfig = querier.query_app_config()?;
-
-        // Check if the PythHandler is initialized.
-        if self.pyth_handler.is_none() {
-            return Ok(txs);
-        }
-
-        // Should we find a way to start and connect the PythClientPPHandler at startup?
-        // How to know which ids should be used?
-        let mut pyth_handler = self.pyth_handler.as_ref().unwrap().lock().unwrap();
-
-        // Update the Pyth stream if the PythIds in the oracle have changed.
-        if let Err(err) = pyth_handler.update_stream(querier, cfg.addresses.oracle) {
-            error!("Failed to update Pyth stream: {:?}", err);
-        }
-
-        // Retrieve the PriceUpdate.
-        let maybe_price_update = pyth_handler.fetch_latest_price_update();
-
-        // Return if there are no new prices to feed.
-        let Some(price_update) = maybe_price_update else {
-            return Ok(txs);
-        };
-
-        // Build the tx.
-        let tx = Tx {
-            sender: cfg.addresses.oracle,
-            gas_limit: GAS_LIMIT,
-            msgs: NonEmpty::new_unchecked(vec![Message::execute(
-                cfg.addresses.oracle,
-                &ExecuteMsg::FeedPrices(price_update),
-                Coins::new(),
-            )?]),
-            data: Json::null(),
-            credential: Json::null(),
-        };
-
-        txs.insert(0, tx.to_json_vec()?.into());
-
-        #[cfg(feature = "metrics")]
-        histogram!("proposal_preparer.prepare_proposal.duration",)
-            .record(start.elapsed().as_secs_f64());
-
-        Ok(txs)
+        self.pyth.prepare_proposal(querier, txs, max_tx_bytes)
     }
-}
-
-#[cfg(feature = "metrics")]
-pub fn init_metrics() {
-    describe_histogram!(
-        "proposal_preparer.prepare_proposal.duration",
-        "Duration of the `prepare_proposal` method in seconds",
-    );
 }

--- a/dango/proposal-preparer/src/pyth_handler.rs
+++ b/dango/proposal-preparer/src/pyth_handler.rs
@@ -77,18 +77,15 @@ impl PythHandler<PythClient> {
             return Self { inner: None };
         }
 
-        // `endpoints` is non-empty (length > 0 verified above), so wrapping in
-        // `NonEmpty` is infallible.
-        let client = match PythClient::new(NonEmpty::new_unchecked(endpoints), access_token) {
-            Ok(c) => c,
-            Err(err) => {
-                warn!(
-                    ?err,
-                    "Failed to construct Pyth client; oracle feeding is disabled"
-                );
-                return Self { inner: None };
-            },
-        };
+        // Infallible: `endpoints.length() == 0` ruled out above.
+        let endpoints = NonEmpty::new(endpoints).unwrap();
+
+        // Fail loudly on construction error. Silently producing a disabled
+        // handler would mean every block runs without fresh oracle prices,
+        // the market-making vault never re-quotes, and liquidation logic
+        // uses stale inputs — far worse than a noisy startup failure.
+        let client = PythClient::new(endpoints, access_token).unwrap();
+
         Self {
             inner: Some(Mutex::new(PythHandlerInner::new(client))),
         }
@@ -105,16 +102,10 @@ impl PythHandler<PythClientCache> {
         #[cfg(feature = "metrics")]
         init_metrics();
 
-        let client = match PythClientCache::new(endpoints, access_token) {
-            Ok(c) => c,
-            Err(err) => {
-                warn!(
-                    ?err,
-                    "Failed to construct Pyth cache client; oracle feeding is disabled",
-                );
-                return Self { inner: None };
-            },
-        };
+        // Fail loudly on construction error — same rationale as
+        // `PythHandler::<PythClient>::new`.
+        let client = PythClientCache::new(endpoints, access_token).unwrap();
+
         Self {
             inner: Some(Mutex::new(PythHandlerInner::new(client))),
         }
@@ -128,15 +119,20 @@ where
     pub fn fetch_latest_price_update(&self) -> Option<PriceUpdate> {
         // Retrieve the VAAs from the shared memory and consume them in order
         // to avoid pushing the same VAAs again.
-        let inner = self.inner.as_ref()?.lock().ok()?;
+        //
+        // Panic on a poisoned mutex: it means a prior caller panicked while
+        // holding the lock — that's a real bug, and silently swallowing it
+        // would let the chain produce many blocks without fresh oracle
+        // prices.
+        let inner = self.inner.as_ref()?.lock().unwrap();
         inner.shared_vaas.replace(None)
     }
 
     pub fn close_stream(&self) {
-        if let Some(inner) = &self.inner
-            && let Ok(mut inner) = inner.lock()
-        {
-            inner.close_stream();
+        if let Some(inner) = &self.inner {
+            // Panic on a poisoned mutex — same rationale as
+            // `fetch_latest_price_update`.
+            inner.lock().unwrap().close_stream();
         }
     }
 }
@@ -150,13 +146,10 @@ where
         let Some(inner) = &self.inner else {
             return Ok(());
         };
-        match inner.lock() {
-            Ok(mut guard) => guard.update_stream(querier, oracle),
-            Err(_) => {
-                error!("PythHandler mutex poisoned; skipping stream update");
-                Ok(())
-            },
-        }
+
+        // Panic on a poisoned mutex — same rationale as
+        // `fetch_latest_price_update`.
+        inner.lock().unwrap().update_stream(querier, oracle)
     }
 }
 

--- a/dango/proposal-preparer/src/pyth_handler.rs
+++ b/dango/proposal-preparer/src/pyth_handler.rs
@@ -1,13 +1,20 @@
 use {
-    dango_types::oracle::{PriceSource, QueryPriceSourcesRequest},
-    grug::{Addr, Lengthy, NonEmpty, QuerierExt, QuerierWrapper, Shared, StdResult},
+    dango_types::{
+        config::AppConfig,
+        oracle::{ExecuteMsg, PriceSource, QueryPriceSourcesRequest},
+    },
+    grug::{
+        Addr, Coins, Json, JsonSerExt, Lengthy, Message, NonEmpty, QuerierExt, QuerierWrapper,
+        Shared, StdError, StdResult, Tx,
+    },
+    prost::bytes::Bytes,
     pyth_client::{PythClient, PythClientCache, PythClientTrait},
     pyth_types::{PriceUpdate, PythLazerSubscriptionDetails},
     reqwest::IntoUrl,
     std::{
         fmt::Debug,
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicBool, Ordering},
         },
         thread,
@@ -15,15 +22,32 @@ use {
     },
     tokio::{runtime::Runtime, time::sleep},
     tokio_stream::StreamExt,
-    tracing::error,
+    tracing::{error, warn},
+};
+#[cfg(feature = "metrics")]
+use {
+    metrics::{describe_histogram, histogram},
+    std::time::Instant,
 };
 
 /// Number of attempts to connect to the Pyth stream before giving up.
 const CONNECT_ATTEMPTS: usize = 3;
 
+/// Gas limit for the oracle price-feed transaction injected at the top of
+/// each block.
+const GAS_LIMIT: u64 = 50_000_000;
+
 /// Handler for the PythClient to be used in the ProposalPreparer, used to
 /// keep all code related to Pyth for PP in a single structure.
 pub struct PythHandler<P>
+where
+    P: PythClientTrait,
+{
+    /// `None` when Pyth feeding is disabled (no token / no endpoints).
+    inner: Option<Mutex<PythHandlerInner<P>>>,
+}
+
+struct PythHandlerInner<P>
 where
     P: PythClientTrait,
 {
@@ -34,27 +58,66 @@ where
 }
 
 impl PythHandler<PythClient> {
-    pub fn new<V, U, T>(endpoints: NonEmpty<V>, access_token: T) -> PythHandler<PythClient>
+    pub fn new<V, U, T>(endpoints: V, access_token: T) -> Self
     where
         V: IntoIterator<Item = U> + Lengthy,
         U: IntoUrl,
         T: ToString,
     {
-        Self::new_with_client(PythClient::new(endpoints, access_token).unwrap())
+        #[cfg(feature = "metrics")]
+        init_metrics();
+
+        if access_token.to_string().is_empty() {
+            warn!("Pyth Lazer access token is empty! Oracle feeding is disabled");
+            return Self { inner: None };
+        }
+
+        if endpoints.length() == 0 {
+            warn!("Pyth Lazer endpoints not provided! Oracle feeding is disabled");
+            return Self { inner: None };
+        }
+
+        // `endpoints` is non-empty (length > 0 verified above), so wrapping in
+        // `NonEmpty` is infallible.
+        let client = match PythClient::new(NonEmpty::new_unchecked(endpoints), access_token) {
+            Ok(c) => c,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    "Failed to construct Pyth client; oracle feeding is disabled"
+                );
+                return Self { inner: None };
+            },
+        };
+        Self {
+            inner: Some(Mutex::new(PythHandlerInner::new(client))),
+        }
     }
 }
 
 impl PythHandler<PythClientCache> {
-    pub fn new_with_cache<V, U, T>(
-        endpoints: NonEmpty<V>,
-        access_token: T,
-    ) -> PythHandler<PythClientCache>
+    pub fn new_with_cache<V, U, T>(endpoints: NonEmpty<V>, access_token: T) -> Self
     where
         V: IntoIterator<Item = U> + Lengthy,
         U: IntoUrl,
         T: ToString,
     {
-        Self::new_with_client(PythClientCache::new(endpoints, access_token).unwrap())
+        #[cfg(feature = "metrics")]
+        init_metrics();
+
+        let client = match PythClientCache::new(endpoints, access_token) {
+            Ok(c) => c,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    "Failed to construct Pyth cache client; oracle feeding is disabled",
+                );
+                return Self { inner: None };
+            },
+        };
+        Self {
+            inner: Some(Mutex::new(PythHandlerInner::new(client))),
+        }
     }
 }
 
@@ -62,7 +125,126 @@ impl<P> PythHandler<P>
 where
     P: PythClientTrait + QueryPythId,
 {
-    fn new_with_client(client: P) -> PythHandler<P> {
+    pub fn fetch_latest_price_update(&self) -> Option<PriceUpdate> {
+        // Retrieve the VAAs from the shared memory and consume them in order
+        // to avoid pushing the same VAAs again.
+        let inner = self.inner.as_ref()?.lock().ok()?;
+        inner.shared_vaas.replace(None)
+    }
+
+    pub fn close_stream(&self) {
+        if let Some(inner) = &self.inner
+            && let Ok(mut inner) = inner.lock()
+        {
+            inner.close_stream();
+        }
+    }
+}
+
+impl<P> PythHandler<P>
+where
+    P: PythClientTrait + QueryPythId + Send + 'static,
+    P::Error: Debug,
+{
+    pub fn update_stream(&self, querier: QuerierWrapper, oracle: Addr) -> StdResult<()> {
+        let Some(inner) = &self.inner else {
+            return Ok(());
+        };
+        match inner.lock() {
+            Ok(mut guard) => guard.update_stream(querier, oracle),
+            Err(_) => {
+                error!("PythHandler mutex poisoned; skipping stream update");
+                Ok(())
+            },
+        }
+    }
+}
+
+impl<P> Clone for PythHandler<P>
+where
+    P: PythClientTrait,
+{
+    /// Cloning produces a "dud" copy with no inner state — the streaming
+    /// thread is never duplicated.
+    fn clone(&self) -> Self {
+        Self { inner: None }
+    }
+}
+
+impl<P> Drop for PythHandler<P>
+where
+    P: PythClientTrait,
+{
+    fn drop(&mut self) {
+        if let Some(inner) = &self.inner
+            && let Ok(mut inner) = inner.lock()
+        {
+            inner.close_stream();
+        }
+    }
+}
+
+impl<P> grug_app::ProposalPreparer for PythHandler<P>
+where
+    P: PythClientTrait + QueryPythId + Send + 'static,
+    P::Error: Debug,
+{
+    type Error = StdError;
+
+    fn prepare_proposal(
+        &self,
+        querier: QuerierWrapper,
+        mut txs: Vec<Bytes>,
+        _max_tx_bytes: usize,
+    ) -> Result<Vec<Bytes>, Self::Error> {
+        #[cfg(feature = "metrics")]
+        let start = Instant::now();
+
+        // Disabled handler — pass through.
+        if self.inner.is_none() {
+            return Ok(txs);
+        }
+
+        let cfg: AppConfig = querier.query_app_config()?;
+
+        // Update the Pyth stream if the PythIds in the oracle have changed.
+        if let Err(err) = self.update_stream(querier, cfg.addresses.oracle) {
+            error!("Failed to update Pyth stream: {:?}", err);
+        }
+
+        // Retrieve the PriceUpdate.
+        let Some(price_update) = self.fetch_latest_price_update() else {
+            return Ok(txs);
+        };
+
+        // Build the tx and insert it at the front of the block.
+        let tx = Tx {
+            sender: cfg.addresses.oracle,
+            gas_limit: GAS_LIMIT,
+            msgs: NonEmpty::new_unchecked(vec![Message::execute(
+                cfg.addresses.oracle,
+                &ExecuteMsg::FeedPrices(price_update),
+                Coins::new(),
+            )?]),
+            data: Json::null(),
+            credential: Json::null(),
+        };
+
+        txs.insert(0, tx.to_json_vec()?.into());
+
+        #[cfg(feature = "metrics")]
+        histogram!("proposal_preparer.prepare_proposal.duration",)
+            .record(start.elapsed().as_secs_f64());
+
+        Ok(txs)
+    }
+}
+
+impl<P> PythHandlerInner<P>
+where
+    P: PythClientTrait,
+{
+    fn new(client: P) -> Self {
         Self {
             client,
             shared_vaas: Shared::new(None),
@@ -71,13 +253,7 @@ where
         }
     }
 
-    pub fn fetch_latest_price_update(&self) -> Option<PriceUpdate> {
-        // Retrieve the VAAs from the shared memory and consume them in order to
-        // avoid pushing the same VAAs again.
-        self.shared_vaas.replace(None)
-    }
-
-    pub fn close_stream(&mut self) {
+    fn close_stream(&mut self) {
         if let Some((keep_running, _handle)) = self.stoppable_thread.take() {
             keep_running.store(false, Ordering::SeqCst);
         }
@@ -87,7 +263,7 @@ where
     }
 }
 
-impl<P> PythHandler<P>
+impl<P> PythHandlerInner<P>
 where
     P: PythClientTrait + QueryPythId + Send + 'static,
     P::Error: Debug,
@@ -122,7 +298,7 @@ where
                         match client.stream(ids.clone()).await {
                             Ok(stream) => {
                                 break stream;
-                            }
+                            },
                             Err(err) => {
                                 attempts += 1;
 
@@ -161,7 +337,7 @@ where
         ));
     }
 
-    pub fn update_stream(&mut self, querier: QuerierWrapper, oracle: Addr) -> StdResult<()> {
+    fn update_stream(&mut self, querier: QuerierWrapper, oracle: Addr) -> StdResult<()> {
         // Retrieve the Pyth ids from the Oracle contract.
         let pyth_ids = self.client.pyth_ids(querier, oracle)?;
 
@@ -244,4 +420,12 @@ fn pyth_ids_lazer(
         .collect::<Vec<_>>();
 
     Ok(new_ids)
+}
+
+#[cfg(feature = "metrics")]
+pub fn init_metrics() {
+    describe_histogram!(
+        "proposal_preparer.prepare_proposal.duration",
+        "Duration of the `prepare_proposal` method in seconds",
+    );
 }

--- a/dango/proposal-preparer/src/pyth_handler.rs
+++ b/dango/proposal-preparer/src/pyth_handler.rs
@@ -422,3 +422,42 @@ pub fn init_metrics() {
         "Duration of the `prepare_proposal` method in seconds",
     );
 }
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        grug_app::{NaiveQuerier, ProposalPreparer as _},
+    };
+
+    /// Disabled handler must short-circuit `prepare_proposal` before touching
+    /// the querier — passing `NaiveQuerier` (which panics on any query)
+    /// proves the early-return path runs.
+    #[test]
+    fn disabled_handler_when_token_empty_passes_through() {
+        let handler: PythHandler<PythClient> = PythHandler::new(["http://example.com"], "");
+        assert!(handler.inner.is_none());
+
+        let querier = QuerierWrapper::new(&NaiveQuerier);
+        let txs: Vec<Bytes> = vec![Bytes::from_static(b"tx1"), Bytes::from_static(b"tx2")];
+        let out = handler
+            .prepare_proposal(querier, txs.clone(), usize::MAX)
+            .unwrap();
+        assert_eq!(out, txs);
+    }
+
+    #[test]
+    fn disabled_handler_when_endpoints_empty_passes_through() {
+        let handler: PythHandler<PythClient> = PythHandler::new(Vec::<&str>::new(), "lazer_token");
+        assert!(handler.inner.is_none());
+
+        let querier = QuerierWrapper::new(&NaiveQuerier);
+        let txs: Vec<Bytes> = vec![Bytes::from_static(b"tx1")];
+        let out = handler
+            .prepare_proposal(querier, txs.clone(), usize::MAX)
+            .unwrap();
+        assert_eq!(out, txs);
+    }
+}

--- a/dango/testing/tests/pyth_handler.rs
+++ b/dango/testing/tests/pyth_handler.rs
@@ -54,7 +54,7 @@ fn handler() {
         .should_succeed();
 
     let querier = QuerierWrapper::new(&suite);
-    let mut handler =
+    let handler =
         PythHandler::new_with_cache(NonEmpty::new_unchecked(LAZER_ENDPOINTS_TEST), "lazer_token");
 
     // Start the handler with oracle.


### PR DESCRIPTION
Introduce a new block building rule that protects makers from arbitrage that exploits stale quotes. Specifically, transactions that contain only order cancellations and submissions of post-only orders are promoted to the front of the block, only after the oracle update. This mirror Hyperliquid's: https://hyperliquid.medium.com/latency-and-transaction-ordering-on-hyperliquid-cf28df3648eb