### PR TITLE
feat(perps): add `realized_funding` to events

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -1444,6 +1444,7 @@ The `data` field contains the event-specific payload as JSON. For example, an `o
   "closing_size": "0.000000",
   "opening_size": "0.100000",
   "realized_pnl": "0.000000",
+  "realized_funding": "0.000000",
   "fee": "6.500000",
   "client_order_id": "42",
   "fill_id": "17",
@@ -2200,11 +2201,11 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 ### Order events
 
-| Event             | Fields                                                                                                                                                       | Description                     |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `fee`, `client_order_id?`, `fill_id?`, `is_maker?` | Order partially or fully filled |
-| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                                                     | Limit order placed on book      |
-| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                                                  | Order removed from book         |
+| Event             | Fields                                                                                                                                                                            | Description                     |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `realized_funding?`, `fee`, `client_order_id?`, `fill_id?`, `is_maker?` | Order partially or fully filled |
+| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                                                                          | Limit order placed on book      |
+| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                                                                       | Order removed from book         |
 
 `client_order_id` is `null` if the order was submitted without one. Off-chain consumers can use it to correlate fills, persistence, and removal with the originally-submitted client id.
 
@@ -2212,7 +2213,11 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 `is_maker` is `true` for the maker side of a match and `false` for the taker side. Within a single match's pair of `order_filled` events (sharing one `fill_id`), exactly one carries `is_maker = true` and one carries `is_maker = false`. `is_maker` is `null` for trades executed before v0.16.0 — the maker/taker flag was not recorded prior to that release.
 
-`realized_pnl` on `order_filled`, `deleveraged`, and `liquidated` (as `adl_realized_pnl`) includes both the closing PnL on the fill and the funding settled on the user's pre-existing position immediately before the fill is applied. Trading fees are reported separately in the `fee` field on `order_filled`; ADL and deleverage fills incur no trading fees.
+`realized_pnl` on `order_filled` and `deleveraged` (and `adl_realized_pnl` on `liquidated`) reports the closing PnL on the fill — price movement on the closed portion. The funding settled on the user's pre-existing position immediately before the fill is reported separately as `realized_funding` (or `adl_realized_funding` on `liquidated`).
+
+`realized_funding` is `null` for events emitted before v0.17.0 — funding was bundled into `realized_pnl` (and `adl_realized_pnl`) prior to that release. From v0.17.0 onward the field is always present and `realized_pnl + realized_funding` equals the pre-v0.17.0 lump sum.
+
+Trading fees are reported separately in the `fee` field on `order_filled`; ADL and deleverage fills incur no trading fees.
 
 ### Conditional order events
 
@@ -2224,11 +2229,11 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 ### Liquidation events
 
-| Event              | Fields                                                          | Description                      |
-| ------------------ | --------------------------------------------------------------- | -------------------------------- |
-| `liquidated`       | `user`, `pair_id`, `adl_size`, `adl_price`, `adl_realized_pnl`  | Position liquidated in a pair    |
-| `deleveraged`      | `user`, `pair_id`, `closing_size`, `fill_price`, `realized_pnl` | Counter-party hit by ADL         |
-| `bad_debt_covered` | `liquidated_user`, `amount`, `insurance_fund_remaining`         | Insurance fund absorbed bad debt |
+| Event              | Fields                                                                                  | Description                      |
+| ------------------ | --------------------------------------------------------------------------------------- | -------------------------------- |
+| `liquidated`       | `user`, `pair_id`, `adl_size`, `adl_price`, `adl_realized_pnl`, `adl_realized_funding?` | Position liquidated in a pair    |
+| `deleveraged`      | `user`, `pair_id`, `closing_size`, `fill_price`, `realized_pnl`, `realized_funding?`    | Counter-party hit by ADL         |
+| `bad_debt_covered` | `liquidated_user`, `amount`, `insurance_fund_remaining`                                 | Insurance fund absorbed bad debt |
 
 ### ReasonForOrderRemoval
 

--- a/dango/indexer/sql/src/entity/perps_trade.rs
+++ b/dango/indexer/sql/src/entity/perps_trade.rs
@@ -28,8 +28,20 @@ pub struct PerpsTrade {
     #[cfg_attr(feature = "async-graphql", graphql(name = "openingSize"))]
     pub opening_size: String,
 
+    /// Closing PnL on the fill (price movement on the closed portion).
+    /// Prior to v0.17.0 (exclusive) this also included funding settled
+    /// on the user's pre-existing position; from v0.17.0 (inclusive)
+    /// onward, that funding component is reported separately as
+    /// `realized_funding`.
     #[cfg_attr(feature = "async-graphql", graphql(name = "realizedPnl"))]
     pub realized_pnl: String,
+
+    /// Funding settled on the user's pre-existing position immediately
+    /// before this fill. `None` for trades executed before v0.17.0 —
+    /// funding was reported as part of `realized_pnl` prior to that
+    /// release.
+    #[cfg_attr(feature = "async-graphql", graphql(name = "realizedFunding"))]
+    pub realized_funding: Option<String>,
 
     pub fee: String,
 

--- a/dango/indexer/sql/src/indexer/perps_events.rs
+++ b/dango/indexer/sql/src/indexer/perps_events.rs
@@ -228,6 +228,10 @@ fn try_build_perps_trade(
         closing_size: order_filled.closing_size.to_string(),
         opening_size: order_filled.opening_size.to_string(),
         realized_pnl: order_filled.realized_pnl.to_string(),
+        realized_funding: order_filled
+            .realized_funding
+            .as_ref()
+            .map(ToString::to_string),
         fee: order_filled.fee.to_string(),
         created_at: created_at.to_string(),
         block_height,

--- a/dango/indexer/sql/src/indexer/perps_trades/cache.rs
+++ b/dango/indexer/sql/src/indexer/perps_trades/cache.rs
@@ -68,6 +68,10 @@ impl PerpsTradeCache {
                 closing_size: order_filled.closing_size.to_string(),
                 opening_size: order_filled.opening_size.to_string(),
                 realized_pnl: order_filled.realized_pnl.to_string(),
+                realized_funding: order_filled
+                    .realized_funding
+                    .as_ref()
+                    .map(ToString::to_string),
                 fee: order_filled.fee.to_string(),
                 created_at: Timestamp::from(row.created_at).to_rfc3339_string(),
                 block_height: row.block_height as u64,

--- a/dango/perps/src/core/fill.rs
+++ b/dango/perps/src/core/fill.rs
@@ -8,12 +8,38 @@ use {
     std::cmp::Ordering,
 };
 
+/// PnL realized by a single fill, decomposed into its two sources.
+///
+/// Positive components = user gains, negative = user loses. The total
+/// (`funding + closing`) is what gets applied to the user's margin; the
+/// decomposition is exposed so callers can report the components
+/// separately (e.g. `realized_funding` vs. `realized_pnl` on
+/// `OrderFilled`).
+#[derive(Debug, Clone, Copy)]
+pub struct FillPnl {
+    /// PnL from funding settled on the user's pre-existing position.
+    /// Zero if the user had no prior position in this pair.
+    pub funding: UsdValue,
+
+    /// PnL from price movement on the closed portion. Zero on pure-
+    /// opening fills.
+    pub closing: UsdValue,
+}
+
+impl FillPnl {
+    /// Sum of funding and closing components. This is the value that
+    /// gets applied to the user's margin.
+    pub fn total(&self) -> MathResult<UsdValue> {
+        self.funding.checked_add(self.closing)
+    }
+}
+
 /// Execute a fill for a single user. Updates position and OI; settles
 /// funding on the existing position.
 ///
-/// Returns the raw PnL (funding + realized) as a `UsdValue`.
-/// Positive = user gains, negative = user loses.
-/// Does NOT include trading fees — the caller handles those separately.
+/// Returns the funding and closing PnL components separately as
+/// [`FillPnl`]. Does NOT include trading fees — the caller handles those
+/// separately.
 pub fn execute_fill(
     pair_id: &PairId,
     pair_state: &mut PairState,
@@ -21,19 +47,18 @@ pub fn execute_fill(
     fill_price: UsdPrice,
     closing_size: Quantity,
     opening_size: Quantity,
-) -> MathResult<UsdValue> {
-    let mut total_pnl = UsdValue::ZERO;
+) -> MathResult<FillPnl> {
+    let mut funding = UsdValue::ZERO;
+    let mut closing = UsdValue::ZERO;
 
     // Settle funding on the existing position (if any).
     if let Some(position) = user_state.positions.get_mut(pair_id) {
-        let funding_pnl = settle_funding(position, pair_state)?;
-        total_pnl = total_pnl.checked_add(funding_pnl)?;
+        funding = settle_funding(position, pair_state)?;
     }
 
     // Execute the closing portion — realize PnL.
     if closing_size.is_non_zero() {
-        let closing_pnl = apply_closing(user_state, pair_id, closing_size, fill_price)?;
-        total_pnl = total_pnl.checked_add(closing_pnl)?;
+        closing = apply_closing(user_state, pair_id, closing_size, fill_price)?;
     }
 
     // Execute the opening portion — grow or create position.
@@ -44,7 +69,7 @@ pub fn execute_fill(
     // Update open interest.
     update_oi(pair_state, closing_size, opening_size)?;
 
-    Ok(total_pnl)
+    Ok(FillPnl { funding, closing })
 }
 
 /// Settle funding accrued on a position since it was last touched.
@@ -225,7 +250,8 @@ mod tests {
         .unwrap();
 
         // No PnL on opening.
-        assert_eq!(pnl, UsdValue::ZERO);
+        assert_eq!(pnl.funding, UsdValue::ZERO);
+        assert_eq!(pnl.closing, UsdValue::ZERO);
 
         // Position created.
         let pos = user_state.positions.get(&pair_id()).unwrap();
@@ -252,7 +278,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(pnl, UsdValue::ZERO);
+        assert_eq!(pnl.funding, UsdValue::ZERO);
+        assert_eq!(pnl.closing, UsdValue::ZERO);
 
         let pos = user_state.positions.get(&pair_id()).unwrap();
         assert_eq!(pos.size, Quantity::new_int(-10));
@@ -280,8 +307,9 @@ mod tests {
         )
         .unwrap();
 
-        // PnL = 10 * (55000 - 50000) = 50000 USD
-        assert_eq!(pnl, UsdValue::new_int(50_000));
+        // closing PnL = 10 * (55000 - 50000) = 50000 USD; no funding accrued.
+        assert_eq!(pnl.funding, UsdValue::ZERO);
+        assert_eq!(pnl.closing, UsdValue::new_int(50_000));
 
         // Position removed.
         assert!(!user_state.positions.contains_key(&pair_id()));
@@ -306,8 +334,9 @@ mod tests {
         )
         .unwrap();
 
-        // PnL = 10 * (48000 - 50000) = -20000 USD
-        assert_eq!(pnl, UsdValue::new_int(-20_000));
+        // closing PnL = 10 * (48000 - 50000) = -20000 USD; no funding accrued.
+        assert_eq!(pnl.funding, UsdValue::ZERO);
+        assert_eq!(pnl.closing, UsdValue::new_int(-20_000));
     }
 
     #[test]
@@ -326,8 +355,9 @@ mod tests {
         )
         .unwrap();
 
-        // PnL = 10 * (50000 - 48000) = 20000 USD
-        assert_eq!(pnl, UsdValue::new_int(20_000));
+        // closing PnL = 10 * (50000 - 48000) = 20000 USD; no funding accrued.
+        assert_eq!(pnl.funding, UsdValue::ZERO);
+        assert_eq!(pnl.closing, UsdValue::new_int(20_000));
     }
 
     // ---- execute_fill: partial close ----
@@ -398,7 +428,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(pnl, UsdValue::ZERO);
+        assert_eq!(pnl.funding, UsdValue::ZERO);
+        assert_eq!(pnl.closing, UsdValue::ZERO);
 
         let pos = user_state.positions.get(&pair_id()).unwrap();
         assert_eq!(pos.size, Quantity::new_int(20));
@@ -443,10 +474,57 @@ mod tests {
 
         // Funding accrued = 10 * (100 - 0) = 1000 USD. User pays (longs pay when funding positive).
         // settle_funding returns negated accrued = -1000 USD as PnL.
-        assert_eq!(pnl, UsdValue::new_int(-1000));
+        // No closing portion on this fill, so closing PnL is zero.
+        assert_eq!(pnl.funding, UsdValue::new_int(-1000));
+        assert_eq!(pnl.closing, UsdValue::ZERO);
 
         // Funding entry point reset.
         let pos = user_state.positions.get(&pair_id()).unwrap();
         assert_eq!(pos.entry_funding_per_unit, FundingPerUnit::new_int(100));
+    }
+
+    // ---- execute_fill: combined funding + closing ----
+
+    /// Verifies that funding and closing PnL are reported as separate
+    /// components on a fill that has both: a long position with accrued
+    /// funding, partially closed at a profitable price.
+    #[test]
+    fn funding_and_closing_reported_separately() {
+        let mut pair_state = default_pair_state();
+        // 100 USD per unit of accumulated funding.
+        pair_state.funding_per_unit = FundingPerUnit::new_int(100);
+        pair_state.long_oi = Quantity::new_int(10);
+
+        let mut positions = BTreeMap::new();
+        positions.insert(pair_id(), Position {
+            size: Quantity::new_int(10),
+            entry_price: UsdPrice::new_int(50_000),
+            entry_funding_per_unit: FundingPerUnit::ZERO,
+            conditional_order_above: None,
+            conditional_order_below: None,
+        });
+        let mut user_state = UserState {
+            positions,
+            ..Default::default()
+        };
+
+        // Close half of the long at a 5000 USD per-unit profit.
+        let pnl = execute_fill(
+            &pair_id(),
+            &mut pair_state,
+            &mut user_state,
+            UsdPrice::new_int(55_000),
+            Quantity::new_int(-5),
+            Quantity::ZERO,
+        )
+        .unwrap();
+
+        // Funding accrued on the full pre-existing 10 units, settled before
+        // closing: 10 * (100 - 0) = 1000 USD owed (negated => -1000).
+        assert_eq!(pnl.funding, UsdValue::new_int(-1000));
+        // Closing PnL: 5 * (55_000 - 50_000) = 25_000 USD profit.
+        assert_eq!(pnl.closing, UsdValue::new_int(25_000));
+        // Total applied to margin = closing - funding owed.
+        assert_eq!(pnl.total().unwrap(), UsdValue::new_int(24_000));
     }
 }

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -639,7 +639,7 @@ fn execute_close_schedule(
             // zero, so the margin delta equals the realized PnL from ADL).
             let user_margin_pre_adl = user_state.margin;
 
-            let (adl_size, adl_price) = execute_adl(
+            let (adl_size, adl_price, adl_funding) = execute_adl(
                 storage,
                 contract,
                 &liq_param,
@@ -660,7 +660,12 @@ fn execute_close_schedule(
             closed_notional
                 .checked_add_assign(adl_size.checked_abs()?.checked_mul(oracle_price)?)?;
 
-            let adl_realized_pnl = user_state.margin.checked_sub(user_margin_pre_adl)?;
+            // Margin delta = closing PnL + funding settled. Subtract funding
+            // to get the closing-only `adl_realized_pnl` for v0.17.0+.
+            let adl_realized_pnl = user_state
+                .margin
+                .checked_sub(user_margin_pre_adl)?
+                .checked_sub(adl_funding)?;
 
             events.push(Liquidated {
                 user,
@@ -668,6 +673,7 @@ fn execute_close_schedule(
                 adl_size,
                 adl_price: Some(adl_price),
                 adl_realized_pnl,
+                adl_realized_funding: Some(adl_funding),
             })?;
 
             #[cfg(feature = "metrics")]
@@ -685,6 +691,7 @@ fn execute_close_schedule(
                 adl_size: Quantity::ZERO,
                 adl_price: None,
                 adl_realized_pnl: UsdValue::ZERO,
+                adl_realized_funding: Some(UsdValue::ZERO),
             })?;
         }
     }
@@ -703,7 +710,10 @@ fn execute_close_schedule(
 
 /// ADL the unfilled remainder of a liquidation against counter-positions.
 ///
-/// Returns: (total ADL size, bankruptcy price used).
+/// Returns: `(total_adl_size, bankruptcy_price, total_user_funding)` —
+/// where `total_user_funding` is the funding settled on the liquidated
+/// user's position across all of this call's per-fill `settle_fill`s,
+/// summed into a single value for `Liquidated.adl_realized_funding`.
 ///
 /// This is a leaf helper private to `execute_close_schedule` and keeps `&mut`
 /// parameters by design; it is not part of the pure set.
@@ -723,7 +733,7 @@ fn execute_adl(
     all_volumes: &mut BTreeMap<Addr, UsdValue>,
     index_updates: &mut Vec<PositionIndexUpdate>,
     events: &mut EventBuilder,
-) -> anyhow::Result<(Quantity, UsdPrice)> {
+) -> anyhow::Result<(Quantity, UsdPrice, UsdValue)> {
     let mut remaining = unfilled;
     let taker_is_selling = unfilled.is_negative();
 
@@ -743,6 +753,7 @@ fn execute_adl(
     };
 
     let mut total_adl_size = Quantity::ZERO;
+    let mut total_user_funding = UsdValue::ZERO;
 
     for (entry_price, counter_user) in counter_parties {
         if remaining.is_zero() {
@@ -799,10 +810,14 @@ fn execute_adl(
             Dimensionless::ZERO,
             None,
         )?;
+
+        total_user_funding.checked_add_assign(user_settlement.funding)?;
+
         all_volumes
             .entry(user)
             .or_default()
             .checked_add_assign(user_settlement.volume)?;
+
         if let Some(diff) = compute_position_diff(
             pair_id,
             user,
@@ -887,7 +902,7 @@ fn execute_adl(
         maker_states.insert(counter_user, counter_state);
     }
 
-    Ok((total_adl_size, bankruptcy_price))
+    Ok((total_adl_size, bankruptcy_price, total_user_funding))
 }
 
 /// Compute the liquidation fee, capped at the user's remaining margin.

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -886,13 +886,17 @@ fn execute_adl(
             )?;
         }
 
-        // Emit Deleveraged event for counter-party.
+        // Emit Deleveraged event for counter-party. Split funding off the
+        // total so `realized_pnl` is the closing-only component (v0.17.0+).
         events.push(Deleveraged {
             user: counter_user,
             pair_id: pair_id.clone(),
             closing_size: user_close.checked_neg()?,
             fill_price: bankruptcy_price,
-            realized_pnl: counter_settlement.pnl,
+            realized_pnl: counter_settlement
+                .pnl
+                .checked_sub(counter_settlement.funding)?,
+            realized_funding: Some(counter_settlement.funding),
         })?;
 
         remaining = remaining.checked_sub(user_close)?;

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -811,7 +811,7 @@ fn execute_adl(
             None,
         )?;
 
-        total_user_funding.checked_add_assign(user_settlement.funding)?;
+        total_user_funding.checked_add_assign(user_settlement.pnl.funding)?;
 
         all_volumes
             .entry(user)
@@ -876,27 +876,25 @@ fn execute_adl(
                 state,
                 user,
                 user_state,
-                user_settlement.pnl,
+                user_settlement.pnl.total()?,
                 user_settlement.fee,
                 counter_user,
                 &mut counter_state,
-                counter_settlement.pnl,
+                counter_settlement.pnl.total()?,
                 counter_settlement.fee,
                 vault_state_opt,
             )?;
         }
 
-        // Emit Deleveraged event for counter-party. Split funding off the
-        // total so `realized_pnl` is the closing-only component (v0.17.0+).
+        // Emit Deleveraged event for counter-party. The closing /
+        // funding split lives on `pnl` directly (no inline arithmetic).
         events.push(Deleveraged {
             user: counter_user,
             pair_id: pair_id.clone(),
             closing_size: user_close.checked_neg()?,
             fill_price: bankruptcy_price,
-            realized_pnl: counter_settlement
-                .pnl
-                .checked_sub(counter_settlement.funding)?,
-            realized_funding: Some(counter_settlement.funding),
+            realized_pnl: counter_settlement.pnl.closing,
+            realized_funding: Some(counter_settlement.pnl.funding),
         })?;
 
         remaining = remaining.checked_sub(user_close)?;

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -1125,9 +1125,16 @@ pub fn match_order(
 /// `pnl` and `fee` directly into [`settle_pnls`], and accumulate `volume`
 /// across all of a taker order's fills for `apply_fee_commissions` and
 /// `flush_volumes`.
+///
+/// `funding` is the funding-settlement component of `pnl` (so
+/// `pnl - funding` is the closing-PnL component). Exposed so callers
+/// that report PnL components separately — e.g. the ADL path emitting
+/// `Liquidated.adl_realized_funding` — can pull funding off without
+/// recomputing it.
 #[derive(Debug, Clone, Copy)]
 pub struct FillSettlement {
     pub pnl: UsdValue,
+    pub funding: UsdValue,
     pub fee: UsdValue,
     pub volume: UsdValue,
 }
@@ -1224,7 +1231,12 @@ pub fn settle_fill(
         .record(fee.to_f64().abs());
     }
 
-    Ok(FillSettlement { pnl, fee, volume })
+    Ok(FillSettlement {
+        pnl,
+        funding: fill_pnl.funding,
+        fee,
+        volume,
+    })
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         MAX_ORACLE_STALENESS, VOLUME_LOOKBACK,
         core::{
-            check_margin, check_minimum_order_size, check_oi_constraint, check_price_band,
+            FillPnl, check_margin, check_minimum_order_size, check_oi_constraint, check_price_band,
             compute_available_margin, compute_notional, compute_required_margin,
             compute_target_price, compute_trading_fee, decompose_fill, execute_fill,
             is_price_constraint_violated, validate_slippage,
@@ -994,11 +994,11 @@ pub fn match_order(
                 &mut state,
                 taker,
                 &mut taker_state,
-                taker_settlement.pnl,
+                taker_settlement.pnl.total()?,
                 taker_settlement.fee,
                 maker_user,
                 &mut maker_state,
-                maker_settlement.pnl,
+                maker_settlement.pnl.total()?,
                 maker_settlement.fee,
                 vault_state_opt,
             )?
@@ -1122,19 +1122,17 @@ pub fn match_order(
 }
 
 /// Per-fill outcome returned by [`settle_fill`]. Callers typically feed
-/// `pnl` and `fee` directly into [`settle_pnls`], and accumulate `volume`
-/// across all of a taker order's fills for `apply_fee_commissions` and
-/// `flush_volumes`.
+/// `pnl.total()?` and `fee` directly into [`settle_pnls`], and accumulate
+/// `volume` across all of a taker order's fills for `apply_fee_commissions`
+/// and `flush_volumes`.
 ///
-/// `funding` is the funding-settlement component of `pnl` (so
-/// `pnl - funding` is the closing-PnL component). Exposed so callers
-/// that report PnL components separately — e.g. the ADL path emitting
-/// `Liquidated.adl_realized_funding` — can pull funding off without
-/// recomputing it.
+/// `pnl` is the [`FillPnl`] split into its `funding` and `closing`
+/// components so callers that report them separately — e.g. the ADL path
+/// emitting `Liquidated.adl_realized_funding` — can read each without
+/// arithmetic.
 #[derive(Debug, Clone, Copy)]
 pub struct FillSettlement {
-    pub pnl: UsdValue,
-    pub funding: UsdValue,
+    pub pnl: FillPnl,
     pub fee: UsdValue,
     pub volume: UsdValue,
 }
@@ -1174,10 +1172,9 @@ pub fn settle_fill(
         decompose_fill(fill_size, current_pos)
     };
 
-    let fill_pnl = execute_fill(
+    let pnl = execute_fill(
         pair_id, pair_state, user_state, fill_price, closing, opening,
     )?;
-    let pnl = fill_pnl.total()?;
 
     // The vault is exempt from trading fees.
     let fee = if user != contract {
@@ -1197,8 +1194,8 @@ pub fn settle_fill(
             fill_size,
             closing_size: closing,
             opening_size: opening,
-            realized_pnl: fill_pnl.closing,
-            realized_funding: Some(fill_pnl.funding),
+            realized_pnl: pnl.closing,
+            realized_funding: Some(pnl.funding),
             fee,
             client_order_id,
             fill_id: Some(fill_id),
@@ -1231,12 +1228,7 @@ pub fn settle_fill(
         .record(fee.to_f64().abs());
     }
 
-    Ok(FillSettlement {
-        pnl,
-        funding: fill_pnl.funding,
-        fee,
-        volume,
-    })
+    Ok(FillSettlement { pnl, fee, volume })
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -1167,9 +1167,10 @@ pub fn settle_fill(
         decompose_fill(fill_size, current_pos)
     };
 
-    let pnl = execute_fill(
+    let fill_pnl = execute_fill(
         pair_id, pair_state, user_state, fill_price, closing, opening,
     )?;
+    let pnl = fill_pnl.total()?;
 
     // The vault is exempt from trading fees.
     let fee = if user != contract {
@@ -1189,7 +1190,8 @@ pub fn settle_fill(
             fill_size,
             closing_size: closing,
             opening_size: opening,
-            realized_pnl: pnl,
+            realized_pnl: fill_pnl.closing,
+            realized_funding: Some(fill_pnl.funding),
             fee,
             client_order_id,
             fill_id: Some(fill_id),

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -562,6 +562,7 @@ fn liquidation_with_adl() {
     // funding component is `Some(ZERO)` and the closing-only `adl_realized_pnl`
     // matches the full margin delta of -$1,090.
     let liquidated_events = liq_events
+        .clone()
         .search_event::<CheckedContractEvent>()
         .with_predicate(|e| e.ty == "liquidated")
         .take()
@@ -584,6 +585,35 @@ fn liquidation_with_adl() {
         liq.adl_realized_funding,
         Some(UsdValue::ZERO),
         "v0.17.0+ Liquidated events always carry Some(adl_realized_funding); \
+         with no funding accrued it must be Some(ZERO)"
+    );
+
+    // The Deleveraged event for the counter-party (Trader B) should
+    // mirror the split: closing-only `realized_pnl = +$1,090` (Trader B
+    // shorted at $2,000 and got bought back at $1,782 for 5 ETH) and
+    // `realized_funding = Some(ZERO)`.
+    let deleveraged_events = liq_events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "deleveraged")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Deleveraged>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        deleveraged_events.len(),
+        1,
+        "exactly one Deleveraged event expected (single counter-party)"
+    );
+    let dlv = &deleveraged_events[0];
+    assert_eq!(dlv.user, accounts.user3.address());
+    assert_eq!(dlv.fill_price, UsdPrice::new_int(1_782));
+    assert_eq!(dlv.realized_pnl, UsdValue::new_int(1_090));
+    assert_eq!(
+        dlv.realized_funding,
+        Some(UsdValue::ZERO),
+        "v0.17.0+ Deleveraged events always carry Some(realized_funding); \
          with no funding accrued it must be Some(ZERO)"
     );
 

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -5,8 +5,8 @@ use {
         Dimensionless, Quantity, UsdPrice, UsdValue,
         constants::usdc,
         perps::{
-            self, Deleveraged, OrderFilled, PairParam, Param, QueryOrdersByUserResponseItem,
-            UserState,
+            self, Deleveraged, Liquidated, OrderFilled, PairParam, Param,
+            QueryOrdersByUserResponseItem, UserState,
         },
     },
     grug::{
@@ -545,7 +545,7 @@ fn liquidation_with_adl() {
     //   margin after = $9,990 + $1,090 = $11,080.
     // -------------------------------------------------------------------------
 
-    suite
+    let liq_events = suite
         .execute(
             &mut accounts.owner,
             contracts.perps,
@@ -554,7 +554,38 @@ fn liquidation_with_adl() {
             }),
             Coins::new(),
         )
-        .should_succeed();
+        .should_succeed()
+        .events;
+
+    // The Liquidated event should report the user's PnL split. No funding
+    // accrued in this test (oracle moved without time passing), so the
+    // funding component is `Some(ZERO)` and the closing-only `adl_realized_pnl`
+    // matches the full margin delta of -$1,090.
+    let liquidated_events = liq_events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "liquidated")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Liquidated>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        liquidated_events.len(),
+        1,
+        "exactly one Liquidated event expected for the single-pair liquidation"
+    );
+    let liq = &liquidated_events[0];
+    assert_eq!(liq.user, accounts.user1.address());
+    assert_eq!(liq.adl_size, Quantity::new_int(-5));
+    assert_eq!(liq.adl_price, Some(UsdPrice::new_int(1_782)));
+    assert_eq!(liq.adl_realized_pnl, UsdValue::new_int(-1_090));
+    assert_eq!(
+        liq.adl_realized_funding,
+        Some(UsdValue::ZERO),
+        "v0.17.0+ Liquidated events always carry Some(adl_realized_funding); \
+         with no funding accrued it must be Some(ZERO)"
+    );
 
     // Trader A should have no positions and $0 margin.
     let state = suite

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -1383,6 +1383,18 @@ fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
         match1.into_inner() + 1,
         "fill ids increment by one per match"
     );
+
+    // None of the participants held a prior position in this pair, so
+    // funding is zero on every leg — but the field must still be `Some`
+    // (the `None` shape is reserved for pre-v0.17.0 fills).
+    for fill in &fills {
+        assert_eq!(
+            fill.realized_funding,
+            Some(UsdValue::ZERO),
+            "v0.17.0+ OrderFilled events always carry a Some(realized_funding); \
+             with no prior position it must be Some(ZERO)"
+        );
+    }
 }
 
 /// Bug reproduction: sell-side market order with partial fill is incorrectly

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1431,16 +1431,27 @@ pub struct OrderFilled {
     pub closing_size: Quantity,
     pub opening_size: Quantity,
 
-    /// PnL realized by the user on this fill. Includes both:
+    /// PnL realized by the user on this fill from price movement on the
+    /// closed portion: `|closing_size| * (fill_price - entry_price)` for
+    /// longs, mirrored for shorts. Zero on pure-opening fills.
     ///
-    /// 1. Closing PnL: `|closing_size| * (fill_price - entry_price)` for
-    ///    longs, mirrored for shorts. Zero on pure-opening fills.
-    /// 2. Funding settled on the user's pre-existing position immediately
-    ///    before this fill is applied. Can be non-zero even on
-    ///    pure-opening fills if the user already held a position.
+    /// Prior to v0.17.0 (exclusive) this field also bundled the funding
+    /// settled on the user's pre-existing position immediately before the
+    /// fill. From v0.17.0 (inclusive) onward, that funding component is
+    /// reported separately as `realized_funding` and is no longer included
+    /// here.
     ///
     /// Does not include trading fees (see `fee`).
     pub realized_pnl: UsdValue,
+
+    /// Funding settled on the user's pre-existing position immediately
+    /// before this fill is applied. Can be non-zero even on pure-opening
+    /// fills if the user already held a position. Zero if the user had no
+    /// prior position in this pair.
+    ///
+    /// `None` for trades executed before v0.17.0 — funding was reported as
+    /// part of `realized_pnl` prior to that release.
+    pub realized_funding: Option<UsdValue>,
 
     /// Trading fee charged on this fill, in USD. Always non-negative.
     /// Already deducted from the user's margin in the same transaction;
@@ -1454,8 +1465,10 @@ pub struct OrderFilled {
 
     /// Identifier shared between the two `OrderFilled` events of a single
     /// order-book match (taker + maker). Strictly increasing across
-    /// matches. `None` for trades executed before v0.15.0 — fill IDs
-    /// were not assigned prior to that release.
+    /// matches.
+    ///
+    /// `None` for trades executed before v0.15.0 — fill IDs were not assigned
+    /// prior to that release.
     ///
     /// Equivalents at other venues:
     ///

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1613,11 +1613,25 @@ pub struct Liquidated {
     pub adl_price: Option<UsdPrice>,
 
     /// PnL realized by the liquidated user from ADL fills, accumulated
-    /// across all counter-party fills for this pair. Includes both the
-    /// closing PnL on each ADL fill and the funding settled on the user's
-    /// position immediately before each fill. Zero if no ADL happened.
-    /// ADL fills incur no trading fees.
+    /// across all counter-party fills for this pair. Reports the closing
+    /// PnL on each ADL fill (price movement on the closed portion).
+    /// Zero if no ADL happened. ADL fills incur no trading fees.
+    ///
+    /// Prior to v0.17.0 (exclusive) this field also bundled the funding
+    /// settled on the user's position immediately before each ADL fill.
+    /// From v0.17.0 (inclusive) onward, that funding component is
+    /// reported separately as `adl_realized_funding` and is no longer
+    /// included here.
     pub adl_realized_pnl: UsdValue,
+
+    /// Funding settled on the liquidated user's position immediately
+    /// before each ADL fill, accumulated across all counter-party fills
+    /// for this pair. Zero if no ADL happened or if no funding had
+    /// accrued.
+    ///
+    /// `None` for liquidations executed before v0.17.0 — funding was
+    /// reported as part of `adl_realized_pnl` prior to that release.
+    pub adl_realized_funding: Option<UsdValue>,
 }
 
 /// Event indicating a counter-party's position was reduced during ADL.

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -1649,11 +1649,23 @@ pub struct Deleveraged {
     /// Fill price (the liquidated user's bankruptcy price).
     pub fill_price: UsdPrice,
 
-    /// PnL realized by the counter-party from this ADL fill. Includes
-    /// both the closing PnL on the ADL fill and the funding settled on
-    /// the counter-party's pre-existing position immediately before the
-    /// fill is applied. ADL fills incur no trading fees.
+    /// PnL realized by the counter-party from this ADL fill from price
+    /// movement on the closed portion. ADL fills incur no trading fees.
+    ///
+    /// Prior to v0.17.0 (exclusive) this field also bundled the funding
+    /// settled on the counter-party's pre-existing position immediately
+    /// before the fill. From v0.17.0 (inclusive) onward, that funding
+    /// component is reported separately as `realized_funding` and is no
+    /// longer included here.
     pub realized_pnl: UsdValue,
+
+    /// Funding settled on the counter-party's pre-existing position
+    /// immediately before this ADL fill is applied. Zero if the
+    /// counter-party had no funding accrued in this pair.
+    ///
+    /// `None` for ADL fills executed before v0.17.0 — funding was
+    /// reported as part of `realized_pnl` prior to that release.
+    pub realized_funding: Option<UsdValue>,
 }
 
 /// Event indicating the insurance fund absorbed bad debt from a liquidation.

--- a/sdk/rust/src/schemas/schema.graphql
+++ b/sdk/rust/src/schemas/schema.graphql
@@ -576,7 +576,21 @@ type PerpsTrade {
 	fillSize: String!
 	closingSize: String!
 	openingSize: String!
+	"""
+	Closing PnL on the fill (price movement on the closed portion).
+	Prior to v0.17.0 (exclusive) this also included funding settled
+	on the user's pre-existing position; from v0.17.0 (inclusive)
+	onward, that funding component is reported separately as
+	`realized_funding`.
+	"""
 	realizedPnl: String!
+	"""
+	Funding settled on the user's pre-existing position immediately
+	before this fill. `None` for trades executed before v0.17.0 —
+	funding was reported as part of `realized_pnl` prior to that
+	release.
+	"""
+	realizedFunding: String
 	fee: String!
 	createdAt: String!
 	blockHeight: Int!

--- a/sdk/typescript/dango/src/types/indexer.ts
+++ b/sdk/typescript/dango/src/types/indexer.ts
@@ -102,7 +102,21 @@ export type OrderFilledData = {
   fill_size: string;
   closing_size: string;
   opening_size: string;
+  /**
+   * Closing PnL on the fill (price movement on the closed portion).
+   * Prior to v0.17.0 (exclusive) this also bundled the funding settled
+   * on the user's pre-existing position; from v0.17.0 (inclusive)
+   * onward, that funding component is reported separately as
+   * `realized_funding`.
+   */
   realized_pnl: string;
+  /**
+   * Funding settled on the user's pre-existing position immediately
+   * before this fill. `null` for trades executed before v0.17.0 —
+   * funding was reported as part of `realized_pnl` prior to that
+   * release.
+   */
+  realized_funding?: string | null;
   fee: string;
   /**
    * Identifier shared between the two `OrderFilled` events of a single
@@ -123,7 +137,23 @@ export type LiquidatedData = {
   pair_id: string;
   adl_size: string;
   adl_price: string | null;
+  /**
+   * Closing PnL realized by the liquidated user from ADL fills,
+   * accumulated across all counter-party fills for this pair. Prior to
+   * v0.17.0 (exclusive) this also bundled the funding settled on the
+   * user's position immediately before each ADL fill; from v0.17.0
+   * (inclusive) onward, that funding component is reported separately
+   * as `adl_realized_funding`.
+   */
   adl_realized_pnl: string;
+  /**
+   * Funding settled on the liquidated user's position immediately
+   * before each ADL fill, accumulated across all counter-party fills
+   * for this pair. `null` for liquidations executed before v0.17.0 —
+   * funding was reported as part of `adl_realized_pnl` prior to that
+   * release.
+   */
+  adl_realized_funding?: string | null;
 };
 
 export type DeleveragedData = {
@@ -131,7 +161,21 @@ export type DeleveragedData = {
   pair_id: string;
   closing_size: string;
   fill_price: string;
+  /**
+   * Closing PnL realized by the counter-party from this ADL fill.
+   * Prior to v0.17.0 (exclusive) this also bundled the funding settled
+   * on the counter-party's pre-existing position immediately before
+   * the fill; from v0.17.0 (inclusive) onward, that funding component
+   * is reported separately as `realized_funding`.
+   */
   realized_pnl: string;
+  /**
+   * Funding settled on the counter-party's pre-existing position
+   * immediately before this ADL fill. `null` for ADL fills executed
+   * before v0.17.0 — funding was reported as part of `realized_pnl`
+   * prior to that release.
+   */
+  realized_funding?: string | null;
 };
 
 export type PerpsEvent = {


### PR DESCRIPTION
Up to this point, realized funding payment is lumped into a `realized_pnl` term in `OrderFilled`, `Liquidated`, and `Deleveraged` events. This PR splits it out to a separate field, so that the frontend can display more fine-grained data to users.