### PR TITLE
feat(indexer): add volume_usd column to perps_fees

### DIFF
--- a/dango/indexer/clickhouse/src/entities/perps_fees.rs
+++ b/dango/indexer/clickhouse/src/entities/perps_fees.rs
@@ -43,6 +43,16 @@ pub struct PerpsFees {
     /// suffices per-block; aggregate queries widen to `u64` to avoid
     /// overflow across long windows.
     pub fee_events_count: u32,
+    /// USD notional volume from `OrderFilled` and `Deleveraged` events in
+    /// this block, summed across all pairs. `OrderFilled` is counted only
+    /// for the positive-sized side of each match (the maker/taker pair
+    /// shares one `fill_id`). `Deleveraged` is counted unconditionally
+    /// (one event per ADL counter-party, no double-emission).
+    /// `Liquidated.adl_size` is intentionally excluded — its magnitude
+    /// already equals the sum of `Deleveraged.closing_size` for the same
+    /// liquidation, so counting both would double the ADL contribution.
+    #[serde(with = "crate::entities::pair_price::dec")]
+    pub volume_usd: Udec128_6,
 }
 
 #[cfg(feature = "async-graphql")]
@@ -57,6 +67,8 @@ struct FeesAggregateRow {
     #[serde(with = "dec")]
     referrer_payout: Udec128_6,
     fee_events_count: u64,
+    #[serde(with = "dec")]
+    volume_usd: Udec128_6,
 }
 
 /// Aggregated fee/revenue totals over a `[from, to]` window.
@@ -78,6 +90,8 @@ pub struct PerpsFeesAndRevenue {
     pub referrer_payout: Udec128_6,
     #[graphql(name = "feeEventsCount")]
     pub fee_events_count: u64,
+    #[graphql(skip)]
+    pub volume_usd: Udec128_6,
 }
 
 #[cfg(feature = "async-graphql")]
@@ -111,7 +125,8 @@ impl PerpsFeesAndRevenue {
                     toUInt128(sum(vault_fee))       AS vault_fee,
                     toUInt128(sum(referee_rebate))  AS referee_rebate,
                     toUInt128(sum(referrer_payout)) AS referrer_payout,
-                    toUInt64(sum(fee_events_count)) AS fee_events_count
+                    toUInt64(sum(fee_events_count)) AS fee_events_count,
+                    toUInt128(sum(volume_usd))      AS volume_usd
                 FROM perps_fees
                 WHERE created_at >= fromUnixTimestamp64Micro(?)
                   AND created_at <= fromUnixTimestamp64Micro(?)
@@ -123,7 +138,8 @@ impl PerpsFeesAndRevenue {
                     toUInt128(sum(vault_fee))       AS vault_fee,
                     toUInt128(sum(referee_rebate))  AS referee_rebate,
                     toUInt128(sum(referrer_payout)) AS referrer_payout,
-                    toUInt64(sum(fee_events_count)) AS fee_events_count
+                    toUInt64(sum(fee_events_count)) AS fee_events_count,
+                    toUInt128(sum(volume_usd))      AS volume_usd
                 FROM perps_fees_hourly
                 WHERE hour >= toStartOfHour(fromUnixTimestamp64Micro(?))
                   AND hour <= toStartOfHour(fromUnixTimestamp64Micro(?))
@@ -145,6 +161,7 @@ impl PerpsFeesAndRevenue {
             referee_rebate: row.referee_rebate,
             referrer_payout: row.referrer_payout,
             fee_events_count: row.fee_events_count,
+            volume_usd: row.volume_usd,
         })
     }
 }
@@ -177,6 +194,10 @@ impl PerpsFeesAndRevenue {
     async fn referrer_payout(&self) -> GraphqlBigDecimal {
         udec128_6_to_big_decimal(&self.referrer_payout)
     }
+
+    async fn volume_usd(&self) -> GraphqlBigDecimal {
+        udec128_6_to_big_decimal(&self.volume_usd)
+    }
 }
 
 #[cfg(feature = "async-graphql")]
@@ -184,4 +205,36 @@ fn udec128_6_to_big_decimal(v: &Udec128_6) -> GraphqlBigDecimal {
     let inner_value = v.inner();
     let bigint = BigInt::from(*inner_value);
     BigDecimal::new(bigint, 6).normalized().into()
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {super::*, chrono::SubsecRound, grug::NumberConst};
+
+    /// Round-trip the row through serde with the ClickHouse-shaped
+    /// adapters (`UInt128 ↔ Udec128_6`) to guard against accidental
+    /// breakage of the wire format when fields are added.
+    #[test]
+    fn serde_perps_fees_roundtrip_with_volume_usd() {
+        let row = PerpsFees {
+            block_height: 42,
+            // CI sometimes reports nanoseconds (9), local micros (6); truncate
+            // to the precision actually stored by ClickHouse.
+            created_at: Utc::now().trunc_subsecs(6),
+            protocol_fee: Udec128_6::MAX,
+            vault_fee: Udec128_6::MAX,
+            referee_rebate: Udec128_6::MAX,
+            referrer_payout: Udec128_6::MAX,
+            fee_events_count: 7,
+            volume_usd: Udec128_6::MAX,
+        };
+
+        let serialized = serde_json::to_string(&row).unwrap();
+        let mut deserialized: PerpsFees = serde_json::from_str(&serialized).unwrap();
+        deserialized.created_at = deserialized.created_at.trunc_subsecs(6);
+
+        assert_eq!(row, deserialized);
+    }
 }

--- a/dango/indexer/clickhouse/src/indexer/perps_fees.rs
+++ b/dango/indexer/clickhouse/src/indexer/perps_fees.rs
@@ -6,11 +6,14 @@ use {
         indexer::Indexer,
     },
     chrono::{DateTime, Utc},
-    dango_types::{UsdValue, perps::FeeDistributed},
+    dango_types::{
+        Quantity, UsdPrice, UsdValue,
+        perps::{Deleveraged, FeeDistributed, OrderFilled},
+    },
     grug::{
         Addr, BlockAndBlockOutcomeWithHttpDetails, CommitmentStatus, EventName, EventStatus,
-        EvtCron, FlatCommitmentStatus, FlatEvent, FlatEventInfo, FlatEventStatus, JsonDeExt,
-        NaiveFlatten, Number as _, NumberConst, SearchEvent, Signed, Udec128_6,
+        EvtCron, FlatCommitmentStatus, FlatEvent, FlatEventInfo, FlatEventStatus, IsZero,
+        JsonDeExt, NaiveFlatten, Number as _, NumberConst, SearchEvent, Sign, Signed, Udec128_6,
     },
 };
 
@@ -58,12 +61,17 @@ impl Indexer {
 
                 if contract_event.ty == FeeDistributed::EVENT_NAME {
                     process_fee_distributed(contract_event, &mut acc, block_height);
+                } else if contract_event.ty == OrderFilled::EVENT_NAME {
+                    process_order_filled(contract_event, &mut acc, block_height);
+                } else if contract_event.ty == Deleveraged::EVENT_NAME {
+                    process_deleveraged(contract_event, &mut acc, block_height);
                 }
             }
         }
 
         // End-of-block cron: the usual path where the perps settlement emits
-        // `FeeDistributed` for matched / liquidated fills.
+        // `FeeDistributed` / `OrderFilled` / `Deleveraged` for matched,
+        // liquidated, and ADL fills.
         for outcome in &block_and_block_outcome.block_outcome.cron_outcomes {
             let CommitmentStatus::Committed(EventStatus::Ok(EvtCron {
                 guest_event: EventStatus::Ok(ref event),
@@ -93,11 +101,20 @@ impl Indexer {
 
                 if contract_event.ty == FeeDistributed::EVENT_NAME {
                     process_fee_distributed(contract_event, &mut acc, block_height);
+                } else if contract_event.ty == OrderFilled::EVENT_NAME {
+                    process_order_filled(contract_event, &mut acc, block_height);
+                } else if contract_event.ty == Deleveraged::EVENT_NAME {
+                    process_deleveraged(contract_event, &mut acc, block_height);
                 }
             }
         }
 
-        if acc.count == 0 {
+        // Insert a row whenever the block had any fee activity OR any
+        // perps trading volume. Vault-fill blocks emit `OrderFilled` with
+        // `fee = 0` and no `FeeDistributed`, and ADL-only blocks emit
+        // `Deleveraged` with no `FeeDistributed` either; both still carry
+        // real volume and need to be captured.
+        if acc.count == 0 && acc.volume_usd.is_zero() {
             return Ok(());
         }
 
@@ -123,6 +140,7 @@ impl Indexer {
             referee_rebate: acc.referee_rebate,
             referrer_payout: acc.referrer_payout,
             fee_events_count: acc.count,
+            volume_usd: acc.volume_usd,
         };
 
         let clickhouse_client = context.clickhouse_client().clone();
@@ -159,6 +177,10 @@ struct FeesAccumulator {
     referee_rebate: Udec128_6,
     referrer_payout: Udec128_6,
     count: u32,
+    /// Sum of `|fill_size| × |fill_price|` across all `OrderFilled` (one
+    /// side per match) and `Deleveraged` events in the block, across all
+    /// pairs.
+    volume_usd: Udec128_6,
 }
 
 fn process_fee_distributed(
@@ -249,6 +271,158 @@ fn process_fee_distributed(
     acc.count = acc.count.saturating_add(1);
 }
 
+/// Add `|fill_size| × |fill_price|` from an `OrderFilled` event to the
+/// block's `volume_usd` accumulator. Each order-book match emits two
+/// events sharing one `fill_id` with opposite signs; we count only the
+/// positive side to avoid double-counting. Same convention as
+/// `perps_candles/mod.rs::process_order_filled`.
+fn process_order_filled(
+    contract_event: &grug_types::CheckedContractEvent,
+    acc: &mut FeesAccumulator,
+    #[cfg_attr(not(feature = "tracing"), allow(unused_variables))] block_height: u64,
+) {
+    let event: OrderFilled = match contract_event.data.clone().deserialize_json() {
+        Ok(e) => e,
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                block_height,
+                err = %_err,
+                "Failed to deserialize OrderFilled event; skipping"
+            );
+            return;
+        },
+    };
+
+    if event.fill_size.is_negative() {
+        return;
+    }
+
+    accumulate_volume_usd(
+        event.fill_size,
+        event.fill_price,
+        acc,
+        block_height,
+        "order_filled",
+    );
+}
+
+/// Add `|closing_size| × |fill_price|` from a `Deleveraged` event (one per
+/// ADL counter-party hit, never duplicated). The signed magnitude is
+/// taken absolute since `Deleveraged.closing_size` carries the
+/// counter-party's reduction sign — equal in magnitude to the liquidated
+/// user's slice but opposite in direction.
+///
+/// We deliberately do NOT also accumulate from `Liquidated.adl_size`:
+/// `Σ Deleveraged.closing_size` for a liquidation already equals
+/// `Liquidated.adl_size`, so summing both would double-count the ADL
+/// contribution.
+fn process_deleveraged(
+    contract_event: &grug_types::CheckedContractEvent,
+    acc: &mut FeesAccumulator,
+    #[cfg_attr(not(feature = "tracing"), allow(unused_variables))] block_height: u64,
+) {
+    let event: Deleveraged = match contract_event.data.clone().deserialize_json() {
+        Ok(e) => e,
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                block_height,
+                err = %_err,
+                "Failed to deserialize Deleveraged event; skipping"
+            );
+            return;
+        },
+    };
+
+    accumulate_volume_usd(
+        event.closing_size,
+        event.fill_price,
+        acc,
+        block_height,
+        "deleveraged",
+    );
+}
+
+/// Compute `|size| × |price|` and fold it into the block accumulator.
+/// Any conversion or arithmetic failure is logged and the event is
+/// dropped rather than corrupting the aggregate by wrapping.
+#[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+fn accumulate_volume_usd(
+    size: Quantity,
+    price: UsdPrice,
+    acc: &mut FeesAccumulator,
+    block_height: u64,
+    event_name: &'static str,
+) {
+    let size_abs = match size
+        .into_inner()
+        .checked_abs()
+        .and_then(|v| v.checked_into_unsigned())
+    {
+        Ok(v) => v,
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                block_height,
+                event = event_name,
+                err = %_err,
+                "Failed to take |size| for volume_usd; skipping event"
+            );
+            #[cfg(feature = "metrics")]
+            metrics::counter!("indexer.clickhouse.perps_fees.overflow.total").increment(1);
+            return;
+        },
+    };
+
+    let price_abs = match price
+        .into_inner()
+        .checked_abs()
+        .and_then(|v| v.checked_into_unsigned())
+    {
+        Ok(v) => v,
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                block_height,
+                event = event_name,
+                err = %_err,
+                "Failed to take |price| for volume_usd; skipping event"
+            );
+            #[cfg(feature = "metrics")]
+            metrics::counter!("indexer.clickhouse.perps_fees.overflow.total").increment(1);
+            return;
+        },
+    };
+
+    let volume_usd = match size_abs.checked_mul(price_abs) {
+        Ok(v) => v,
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                block_height,
+                event = event_name,
+                err = %_err,
+                "volume_usd overflow on |size| * |price|; skipping event"
+            );
+            #[cfg(feature = "metrics")]
+            metrics::counter!("indexer.clickhouse.perps_fees.overflow.total").increment(1);
+            return;
+        },
+    };
+
+    if acc.volume_usd.checked_add_assign(volume_usd).is_err() {
+        #[cfg(feature = "tracing")]
+        tracing::error!(
+            block_height,
+            event = event_name,
+            "perps_fees block volume_usd accumulator overflowed; skipping event"
+        );
+        #[cfg(feature = "metrics")]
+        metrics::counter!("indexer.clickhouse.perps_fees.overflow.total").increment(1);
+    }
+}
+
 /// Convert a signed `UsdValue` to `Udec128_6`, enforcing the contract's
 /// non-negativity invariant. A negative value indicates a contract-side bug
 /// (param validation allowed `taker_fee + maker_fee < 0` or a fee-rate outside
@@ -292,4 +466,151 @@ fn to_non_negative(
             );
         })
         .ok()
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        dango_types::{Quantity, UsdPrice, UsdValue, perps::PairId},
+        grug::{Denom, Uint64},
+        std::str::FromStr,
+    };
+
+    fn perp_pair() -> PairId {
+        Denom::from_str("perp/btcusd").unwrap()
+    }
+
+    fn order_filled_event(fill_size_int: i128, fill_price_int: i128) -> OrderFilled {
+        OrderFilled {
+            order_id: Uint64::new(1),
+            pair_id: perp_pair(),
+            user: Addr::mock(1),
+            fill_price: UsdPrice::new_int(fill_price_int),
+            fill_size: Quantity::new_int(fill_size_int),
+            closing_size: Quantity::new_int(0),
+            opening_size: Quantity::new_int(fill_size_int),
+            realized_pnl: UsdValue::new_int(0),
+            realized_funding: Some(UsdValue::new_int(0)),
+            fee: UsdValue::new_int(0),
+            client_order_id: None,
+            fill_id: Some(Uint64::new(42)),
+            is_maker: Some(false),
+        }
+    }
+
+    fn deleveraged_event(closing_size_int: i128, fill_price_int: i128) -> Deleveraged {
+        Deleveraged {
+            user: Addr::mock(2),
+            pair_id: perp_pair(),
+            closing_size: Quantity::new_int(closing_size_int),
+            fill_price: UsdPrice::new_int(fill_price_int),
+            realized_pnl: UsdValue::new_int(0),
+            realized_funding: Some(UsdValue::new_int(0)),
+        }
+    }
+
+    fn checked_event<T: serde::Serialize>(ty: &str, data: &T) -> grug_types::CheckedContractEvent {
+        grug_types::CheckedContractEvent::new(Addr::mock(0), ty, data).unwrap()
+    }
+
+    fn expected_volume(size: i128, price: i128) -> Udec128_6 {
+        // Both inputs are integer values stored at scale 10^6, so the
+        // accumulator's Udec128_6 raw value (also at scale 10^6) is
+        // size * price * 10^6.
+        let raw = size
+            .unsigned_abs()
+            .checked_mul(price.unsigned_abs())
+            .unwrap()
+            .checked_mul(1_000_000)
+            .unwrap();
+        Udec128_6::raw(grug::Uint128::new(raw))
+    }
+
+    /// `OrderFilled` events come in pairs (maker/taker) sharing one
+    /// `fill_id` but with opposite `fill_size` signs. We must count only
+    /// the positive side to avoid double-counting volume.
+    #[test]
+    fn order_filled_skips_negative_side() {
+        let mut acc = FeesAccumulator::default();
+
+        process_order_filled(
+            &checked_event("order_filled", &order_filled_event(10, 50_000)),
+            &mut acc,
+            1,
+        );
+        process_order_filled(
+            &checked_event("order_filled", &order_filled_event(-10, 50_000)),
+            &mut acc,
+            1,
+        );
+
+        assert_eq!(acc.volume_usd, expected_volume(10, 50_000));
+        assert_eq!(acc.count, 0); // OrderFilled does not bump fee_events_count
+    }
+
+    /// Multiple `OrderFilled` events on the positive side should sum.
+    #[test]
+    fn order_filled_accumulates_across_fills() {
+        let mut acc = FeesAccumulator::default();
+
+        process_order_filled(
+            &checked_event("order_filled", &order_filled_event(10, 50_000)),
+            &mut acc,
+            1,
+        );
+        process_order_filled(
+            &checked_event("order_filled", &order_filled_event(5, 60_000)),
+            &mut acc,
+            1,
+        );
+
+        let expected = expected_volume(10, 50_000)
+            .checked_add(expected_volume(5, 60_000))
+            .unwrap();
+        assert_eq!(acc.volume_usd, expected);
+    }
+
+    /// `Deleveraged` is emitted once per ADL counter-party hit. There is
+    /// no two-sided sibling event, so we count both positive and negative
+    /// `closing_size` magnitudes.
+    #[test]
+    fn deleveraged_counts_both_signs() {
+        let mut acc = FeesAccumulator::default();
+
+        process_deleveraged(
+            &checked_event("deleveraged", &deleveraged_event(7, 30_000)),
+            &mut acc,
+            1,
+        );
+        process_deleveraged(
+            &checked_event("deleveraged", &deleveraged_event(-3, 30_000)),
+            &mut acc,
+            1,
+        );
+
+        let expected = expected_volume(7, 30_000)
+            .checked_add(expected_volume(3, 30_000))
+            .unwrap();
+        assert_eq!(acc.volume_usd, expected);
+    }
+
+    /// Deserialization failures must not panic and must not mutate the
+    /// accumulator — they only log/warn.
+    #[test]
+    fn malformed_event_payload_is_ignored() {
+        let mut acc = FeesAccumulator::default();
+        let bogus = grug_types::CheckedContractEvent::new(
+            Addr::mock(0),
+            "order_filled",
+            serde_json::json!({"not": "an OrderFilled"}),
+        )
+        .unwrap();
+
+        process_order_filled(&bogus, &mut acc, 1);
+
+        assert_eq!(acc.volume_usd, Udec128_6::ZERO);
+    }
 }

--- a/dango/indexer/clickhouse/src/migrations/perps_fees.rs
+++ b/dango/indexer/clickhouse/src/migrations/perps_fees.rs
@@ -6,7 +6,8 @@ pub const PERPS_FEES_TABLE: &str = r#"
     vault_fee UInt128,
     referee_rebate UInt128,
     referrer_payout UInt128,
-    fee_events_count UInt32
+    fee_events_count UInt32,
+    volume_usd UInt128 DEFAULT 0
   ) ENGINE = MergeTree()
   PARTITION BY toYYYYMM(created_at)
   ORDER BY (created_at, block_height)
@@ -23,10 +24,35 @@ pub const PERPS_FEES_HOURLY_TABLE: &str = r#"
     vault_fee UInt128,
     referee_rebate UInt128,
     referrer_payout UInt128,
-    fee_events_count UInt64
+    fee_events_count UInt64,
+    volume_usd UInt128 DEFAULT 0
   ) ENGINE = SummingMergeTree()
   PARTITION BY toYYYYMM(hour)
   ORDER BY hour
+"#;
+
+/// Idempotent column add for existing deployments. No-op on fresh installs
+/// (the `CREATE TABLE` strings above already include `volume_usd`). Existing
+/// rows get the `DEFAULT 0` value — long-range queries that span the
+/// migration boundary therefore under-report volume; backfill is out of
+/// scope and would be a separate one-shot SQL job against
+/// `perps_pair_prices`.
+pub const PERPS_FEES_ADD_VOLUME_USD: &str = r#"
+  ALTER TABLE perps_fees ADD COLUMN IF NOT EXISTS volume_usd UInt128 DEFAULT 0
+"#;
+
+pub const PERPS_FEES_HOURLY_ADD_VOLUME_USD: &str = r#"
+  ALTER TABLE perps_fees_hourly ADD COLUMN IF NOT EXISTS volume_usd UInt128 DEFAULT 0
+"#;
+
+/// `CREATE MATERIALIZED VIEW IF NOT EXISTS` won't update the projection of
+/// an existing MV, so for evolving schemas we drop and recreate the
+/// trigger view (the underlying `perps_fees_hourly` table is preserved —
+/// the MV is only an INSERT trigger and holds no data). The drop is safe
+/// because migrations run inside `Indexer::start()` *before* indexing
+/// begins, so no block writes race the gap.
+pub const PERPS_FEES_HOURLY_MV_DROP: &str = r#"
+  DROP VIEW IF EXISTS perps_fees_hourly_mv
 "#;
 
 /// Trigger-style materialized view: each INSERT into `perps_fees` is
@@ -43,7 +69,8 @@ pub const PERPS_FEES_HOURLY_MV: &str = r#"
     vault_fee,
     referee_rebate,
     referrer_payout,
-    toUInt64(fee_events_count) AS fee_events_count
+    toUInt64(fee_events_count) AS fee_events_count,
+    volume_usd
   FROM perps_fees
 "#;
 
@@ -51,6 +78,9 @@ pub fn migrations() -> Vec<String> {
     vec![
         PERPS_FEES_TABLE.to_string(),
         PERPS_FEES_HOURLY_TABLE.to_string(),
+        PERPS_FEES_ADD_VOLUME_USD.to_string(),
+        PERPS_FEES_HOURLY_ADD_VOLUME_USD.to_string(),
+        PERPS_FEES_HOURLY_MV_DROP.to_string(),
         PERPS_FEES_HOURLY_MV.to_string(),
     ]
 }

--- a/sdk/rust/src/schemas/schema.graphql
+++ b/sdk/rust/src/schemas/schema.graphql
@@ -533,6 +533,7 @@ type PerpsFeesAndRevenue {
 	vaultFee: BigDecimal!
 	refereeRebate: BigDecimal!
 	referrerPayout: BigDecimal!
+	volumeUsd: BigDecimal!
 }
 
 """


### PR DESCRIPTION
## Summary

- Adds `volume_usd UInt128` column to ClickHouse `perps_fees` (per-block) and `perps_fees_hourly` (SummingMergeTree) — total perps trading notional in USD, summed across all pairs.
- The `perpsFeesAndRevenue` GraphQL query now exposes the field as `volumeUsd` (BigDecimal at scale 10⁻⁶), reusing the existing adaptive routing (per-block table for ranges < 3 days, hourly MV otherwise).
- Volume is populated in the existing `Indexer::store_perps_fees` `post_indexing` hook from two event sources:
  - `OrderFilled`: only the positive-`fill_size` side of each match is counted (the maker/taker pair shares one `fill_id` with opposite signs — same convention as `perps_candles/mod.rs::process_order_filled`, avoids double-count).
  - `Deleveraged`: counted unconditionally (one event per ADL counter-party). `Liquidated.adl_size` is intentionally **not** counted because its magnitude equals the sum of `Deleveraged.closing_size` for the same liquidation.
- The block-row insertion gate now triggers on either fee activity or volume (so vault-fill blocks with fee=0 and ADL-only blocks are captured).
- The materialized view is recreated (`DROP VIEW IF EXISTS` + `CREATE MATERIALIZED VIEW IF NOT EXISTS`) inside `Indexer::start()` migrations, before indexing begins, to project the new column.

## Validation

### Completed
- [x] `cargo check -p dango-indexer-clickhouse --all-features`
- [x] `cargo clippy -p dango-indexer-clickhouse --all-features --tests -- -D warnings`
- [x] `cargo test -p dango-indexer-clickhouse --all-features` (28/28 pass, including 5 new unit tests):
  - serde round-trip for `PerpsFees` with `volume_usd`
  - `OrderFilled` skips negative-size side (no double-count)
  - `OrderFilled` accumulates positive-side fills across multiple events
  - `Deleveraged` counts both signs (no skip)
  - malformed event JSON does not panic and leaves the accumulator untouched

### Remaining
- [ ] Smoke test on devnet/local: execute perps trades on ≥ 2 pairs, query `perpsFeesAndRevenue`, cross-check `volumeUsd` against `SUM(volume_usd) FROM perps_pair_prices` for the same window (must coincide; ADL contributions appear only in `volumeUsd`).
- [ ] Long-range smoke (> 3 days) to verify the hourly MV projection.
- [ ] Liquidation/ADL scenario to confirm `Deleveraged` volume is captured in `volumeUsd` but not in `perps_pair_prices`.

## Manual QA

1. Bring up devnet with the indexer: `pnpm dev:portal-web` (or equivalent local stack with ClickHouse).
2. Submit a few perps orders on at least two distinct pairs and let them match.
3. Query GraphQL:
   ```graphql
   { perpsFeesAndRevenue(from: "...", to: "...") { volumeUsd protocolFee vaultFee } }
   ```
4. Independently verify against `perps_pair_prices`:
   ```sql
   SELECT toUInt128(sum(volume_usd)) FROM perps_pair_prices
   WHERE created_at BETWEEN ? AND ?;
   ```
   The two should match modulo any ADL contributions.

## Notes / out of scope

- Existing rows in `perps_fees` and `perps_fees_hourly` get `volume_usd = 0` via `DEFAULT 0` (idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`). Queries spanning the migration boundary will under-report; a one-shot backfill from `perps_pair_prices` is left as a follow-up.
- The MV `DROP`+`CREATE` runs on every startup. It's safe (the underlying SummingMergeTree table is preserved; migrations run inside `start()` before indexing begins, so no block writes race the gap), but introducing versioned migrations would avoid the per-restart churn — also a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)