### PR TITLE
fix(perps): drop fee share ratio precondition for referrers

### DIFF
--- a/dango/perps/src/referral/apply_fee_commissions.rs
+++ b/dango/perps/src/referral/apply_fee_commissions.rs
@@ -12,7 +12,9 @@ use {
     dango_types::{
         UsdValue,
         account_factory::UserIndex,
-        perps::{FeeDistributed, Param, Referee, Referrer, ReferrerSettings, UserState},
+        perps::{
+            FeeDistributed, FeeShareRatio, Param, Referee, Referrer, ReferrerSettings, UserState,
+        },
     },
     grug::{Addr, EventBuilder, QuerierWrapper, StdResult, Storage, Timestamp},
     std::collections::BTreeMap,
@@ -267,7 +269,10 @@ pub fn apply_fee_commissions(
 }
 
 /// Look up or compute referrer settings for a user, with caching.
-/// N.B. This function assumes the user is a valid referrer (has set a fee share ratio).
+///
+/// A user with no `FEE_SHARE_RATIO` entry defaults to zero — the referrer
+/// receives the full post-protocol commission, and the referee gets no
+/// rebate.
 fn compute_referrer_settings(
     storage: &dyn Storage,
     user: UserIndex,
@@ -281,7 +286,9 @@ fn compute_referrer_settings(
 
     let commission_rate = calculate_commission_rate(storage, user, block_timestamp, param)?;
 
-    let share_ratio = FEE_SHARE_RATIO.load(storage, user)?;
+    let share_ratio = FEE_SHARE_RATIO
+        .may_load(storage, user)?
+        .unwrap_or(FeeShareRatio::ZERO);
 
     let settings = ReferrerSettings {
         commission_rate,

--- a/dango/perps/src/referral/set_referral.rs
+++ b/dango/perps/src/referral/set_referral.rs
@@ -2,10 +2,7 @@ use {
     crate::{
         account_factory,
         referral::load_referral_data,
-        state::{
-            FEE_SHARE_RATIO, REFEREE_TO_REFERRER, REFERRER_TO_REFEREE_STATISTICS,
-            USER_REFERRAL_DATA,
-        },
+        state::{REFEREE_TO_REFERRER, REFERRER_TO_REFEREE_STATISTICS, USER_REFERRAL_DATA},
         volume::round_to_day,
     },
     anyhow::ensure,
@@ -53,12 +50,6 @@ pub fn set_referral(
         );
     }
 
-    // The referrer must have a share ratio set (i.e. has opted in as a referrer).
-    ensure!(
-        FEE_SHARE_RATIO.has(ctx.storage, referrer),
-        "referrer {referrer} has no fee share ratio set"
-    );
-
     // The referral relationship is immutable once set.
     ensure!(
         !REFEREE_TO_REFERRER.has(ctx.storage, referee),
@@ -93,6 +84,7 @@ pub fn set_referral(
 mod tests {
     use {
         super::*,
+        crate::state::FEE_SHARE_RATIO,
         dango_types::{
             account_factory::Account,
             config::{AppAddresses, AppConfig},
@@ -230,18 +222,26 @@ mod tests {
         );
     }
 
-    /// The owner branch is still subject to the referrer-opt-in requirement.
+    /// A user can be assigned as a referrer even when they have not chosen
+    /// a fee share ratio — the missing ratio defaults to zero in
+    /// `apply_fee_commissions`.
     #[test]
-    fn referrer_without_fee_share_ratio_rejected() {
+    fn referrer_without_fee_share_ratio_accepted() {
         let mut ctx = MockContext::new()
             .with_querier(base_querier())
             .with_sender(OWNER)
-            .with_funds(Coins::default());
+            .with_funds(Coins::default())
+            .with_block_timestamp(BLOCK_TIME);
 
-        // Deliberately do NOT seed FEE_SHARE_RATIO.
+        // Deliberately do NOT seed FEE_SHARE_RATIO — the relationship should
+        // still be created.
 
-        set_referral(ctx.as_mutable(), REFERRER, REFEREE)
-            .should_fail_with_error("has no fee share ratio set");
+        set_referral(ctx.as_mutable(), REFERRER, REFEREE).should_succeed();
+
+        assert_eq!(
+            REFEREE_TO_REFERRER.load(&ctx.storage, REFEREE).unwrap(),
+            REFERRER,
+        );
     }
 
     /// Immutability still applies to the owner branch: a referee with an

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -229,12 +229,14 @@ fn referral_self_refer_fails() {
         .should_fail_with_error("a user cannot refer themselves");
 }
 
-/// A referral cannot be set if the referrer has no fee share ratio.
+/// A user can be assigned as a referrer even without choosing a fee share
+/// ratio. The missing ratio defaults to zero — the referrer receives the
+/// full post-protocol commission, and the referee gets no rebate.
 #[test]
-fn referral_without_share_ratio_fails() {
+fn referral_without_share_ratio_succeeds() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    // User1 has NOT set a share ratio. Trying to set User1 as referrer should fail.
+    // User1 has NOT set a share ratio. The relationship should still be saved.
     suite
         .execute(
             &mut accounts.user2,
@@ -245,7 +247,130 @@ fn referral_without_share_ratio_fails() {
             }),
             Coins::new(),
         )
-        .should_fail_with_error("referrer 1 has no fee share ratio set");
+        .should_succeed();
+
+    assert_eq!(
+        suite
+            .query_wasm_smart(contracts.perps, perps::QueryReferrerRequest { referee: 2 })
+            .should_succeed(),
+        Some(1),
+    );
+}
+
+/// Regression: a referrer who never opted into a fee share ratio still
+/// receives commissions on referee fills. The missing ratio defaults to zero,
+/// so the referrer gets the full post-protocol commission and the referee
+/// gets no rebate.
+#[test]
+fn referrer_without_share_ratio_receives_full_commission() {
+    let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
+
+    // Set protocol fee to 50% for predictable splits.
+    let mut param: perps::Param = suite
+        .query_wasm_smart(contracts.perps, perps::QueryParamRequest {})
+        .should_succeed();
+    param.protocol_fee_rate = Dimensionless::new_percent(50);
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param,
+                pair_params: Default::default(),
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000);
+
+    // User1 is set as User2's referrer — without setting a fee share ratio.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetReferral {
+                referrer: 1,
+                referee: 2,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Pin the commission rate for deterministic math; this also bypasses the
+    // volume requirement that would otherwise apply to user1.
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetCommissionRateOverride {
+                user: 1,
+                commission_rate: Op::Insert(CommissionRate::new_percent(50)),
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let user1_addr = accounts.user1.address();
+    let pre: perps::UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: user1_addr,
+        })
+        .should_succeed()
+        .expect("user1 should have a UserState after deposit");
+
+    place_ask_order(
+        &mut suite,
+        contracts.perps,
+        &mut accounts.user8,
+        UsdPrice::new_int(2_000),
+        1,
+    );
+    let events = place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1);
+
+    // Notional = $2,000. Taker fee = 0.1% = $2.
+    // protocol_fee = $2 × 50% = $1. vault_fee (before commissions) = $1.
+    // commission_rate = 50%, share_ratio = 0% (defaulted because user1 never set one).
+    // total_commission = $1 × 50% = $0.50
+    // referee_share    = $0.50 × 0% = $0
+    // referrer_share   = $0.50 − $0 = $0.50
+    let expected_referee_share = UsdValue::ZERO;
+    let expected_referrer_share = UsdValue::new_int(1)
+        .checked_mul(CommissionRate::new_percent(50))
+        .unwrap();
+
+    let fee_events: Vec<FeeDistributed> = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "fee_distributed")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json().unwrap())
+        .collect();
+
+    let taker_event = fee_events
+        .iter()
+        .find(|e| e.payer_addr == accounts.user2.address())
+        .expect("taker must have a FeeDistributed event");
+
+    assert_eq!(taker_event.commissions.len(), 2);
+    assert_eq!(taker_event.commissions[0], expected_referee_share);
+    assert_eq!(taker_event.commissions[1], expected_referrer_share);
+
+    // User1's UserState margin should have gained the full referrer share.
+    let post: perps::UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: user1_addr,
+        })
+        .should_succeed()
+        .expect("user1 should still have a UserState");
+    assert_eq!(
+        post.margin.checked_sub(pre.margin).unwrap(),
+        expected_referrer_share,
+    );
 }
 
 /// Only the referee (or the account factory) can set the referral relationship.


### PR DESCRIPTION
A user no longer needs to opt into a fee share ratio before being assigned as a referrer. A missing `FEE_SHARE_RATIO` entry defaults to zero in `apply_fee_commissions`: the referrer receives the full post-protocol commission and the referee gets no rebate.