### PR TITLE
feat(perps): add WithdrawFromTreasury maintainer message

### DIFF
--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -171,6 +171,7 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
                 user,
                 maker_taker_fee_rates,
             } => maintain::set_fee_rate_override(ctx, user, maker_taker_fee_rates),
+            MaintainerMsg::WithdrawFromTreasury {} => maintain::withdraw_from_treasury(ctx),
         },
         ExecuteMsg::Trade(msg) => match msg {
             TraderMsg::Deposit { to } => trade::deposit(ctx, to),

--- a/dango/perps/src/maintain.rs
+++ b/dango/perps/src/maintain.rs
@@ -2,5 +2,8 @@ mod configure;
 mod donate;
 mod liquidate;
 mod set_fee_rate_override;
+mod withdraw_from_treasury;
 
-pub use {configure::*, donate::*, liquidate::*, set_fee_rate_override::*};
+pub use {
+    configure::*, donate::*, liquidate::*, set_fee_rate_override::*, withdraw_from_treasury::*,
+};

--- a/dango/perps/src/maintain/withdraw_from_treasury.rs
+++ b/dango/perps/src/maintain/withdraw_from_treasury.rs
@@ -1,0 +1,165 @@
+use {
+    crate::state::{STATE, USER_STATES},
+    anyhow::ensure,
+    dango_types::UsdValue,
+    grug::{MutableCtx, QuerierExt, Response},
+};
+
+/// Move the entire protocol treasury balance into the chain owner's
+/// `UserState.margin`. The owner can then convert it to USDC via the
+/// regular [`TraderMsg::Withdraw`](dango_types::perps::TraderMsg::Withdraw)
+/// flow.
+///
+/// Treasury is internal accounting (`UsdValue`); the actual USDC backing it
+/// already sits in the contract's bank balance. No bank transfer is needed
+/// here — only a state-level credit/debit.
+pub fn withdraw_from_treasury(ctx: MutableCtx) -> anyhow::Result<Response> {
+    let owner = ctx.querier.query_owner()?;
+
+    ensure!(
+        ctx.sender == owner,
+        "you don't have the right, O you don't have the right"
+    );
+
+    let mut state = STATE.load(ctx.storage)?;
+    let amount = state.treasury;
+
+    if amount.is_zero() {
+        return Ok(Response::new());
+    }
+
+    state.treasury = UsdValue::ZERO;
+    STATE.save(ctx.storage, &state)?;
+
+    let mut user_state = USER_STATES
+        .may_load(ctx.storage, owner)?
+        .unwrap_or_default();
+    user_state.margin.checked_add_assign(amount)?;
+    USER_STATES.save(ctx.storage, owner, &user_state)?;
+
+    Ok(Response::new())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        dango_types::perps::{State, UserState},
+        grug::{
+            Addr, Coins, Config, Duration, MockContext, MockQuerier, Permission, Permissions,
+            ResultExt,
+        },
+        std::collections::BTreeMap,
+    };
+
+    const OWNER: Addr = Addr::mock(0);
+    const NON_OWNER: Addr = Addr::mock(1);
+
+    fn mock_config() -> Config {
+        Config {
+            owner: OWNER,
+            bank: Addr::mock(2),
+            taxman: Addr::mock(3),
+            cronjobs: BTreeMap::new(),
+            permissions: Permissions {
+                upload: Permission::Nobody,
+                instantiate: Permission::Nobody,
+            },
+            max_orphan_age: Duration::from_seconds(0),
+        }
+    }
+
+    #[test]
+    fn non_owner_rejected() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(NON_OWNER)
+            .with_funds(Coins::default());
+
+        STATE
+            .save(&mut ctx.storage, &State {
+                treasury: UsdValue::new_int(100),
+                ..Default::default()
+            })
+            .unwrap();
+
+        withdraw_from_treasury(ctx.as_mutable()).should_fail_with_error("you don't have the right");
+    }
+
+    #[test]
+    fn zero_treasury_noop() {
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        STATE.save(&mut ctx.storage, &State::default()).unwrap();
+
+        withdraw_from_treasury(ctx.as_mutable()).should_succeed();
+
+        // Owner's UserState should not have been touched.
+        assert!(USER_STATES.may_load(&ctx.storage, OWNER).unwrap().is_none());
+    }
+
+    #[test]
+    fn owner_withdraws_treasury_succeeds() {
+        let amount = UsdValue::new_int(1_000);
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        STATE
+            .save(&mut ctx.storage, &State {
+                treasury: amount,
+                ..Default::default()
+            })
+            .unwrap();
+
+        withdraw_from_treasury(ctx.as_mutable()).should_succeed();
+
+        // Treasury cleared.
+        let state = STATE.load(&ctx.storage).unwrap();
+        assert_eq!(state.treasury, UsdValue::ZERO);
+
+        // Owner's UserState credited.
+        let user_state = USER_STATES.load(&ctx.storage, OWNER).unwrap();
+        assert_eq!(user_state.margin, amount);
+    }
+
+    #[test]
+    fn owner_withdraws_adds_to_existing_margin() {
+        let prior_margin = UsdValue::new_int(200);
+        let treasury_amount = UsdValue::new_int(500);
+        let mut ctx = MockContext::new()
+            .with_querier(MockQuerier::new().with_config(mock_config()))
+            .with_sender(OWNER)
+            .with_funds(Coins::default());
+
+        STATE
+            .save(&mut ctx.storage, &State {
+                treasury: treasury_amount,
+                ..Default::default()
+            })
+            .unwrap();
+        USER_STATES
+            .save(&mut ctx.storage, OWNER, &UserState {
+                margin: prior_margin,
+                ..Default::default()
+            })
+            .unwrap();
+
+        withdraw_from_treasury(ctx.as_mutable()).should_succeed();
+
+        let state = STATE.load(&ctx.storage).unwrap();
+        assert_eq!(state.treasury, UsdValue::ZERO);
+
+        let user_state = USER_STATES.load(&ctx.storage, OWNER).unwrap();
+        assert_eq!(
+            user_state.margin,
+            prior_margin.checked_add(treasury_amount).unwrap(),
+        );
+    }
+}

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -18,6 +18,7 @@ mod liquidation;
 mod price_band;
 mod referral;
 mod trading;
+mod treasury;
 mod vault;
 mod vault_snapshots;
 mod vault_withdrawal_health;

--- a/dango/testing/tests/perps/treasury.rs
+++ b/dango/testing/tests/perps/treasury.rs
@@ -1,0 +1,183 @@
+use {
+    crate::{default_pair_param, default_param, register_oracle_prices},
+    dango_testing::{TestOption, perps::pair_id, setup_test_naive},
+    dango_types::{
+        Dimensionless, Quantity, UsdPrice, UsdValue,
+        constants::usdc,
+        perps::{self, Param},
+    },
+    grug::{Addressable, Coins, NumberConst, QuerierExt, ResultExt, Uint128, btree_map},
+};
+
+/// Drive a couple of fills with `protocol_fee_rate = 20%` to seed the treasury,
+/// then exercise `MaintainerMsg::WithdrawFromTreasury`. Verify the treasury
+/// drains to zero, the owner's `UserState.margin` gains the previous treasury
+/// balance, and a follow-up `TraderMsg::Withdraw` round-trips USDC out of the
+/// contract.
+#[test]
+fn treasury_withdrawal_works() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+
+    let pair = pair_id();
+
+    // Configure: set protocol_fee_rate = 20%.
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: Param {
+                    protocol_fee_rate: Dimensionless::new_percent(20),
+                    ..default_param()
+                },
+                pair_params: btree_map! {
+                    pair.clone() => default_pair_param(),
+                },
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Deposit margin for maker (user2) and taker (user1).
+    for user in [&mut accounts.user2, &mut accounts.user1] {
+        suite
+            .execute(
+                user,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+                Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+            )
+            .should_succeed();
+    }
+
+    // Two fills of 10 ETH @ $2,000 each. Per-fill fee = 10 * $2,000 * 0.1% = $20,
+    // protocol cut = 20% = $4. After both fills, treasury == $8.
+    for _ in 0..2 {
+        suite
+            .execute(
+                &mut accounts.user2,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(
+                    perps::SubmitOrderRequest {
+                        pair_id: pair.clone(),
+                        size: Quantity::new_int(-10),
+                        kind: perps::OrderKind::Limit {
+                            limit_price: UsdPrice::new_int(2_000),
+                            time_in_force: perps::TimeInForce::PostOnly,
+                            client_order_id: None,
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
+                    },
+                )),
+                Coins::new(),
+            )
+            .should_succeed();
+
+        suite
+            .execute(
+                &mut accounts.user1,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(
+                    perps::SubmitOrderRequest {
+                        pair_id: pair.clone(),
+                        size: Quantity::new_int(10),
+                        kind: perps::OrderKind::Market {
+                            max_slippage: Dimensionless::new_percent(50),
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
+                    },
+                )),
+                Coins::new(),
+            )
+            .should_succeed();
+    }
+
+    let pre_state: perps::State = suite
+        .query_wasm_smart(contracts.perps, perps::QueryStateRequest {})
+        .should_succeed();
+    assert_eq!(
+        pre_state.treasury,
+        UsdValue::new_int(8),
+        "expected $8 in treasury before withdrawal"
+    );
+
+    let owner_addr = accounts.owner.address();
+    let pre_owner_margin = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: owner_addr,
+        })
+        .should_succeed()
+        .map(|us: perps::UserState| us.margin)
+        .unwrap_or(UsdValue::ZERO);
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::WithdrawFromTreasury {}),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Treasury drained.
+    let post_state: perps::State = suite
+        .query_wasm_smart(contracts.perps, perps::QueryStateRequest {})
+        .should_succeed();
+    assert_eq!(post_state.treasury, UsdValue::ZERO);
+
+    // Owner's UserState margin gained the previous treasury balance.
+    let post_owner_state: perps::UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: owner_addr,
+        })
+        .should_succeed()
+        .expect("owner should now have a UserState");
+    assert_eq!(
+        post_owner_state.margin,
+        pre_owner_margin.checked_add(pre_state.treasury).unwrap(),
+    );
+
+    // Round-trip: owner can convert the credited margin back to USDC via the
+    // standard withdraw path.
+    suite.balances().record(&accounts.owner);
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Withdraw {
+                amount: pre_state.treasury,
+            }),
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Owner should have received the USDC backing the treasury.
+    let owner_post_balance = suite
+        .query_balance(&accounts.owner, usdc::DENOM.clone())
+        .unwrap();
+    assert!(
+        owner_post_balance > Uint128::ZERO,
+        "owner should have non-zero USDC after round-trip withdraw"
+    );
+}
+
+/// Non-owner callers must be rejected, regardless of treasury state.
+#[test]
+fn treasury_withdrawal_rejects_non_owner() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::WithdrawFromTreasury {}),
+            Coins::new(),
+        )
+        .should_fail_with_error("you don't have the right");
+}

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -974,6 +974,12 @@ pub enum MaintainerMsg {
         /// First element is maker rate, second is taker rate.
         maker_taker_fee_rates: Op<(Dimensionless, Dimensionless)>,
     },
+
+    /// Move the entire `state.treasury` balance into the chain owner's
+    /// `UserState.margin`. The owner can then convert it to USDC via the
+    /// regular `TraderMsg::Withdraw` flow.
+    /// Only callable by the chain owner.
+    WithdrawFromTreasury {},
 }
 
 #[grug::derive(Serde)]


### PR DESCRIPTION
Allow the chain owner to move the entire `state.treasury` balance into the owner's `UserState.margin`. The owner can then convert it to USDC via the regular `TraderMsg::Withdraw` flow.