### PR TITLE
feat(taxman): add WithdrawFees execute message

### DIFF
--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -8,9 +8,9 @@ use {
         taxman::{Config, ExecuteMsg, FeeType, InstantiateMsg, ReceiveFee},
     },
     grug::{
-        Addr, AuthCtx, AuthMode, Coins, ContractEvent, IsZero, Map, Message, MultiplyFraction,
-        MutableCtx, Number, NumberConst, Order, QuerierExt, Response, StdResult, Storage,
-        Timestamp, Tx, TxOutcome, Udec128_6, Uint128, coins,
+        Addr, AuthCtx, AuthMode, Coin, Coins, ContractEvent, IsZero, Map, Message,
+        MultiplyFraction, MutableCtx, Number, NumberConst, Order, QuerierExt, Response, StdResult,
+        Storage, Timestamp, Tx, TxOutcome, Udec128_6, Uint128, coins,
     },
     std::collections::BTreeMap,
 };
@@ -28,6 +28,7 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
         ExecuteMsg::Configure { new_cfg } => configure(ctx, new_cfg),
         ExecuteMsg::Pay { ty, payments } => pay(ctx, ty, payments),
         ExecuteMsg::ReportVolumes(volumes) => report_volumes(ctx, volumes),
+        ExecuteMsg::WithdrawFees {} => withdraw_fees(ctx),
     }
 }
 
@@ -41,6 +42,34 @@ fn configure(ctx: MutableCtx, new_cfg: Config) -> anyhow::Result<Response> {
     CONFIG.save(ctx.storage, &new_cfg)?;
 
     Ok(Response::new())
+}
+
+fn withdraw_fees(ctx: MutableCtx) -> anyhow::Result<Response> {
+    // Only the chain's owner can withdraw collected fees.
+    ensure!(
+        ctx.sender == ctx.querier.query_owner()?,
+        "you don't have the right, O you don't have the right"
+    );
+
+    // Read all denoms taxman currently holds.
+    let mut balances = ctx
+        .querier
+        .query_balances(ctx.contract, None, Some(u32::MAX))?;
+
+    // `withhold_fee` runs at the auth phase before this handler executes, so
+    // taxman's balance includes funds that `finalize_fee` must refund. Reserve
+    // those so the refund won't fail.
+    if let Some((fee_cfg, withheld)) = WITHHELD_FEE.may_load(ctx.storage)?
+        && withheld.is_non_zero()
+    {
+        balances.saturating_deduct(Coin::new(fee_cfg.fee_denom, withheld)?)?;
+    }
+
+    if balances.is_empty() {
+        return Ok(Response::new());
+    }
+
+    Ok(Response::new().add_message(Message::transfer(ctx.sender, balances)?))
 }
 
 fn pay(ctx: MutableCtx, ty: FeeType, payments: BTreeMap<Addr, Coins>) -> anyhow::Result<Response> {

--- a/dango/testing/tests/taxman.rs
+++ b/dango/testing/tests/taxman.rs
@@ -2,8 +2,8 @@ use {
     dango_testing::setup_test_naive,
     dango_types::{constants::usdc, taxman},
     grug::{
-        Addressable, BalanceChange, Coins, Inner, MultiplyFraction, ResultExt, Udec128, Uint128,
-        btree_map,
+        Addressable, BalanceChange, Coins, Inner, IsZero, MultiplyFraction, NumberConst, ResultExt,
+        Udec128, Uint128, btree_map,
     },
 };
 
@@ -85,4 +85,119 @@ fn fee_rate_update_works() {
     suite.balances().should_change(&accounts.user1, btree_map! {
         usdc::DENOM.clone() => BalanceChange::Decreased(fee.into_inner()),
     });
+}
+
+const FEE_RATE: Udec128 = Udec128::new_percent(1);
+
+#[test]
+fn withdraw_fees_succeeds_for_owner() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
+
+    // Set a non-zero fee rate so subsequent txs accumulate fees in taxman.
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.taxman,
+            &taxman::ExecuteMsg::Configure {
+                new_cfg: taxman::Config {
+                    fee_denom: usdc::DENOM.clone(),
+                    fee_rate: FEE_RATE,
+                },
+            },
+            Coins::new(),
+        )
+        .should_succeed();
+
+    // Run a few transfer txs from a non-owner so taxman accumulates gas fees.
+    for _ in 0..3 {
+        suite
+            .transfer(&mut accounts.user1, accounts.user2.address(), Coins::new())
+            .should_succeed();
+    }
+
+    let collected = suite
+        .query_balance(&contracts.taxman, usdc::DENOM.clone())
+        .unwrap();
+    assert!(
+        collected.is_non_zero(),
+        "expected some fees to have been collected"
+    );
+
+    suite.balances().record(&accounts.owner);
+
+    // Withdraw — owner pays gas for this tx, but the rest of taxman's USDC
+    // ends up at the owner's address.
+    let success = suite
+        .execute(
+            &mut accounts.owner,
+            contracts.taxman,
+            &taxman::ExecuteMsg::WithdrawFees {},
+            Coins::new(),
+        )
+        .should_succeed();
+
+    let withdraw_gas_fee = Uint128::new(success.gas_used as u128)
+        .checked_mul_dec_ceil(FEE_RATE)
+        .unwrap();
+
+    // The owner should have received `collected`, minus the gas fee paid for
+    // this withdraw tx.
+    suite.balances().should_change(&accounts.owner, btree_map! {
+        usdc::DENOM.clone() => BalanceChange::Increased(
+            (collected - withdraw_gas_fee).into_inner(),
+        ),
+    });
+
+    // After this tx, taxman should hold only the gas fee that the withdraw tx
+    // itself just paid — everything previously collected is gone.
+    let remaining = suite
+        .query_balance(&contracts.taxman, usdc::DENOM.clone())
+        .unwrap();
+    assert_eq!(remaining, withdraw_gas_fee);
+}
+
+#[test]
+fn withdraw_fees_rejects_non_owner() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.taxman,
+            &taxman::ExecuteMsg::WithdrawFees {},
+            Coins::new(),
+        )
+        .should_fail_with_error("you don't have the right");
+}
+
+#[test]
+fn withdraw_fees_noop_when_empty() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
+
+    // Genesis fee rate is zero, and no other state lands in taxman during
+    // setup — this withdraw tx itself is also gas-free for the same reason.
+    let pre = suite
+        .query_balance(&contracts.taxman, usdc::DENOM.clone())
+        .unwrap();
+    assert_eq!(pre, Uint128::ZERO);
+
+    suite.balances().record(&accounts.owner);
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.taxman,
+            &taxman::ExecuteMsg::WithdrawFees {},
+            Coins::new(),
+        )
+        .should_succeed();
+
+    suite.balances().should_change(&accounts.owner, btree_map! {
+        usdc::DENOM.clone() => BalanceChange::Unchanged,
+    });
+
+    let post = suite
+        .query_balance(&contracts.taxman, usdc::DENOM.clone())
+        .unwrap();
+    assert_eq!(post, Uint128::ZERO);
 }

--- a/dango/types/src/taxman.rs
+++ b/dango/types/src/taxman.rs
@@ -54,6 +54,9 @@ pub enum ExecuteMsg {
     /// Report trading volumes of users.
     /// Can only be called by the spot and perp DEX contracts.
     ReportVolumes(BTreeMap<Addr, Udec128_6>),
+    /// Transfer all accumulated fees to the chain's owner.
+    /// Can only be called by the chain's owner.
+    WithdrawFees {},
 }
 
 #[grug::derive(Serde, QueryRequest)]


### PR DESCRIPTION
Allow the chain owner to drain accumulated fees (gas, withdrawal fees, etc.) out of the taxman contract's bank balance.
