### PR TITLE
chore(ui): remove fullpage slideshow from landing page

### DIFF
--- a/.github/workflows/portal-deployment.yaml
+++ b/.github/workflows/portal-deployment.yaml
@@ -84,7 +84,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_ENVIRONMENT: ${{ github.ref_name == 'ui/testnet' && 'test' || github.ref_name == 'ui/release' && 'prod' || 'dev' }}
           PUBLIC_WS_URI: ${{ vars.WS_URI }}
-          PUBLIC_FP: ${{vars.FULLPAGE_KEY_BASE64 }}
           PUBLIC_SENTRY_DSN: ${{ vars.SENTRY_PORTAL_WEB_DSN }}
           PUBLIC_SENTRY_ENVIRONMENT: ${{ github.ref_name == 'ui/release' && 'production' || github.ref_name == 'ui/testnet' && 'test' || github.ref_name == 'main' && 'dev' }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,9 +526,6 @@ importers:
 
   ui/portal/web:
     dependencies:
-      '@fullpage/react-fullpage':
-        specifier: ^0.1.45
-        version: 0.1.45
       '@left-curve/applets-convert':
         specifier: workspace:^
         version: link:../../applets/convert
@@ -1546,10 +1543,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-
-  '@babel/polyfill@7.12.1':
-    resolution: {integrity: sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==}
-    deprecated: 🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.
 
   '@babel/preset-env@7.28.3':
     resolution: {integrity: sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==}
@@ -2579,9 +2572,6 @@ packages:
 
   '@formatjs/intl-pluralrules@5.4.6':
     resolution: {integrity: sha512-2HlOq+c7KsSps829SJ3B5987coX5mzKx9NbPcNwQ07eq8FBHgB3HfMoxt5HvLsdk4oQwCjAEnocbtd+wVwZ2Kg==}
-
-  '@fullpage/react-fullpage@0.1.45':
-    resolution: {integrity: sha512-N6DLBW6Q17shPeier3UGHjAxgbA4qy3G25YccNANsToJuipGUs1Rz6WZXfdfMZ4y0O1WD6a0bLme/O+sBjUXnA==}
 
   '@gerrit0/mini-shiki@3.21.0':
     resolution: {integrity: sha512-9PrsT5DjZA+w3lur/aOIx3FlDeHdyCEFlv9U+fmsVyjPZh61G5SYURQ/1ebe2U63KbDmI2V8IhIUegWb8hjOyg==}
@@ -5431,10 +5421,6 @@ packages:
   core-js-compat@3.45.0:
     resolution: {integrity: sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==}
 
-  core-js@2.6.12:
-    resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
-    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
-
   core-js@3.42.0:
     resolution: {integrity: sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==}
 
@@ -6339,9 +6325,6 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  fullpage.js@4.0.30:
-    resolution: {integrity: sha512-FsLn0AJrK4mv53X/Ovm7BaLQgXMxJOLKbfOXCZfNoHsmngYATJya4Pm8BSWgBaPICl+DoX+GoI/KX8o6rdH3GA==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -10866,11 +10849,6 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.26.8)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/polyfill@7.12.1':
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.13.11
-
   '@babel/preset-env@7.28.3(@babel/core@7.26.8)':
     dependencies:
       '@babel/compat-data': 7.28.0
@@ -11884,11 +11862,6 @@ snapshots:
       '@formatjs/intl-localematcher': 0.6.2
       decimal.js: 10.6.0
       tslib: 2.8.1
-
-  '@fullpage/react-fullpage@0.1.45':
-    dependencies:
-      '@babel/polyfill': 7.12.1
-      fullpage.js: 4.0.30
 
   '@gerrit0/mini-shiki@3.21.0':
     dependencies:
@@ -15036,8 +15009,6 @@ snapshots:
     dependencies:
       browserslist: 4.25.2
 
-  core-js@2.6.12: {}
-
   core-js@3.42.0: {}
 
   core-util-is@1.0.3: {}
@@ -16101,8 +16072,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  fullpage.js@4.0.30: {}
 
   function-bind@1.1.2: {}
 

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -521,23 +521,7 @@
   },
   "welcome": {
     "title": "Welcome to Dango",
-    "description": "We’re delighted to have you with us and look forward to seeing what you do next.",
-    "scroll": "Scroll to learn more",
-    "trade": "Trade",
-    "tradeText": "crypto assets, real world assets, and derivatives on Dango’s blazingly fast exchange.",
-    "tradeText2": "Enjoy deep liquidity, fast execution, and fair prices.",
-    "leverageUp": "Leverage up",
-    "leverageUpText": "with Dango’s unified trading account with low cost and high capital efficiency.",
-    "leverageUpText2": "Spot, perps, vaults; one account, under a unified margin system.",
-    "earn": "Earn",
-    "earnText": "passive yields on your idle assets, by participating in Dango’s passive market making vaults.",
-    "earnText2": "Make your money work for you!",
-    "join": "Join the ",
-    "community": "community",
-    "of": "of",
-    "dangbros": "Dangbros",
-    "privacyPolicy": "Privacy Policy",
-    "termsOfUse": "Terms of Use"
+    "description": "We’re delighted to have you with us and look forward to seeing what you do next."
   },
   "auth": {
     "email": "Email",

--- a/ui/portal/web/package.json
+++ b/ui/portal/web/package.json
@@ -12,7 +12,6 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@fullpage/react-fullpage": "^0.1.45",
     "@left-curve/applets-convert": "workspace:^",
     "@left-curve/applets-kit": "workspace:^",
     "@left-curve/dango": "workspace:^",

--- a/ui/portal/web/src/components/landing/Landing.tsx
+++ b/ui/portal/web/src/components/landing/Landing.tsx
@@ -7,21 +7,19 @@ export function Landing() {
   const { theme } = useTheme();
 
   return (
-    <div className="min-h-svh flex items-center justify-center relative w-full">
-      <div className="min-h-[calc(100svh-5svh)] mx-auto pb-[20svh] p-4 lg:p-0 w-full flex flex-col gap-6 relative flex-1 items-center justify-between lg:items-center lg:justify-center lg:gap-16 lg:pb-60">
-        <img
-          src={`/images/dango${theme === "dark" ? "-dark" : ""}.svg`}
-          alt="Dango"
-          className="max-w-[10rem] lg:max-w-[13rem] select-none"
-        />
-        {isLg && (
-          <div className="relative w-full h-11 z-40 max-w-[38rem]">
-            <SearchMenu />
-          </div>
-        )}
-        <div className="flex w-full max-w-[38rem]">
-          <AppletsSection />
+    <div className="mx-auto pt-[5svh] pb-[15svh] p-4 lg:p-0 w-full flex flex-col gap-6 relative flex-1 items-center justify-between lg:justify-center lg:gap-16 lg:pb-60">
+      <img
+        src={`/images/dango${theme === "dark" ? "-dark" : ""}.svg`}
+        alt="Dango"
+        className="max-w-[10rem] lg:max-w-[13rem] select-none"
+      />
+      {isLg && (
+        <div className="relative w-full h-11 z-40 max-w-[38rem]">
+          <SearchMenu />
         </div>
+      )}
+      <div className="flex w-full max-w-[38rem]">
+        <AppletsSection />
       </div>
     </div>
   );

--- a/ui/portal/web/src/components/landing/Landing.tsx
+++ b/ui/portal/web/src/components/landing/Landing.tsx
@@ -1,64 +1,28 @@
-import { useEffect } from "react";
-import { useApp, useMediaQuery, useTheme } from "@left-curve/applets-kit";
-
-import {
-  Button,
-  createContext,
-  IconChevronDown,
-  IconDiscord,
-  IconMirror,
-  IconTwitter,
-} from "@left-curve/applets-kit";
+import { createContext, useMediaQuery, useTheme } from "@left-curve/applets-kit";
 import { SearchMenu } from "../foundation/SearchMenu";
 import { AppletsSection } from "./AppletsSection";
 
-import { decodeBase64, decodeUtf8 } from "@left-curve/dango/encoding";
-import ReactFullpage from "@fullpage/react-fullpage";
-import { m } from "@left-curve/foundation/paraglide/messages.js";
-import { format } from "date-fns";
-
-import type { fullpageApi } from "@fullpage/react-fullpage";
 import type { PropsWithChildren } from "react";
 
 type LandingProps = {
-  fullpageApi: fullpageApi;
+  fullpageApi?: undefined;
 };
 
-const [LandingProvider, useLanding] = createContext<LandingProps>({
+const [LandingProvider] = createContext<LandingProps>({
   name: "LandingContext",
 });
 
 const LandingContainer: React.FC<PropsWithChildren> = ({ children }) => {
-  const { setQuestBannerVisibility } = useApp();
   return (
     <div className="w-full mx-auto flex flex-col gap-6 pt-0 pb-16 flex-1">
-      <ReactFullpage
-        beforeLeave={(_, destination) => setQuestBannerVisibility(destination.isFirst)}
-        licenseKey={decodeUtf8(decodeBase64(import.meta.env.PUBLIC_FP || "RkFMTEJBQ0tfS0VZCg=="))}
-        scrollingSpeed={1000}
-        credits={{ enabled: false }}
-        render={({ fullpageApi }) => {
-          return (
-            <ReactFullpage.Wrapper>
-              <LandingProvider value={{ fullpageApi }}>{children}</LandingProvider>
-            </ReactFullpage.Wrapper>
-          );
-        }}
-      />
+      <LandingProvider value={{ fullpageApi: undefined }}>{children}</LandingProvider>
     </div>
   );
 };
 
 const Header: React.FC = () => {
-  const { isSidebarVisible } = useApp();
   const { isLg } = useMediaQuery();
   const { theme } = useTheme();
-  const { fullpageApi } = useLanding();
-
-  useEffect(() => {
-    if (!fullpageApi) return;
-    fullpageApi.setAllowScrolling(!isSidebarVisible);
-  }, [fullpageApi, isSidebarVisible]);
 
   return (
     <div className="section min-h-svh flex items-center justify-center relative w-full">
@@ -77,186 +41,8 @@ const Header: React.FC = () => {
           <AppletsSection />
         </div>
       </div>
-      <div
-        className="absolute bottom-[12svh] lg:bottom-[3rem] left-1/2 -translate-x-1/2 cursor-pointer diatype-m-medium"
-        onClick={() => fullpageApi.moveSectionDown()}
-      >
-        <div className="animate-levitate flex items-center justify-center flex-col">
-          <p>{m["welcome.scroll"]()}</p>
-          <IconChevronDown className="w-6 h-6" />
-        </div>
-      </div>
     </div>
   );
 };
 
-const SectionRice: React.FC = () => {
-  const { isSearchBarVisible } = useApp();
-  if (isSearchBarVisible) return null;
-
-  return (
-    <section className="section w-full min-h-svh flex items-center justify-center bg-surface-primary-rice bg-[linear-gradient(212.63deg,_rgba(255,_229,_190,_0.4)_19.52%,_#FFDEAE_94.1%)] dark:bg-[linear-gradient(212.63deg,_#42403D_19.52%,_#807668_94.1%)]">
-      <div className="max-w-[76rem] w-full mx-auto flex flex-col lg:flex-row items-center lg:justify-between p-4 pr-0">
-        <div className="flex flex-col gap-2 max-w-[40rem]">
-          <h1 className="display-heading-l md:display-heading-2xl text-rice-600 dark:text-ink-secondary-rice">
-            {m["welcome.trade"]()}
-          </h1>
-          <p className="diatype-m-regular md:h1-medium text-rice-600 dark:text-ink-secondary-rice">
-            {m["welcome.tradeText"]()}
-          </p>
-          <p className="diatype-m-regular md:h1-medium text-rice-600 dark:text-ink-secondary-rice">
-            {m["welcome.tradeText2"]()}
-          </p>
-        </div>
-        <img
-          src="/images/emojis/detailed/temple.svg"
-          alt="dango-temple"
-          className="w-[90%] lg:w-full max-w-[535px]"
-        />
-      </div>
-    </section>
-  );
-};
-
-const SectionRed: React.FC = () => {
-  const { isSearchBarVisible } = useApp();
-  if (isSearchBarVisible) return null;
-
-  return (
-    <section className="section w-full min-h-svh flex items-center justify-center bg-surface-primary-rice bg-[linear-gradient(212.63deg,_rgba(255,_221,_223,_0.4)_19.52%,_#FFD0D3_94.1%)] dark:bg-[linear-gradient(212.63deg,_#383634_19.52%,_#6A6361_94.1%)]">
-      <div className="max-w-[76rem] w-full mx-auto flex flex-col lg:flex-row items-center lg:justify-between p-4 pr-0">
-        <div className="flex flex-col gap-2 max-w-[40rem]">
-          <h1 className="display-heading-l md:display-heading-2xl text-ink-tertiary-red">
-            {m["welcome.leverageUp"]()}
-          </h1>
-          <p className="diatype-m-regular md:h1-medium text-ink-tertiary-red">
-            {m["welcome.leverageUpText"]()}
-          </p>
-          <p className="diatype-m-regular md:h1-medium text-ink-tertiary-red">
-            {m["welcome.leverageUpText2"]()}
-          </p>
-        </div>
-        <img
-          src="/images/emojis/detailed/fisher.svg"
-          alt="dango-fisher"
-          className="w-[90%] lg:w-full max-w-[535px]"
-        />
-      </div>
-    </section>
-  );
-};
-
-const SectionGreen: React.FC = () => {
-  const { isSearchBarVisible } = useApp();
-  if (isSearchBarVisible) return null;
-
-  return (
-    <section className="section w-full min-h-svh flex items-center justify-center bg-surface-primary-rice bg-[linear-gradient(212.63deg,_rgba(239,_240,_173,_0.4)_19.52%,_#EFF0AD_94.1%)] dark:bg-[linear-gradient(212.63deg,_#373634_19.52%,_#666654_94.1%)]">
-      <div className="max-w-[76rem] w-full mx-auto flex flex-col lg:flex-row items-center lg:justify-between p-4 pr-0">
-        <div className="flex flex-col gap-2 max-w-[40rem]">
-          <h1 className="display-heading-l md:display-heading-2xl text-primitives-green-light-800 dark:text-fg-primary-green">
-            {m["welcome.earn"]()}
-          </h1>
-          <p className="diatype-m-regular md:h1-medium text-primitives-green-light-800 dark:text-fg-primary-green">
-            {m["welcome.earnText"]()}
-          </p>
-        </div>
-        <img
-          src="/images/emojis/detailed/pig.svg"
-          alt="dango-pig"
-          className="w-[90%] lg:w-full max-w-[535px]"
-        />
-      </div>
-    </section>
-  );
-};
-
-const SectionCommunity: React.FC = () => {
-  const { isSearchBarVisible } = useApp();
-
-  if (isSearchBarVisible) return null;
-
-  return (
-    <section className="section w-full min-h-svh flex items-center justify-center lg:justify-end bg-surface-primary-rice bg-[linear-gradient(6.97deg,_#D0CFEB_11.63%,_#F6F6FB_88.19%)] dark:bg-[linear-gradient(6.97deg,_#6E6D77_11.63%,_#373634_88.19%)]">
-      <div className="max-w-[76rem] w-full mx-auto flex flex-col p-4 pb-[10svh] lg:pb-0 min-h-[calc(100svh)] lg:justify-center pt-[76px] gap-4">
-        <div className="w-full flex flex-col lg:flex-row items-center lg:justify-between gap-4 flex-1">
-          <img
-            src="/images/characters/friends.svg"
-            alt="rabbits"
-            className="w-full transition-all max-w-[217px] sm:max-w-[317px] md:max-w-[435px] lg:max-h-[535px]"
-          />
-          <div className="flex flex-col max-w-[33rem] items-center justify-center text-center gap-6 lg:gap-8 z-30">
-            <h2 className="display-heading-m md:display-heading-2xl">
-              {m["welcome.join"]()}
-              <span className="text-primitives-red-light-400">{m["welcome.community"]()}</span>{" "}
-              {m["welcome.of"]()}{" "}
-              <span className="text-primitives-red-light-400">{m["welcome.dangbros"]()}</span>
-            </h2>
-            <div className="flex gap-4">
-              <Button
-                as="a"
-                href="https://x.com/dango"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="gap-0"
-              >
-                <IconTwitter className="w-6 h-6" />
-                <span>Twitter</span>
-              </Button>
-              <Button
-                as="a"
-                href="https://discord.gg/BWJtyySxBM"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="gap-0"
-              >
-                <IconDiscord className="w-5 h-5" />
-                <span className="pl-[6px]">Discord</span>
-              </Button>
-              <Button
-                as="a"
-                href="https://mirror.xyz/0x8E4AA2B6F137D2eD6Ba3E3Bb8E64240D46035DE6"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="gap-0"
-              >
-                <IconMirror className="w-5 h-5" />
-                <span className="pl-[6px]">Mirror</span>
-              </Button>
-            </div>
-          </div>
-        </div>
-        <div className="w-full border-t border-t-outline-tertiary-blue items-center justify-between flex py-6 diatype-m-medium flex-col lg:flex-row gap-1">
-          <p>© 2024-{format(new Date(), "yy")} Left Curve Software</p>
-          <div className="flex gap-10 lg:gap-4 diatype-m-medium">
-            <a
-              href="/documents/Dango%20-%20Terms%20of%20Use.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:underline text-ink-tertiary-500"
-            >
-              {m["welcome.termsOfUse"]()}
-            </a>
-
-            <a
-              href="/documents/Dango%20-%20Privacy%20Policy.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:underline text-ink-tertiary-500"
-            >
-              {m["welcome.privacyPolicy"]()}
-            </a>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-};
-
-export const Landing = Object.assign(LandingContainer, {
-  Header,
-  SectionRice,
-  SectionRed,
-  SectionGreen,
-  SectionCommunity,
-});
+export const Landing = Object.assign(LandingContainer, { Header });

--- a/ui/portal/web/src/components/landing/Landing.tsx
+++ b/ui/portal/web/src/components/landing/Landing.tsx
@@ -8,7 +8,7 @@ export function Landing() {
 
   return (
     <div className="min-h-svh flex items-center justify-center relative w-full">
-      <div className="mx-auto p-4 lg:p-0 w-full flex flex-col gap-6 relative flex-1 items-center justify-between lg:items-center lg:justify-center lg:gap-16">
+      <div className="min-h-[calc(100svh-5svh)] mx-auto pb-[20svh] p-4 lg:p-0 w-full flex flex-col gap-6 relative flex-1 items-center justify-between lg:items-center lg:justify-center lg:gap-16 lg:pb-60">
         <img
           src={`/images/dango${theme === "dark" ? "-dark" : ""}.svg`}
           alt="Dango"

--- a/ui/portal/web/src/components/landing/Landing.tsx
+++ b/ui/portal/web/src/components/landing/Landing.tsx
@@ -1,32 +1,14 @@
-import { createContext, useMediaQuery, useTheme } from "@left-curve/applets-kit";
+import { useMediaQuery, useTheme } from "@left-curve/applets-kit";
 import { SearchMenu } from "../foundation/SearchMenu";
 import { AppletsSection } from "./AppletsSection";
 
-import type { PropsWithChildren } from "react";
-
-type LandingProps = {
-  fullpageApi?: undefined;
-};
-
-const [LandingProvider] = createContext<LandingProps>({
-  name: "LandingContext",
-});
-
-const LandingContainer: React.FC<PropsWithChildren> = ({ children }) => {
-  return (
-    <div className="w-full mx-auto flex flex-col gap-6 pt-0 pb-16 flex-1">
-      <LandingProvider value={{ fullpageApi: undefined }}>{children}</LandingProvider>
-    </div>
-  );
-};
-
-const Header: React.FC = () => {
+export function Landing() {
   const { isLg } = useMediaQuery();
   const { theme } = useTheme();
 
   return (
-    <div className="section min-h-svh flex items-center justify-center relative w-full">
-      <div className="min-h-[calc(100svh-5svh)] mx-auto pb-[20svh] p-4 lg:p-0 w-full flex flex-col gap-6 relative flex-1 items-center justify-between lg:items-center lg:justify-center lg:gap-16 lg:pb-60">
+    <div className="min-h-svh flex items-center justify-center relative w-full">
+      <div className="mx-auto p-4 lg:p-0 w-full flex flex-col gap-6 relative flex-1 items-center justify-between lg:items-center lg:justify-center lg:gap-16">
         <img
           src={`/images/dango${theme === "dark" ? "-dark" : ""}.svg`}
           alt="Dango"
@@ -43,6 +25,4 @@ const Header: React.FC = () => {
       </div>
     </div>
   );
-};
-
-export const Landing = Object.assign(LandingContainer, { Header });
+}

--- a/ui/portal/web/src/pages/(app)/_app.index.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.index.tsx
@@ -3,13 +3,6 @@ import { m } from "@left-curve/foundation/paraglide/messages.js";
 
 import { Landing } from "~/components/landing/Landing";
 
-export function getFullpageLicenseKey() {
-  if (!process.env.NEXT_PUBLIC_FULLPAGE_KEY) return "FALLBACK_KEY";
-  return new TextDecoder("utf-8", { fatal: true }).decode(
-    Uint8Array.from(atob(process.env.NEXT_PUBLIC_FULLPAGE_KEY), (c) => c.charCodeAt(0)),
-  );
-}
-
 export const Route = createFileRoute("/(app)/_app/")({
   head: () => ({
     meta: [{ title: `Dango | ${m["common.overview"]()}` }],
@@ -21,10 +14,6 @@ function OverviewComponent() {
   return (
     <Landing>
       <Landing.Header />
-      <Landing.SectionRice />
-      <Landing.SectionRed />
-      <Landing.SectionGreen />
-      <Landing.SectionCommunity />
     </Landing>
   );
 }

--- a/ui/portal/web/src/pages/(app)/_app.index.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.index.tsx
@@ -11,9 +11,5 @@ export const Route = createFileRoute("/(app)/_app/")({
 });
 
 function OverviewComponent() {
-  return (
-    <Landing>
-      <Landing.Header />
-    </Landing>
-  );
+  return <Landing />;
 }

--- a/ui/portal/web/src/pages/(app)/_app.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.tsx
@@ -102,7 +102,6 @@ function LayoutApp() {
 
   const { theme } = useTheme();
 
-  const isHomePage = location.pathname === "/";
   const lockedY = Number(document.body.dataset.scrollLockY || 0);
 
   const effectiveIsScrolled = isSidebarVisible ? lockedY > headerThreshold : isScrolled;
@@ -112,10 +111,7 @@ function LayoutApp() {
       <img
         src={theme === "dark" ? "/images/union-dark.png" : "/images/union.png"}
         alt="bg-image"
-        className={twMerge(
-          "pointer-events-none drag-none select-none h-[20vh] lg:h-[20vh] w-full fixed lg:absolute bottom-0 lg:top-0 left-0 z-40 lg:z-0 rotate-180 lg:rotate-0 object-cover object-bottom",
-          { hidden: isHomePage && !isLg },
-        )}
+        className="pointer-events-none drag-none select-none h-[20vh] lg:h-[20vh] w-full fixed lg:absolute bottom-0 lg:top-0 left-0 z-40 lg:z-0 rotate-180 lg:rotate-0 object-cover object-bottom"
       />
       {!isLg ? <div id="quest-banner-mobile" /> : null}
       {!isLg ? <TestnetBanner /> : null}

--- a/ui/portal/web/tests/pages/landing.spec.ts
+++ b/ui/portal/web/tests/pages/landing.spec.ts
@@ -7,40 +7,6 @@ test.describe("Landing Page - Not Authenticated", () => {
     await waitForStorageHydration(page);
   });
 
-  test.describe("Section Navigation", () => {
-    test("landing page renders with Learn More button", async ({ page }) => {
-      await expect(page.locator("text=Learn More")).toBeVisible();
-    });
-
-    test("can scroll through landing sections", async ({ page }) => {
-      // Landing uses fullpage.js sections
-      // First section: header with search
-      await expect(page.locator('[data-testid="landing-header"]').or(page.locator("header"))).toBeVisible();
-
-      // Scroll indicator should be visible
-      const scrollIndicator = page.getByText("Scroll to continue");
-      if (await scrollIndicator.isVisible()) {
-        await expect(scrollIndicator).toBeVisible();
-      }
-    });
-
-    test("community section shows social links", async ({ page }) => {
-      // Navigate to community section (last section)
-      // Use keyboard or scroll to navigate
-      await page.keyboard.press("End");
-      await page.waitForTimeout(500);
-
-      // Check for social links - they may be in footer
-      const twitterLink = page.locator('a[href*="twitter.com"], a[href*="x.com"]');
-      const discordLink = page.locator('a[href*="discord"]');
-
-      // At least one social link should exist
-      const socialLinksExist =
-        (await twitterLink.count()) > 0 || (await discordLink.count()) > 0;
-      expect(socialLinksExist).toBeTruthy();
-    });
-  });
-
   test.describe("Search Bar Functionality", () => {
     test("clicking search bar expands container", async ({ page }) => {
       // Try keyboard shortcut first as it's more reliable


### PR DESCRIPTION
Delete pages 2-5 (trade/leverage/earn/community sections) and the
"Scroll to learn more" CTA from the homepage, and drop the
@fullpage/react-fullpage dependency.

Also remove:
- the orphaned PUBLIC_FP build env var from the deployment workflow
- the welcome.* message keys used only by the deleted sections
- the section-navigation tests that exercised the removed pages
- the unused getFullpageLicenseKey helper