### PR TITLE
fix(indexer-cache): stop dango indexer s3-sync from piling up

### DIFF
--- a/dango/cli/src/indexer.rs
+++ b/dango/cli/src/indexer.rs
@@ -6,7 +6,7 @@ use {
     metrics_exporter_prometheus::PrometheusBuilder,
     std::{
         sync::{Arc, Mutex},
-        time::Instant,
+        time::{Duration, Instant},
     },
     tokio::task::JoinSet,
 };
@@ -21,6 +21,7 @@ pub struct IndexerCmd {
 enum SubCmd {
     /// View a block and results
     Block { height: u64 },
+
     /// View a range of blocks and results
     Blocks {
         /// Start height (inclusive)
@@ -28,6 +29,7 @@ enum SubCmd {
         /// End height (inclusive)
         end: u64,
     },
+
     /// Search for a pattern in the given inclusive range of blocks
     // TODO: make block range optional and figure it out automatically
     Find {
@@ -37,12 +39,19 @@ enum SubCmd {
         /// End height (inclusive)
         end: u64,
     },
+
     /// Start the metrics HTTP server
     MetricsHttpd,
+
     /// Verify integrity of candle data in ClickHouse
     CheckCandles,
+
     /// Sync the indexer block cache to S3
-    S3Sync,
+    S3Sync {
+        /// Wallclock ceiling for the whole sync, in seconds.
+        #[arg(long, default_value_t = 480)]
+        timeout_secs: u64,
+    },
 }
 
 impl IndexerCmd {
@@ -160,7 +169,7 @@ impl IndexerCmd {
 
                 clickhouse_indexer.check_all().await?;
             },
-            SubCmd::S3Sync => {
+            SubCmd::S3Sync { timeout_secs } => {
                 let cfg: Config = parse_config(app_dir.config_file())?;
 
                 let mut indexer_cache = indexer_cache::Cache::new_with_dir(app_dir.indexer_dir());
@@ -173,14 +182,32 @@ impl IndexerCmd {
 
                 let start = Instant::now();
 
-                tracing::info!(last_synced_height, "Starting S3 sync");
+                tracing::info!(last_synced_height, timeout_secs, "Starting S3 sync");
 
-                let new_height = indexer_cache::Cache::sync_to_s3(
-                    &indexer_cache.context,
-                    indexer_cache.s3_bitmap.clone(),
-                    last_synced_height,
+                // Wrap the sync in a wallclock timeout. Without this a single
+                // unreachable bucket lets a `*/10` cron stack invocations on
+                // top of each other forever — the prod incident on
+                // 2026-05-03 saw 30+ accumulated processes after 7h. The
+                // `JoinSet` in `sync_to_s3` ensures hitting the deadline
+                // actually cancels the spawned upload tasks rather than
+                // leaking them on the runtime.
+                let new_height = match tokio::time::timeout(
+                    Duration::from_secs(timeout_secs),
+                    indexer_cache::Cache::sync_to_s3(
+                        &indexer_cache.context,
+                        indexer_cache.s3_bitmap.clone(),
+                        last_synced_height,
+                    ),
                 )
-                .await?;
+                .await
+                {
+                    Ok(Ok(h)) => h,
+                    Ok(Err(e)) => return Err(e.into()),
+                    Err(_elapsed) => {
+                        tracing::error!(timeout_secs, "S3 sync exceeded deadline; aborting");
+                        anyhow::bail!("s3 sync timed out after {timeout_secs}s");
+                    },
+                };
 
                 // Only store the new height if sync succeeded and made progress
                 if let Some(height) = new_height {

--- a/deploy/roles/full-app/tasks/s3_sync_cron.yml
+++ b/deploy/roles/full-app/tasks/s3_sync_cron.yml
@@ -1,6 +1,26 @@
+# Defense-in-depth wrapper around the s3-sync invocation. The dango binary
+# itself now has a wallclock timeout (`--timeout-secs`, default 480s) and
+# bounded SDK timeouts, but this cron line still has to be safe even when
+# running against an old binary that hasn't been redeployed yet — that gap
+# is exactly how the 2026-05-03 prod incident accumulated 30+ processes
+# after a reboot.
+#
+# `flock -n` on a per-deployment lock makes a new firing exit immediately
+# if the previous one is still running. This alone would have prevented
+# the pile-up: even with a hung binary, only one process exists at a time.
+#
+# `timeout --kill-after=30s 540s` is the outermost ceiling. It sits just
+# under the 10-min cron interval and just above the Rust-side 480s, so
+# the in-binary deadline fires first under normal conditions and `timeout`
+# is the SIGKILL safety net for binaries that ignore SIGTERM.
 - name: Setup S3 sync cron job
   ansible.builtin.cron:
     name: "dango s3 sync - {{ deployment_name }}"
     minute: "*/10"
-    job: "cd {{ deployment_dir }} && /usr/bin/docker compose exec -T dango dango indexer s3-sync 2>&1 | logger -t dango-s3-sync"
+    job: >-
+      cd {{ deployment_dir }} &&
+      /usr/bin/flock -n /tmp/dango-s3-sync-{{ deployment_name }}.lock
+      /usr/bin/timeout --kill-after=30s 540s
+      /usr/bin/docker compose exec -T dango dango indexer s3-sync
+      2>&1 | logger -t dango-s3-sync
     state: present

--- a/deploy/roles/full-app/tasks/s3_sync_cron.yml
+++ b/deploy/roles/full-app/tasks/s3_sync_cron.yml
@@ -1,18 +1,19 @@
-# Defense-in-depth wrapper around the s3-sync invocation. The dango binary
-# itself now has a wallclock timeout (`--timeout-secs`, default 480s) and
-# bounded SDK timeouts, but this cron line still has to be safe even when
-# running against an old binary that hasn't been redeployed yet — that gap
-# is exactly how the 2026-05-03 prod incident accumulated 30+ processes
-# after a reboot.
+# On 2026-05-03 ovh1 became unresponsive: 30+ `dango indexer s3-sync` processes
+# accumulated and dockerd hit 805% CPU. Two bugs combined:
 #
-# `flock -n` on a per-deployment lock makes a new firing exit immediately
-# if the previous one is still running. This alone would have prevented
-# the pile-up: even with a hung binary, only one process exists at a time.
+# 1. Tailscale had overwritten the host's `/etc/resolv.conf` so the S3 bucket no
+#    longer resolved;
+# 2. `dango indexer s3-sync` retried failed uploads indefinitely instead of
+#    bailing out, so each cron firing stacked on top of the previous one.
 #
-# `timeout --kill-after=30s 540s` is the outermost ceiling. It sits just
-# under the 10-min cron interval and just above the Rust-side 480s, so
-# the in-binary deadline fires first under normal conditions and `timeout`
-# is the SIGKILL safety net for binaries that ignore SIGTERM.
+# The dango-cli side is fixed at `dango/cli/src/indexer.rs:194` with a
+# `tokio::time::timeout` wrap (default 480s via `--timeout-secs`).
+#
+# Below employs a defense-in-depth at the cron layer:
+#
+# - `flock -n` skips the firing if the previous one is still running;
+# - `timeout --kill-after=30s 540s` sits just under the 10-min cron interval as
+#   a SIGKILL safety net.
 - name: Setup S3 sync cron job
   ansible.builtin.cron:
     name: "dango s3 sync - {{ deployment_name }}"

--- a/indexer/cache/src/indexer.rs
+++ b/indexer/cache/src/indexer.rs
@@ -245,8 +245,15 @@ impl Cache {
         #[cfg(feature = "tracing")]
         let path = file_path.clone();
 
-        // Naive retries, in case of network error.
-        for _ in 0..=10 {
+        // Outer retry loop on top of the SDK's own retry budget (configured
+        // in `s3::S3Config::client`, currently 3 attempts). Three outer
+        // attempts × ~30s SDK ceiling × 100 concurrent blocks is already a
+        // worst case of several minutes when S3 is unreachable; eleven outer
+        // attempts × 1s sleep was on top of that and turned a single bad
+        // bucket into a half-hour-long process. Exponential backoff (200ms,
+        // 400ms, 800ms) instead of a flat 1s sleep so we recover faster from
+        // transient blips without hammering on persistent failure.
+        for attempt in 0u32..3 {
             // When restarting the node, we could have some already copied over blocks. Skipping those.
             match s3_client.exists(&s3_key).await {
                 Ok(false) => {
@@ -338,7 +345,7 @@ impl Cache {
                     #[cfg(feature = "metrics")]
                     metrics::counter!("indexer.s3.upload.failure").increment(1);
 
-                    sleep(Duration::from_secs(1)).await;
+                    sleep(Duration::from_millis(200u64 << attempt)).await;
                 },
             }
         }

--- a/indexer/cache/src/indexer.rs
+++ b/indexer/cache/src/indexer.rs
@@ -625,6 +625,8 @@ impl grug_app::Indexer for Cache {
     }
 }
 
+// ----------------------------------- tests -----------------------------------
+
 #[cfg(all(test, feature = "s3"))]
 mod tests {
     use {super::*, crate::S3Config};

--- a/indexer/cache/src/indexer.rs
+++ b/indexer/cache/src/indexer.rs
@@ -624,3 +624,74 @@ impl grug_app::Indexer for Cache {
         Ok(())
     }
 }
+
+#[cfg(all(test, feature = "s3"))]
+mod tests {
+    use {super::*, crate::S3Config};
+
+    /// Regression test for the production hang on 2026-05-03: with an
+    /// unreachable S3 endpoint, `sync_to_s3` must return `Err` quickly
+    /// rather than running indefinitely. If this ever takes >15s the
+    /// pile-up bug is back. The outer `tokio::time::timeout` is the
+    /// safety net so a regression fails the test rather than hangs CI.
+    ///
+    /// We point the SDK at `127.0.0.1:1` so connect attempts are refused
+    /// immediately (no DNS, no real wait) — this exercises the
+    /// SDK-timeout / outer-retry / `JoinSet` chain end to end without
+    /// requiring any network. Happy-path runtime is ~3s; the 15s ceiling
+    /// is ~4× margin and caps CI cost on regression.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sync_to_s3_fails_fast_when_s3_unreachable() {
+        let cache = Cache {
+            context: Context {
+                s3: S3Config {
+                    enabled: true,
+                    path: "test/".to_string(),
+                    endpoint: "http://127.0.0.1:1".to_string(),
+                    access_key: "access".to_string(),
+                    secret_key: "secret".to_string(),
+                    bucket: "test-bucket".to_string(),
+                    region: "us-east-1".to_string(),
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        cache
+            .context
+            .indexer_path
+            .create_dirs_if_needed()
+            .expect("create blocks dir");
+
+        // Put one block on disk and record it as the highest stored height,
+        // so `sync_to_s3` finds work to do and actually exercises the S3
+        // client.
+        {
+            let block_height: u64 = 1;
+            let block_file_path =
+                CacheFile::file_path(cache.context.indexer_path.block_path(block_height));
+
+            std::fs::create_dir_all(block_file_path.parent().expect("block parent dir"))
+                .expect("create block subdir");
+            std::fs::write(&block_file_path, b"placeholder").expect("write block file");
+
+            Cache::store_last_block_height(&cache.context, block_height, HIGHEST_BLOCK_FILENAME)
+                .expect("store last block height")
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(15),
+            Cache::sync_to_s3(&cache.context, cache.s3_bitmap.clone(), 0),
+        )
+        .await;
+
+        match result {
+            Err(_elapsed) => {
+                panic!("sync_to_s3 hung past 15s — fail-fast regression is back")
+            },
+            Ok(Ok(_)) => panic!("sync_to_s3 unexpectedly succeeded against a dead endpoint"),
+            Ok(Err(_)) => {},
+        }
+    }
+}

--- a/indexer/cache/src/indexer.rs
+++ b/indexer/cache/src/indexer.rs
@@ -15,13 +15,12 @@ use {
 use {
     crate::error::IndexerError,
     crate::s3,
-    futures::future::try_join_all,
     roaring::RoaringTreemap,
     std::fs::File,
     std::io::{BufReader, BufWriter},
     std::time::Duration,
     std::time::Instant,
-    tokio::{sync::Semaphore, time::sleep},
+    tokio::{sync::Semaphore, task::JoinSet, time::sleep},
 };
 
 #[cfg(feature = "http-request-details")]
@@ -373,7 +372,21 @@ impl Cache {
         }
 
         let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_S3_UPLOADS));
-        let mut tasks = Vec::new();
+        // Use a `JoinSet` instead of collecting `JoinHandle`s into a `Vec` and
+        // joining via `try_join_all`. Two reasons, both about cancellation:
+        //
+        // 1. `try_join_all` short-circuits on the first `Err`, but the dropped
+        //    `JoinHandle`s for the other in-flight uploads do NOT get
+        //    cancelled — they keep running on the runtime, wasting work
+        //    against a bucket we already know is broken.
+        // 2. Dropping a `JoinSet` aborts all of its tasks. That's what makes
+        //    an outer `tokio::time::timeout(...)` actually free resources
+        //    rather than leak them. The CLI handler relies on this for the
+        //    wallclock timeout.
+        //
+        // We also `set.shutdown().await` on the first error so siblings stop
+        // immediately rather than running until natural completion.
+        let mut set: JoinSet<Result<()>> = JoinSet::new();
 
         for block_height in (last_synced_height + 1)..=last_stored_height {
             let context = context.clone();
@@ -384,17 +397,24 @@ impl Cache {
                 .expect("Semaphore should not be acquired");
             let s3_bitmap = s3_bitmap.clone();
 
-            let task = tokio::spawn(async move {
+            set.spawn(async move {
                 let _permit = permit;
                 Self::sync_block_to_s3(&context, s3_bitmap, block_height).await
             });
-
-            tasks.push(task);
         }
 
-        let results = try_join_all(tasks).await?;
-        for result in results {
-            result?;
+        while let Some(joined) = set.join_next().await {
+            match joined {
+                Ok(Ok(())) => {},
+                Ok(Err(err)) => {
+                    set.shutdown().await;
+                    return Err(err);
+                },
+                Err(join_err) => {
+                    set.shutdown().await;
+                    return Err(join_err.into());
+                },
+            }
         }
 
         #[cfg(feature = "tracing")]

--- a/indexer/cache/src/indexer.rs
+++ b/indexer/cache/src/indexer.rs
@@ -667,8 +667,9 @@ mod tests {
         // Put one block on disk and record it as the highest stored height,
         // so `sync_to_s3` finds work to do and actually exercises the S3
         // client.
+        let block_height: u64 = 1;
+
         {
-            let block_height: u64 = 1;
             let block_file_path =
                 CacheFile::file_path(cache.context.indexer_path.block_path(block_height));
 
@@ -688,10 +689,27 @@ mod tests {
 
         match result {
             Err(_elapsed) => {
-                panic!("sync_to_s3 hung past 15s — fail-fast regression is back")
+                panic!("sync_to_s3 hung past 15s — fail-fast regression is back");
             },
-            Ok(Ok(_)) => panic!("sync_to_s3 unexpectedly succeeded against a dead endpoint"),
-            Ok(Err(_)) => {},
+            Ok(Ok(_)) => {
+                panic!("sync_to_s3 unexpectedly succeeded against a dead endpoint");
+            },
+            // The dead endpoint causes `sync_block_to_s3` to exhaust
+            // its outer retry budget and return `S3UploadFailed`. The
+            // `JoinSet` arm then propagates that exact error out of
+            // `sync_to_s3`. With only one block in the test
+            // (`block_height = 1`), the error must reference that
+            // block — anything else means we're failing for a reason
+            // other than what this test is supposed to cover.
+            Ok(Err(IndexerError::S3UploadFailed {
+                block_height: failed_height,
+                ..
+            })) => {
+                assert_eq!(failed_height, block_height, "wrong block in S3UploadFailed");
+            },
+            Ok(Err(other)) => {
+                panic!("expected IndexerError::S3UploadFailed, got: {other:?}")
+            },
         }
     }
 }

--- a/indexer/cache/src/s3.rs
+++ b/indexer/cache/src/s3.rs
@@ -1,13 +1,13 @@
 use {
     crate::error::{IndexerError, Result},
-    aws_config::{BehaviorVersion, Region},
+    aws_config::{BehaviorVersion, Region, retry::RetryConfig, timeout::TimeoutConfig},
     aws_credential_types::Credentials,
     aws_sdk_s3::{
         Client as AwsS3Client, config::Builder as S3ConfigBuilder, error::SdkError,
         operation::head_object::HeadObjectError, primitives::ByteStream,
     },
     serde::{Deserialize, Serialize},
-    std::path::Path,
+    std::{path::Path, time::Duration},
 };
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -31,9 +31,36 @@ impl S3Config {
             None,
             "static",
         );
+
+        // Bound every S3 operation in wall-clock terms. Without this the SDK
+        // inherits its built-in defaults (effectively no read timeout for
+        // large bodies, ~30s connect), so a network black-hole — DNS that
+        // returns timeouts instead of NXDOMAIN, an unreachable bucket, a
+        // stalled TLS handshake — leaves each call hanging until something
+        // upstream gives up. Combined with the per-block retry loop in
+        // `sync_block_to_s3`, that turns a single failed bucket into minutes
+        // of wasted work per cron firing and processes pile up.
+        //
+        // `operation_timeout` caps the whole call including SDK-level retries;
+        // `operation_attempt_timeout` caps a single attempt. With
+        // `RetryConfig::standard().with_max_attempts(3)` the worst case is
+        // bounded at ~30s per S3 op.
+        let timeout_cfg = TimeoutConfig::builder()
+            .connect_timeout(Duration::from_secs(3))
+            .read_timeout(Duration::from_secs(10))
+            .operation_attempt_timeout(Duration::from_secs(15))
+            .operation_timeout(Duration::from_secs(30))
+            .build();
+
+        let retry_cfg = RetryConfig::standard()
+            .with_max_attempts(3)
+            .with_initial_backoff(Duration::from_millis(200));
+
         let base_cfg = aws_config::defaults(BehaviorVersion::latest())
             .region(Region::new(self.region.clone()))
             .credentials_provider(creds)
+            .timeout_config(timeout_cfg)
+            .retry_config(retry_cfg)
             .load()
             .await;
 


### PR DESCRIPTION
On 2026-05-03 ovh1 became unresponsive: `top` showed 30+ `dango` processes and dockerd at 805% CPU after a routine reboot. Root cause was a `*/10` cron running `dango indexer s3-sync` against a stale S3 bucket name (`dango-devnet-20260419132740`) that no longer resolved. Each invocation ran for many minutes — the AWS SDK had no explicit timeouts, the per-block loop retried 11× with 1s sleep, `try_join_all` left siblings running after the first error, and there was no wallclock cap on the whole command. With nothing to bound any of those layers, every cron firing stacked on top of the previous one.

The original DNS trigger has been fixed separately. This PR fixes the *amplifier* so the next time something makes S3 unreachable, the host doesn't melt.

Five layered changes:

1. **AWS SDK timeouts + retry budget** (`indexer/cache/src/s3.rs`) — `connect=3s`, `read=10s`, `attempt=15s`, `operation=30s`, `max_attempts=3`. Every S3 op now fails in ~30s worst case instead of indefinitely.
2. **`try_join_all` → `JoinSet`** (`indexer/cache/src/indexer.rs`) — first error now aborts siblings via `shutdown().await`. Also makes the upcoming wallclock timeout actually free resources rather than leak tasks (dropping a `JoinSet` cancels its tasks; dropping `JoinHandle`s does not).
3. **Per-block retry cut from 11×1s flat to 3× exponential** (`indexer/cache/src/indexer.rs`) — the SDK now does its own 3 attempts; piling 11 more on top of that turned a single failed bucket into multi-minute work per cron.
4. **CLI `--timeout-secs` + `tokio::time::timeout` wrap** (`dango/cli/src/indexer.rs`) — default 480s, hard ceiling well below the 10-min cron interval. Includes a regression test that points the SDK at `127.0.0.1:1` and asserts `sync_to_s3` returns `Err` in <15s (actual happy-path runtime: ~3s).
5. **Cron `flock -n` + GNU `timeout 540s`** (`deploy/roles/full-app/tasks/s3_sync_cron.yml`) — defense in depth that protects hosts running an old binary that hasn't been redeployed yet. `flock` alone would have prevented the original pile-up.