### PR TITLE
chore(deploy): cometbft reduce consensus timeouts

### DIFF
--- a/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
+++ b/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
@@ -450,7 +450,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
@@ -458,7 +458,7 @@ timeout_prevote = "1s"
 # How much the timeout_prevote increases with each round
 timeout_prevote_delta = "500ms"
 # How long we wait after receiving +2/3 precommits for “anything” (ie. not a single block or nil)
-timeout_precommit = "1s"
+timeout_precommit = "500ms"
 # How much the timeout_precommit increases with each round
 timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new

--- a/localdango/configs/cometbft/config/config.toml
+++ b/localdango/configs/cometbft/config/config.toml
@@ -448,7 +448,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "1s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
@@ -456,7 +456,7 @@ timeout_prevote = "1s"
 # How much the timeout_prevote increases with each round
 timeout_prevote_delta = "500ms"
 # How long we wait after receiving +2/3 precommits for “anything” (ie. not a single block or nil)
-timeout_precommit = "1s"
+timeout_precommit = "500ms"
 # How much the timeout_precommit increases with each round
 timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new


### PR DESCRIPTION
Reduce `timeout_propose` from 3s to 1s and `timeout_precommit` from 1s to
500ms. These shorten the stall when a round-0 proposer is offline
(~4.4s to ~1.9s) while staying comfortably above the worst-case
proposer-side latency in the current validator set, so live-but-slow
proposers are not prematurely timed out.