### PR TITLE
fix(deploy): match Debian security repo in unattended-upgrades

### DIFF
--- a/deploy/roles/common/templates/50unattended-upgrades.j2
+++ b/deploy/roles/common/templates/50unattended-upgrades.j2
@@ -1,7 +1,6 @@
-Unattended-Upgrade::Allowed-Origins {
-  "${distro_id}:${distro_codename}-security";
-  "${distro_id}ESMApps:${distro_codename}-apps-security";
-  "${distro_id}ESM:${distro_codename}-infra-security";
+Unattended-Upgrade::Origins-Pattern {
+  "origin=Debian,codename=${distro_codename},label=Debian-Security";
+  "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
 };
 Unattended-Upgrade::AutoFixInterruptedDpkg "true";
 Unattended-Upgrade::Remove-Unused-Dependencies "true";


### PR DESCRIPTION
The Allowed-Origins shorthand `${distro_id}:${distro_codename}-security` expanded to `o=Debian,a=trixie-security`, but Debian's security archive is published with `Suite: stable-security`, so the pattern matched nothing. The two ESM entries below it are Ubuntu Pro origins that don't exist on Debian. Net result: unattended-upgrades had no allowed origins on these hosts and was a no-op since provisioning, leaving security updates uninstalled.

Replace with `Origins-Pattern` matching by codename + Debian-Security label — the upstream Debian default. Covers both security.debian.org (codename `${distro_codename}-security`) and security entries that arrive in point releases of the main suite.