### PR TITLE
feat(sdk-rust): add trade-history CSV example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,6 +4328,7 @@ dependencies = [
  "assertor",
  "async-trait",
  "bip32",
+ "csv",
  "dango-account-factory",
  "dango-auth",
  "dango-genesis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ colored                     = "3"
 colored_json                = "5"
 config                      = "0.15"
 criterion                   = "0.8"
+csv                         = "1.3"
 data-encoding               = "2"
 dialoguer                   = "0.12"
 digest                      = "0.10" # FIXME: can't bump to 0.11 because RustCrypto requires 0.10

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -44,6 +44,7 @@ url               = { workspace = true }
 [dev-dependencies]
 assert-json-diff      = { workspace = true }
 assertor              = { workspace = true }
+csv                   = { workspace = true }
 dango-account-factory = { workspace = true, features = ["library"] }
 dango-genesis         = { workspace = true }
 dango-mock-httpd      = { workspace = true }

--- a/sdk/rust/examples/trade_history_csv.rs
+++ b/sdk/rust/examples/trade_history_csv.rs
@@ -1,0 +1,127 @@
+//! Fetch the entire `order_filled` history for a single user from the
+//! Dango indexer and write it to a CSV file.
+//!
+//! Uses paginated GraphQL queries because an active account can have
+//! thousands of fills.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run -p dango-sdk --example trade_history_csv
+//! ```
+
+use {
+    anyhow::{Context, Result},
+    dango_sdk::{HttpClient, PageInfo, perps_events},
+    serde::{Deserialize, Serialize},
+};
+
+const HTTP_URL: &str = "https://api-mainnet.dango.zone";
+const USER_ADDR: &str = "0x0000000000000000000000000000000000000000";
+const OUTPUT_PATH: &str = "trades.csv";
+// The indexer caps `first` at 100.
+const PAGE_SIZE: i64 = 100;
+
+// Mirrors the `data` payload of an `order_filled` event
+// (`dango_types::perps::OrderFilled`). Defined locally so the example
+// stays self-contained and does not depend on dango-types.
+#[derive(Debug, Deserialize)]
+struct OrderFilledData {
+    order_id: String,
+    fill_price: String,
+    fill_size: String,
+    closing_size: String,
+    opening_size: String,
+    realized_pnl: String,
+    realized_funding: Option<String>,
+    fee: String,
+    client_order_id: Option<String>,
+    fill_id: Option<String>,
+    is_maker: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct CsvRow {
+    block_height: i64,
+    created_at: String,
+    tx_hash: String,
+    pair_id: String,
+    user_addr: String,
+    idx: i64,
+    order_id: String,
+    fill_id: Option<String>,
+    is_maker: Option<bool>,
+    fill_price: String,
+    fill_size: String,
+    closing_size: String,
+    opening_size: String,
+    realized_pnl: String,
+    realized_funding: Option<String>,
+    fee: String,
+    client_order_id: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = HttpClient::new(HTTP_URL)?;
+
+    println!("fetching order_filled events for {USER_ADDR} from {HTTP_URL}");
+
+    let events = client
+        .paginate_all(
+            Some(PAGE_SIZE),
+            None,
+            |after, before, first, last| perps_events::Variables {
+                after,
+                before,
+                first,
+                last,
+                user_addr: Some(USER_ADDR.to_string()),
+                event_type: Some("order_filled".to_string()),
+                ..Default::default()
+            },
+            |data| {
+                let pi = data.perps_events.page_info;
+                (data.perps_events.nodes, PageInfo {
+                    start_cursor: pi.start_cursor,
+                    end_cursor: pi.end_cursor,
+                    has_next_page: pi.has_next_page,
+                    has_previous_page: pi.has_previous_page,
+                })
+            },
+        )
+        .await?;
+
+    println!("fetched {} fills; writing to {OUTPUT_PATH}", events.len());
+
+    let mut writer = csv::Writer::from_path(OUTPUT_PATH)
+        .with_context(|| format!("opening {OUTPUT_PATH} for writing"))?;
+
+    for ev in events {
+        let parsed: OrderFilledData = serde_json::from_value(ev.data.clone())
+            .with_context(|| format!("decoding order_filled data at idx={}", ev.idx))?;
+        writer.serialize(CsvRow {
+            block_height: ev.block_height,
+            created_at: ev.created_at,
+            tx_hash: ev.tx_hash,
+            pair_id: ev.pair_id,
+            user_addr: ev.user_addr,
+            idx: ev.idx,
+            order_id: parsed.order_id,
+            fill_id: parsed.fill_id,
+            is_maker: parsed.is_maker,
+            fill_price: parsed.fill_price,
+            fill_size: parsed.fill_size,
+            closing_size: parsed.closing_size,
+            opening_size: parsed.opening_size,
+            realized_pnl: parsed.realized_pnl,
+            realized_funding: parsed.realized_funding,
+            fee: parsed.fee,
+            client_order_id: parsed.client_order_id,
+        })?;
+    }
+
+    writer.flush()?;
+    println!("done; wrote {OUTPUT_PATH}");
+    Ok(())
+}

--- a/sdk/rust/examples/trade_history_csv.rs
+++ b/sdk/rust/examples/trade_history_csv.rs
@@ -13,32 +13,16 @@
 use {
     anyhow::{Context, Result},
     dango_sdk::{HttpClient, PageInfo, perps_events},
-    serde::{Deserialize, Serialize},
+    dango_types::perps::OrderFilled,
+    grug::EventName,
+    serde::Serialize,
 };
 
 const HTTP_URL: &str = "https://api-mainnet.dango.zone";
-const USER_ADDR: &str = "0x0000000000000000000000000000000000000000";
+const USER_ADDR: &str = "0x0000000000000000000000000000000000000000"; // replace with the actual address of interest
 const OUTPUT_PATH: &str = "trades.csv";
 // The indexer caps `first` at 100.
 const PAGE_SIZE: i64 = 100;
-
-// Mirrors the `data` payload of an `order_filled` event
-// (`dango_types::perps::OrderFilled`). Defined locally so the example
-// stays self-contained and does not depend on dango-types.
-#[derive(Debug, Deserialize)]
-struct OrderFilledData {
-    order_id: String,
-    fill_price: String,
-    fill_size: String,
-    closing_size: String,
-    opening_size: String,
-    realized_pnl: String,
-    realized_funding: Option<String>,
-    fee: String,
-    client_order_id: Option<String>,
-    fill_id: Option<String>,
-    is_maker: Option<bool>,
-}
 
 #[derive(Debug, Serialize)]
 struct CsvRow {
@@ -77,7 +61,7 @@ async fn main() -> Result<()> {
                 first,
                 last,
                 user_addr: Some(USER_ADDR.to_string()),
-                event_type: Some("order_filled".to_string()),
+                event_type: Some(OrderFilled::EVENT_NAME.to_string()),
                 ..Default::default()
             },
             |data| {
@@ -98,8 +82,9 @@ async fn main() -> Result<()> {
         .with_context(|| format!("opening {OUTPUT_PATH} for writing"))?;
 
     for ev in events {
-        let parsed: OrderFilledData = serde_json::from_value(ev.data.clone())
+        let parsed: OrderFilled = serde_json::from_value(ev.data.clone())
             .with_context(|| format!("decoding order_filled data at idx={}", ev.idx))?;
+
         writer.serialize(CsvRow {
             block_height: ev.block_height,
             created_at: ev.created_at,
@@ -107,21 +92,23 @@ async fn main() -> Result<()> {
             pair_id: ev.pair_id,
             user_addr: ev.user_addr,
             idx: ev.idx,
-            order_id: parsed.order_id,
-            fill_id: parsed.fill_id,
+            order_id: parsed.order_id.to_string(),
+            fill_id: parsed.fill_id.map(|v| v.to_string()),
             is_maker: parsed.is_maker,
-            fill_price: parsed.fill_price,
-            fill_size: parsed.fill_size,
-            closing_size: parsed.closing_size,
-            opening_size: parsed.opening_size,
-            realized_pnl: parsed.realized_pnl,
-            realized_funding: parsed.realized_funding,
-            fee: parsed.fee,
-            client_order_id: parsed.client_order_id,
+            fill_price: parsed.fill_price.to_string(),
+            fill_size: parsed.fill_size.to_string(),
+            closing_size: parsed.closing_size.to_string(),
+            opening_size: parsed.opening_size.to_string(),
+            realized_pnl: parsed.realized_pnl.to_string(),
+            realized_funding: parsed.realized_funding.map(|v| v.to_string()),
+            fee: parsed.fee.to_string(),
+            client_order_id: parsed.client_order_id.map(|v| v.to_string()),
         })?;
     }
 
     writer.flush()?;
+
     println!("done; wrote {OUTPUT_PATH}");
+
     Ok(())
 }


### PR DESCRIPTION
Paginate `perpsEvents` filtered to a user's `order_filled` events
via `HttpClient::paginate_all` and write each fill to a CSV file.
Complements the existing WebSocket `subscribe_order_filled` example
by demonstrating historical retrieval over HTTP.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>