### PR TITLE
fix(deploy): migrate from artis3n.tailscale standalone role to collection

### DIFF
--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -4,10 +4,9 @@ collections:
   - name: community.general
   - name: community.clickhouse
   - name: amazon.aws
-roles:
   - name: artis3n.tailscale
-    src: artis3n.tailscale
-    version: "v5.0.1"
+    version: "1.2.1"
+roles:
   - name: MonolithProjects.github_actions_runner
     src: MonolithProjects.github_actions_runner
     version: "1.28.0"

--- a/deploy/tailscale.yml
+++ b/deploy/tailscale.yml
@@ -3,9 +3,7 @@
   remote_user: debian
   vars_files:
     - vaults/debian/root_vault.yml
-  collections:
-    - artis3n.tailscale
   vars:
     tailscale_args: "--accept-dns=false"
   roles:
-    - role: artis3n.tailscale
+    - role: artis3n.tailscale.machine


### PR DESCRIPTION
The standalone role v5.0.1 contains a deprecation-marker task whose when: clause is a Jinja filter expression that returns a string (via print_warn). ansible-core 2.20+ enforces strict boolean conditionals and rejects this with "Conditionals must have a boolean result", aborting the play before any tailscale tasks can run.

The standalone role is deprecated upstream in favor of the artis3n.tailscale collection. The collection's role artis3n.tailscale.machine exposes the same parameter API (tailscale_authkey, tailscale_args), so existing playbook usage is unchanged. Bumped requirements.yml accordingly and dropped the collections: directive in tailscale.yml since the role is now referenced by FQCN.