### PR TITLE
fix(deploy): set `remote_user: debian` on the promtail/node-exporter play

### DIFF
--- a/deploy/playbook.yml
+++ b/deploy/playbook.yml
@@ -20,6 +20,7 @@
 
 - hosts: all
   become: true
+  remote_user: debian
   become_user: "{{ deploy_user }}"
   vars:
     ansible_ssh_common_args: >-


### PR DESCRIPTION
The second play in `playbook.yml` (which applies node-exporter and promtail) was missing `remote_user: debian`, so ansible defaulted to the operator's local username for SSH. Combined with the play's `IdentitiesOnly=yes + IdentityFile=...debian.pub`, SSH would only offer the debian key while connecting as the local user, whose `authorized_keys` on the target accepts a different key entirely. The result was `Permission denied (publickey)` at "Gathering Facts" of the second play during fresh provisioning.

Bringing this play in line with plays 1 and 3 (both of which already declare `remote_user: debian`) resolves it and makes the playbook robust to operators who haven't set `ANSIBLE_REMOTE_USER` in their environment.