### PR TITLE
feat(perps): expose `tp`/`sl`/`client_order_id` on order query responses

### DIFF
--- a/dango/order-book/src/types.rs
+++ b/dango/order-book/src/types.rs
@@ -173,6 +173,9 @@ pub struct QueryOrderResponse {
     pub reduce_only: bool,
     pub reserved_margin: UsdValue,
     pub created_at: Timestamp,
+    pub tp: Option<ChildOrder>,
+    pub sl: Option<ChildOrder>,
+    pub client_order_id: Option<ClientOrderId>,
 }
 
 #[grug::derive(Serde)]
@@ -183,6 +186,9 @@ pub struct QueryOrdersByUserResponseItem {
     pub reduce_only: bool,
     pub reserved_margin: UsdValue,
     pub created_at: Timestamp,
+    pub tp: Option<ChildOrder>,
+    pub sl: Option<ChildOrder>,
+    pub client_order_id: Option<ClientOrderId>,
 }
 
 #[grug::derive(Serde)]

--- a/dango/perps/src/query.rs
+++ b/dango/perps/src/query.rs
@@ -283,6 +283,9 @@ fn limit_order_to_response(
         reduce_only: order.reduce_only,
         reserved_margin: order.reserved_margin,
         created_at: order.created_at,
+        tp: order.tp,
+        sl: order.sl,
+        client_order_id: order.client_order_id,
     }
 }
 
@@ -298,6 +301,9 @@ fn limit_order_to_item(
         reduce_only: order.reduce_only,
         reserved_margin: order.reserved_margin,
         created_at: order.created_at,
+        tp: order.tp,
+        sl: order.sl,
+        client_order_id: order.client_order_id,
     }
 }
 


### PR DESCRIPTION
Forward `tp`, `sl`, and `client_order_id` from the stored `LimitOrder` through `QueryOrderResponse` and `QueryOrdersByUserResponseItem` so clients can recover caller-assigned ids and child triggers without round-tripping through events.