### PR TITLE
feat(httpd): expose hostname on /up endpoint

### DIFF
--- a/grug/httpd/src/routes/index.rs
+++ b/grug/httpd/src/routes/index.rs
@@ -26,6 +26,7 @@ pub struct UpResponse<'a> {
     pub git_commit: &'a str,
     pub indexed_block_height: Option<u64>,
     pub chain_id: &'a str,
+    pub hostname: &'a str,
 }
 
 #[get("/up")]
@@ -46,5 +47,6 @@ pub async fn up(app_ctx: web::Data<Context>) -> Result<impl Responder, Error> {
         git_commit: GIT_COMMIT,
         indexed_block_height: None,
         chain_id: var("CHAIN_ID").unwrap_or_default().as_str(),
+        hostname: var("HOSTNAME").unwrap_or_default().as_str(),
     }))
 }

--- a/indexer/httpd/src/routes/index.rs
+++ b/indexer/httpd/src/routes/index.rs
@@ -38,6 +38,7 @@ pub async fn up(app_ctx: web::Data<Context>) -> Result<impl Responder, Error> {
         indexed_block_height,
         git_commit: GIT_COMMIT,
         chain_id: var("CHAIN_ID").unwrap_or_default().as_str(),
+        hostname: var("HOSTNAME").unwrap_or_default().as_str(),
     }))
 }
 


### PR DESCRIPTION
Add a `hostname` field to the `/up` response, sourced from the `HOSTNAME` env var. Production runs multiple servers behind a Cloudflare load balancer, so when the maintenance-page check observes `is_running = false`, ops can now identify which backend is unhealthy by curling `/up` directly.

The same struct is constructed in both `grug-httpd` and `indexer-httpd`, so both handlers are updated. No frontend changes — both consumers destructure only `is_running` from the JSON response.