### PR TITLE
feat(ui): show frontend git commit in settings

### DIFF
--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1026,7 +1026,8 @@
         "chainId": "Chain ID",
         "latestBlockHeight": "Latest Block Height",
         "latestBlockTime": "Latest Block Time",
-        "endpoint": "Endpoint"
+        "endpoint": "Endpoint",
+        "frontendVersion": "Frontend Version"
       },
       "time": { "hours": "h", "minutes": "m", "seconds": "s" },
       "username": {

--- a/ui/portal/web/env.d.ts
+++ b/ui/portal/web/env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="@rsbuild/core/types" />
+
+interface ImportMetaEnv {
+  readonly GIT_COMMIT: string;
+  readonly CONFIG_ENVIRONMENT: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/ui/portal/web/rsbuild.config.ts
+++ b/ui/portal/web/rsbuild.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import crypto from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,6 +32,17 @@ const environment = process.env.CONFIG_ENVIRONMENT || "test";
 const enabledFeatures = process.env.ENABLED_FEATURES
   ? process.env.ENABLED_FEATURES.split(",").map((f) => f.trim())
   : [];
+
+const gitCommit = (() => {
+  if (process.env.GIT_COMMIT) return process.env.GIT_COMMIT;
+  try {
+    return execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+})();
 
 const workspaceRoot = path.resolve(__dirname, "../../../");
 
@@ -168,6 +180,7 @@ export default defineConfig({
       ...publicVars,
       "import.meta.env.CONFIG_ENVIRONMENT": `"${process.env.CONFIG_ENVIRONMENT || "local"}"`,
       "import.meta.env.HYPERLANE_CONFIG": JSON.stringify(await hyperlaneConfig()),
+      "import.meta.env.GIT_COMMIT": `"${gitCommit}"`,
       "process.env": {},
       "import.meta.env": {},
     },

--- a/ui/portal/web/src/components/settings/SessionSection.tsx
+++ b/ui/portal/web/src/components/settings/SessionSection.tsx
@@ -171,6 +171,15 @@ const NetworkSection: React.FC = () => {
               {chain.urls.indexer.replace(/\/graphql$/, "")}
             </p>
           </div>
+
+          <div className="flex md:items-center flex-col md:flex-row diatype-sm-regular">
+            <p className="md:min-w-[10rem] text-ink-tertiary-500">
+              {m["settings.session.network.frontendVersion"]()}
+            </p>
+            <p className="break-all whitespace-normal">
+              {import.meta.env.GIT_COMMIT}
+            </p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Mirror the backend's `GIT_COMMIT` injection (see `grug/types/src/git_info.rs` and `httpd`'s `/up` endpoint) on the frontend. The commit hash is substituted at build time via Rspack's `source.define`, sourced from `process.env.GIT_COMMIT` (already passed by the frontend Docker build) with a `git rev-parse HEAD` fallback for local dev. A new "Frontend Version" row appears in Settings → Current Session → Network alongside Endpoint and block info.