### PR TITLE
ci: trigger rust workflow on push to v0.17

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - "main"
       - "develop"
+      - "v0.17"
       # - "ui/testnet"
       # - "ui/release"
     paths:


### PR DESCRIPTION
Add `v0.17` to the push branches list so the docker build of the
backend (and other rust workflow jobs) runs when commits land on the
v0.17 maintenance branch.