### PR TITLE
chore(deploy): move hyperlane validator 1 to hetzner5

### DIFF
--- a/deploy/inventory
+++ b/deploy/inventory
@@ -134,7 +134,7 @@ perp-liquidator-testnet
 perp-liquidator-mainnet
 
 [hyperlane]
-100.89.7.33    # inter1
+100.72.62.100  # hetzner5
 100.66.234.16  # inter2
 100.126.8.2    # hetzner1
 100.90.163.19  # hetzner2

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -291,7 +291,7 @@ deploy-hyperlane network agent limit index="":
       2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-hyperlane.log
 
 deploy-hyperlane-mainnet:
-  just deploy-hyperlane mainnet validator 100.89.7.33 1
+  just deploy-hyperlane mainnet validator 100.72.62.100 1
   just deploy-hyperlane mainnet validator 100.66.234.16 2
   just deploy-hyperlane mainnet validator 100.126.8.2 3
   just deploy-hyperlane mainnet validator 100.76.197.30 4
@@ -303,7 +303,7 @@ deploy-hyperlane-testnet:
   just deploy-hyperlane testnet relayer 100.109.200.70
 
 # Stop a single Hyperlane instance
-# Usage: just stop-hyperlane mainnet validator 100.89.7.33 1
+# Usage: just stop-hyperlane mainnet validator 100.72.62.100 1
 #        just stop-hyperlane testnet relayer 100.109.200.70
 stop-hyperlane network agent limit index="":
   mkdir -p {{justfile_directory()}}/logs \
@@ -315,7 +315,7 @@ stop-hyperlane network agent limit index="":
       2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-stop-hyperlane.log
 
 stop-hyperlane-mainnet-validators:
-  just stop-hyperlane mainnet validator 100.89.7.33 1
+  just stop-hyperlane mainnet validator 100.72.62.100 1
   just stop-hyperlane mainnet validator 100.66.234.16 2
   just stop-hyperlane mainnet validator 100.126.8.2 3
   just stop-hyperlane mainnet validator 100.76.197.30 4

--- a/deploy/roles/hyperlane/files/validator-config.json
+++ b/deploy/roles/hyperlane/files/validator-config.json
@@ -1,4 +1,5 @@
 {
+  "db": "/app/hyperlane_db",
   "validator": {
     "type": "aws",
     "region": "eu-north-1"

--- a/deploy/roles/prometheus/templates/prometheus.yml
+++ b/deploy/roles/prometheus/templates/prometheus.yml
@@ -160,7 +160,7 @@ scrape_configs:
 
   - job_name: 'hyperlane-validator'
     static_configs:
-      - targets: ['inter1:9500']
+      - targets: ['hetzner5:9500']
         labels:
           service: 'hyperlane'
           role: 'validator'


### PR DESCRIPTION
## Summary

- inter1 has been decommissioned; redeploy hyperlane validator 1 from scratch on hetzner5 (`100.72.62.100`). The KMS key, dango signer key, and S3 checkpoint bucket are vaulted by validator index (not by host), so hetzner5 reuses the same identity — no secret rotation needed.
- Updates `inventory` `[hyperlane]` group, the two mainnet validator-1 just recipes (`deploy-hyperlane-mainnet`, `stop-hyperlane-mainnet-validators`) and the related `# Usage:` example, plus the prometheus `hyperlane-validator` target for `validator_index: '1'`.
- Fix: explicitly set `"db": "/app/hyperlane_db"` in `validator-config.json` so the agent persists its rocksdb on the mounted host volume `~/hyperlane-agents/<instance>/hyperlane_db` (was writing to a default path inside the container, lost on every container recreate).

This PR is **scoped to hyperlane only**. The broader inter1 → hetzner5 node migration (cometbft/dango/postgres/clickhouse) is tracked in #1999 and overlaps these inventory/justfile lines.

## Validation

### Completed
- [x] `just lint` — no new warnings on the modified files.
- [x] Diff review: only validator-1's IP/host references swap, validators 2–4 untouched.

### Remaining
- [ ] Run `just deploy-hyperlane mainnet validator 100.72.62.100 1` and verify `docker logs mainnet-validator-1 --tail 50` shows the validator starting and posting checkpoints.
- [ ] Run `just deploy-monitoring` to push the new prometheus config to ovh3; verify in Grafana that the `hyperlane-validator{validator_index="1"}` series resolves to `hetzner5:9500` and is `up`.
- [ ] Confirm the validator's KMS-derived address signs checkpoints in S3 within ~1 minute of restart.

## Manual QA

1. Confirm hetzner5 has been provisioned per `NEW_SERVER_SETUP.md` (steps 1–9) — already in `[full-app]`/`host_vars`, so should be done.
2. After deploy: validator-1 panel in Grafana shows the new target up, no scrape errors on inter1 (target removed).
3. Checkpoint S3 bucket continues receiving signatures from validator-1's KMS-derived address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)