### PR TITLE
chore(hyperlane): route relayer/validator via local dango node

### DIFF
--- a/deploy/roles/hyperlane/files/config.json
+++ b/deploy/roles/hyperlane/files/config.json
@@ -2,7 +2,7 @@
   "chains": {
     "dango": {
       "chain_id": "dango-1",
-      "httpd_urls": ["https://api-mainnet.dango.zone"],
+      "httpd_urls": ["http://dango:8080", "https://api-mainnet.dango.zone"],
       "mailbox": "0x974e57564ed3ed7d8f99d0c359fd03f3d78259c7",
       "interchainGasPaymaster": "0x0000000000000000000000000000000000000000",
       "validatorAnnounce": "0x75f38c6fcfc2fb8333e5c3ef89d13b7036abe3ff",
@@ -17,7 +17,7 @@
     },
     "dangotestnet": {
       "chain_id": "dango-testnet-1",
-      "httpd_urls": ["https://api-testnet.dango.zone"],
+      "httpd_urls": ["http://dango:8080", "https://api-testnet.dango.zone"],
       "mailbox": "0x974e57564ed3ed7d8f99d0c359fd03f3d78259c7",
       "interchainGasPaymaster": "0x0000000000000000000000000000000000000000",
       "validatorAnnounce": "0x75f38c6fcfc2fb8333e5c3ef89d13b7036abe3ff",

--- a/deploy/roles/hyperlane/files/docker-compose-relayer.yml
+++ b/deploy/roles/hyperlane/files/docker-compose-relayer.yml
@@ -16,3 +16,10 @@ services:
       - "${HYPERLANE_METRICS_HOST_PORT}:9090"
     command: ["./relayer"]
     restart: unless-stopped
+    networks:
+      - default
+      - traefik
+
+networks:
+  traefik:
+    external: true

--- a/deploy/roles/hyperlane/files/docker-compose-validator.yml
+++ b/deploy/roles/hyperlane/files/docker-compose-validator.yml
@@ -16,3 +16,10 @@ services:
       - "${HYPERLANE_METRICS_HOST_PORT}:9090"
     command: ["./validator"]
     restart: unless-stopped
+    networks:
+      - default
+      - traefik
+
+networks:
+  traefik:
+    external: true


### PR DESCRIPTION
## Summary
- Add `http://dango:8080` as the primary `httpd_urls` entry for both `dango` (mainnet) and `dangotestnet` chains, keeping the public API URL as fallback.
- Attach the relayer and validator containers to the external `traefik` Docker network so they can resolve and reach the local dango service by hostname.

Routes hyperlane traffic through the in-cluster dango node, reducing latency and removing the public edge from the critical path. The public URL is preserved as fallback for resilience.

## Validation

### Completed
- [x] Diff reviewed for YAML/JSON syntax correctness
- [x] Public URL retained as fallback in both chain configs

### Remaining
- [ ] Deploy to testnet first and verify relayer/validator logs show connection to `http://dango:8080`
- [ ] Confirm metrics endpoints still reachable on `${HYPERLANE_METRICS_HOST_PORT}`
- [ ] Validate failover by temporarily blocking the local URL and confirming traffic falls back to the public API

## Manual QA
- On the deploy host, `docker compose up -d` for relayer and validator and tail logs for successful connection to the local dango.
- From inside the relayer container, `curl http://dango:8080` to confirm DNS resolution via the `traefik` network.
- Verify the `traefik` network exists on the host before applying the compose changes (`docker network ls | grep traefik`).