### PR TITLE
chore(deploy): require explicit git SHA for backend image tag

### DIFF
--- a/deploy/justfile
+++ b/deploy/justfile
@@ -213,10 +213,10 @@ deploy-perp-liquidator network tag="latest":
 
 # ---------------------------------- Testnet -----------------------------------
 
-deploy-testnet:
+deploy-testnet git_sha:
   mkdir -p {{justfile_directory()}}/logs \
     && uv run ansible-playbook full-app.yml \
-      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": true, "perps_bot_enabled": true, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-testnet-1", "dango_network": "testnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "latest", "frontend_image_tag": "latest"}' \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": true, "perps_bot_enabled": true, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-testnet-1", "dango_network": "testnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{git_sha}}", "frontend_image_tag": "latest"}' \
       -e frontend_enabled_features='points' \
       --limit {{hetzner2}},{{hetzner4}} \
       2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-testnet.log
@@ -251,10 +251,10 @@ remove-deploy-lock-testnet:
 # Note: the `reset-and-deploy-mainnet` command has been deleted.
 # We don't ever want to reset mainnet. Deleting the command so we don't do it by mistake.
 
-deploy-mainnet:
+deploy-mainnet git_sha:
   mkdir -p {{justfile_directory()}}/logs \
     && uv run ansible-playbook full-app.yml \
-      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "latest", "frontend_image_tag": "latest"}' \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{git_sha}}", "frontend_image_tag": "latest"}' \
       --limit {{hetzner5}},{{inter2}},{{hetzner1}},{{hetzner3}} \
       2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet.log
 


### PR DESCRIPTION
`deploy-testnet` and `deploy-mainnet` now take a mandatory `git_sha` positional that pins `dango_image_tag`. Frontend image tag stays `latest`.

This makes deploys explicit: the operator picks the exact commit to deploy, avoiding the moving `latest` tag and races with in-flight CI publishes during a deploy. CI publishes
`ghcr.io/left-curve/left-curve/dango:$GIT_COMMIT` for every backend build, so any merged commit's image is pullable.