### PR TITLE
refactor(indexer): phase 1 — extract metrics HTTP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,6 +3810,7 @@ dependencies = [
  "indexer-cache",
  "indexer-hooked",
  "indexer-httpd",
+ "indexer-metrics",
  "indexer-sql",
  "libc",
  "metrics",
@@ -4209,6 +4210,7 @@ dependencies = [
  "indexer-disk-saver",
  "indexer-hooked",
  "indexer-httpd",
+ "indexer-metrics",
  "indexer-sql",
  "indexer-testing",
  "itertools 0.14.0",
@@ -5636,7 +5638,6 @@ dependencies = [
  "grug-testing",
  "grug-types",
  "metrics",
- "metrics-exporter-prometheus",
  "sentry-actix",
  "serde",
  "serde_json",
@@ -6682,7 +6683,6 @@ dependencies = [
  "indexer-sql",
  "itertools 0.14.0",
  "metrics",
- "metrics-exporter-prometheus",
  "num_cpus",
  "sea-orm",
  "sentry",
@@ -6697,6 +6697,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "indexer-metrics"
+version = "0.0.0"
+dependencies = [
+ "actix-web",
+ "actix-web-metrics",
+ "metrics-exporter-prometheus",
+ "sentry-actix",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
   "indexer/disk-saver",
   "indexer/hooked",
   "indexer/httpd",
+  "indexer/metrics",
   "indexer/sql",
   "indexer/sql-migration",
   "indexer/testing",
@@ -257,6 +258,7 @@ indexer-cache               = { path = "indexer/cache" }
 indexer-disk-saver          = { path = "indexer/disk-saver" }
 indexer-hooked              = { path = "indexer/hooked" }
 indexer-httpd               = { path = "indexer/httpd", features = ["tracing"] }
+indexer-metrics             = { path = "indexer/metrics" }
 indexer-sql                 = { path = "indexer/sql" }
 indexer-sql-migration       = { path = "indexer/sql-migration" }
 indexer-testing             = { path = "indexer/testing" }

--- a/dango/cli/Cargo.toml
+++ b/dango/cli/Cargo.toml
@@ -31,6 +31,7 @@ home                        = { workspace = true }
 indexer-cache               = { workspace = true, features = ["http-request-details", "metrics", "s3", "tracing"] }
 indexer-hooked              = { workspace = true, features = ["metrics", "tracing"] }
 indexer-httpd               = { workspace = true, features = ["metrics", "tracing"] }
+indexer-metrics             = { workspace = true, features = ["tracing"] }
 indexer-sql                 = { workspace = true, features = ["async-graphql", "metrics", "tracing"] }
 libc                        = { workspace = true }
 metrics                     = { workspace = true }

--- a/dango/cli/src/indexer.rs
+++ b/dango/cli/src/indexer.rs
@@ -148,7 +148,7 @@ impl IndexerCmd {
                 );
 
                 // Run the metrics HTTP server
-                indexer_httpd::server::run_metrics_server(
+                indexer_metrics::run_metrics_server(
                     &cfg.metrics_httpd.ip,
                     cfg.metrics_httpd.port,
                     metrics_handler,

--- a/dango/cli/src/start.rs
+++ b/dango/cli/src/start.rs
@@ -442,7 +442,7 @@ impl StartCmd {
         cfg: &MetricsHttpdConfig,
         metrics_handler: PrometheusHandle,
     ) -> anyhow::Result<()> {
-        indexer_httpd::server::run_metrics_server(&cfg.ip, cfg.port, metrics_handler)
+        indexer_metrics::run_metrics_server(&cfg.ip, cfg.port, metrics_handler)
             .await
             .map_err(|err| {
                 tracing::error!("Failed to run metrics HTTP server: {err:?}");

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -36,6 +36,7 @@ identity                 = { workspace = true }
 indexer-cache            = { workspace = true, features = ["metrics", "tracing"] }
 indexer-hooked           = { workspace = true, features = ["metrics", "tracing"] }
 indexer-httpd            = { workspace = true, features = ["metrics"] }
+indexer-metrics          = { workspace = true }
 indexer-sql              = { workspace = true, features = ["async-graphql", "testing", "tracing"] }
 k256                     = { workspace = true }
 pyth-client              = { workspace = true }

--- a/dango/testing/tests/httpd/metrics.rs
+++ b/dango/testing/tests/httpd/metrics.rs
@@ -1,7 +1,7 @@
 use {
     assertor::*,
     dango_mock_httpd::{get_mock_socket_addr, wait_for_server_ready},
-    indexer_httpd::server::run_metrics_server,
+    indexer_metrics::run_metrics_server,
     metrics_exporter_prometheus::PrometheusBuilder,
     std::thread,
 };

--- a/grug/httpd/Cargo.toml
+++ b/grug/httpd/Cargo.toml
@@ -13,7 +13,6 @@ version       = { workspace = true }
 metrics = [
   "dep:actix-web-metrics",
   "dep:metrics",
-  "dep:metrics-exporter-prometheus",
 ]
 testing = ["dep:grug-testing"]
 tracing = ["dep:tracing"]
@@ -33,7 +32,6 @@ grug-app                    = { workspace = true, features = ["tracing"] }
 grug-testing                = { workspace = true, optional = true }
 grug-types                  = { workspace = true, features = ["async-graphql", "chrono", "tendermint"] }
 metrics                     = { workspace = true, optional = true }
-metrics-exporter-prometheus = { workspace = true, optional = true }
 sentry-actix                = { workspace = true }
 serde                       = { workspace = true }
 serde_json                  = { workspace = true }

--- a/grug/httpd/Cargo.toml
+++ b/grug/httpd/Cargo.toml
@@ -10,38 +10,35 @@ rust-version  = { workspace = true }
 version       = { workspace = true }
 
 [features]
-metrics = [
-  "dep:actix-web-metrics",
-  "dep:metrics",
-]
+metrics = ["dep:actix-web-metrics", "dep:metrics"]
 testing = ["dep:grug-testing"]
 tracing = ["dep:tracing"]
 
 [dependencies]
-actix                       = { workspace = true }
-actix-cors                  = { workspace = true }
-actix-web                   = { workspace = true }
-actix-web-metrics           = { workspace = true, optional = true }
-anyhow                      = { workspace = true }
-async-graphql               = { workspace = true }
-async-graphql-actix-web     = { workspace = true }
-async-trait                 = { workspace = true }
-chrono                      = { workspace = true }
-futures-util                = { workspace = true }
-grug-app                    = { workspace = true, features = ["tracing"] }
-grug-testing                = { workspace = true, optional = true }
-grug-types                  = { workspace = true, features = ["async-graphql", "chrono", "tendermint"] }
-metrics                     = { workspace = true, optional = true }
-sentry-actix                = { workspace = true }
-serde                       = { workspace = true }
-serde_json                  = { workspace = true }
-tempfile                    = { workspace = true }
-tendermint                  = { workspace = true }
-tendermint-rpc              = { workspace = true, features = ["http-client"] }
-thiserror                   = { workspace = true }
-tokio                       = { workspace = true }
-tracing                     = { workspace = true, optional = true }
-uuid                        = { workspace = true }
+actix                   = { workspace = true }
+actix-cors              = { workspace = true }
+actix-web               = { workspace = true }
+actix-web-metrics       = { workspace = true, optional = true }
+anyhow                  = { workspace = true }
+async-graphql           = { workspace = true }
+async-graphql-actix-web = { workspace = true }
+async-trait             = { workspace = true }
+chrono                  = { workspace = true }
+futures-util            = { workspace = true }
+grug-app                = { workspace = true, features = ["tracing"] }
+grug-testing            = { workspace = true, optional = true }
+grug-types              = { workspace = true, features = ["async-graphql", "chrono", "tendermint"] }
+metrics                 = { workspace = true, optional = true }
+sentry-actix            = { workspace = true }
+serde                   = { workspace = true }
+serde_json              = { workspace = true }
+tempfile                = { workspace = true }
+tendermint              = { workspace = true }
+tendermint-rpc          = { workspace = true, features = ["http-client"] }
+thiserror               = { workspace = true }
+tokio                   = { workspace = true }
+tracing                 = { workspace = true, optional = true }
+uuid                    = { workspace = true }
 
 [dev-dependencies]
 clap               = { workspace = true }

--- a/grug/httpd/src/server.rs
+++ b/grug/httpd/src/server.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "metrics")]
+use actix_web_metrics::ActixWebMetricsBuilder;
 use {
     super::error::Error,
     crate::{
@@ -13,12 +15,6 @@ use {
     grug_types::HttpdConfig,
     sentry_actix::Sentry,
     std::sync::{Arc, atomic::AtomicBool},
-};
-#[cfg(feature = "metrics")]
-use {
-    actix_web_metrics::ActixWebMetricsBuilder,
-    metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle},
-    std::fmt::Display,
 };
 
 /// Run the HTTP server, includes GraphQL and REST endpoints.
@@ -97,66 +93,6 @@ where
     ))
     .worker_max_blocking_threads(httpd_config.worker_max_blocking_threads)
     .bind((&*httpd_config.ip, httpd_config.port))?
-    .run()
-    .await?;
-
-    Ok(())
-}
-
-#[cfg(feature = "metrics")]
-/// Run the metrics HTTP server
-pub async fn run_metrics_server<I>(
-    ip: I,
-    port: u16,
-    metrics_handler: PrometheusHandle,
-) -> Result<(), Error>
-where
-    I: ToString + Display,
-{
-    #[cfg(feature = "tracing")]
-    tracing::info!(%ip, port, "Starting metrics httpd server");
-
-    let metrics = ActixWebMetricsBuilder::new().build();
-
-    let recorder = PrometheusBuilder::new().build_recorder();
-    let metrics_handler2 = recorder.handle();
-
-    HttpServer::new(move || {
-        let metrics_handler = metrics_handler.clone();
-        let metrics_handler2 = metrics_handler2.clone();
-        App::new()
-            .wrap(metrics.clone())
-            .wrap(Sentry::new())
-            .wrap(Logger::default())
-            .wrap(Compress::default())
-            .route(
-                "/health",
-                web::get().to(|| async { HttpResponse::Ok().body("Metrics server is healthy") }),
-            )
-            .route(
-                "/",
-                web::get().to(|| async { HttpResponse::Ok().body("Metrics server is running") }),
-            )
-            .route(
-                "/metrics",
-                web::get().to(move || {
-                    let metrics_handler = metrics_handler.clone();
-                    let metrics_handler2 = metrics_handler2.clone();
-                    metrics_handler2.run_upkeep();
-
-                    async move {
-                        let metrics2 = metrics_handler2.render();
-                        let metrics = metrics_handler.render();
-                        let combined = format!("{metrics}\n{metrics2}");
-
-                        HttpResponse::Ok()
-                            .content_type("text/plain; version=0.0.4")
-                            .body(combined)
-                    }
-                }),
-            )
-    })
-    .bind((ip.to_string(), port))?
     .run()
     .await?;
 

--- a/indexer/httpd/Cargo.toml
+++ b/indexer/httpd/Cargo.toml
@@ -17,7 +17,6 @@ metrics = [
   "dep:actix-web-metrics",
   "dep:futures-util",
   "dep:metrics",
-  "dep:metrics-exporter-prometheus",
   "grug-httpd/metrics",
 ]
 tracing = ["dep:tracing", "grug-app/tracing", "indexer-sql/tracing"]
@@ -43,7 +42,6 @@ indexer-cache               = { workspace = true }
 indexer-sql                 = { workspace = true, features = ["async-graphql"] }
 itertools                   = { workspace = true }
 metrics                     = { workspace = true, optional = true }
-metrics-exporter-prometheus = { workspace = true, optional = true }
 num_cpus                    = { workspace = true }
 sea-orm                     = { workspace = true }
 sentry                      = { workspace = true }

--- a/indexer/httpd/src/server.rs
+++ b/indexer/httpd/src/server.rs
@@ -15,12 +15,7 @@ use {
     sentry_actix::Sentry,
 };
 #[cfg(feature = "metrics")]
-use {
-    crate::middlewares::metrics::init_httpd_metrics,
-    actix_web_metrics::ActixWebMetricsBuilder,
-    metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle},
-    std::fmt::Display,
-};
+use {crate::middlewares::metrics::init_httpd_metrics, actix_web_metrics::ActixWebMetricsBuilder};
 
 /// Run the HTTP server, includes GraphQL and REST endpoints.
 pub async fn run_server<CA, GS>(
@@ -100,66 +95,6 @@ where
     ))
     .worker_max_blocking_threads(httpd_config.worker_max_blocking_threads)
     .bind((&*httpd_config.ip, httpd_config.port))?
-    .run()
-    .await?;
-
-    Ok(())
-}
-
-#[cfg(feature = "metrics")]
-/// Run the metrics HTTP server
-pub async fn run_metrics_server<I>(
-    ip: I,
-    port: u16,
-    metrics_handler: PrometheusHandle,
-) -> Result<(), Error>
-where
-    I: ToString + Display,
-{
-    #[cfg(feature = "tracing")]
-    tracing::info!(%ip, port, "Starting metrics httpd server");
-
-    let metrics = ActixWebMetricsBuilder::new().build();
-
-    let recorder = PrometheusBuilder::new().build_recorder();
-    let metrics_handler2 = recorder.handle();
-
-    HttpServer::new(move || {
-        let metrics_handler = metrics_handler.clone();
-        let metrics_handler2 = metrics_handler2.clone();
-        App::new()
-            .wrap(metrics.clone())
-            .wrap(Sentry::new())
-            .wrap(Logger::default())
-            .wrap(Compress::default())
-            .route(
-                "/health",
-                web::get().to(|| async { HttpResponse::Ok().body("Metrics server is healthy") }),
-            )
-            .route(
-                "/",
-                web::get().to(|| async { HttpResponse::Ok().body("Metrics server is running") }),
-            )
-            .route(
-                "/metrics",
-                web::get().to(move || {
-                    let metrics_handler = metrics_handler.clone();
-                    let metrics_handler2 = metrics_handler2.clone();
-                    metrics_handler2.run_upkeep();
-
-                    async move {
-                        let metrics2 = metrics_handler2.render();
-                        let metrics = metrics_handler.render();
-                        let combined = format!("{metrics}\n{metrics2}");
-
-                        HttpResponse::Ok()
-                            .content_type("text/plain; version=0.0.4")
-                            .body(combined)
-                    }
-                }),
-            )
-    })
-    .bind((ip.to_string(), port))?
     .run()
     .await?;
 

--- a/indexer/metrics/Cargo.toml
+++ b/indexer/metrics/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors       = { workspace = true }
+categories    = { workspace = true }
+documentation = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+name          = "indexer-metrics"
+repository    = { workspace = true }
+rust-version  = { workspace = true }
+version       = { workspace = true }
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+tracing = ["dep:tracing"]
+
+[dependencies]
+actix-web                   = { workspace = true }
+actix-web-metrics           = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+sentry-actix                = { workspace = true }
+tracing                     = { workspace = true, optional = true }

--- a/indexer/metrics/src/lib.rs
+++ b/indexer/metrics/src/lib.rs
@@ -1,0 +1,70 @@
+use {
+    actix_web::{
+        App, HttpResponse, HttpServer,
+        middleware::{Compress, Logger},
+        web,
+    },
+    actix_web_metrics::ActixWebMetricsBuilder,
+    metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle},
+    sentry_actix::Sentry,
+    std::{fmt::Display, io},
+};
+
+/// Run the metrics HTTP server
+pub async fn run_metrics_server<I>(
+    ip: I,
+    port: u16,
+    metrics_handler: PrometheusHandle,
+) -> Result<(), io::Error>
+where
+    I: ToString + Display,
+{
+    #[cfg(feature = "tracing")]
+    tracing::info!(%ip, port, "Starting metrics httpd server");
+
+    let metrics = ActixWebMetricsBuilder::new().build();
+
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let metrics_handler2 = recorder.handle();
+
+    HttpServer::new(move || {
+        let metrics_handler = metrics_handler.clone();
+        let metrics_handler2 = metrics_handler2.clone();
+        App::new()
+            .wrap(metrics.clone())
+            .wrap(Sentry::new())
+            .wrap(Logger::default())
+            .wrap(Compress::default())
+            .route(
+                "/health",
+                web::get().to(|| async { HttpResponse::Ok().body("Metrics server is healthy") }),
+            )
+            .route(
+                "/",
+                web::get().to(|| async { HttpResponse::Ok().body("Metrics server is running") }),
+            )
+            .route(
+                "/metrics",
+                web::get().to(move || {
+                    let metrics_handler = metrics_handler.clone();
+                    let metrics_handler2 = metrics_handler2.clone();
+                    metrics_handler2.run_upkeep();
+
+                    async move {
+                        let metrics2 = metrics_handler2.render();
+                        let metrics = metrics_handler.render();
+                        let combined = format!("{metrics}\n{metrics2}");
+
+                        HttpResponse::Ok()
+                            .content_type("text/plain; version=0.0.4")
+                            .body(combined)
+                    }
+                }),
+            )
+    })
+    .bind((ip.to_string(), port))?
+    .run()
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Move `run_metrics_server` out of `indexer-httpd` into a new
`indexer-metrics` crate at `indexer/metrics/`. The metrics endpoint
just renders Prometheus scrapes from a `PrometheusHandle` — it has
no dependency on SQL state or indexer wiring, so it doesn't belong
in `indexer-httpd`.

Also delete an identical, dead copy of `run_metrics_server` from
`grug-httpd` (zero callers in the workspace) and drop the now-unused
`metrics-exporter-prometheus` dep from both `indexer-httpd` and
`grug-httpd`.