### PR TITLE
fix(testing): make TestSuite mutating methods async to avoid `block_on` deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5522,6 +5522,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tokio",
 ]
 
 [[package]]
@@ -5832,6 +5833,7 @@ dependencies = [
  "serde",
  "test-case",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -5859,6 +5861,7 @@ dependencies = [
  "serde",
  "test-case",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "wasmer",
  "wasmer-middlewares",

--- a/dango/testing/benches/benchmarks.rs
+++ b/dango/testing/benches/benchmarks.rs
@@ -25,7 +25,7 @@ fn random_string(len: usize) -> String {
         .collect()
 }
 
-fn do_send<T, PP, DB, VM>(
+async fn do_send<T, PP, DB, VM>(
     suite: &mut TestSuite<PP, DB, VM>,
     mut accounts: TestAccounts,
     codes: Codes<T>,
@@ -63,6 +63,7 @@ where
             50_000_000,
             NonEmpty::new_unchecked(msgs),
         )
+        .await
         .should_succeed();
 
     // Make a block that contains 100 transactions.
@@ -116,6 +117,13 @@ where
 /// We do this by making a single block that contains 100 transactions, each tx
 /// containing one `Message::Transfer`.
 fn sends(c: &mut Criterion) {
+    // Criterion's `bench_function` takes a sync closure, but the TestSuite API
+    // is async. Build a runtime once and `block_on` per iteration.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
     let mut group = c.benchmark_group("sends");
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Linear));
     group.measurement_time(MEASUREMENT_TIME);
@@ -127,15 +135,14 @@ fn sends(c: &mut Criterion) {
                 let dir = TempDataDir::new(&format!("__dango_bench_sends_{}", random_string(8)));
                 let (mut suite, accounts, codes, contracts, _) = setup_benchmark_rust(&dir);
 
-                let txs = do_send(&mut suite, accounts, codes, contracts);
+                let txs = rt.block_on(do_send(&mut suite, accounts, codes, contracts));
 
                 // Note: `dir` must be passed to the routine, so that it's alive
                 // until the end of this iteration.
                 (dir, suite, txs)
             },
             |(_dir, mut suite, txs)| {
-                suite
-                    .make_block(txs)
+                rt.block_on(suite.make_block(txs))
                     .block_outcome
                     .tx_outcomes
                     .into_iter()

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -303,7 +303,7 @@ where
     A: MaybeDefined<Addr>,
 {
     /// Register the user
-    pub fn register_user<PP, DB, VM, ID>(
+    pub async fn register_user<PP, DB, VM, ID>(
         &self,
         test_suite: &mut TestSuite<PP, DB, VM, ID>,
         factory: Addr,
@@ -338,6 +338,7 @@ where
                 },
                 funds,
             )
+            .await
             .should_succeed();
     }
 }
@@ -345,11 +346,11 @@ where
 impl<A> TestAccount<Defined<UserIndex>, A>
 where
     A: MaybeDefined<Addr>,
-    Self: Signer,
+    Self: Signer + Send + Sync,
 {
     /// Register a new account with the user index and key of this account and returns a new
     /// `TestAccount` with the new account's address.
-    pub fn register_new_account<PP, DB, VM, ID>(
+    pub async fn register_new_account<PP, DB, VM, ID>(
         &mut self,
         test_suite: &mut TestSuite<PP, DB, VM, ID>,
         factory: Addr,
@@ -381,6 +382,7 @@ where
                 &account_factory::ExecuteMsg::RegisterAccount {},
                 funds,
             )
+            .await
             .should_succeed();
 
         Ok(TestAccount {

--- a/dango/testing/src/account_creation.rs
+++ b/dango/testing/src/account_creation.rs
@@ -45,7 +45,8 @@ pub async fn add_account_with_existing_user(
             suite.deref_mut(),
             contracts.account_factory,
             Coins::one(usdc::DENOM.clone(), 100_000_000).unwrap(), // Make sure this is bigger than the minimum deposit.
-        ).await
+        )
+        .await
         .unwrap()
 }
 

--- a/dango/testing/src/account_creation.rs
+++ b/dango/testing/src/account_creation.rs
@@ -12,7 +12,7 @@ use {
     std::ops::DerefMut,
 };
 
-pub fn add_user_public_key(
+pub async fn add_user_public_key(
     suite: &mut HyperlaneTestSuite<MemDb, RustVm, ProposalPreparer<PythClientCache>, HookedIndexer>,
     contracts: &Contracts,
     test_account: &mut TestAccount,
@@ -29,12 +29,13 @@ pub fn add_user_public_key(
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     (pk, key_hash)
 }
 
-pub fn add_account_with_existing_user(
+pub async fn add_account_with_existing_user(
     suite: &mut HyperlaneTestSuite<MemDb, RustVm, ProposalPreparer<PythClientCache>, HookedIndexer>,
     contracts: &Contracts,
     test_account: &mut TestAccount,
@@ -44,11 +45,11 @@ pub fn add_account_with_existing_user(
             suite.deref_mut(),
             contracts.account_factory,
             Coins::one(usdc::DENOM.clone(), 100_000_000).unwrap(), // Make sure this is bigger than the minimum deposit.
-        )
+        ).await
         .unwrap()
 }
 
-pub fn create_user_and_account(
+pub async fn create_user_and_account(
     suite: &mut HyperlaneTestSuite<MemDb, RustVm, ProposalPreparer<PythClientCache>, HookedIndexer>,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
@@ -62,7 +63,8 @@ pub fn create_user_and_account(
     );
 
     // Create the user and its first single-signature account.
-    user.register_user(suite.deref_mut(), contracts.account_factory, Coins::new());
+    user.register_user(suite.deref_mut(), contracts.account_factory, Coins::new())
+        .await;
 
     // Make the initial deposit.
     suite
@@ -73,6 +75,7 @@ pub fn create_user_and_account(
             &user,
             150_000_000, // Make sure this is bigger than the minimum deposit.
         )
+        .await
         .should_succeed();
 
     user.query_user_index(suite.querier())

--- a/dango/testing/src/hyperlane.rs
+++ b/dango/testing/src/hyperlane.rs
@@ -74,9 +74,9 @@ where
         }
     }
 
-    pub fn receive_warp_transfer<R, A>(
+    pub async fn receive_warp_transfer<R, A>(
         &mut self,
-        relayer: &mut dyn Signer,
+        relayer: &mut (dyn Signer + Send + Sync),
         origin_domain: Domain,
         origin_warp: Addr32,
         recipient: &R,
@@ -118,6 +118,7 @@ where
                 },
                 Coins::new(),
             )
+            .await
             .result
             .map_err(|err| anyhow!(err))?;
 

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -15,7 +15,7 @@ pub fn pair_id() -> Denom {
 }
 
 /// Common setup: register oracle prices + deposit margin for user1 and user2.
-pub fn setup_perps_env(
+pub async fn setup_perps_env(
     suite: &mut TestSuiteWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
@@ -40,6 +40,7 @@ pub fn setup_perps_env(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     for account in [&mut accounts.user1, &mut accounts.user2] {
@@ -51,13 +52,14 @@ pub fn setup_perps_env(
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), amount).unwrap(),
             )
+            .await
             .should_succeed();
     }
 }
 
 /// Place a limit ask (user2) then a market buy (user1) to produce an
 /// `OrderFilled` at the given price and size.
-pub fn create_perps_fill(
+pub async fn create_perps_fill(
     suite: &mut TestSuiteWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
@@ -83,6 +85,7 @@ pub fn create_perps_fill(
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -101,5 +104,6 @@ pub fn create_perps_fill(
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }

--- a/dango/testing/tests/bank.rs
+++ b/dango/testing/tests/bank.rs
@@ -421,8 +421,8 @@ async fn set_namespace_owner_works() {
         .should_succeed_and_equal(accounts.user1.address());
 }
 
-#[tokio::test]
-async fn query_namespace_owners_works() {
+#[test]
+fn query_namespace_owners_works() {
     let (suite, _, _, contracts, _) = setup_test_naive(Default::default());
 
     // Query namespace owners. Should succeed.
@@ -458,8 +458,8 @@ async fn query_namespace_owners_works() {
         });
 }
 
-#[tokio::test]
-async fn query_metadatas_works() {
+#[test]
+fn query_metadatas_works() {
     let (suite, _, _, contracts, _) = setup_test_naive(Default::default());
 
     suite
@@ -576,8 +576,8 @@ async fn top_level_denom_cannot_be_minted_or_burned_by_non_chain_owner() {
         );
 }
 
-#[tokio::test]
-async fn query_supplies_works() {
+#[test]
+fn query_supplies_works() {
     let (suite, ..) = setup_test_naive(Default::default());
 
     suite

--- a/dango/testing/tests/bank.rs
+++ b/dango/testing/tests/bank.rs
@@ -15,8 +15,8 @@ use {
     std::collections::BTreeSet,
 };
 
-#[test]
-fn batch_transfer() {
+#[tokio::test]
+async fn batch_transfer() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Create two non-existent recipient addresses.
@@ -49,6 +49,7 @@ fn batch_transfer() {
                 usdc::DENOM.clone() => 500,
             },
         })
+        .await
         .should_succeed()
         .events;
 
@@ -282,8 +283,8 @@ where
     b.is_empty()
 }
 
-#[test]
-fn set_namespace_owner_can_only_be_called_by_owner() {
+#[tokio::test]
+async fn set_namespace_owner_can_only_be_called_by_owner() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Attempt to set namespace owner as non-owner. Should fail.
@@ -297,6 +298,7 @@ fn set_namespace_owner_can_only_be_called_by_owner() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("you don't have the right, O you don't have the right");
 
     // Attempt to set namespace owner as owner. Should succeed.
@@ -310,11 +312,12 @@ fn set_namespace_owner_can_only_be_called_by_owner() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
-#[test]
-fn set_metadata_can_only_be_called_by_non_namespace_owner() {
+#[tokio::test]
+async fn set_metadata_can_only_be_called_by_non_namespace_owner() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Attempt to set metadata as non-namespace owner. Should fail.
@@ -333,6 +336,7 @@ fn set_metadata_can_only_be_called_by_non_namespace_owner() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("sender does not own the namespace `testing`");
 
     // Set user1 as namespace owner of testing
@@ -346,6 +350,7 @@ fn set_metadata_can_only_be_called_by_non_namespace_owner() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Attempt to set metadata as user1. Should succeed.
@@ -365,6 +370,7 @@ fn set_metadata_can_only_be_called_by_non_namespace_owner() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Assert metadata is set correctly
@@ -380,8 +386,8 @@ fn set_metadata_can_only_be_called_by_non_namespace_owner() {
         });
 }
 
-#[test]
-fn set_namespace_owner_works() {
+#[tokio::test]
+async fn set_namespace_owner_works() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Query namespace owner of testing. Should fail because it's not set.
@@ -404,6 +410,7 @@ fn set_namespace_owner_works() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Query namespace owner of testing. Should succeed.
@@ -414,8 +421,8 @@ fn set_namespace_owner_works() {
         .should_succeed_and_equal(accounts.user1.address());
 }
 
-#[test]
-fn query_namespace_owners_works() {
+#[tokio::test]
+async fn query_namespace_owners_works() {
     let (suite, _, _, contracts, _) = setup_test_naive(Default::default());
 
     // Query namespace owners. Should succeed.
@@ -451,8 +458,8 @@ fn query_namespace_owners_works() {
         });
 }
 
-#[test]
-fn query_metadatas_works() {
+#[tokio::test]
+async fn query_metadatas_works() {
     let (suite, _, _, contracts, _) = setup_test_naive(Default::default());
 
     suite
@@ -512,8 +519,8 @@ fn query_metadatas_works() {
         });
 }
 
-#[test]
-fn force_transfer_can_only_be_called_by_taxman() {
+#[tokio::test]
+async fn force_transfer_can_only_be_called_by_taxman() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Attempt to force transfer as non-taxman. Should fail.
@@ -528,11 +535,12 @@ fn force_transfer_can_only_be_called_by_taxman() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("you don't have the right, O you don't have the right");
 }
 
-#[test]
-fn top_level_denom_cannot_be_minted_or_burned_by_non_chain_owner() {
+#[tokio::test]
+async fn top_level_denom_cannot_be_minted_or_burned_by_non_chain_owner() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Attempt to mint as non-owner. Should fail.
@@ -546,6 +554,7 @@ fn top_level_denom_cannot_be_minted_or_burned_by_non_chain_owner() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(
             "only chain owner can mint, burn, or set metadata of top-level denoms",
         );
@@ -561,13 +570,14 @@ fn top_level_denom_cannot_be_minted_or_burned_by_non_chain_owner() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(
             "only chain owner can mint, burn, or set metadata of top-level denoms",
         );
 }
 
-#[test]
-fn query_supplies_works() {
+#[tokio::test]
+async fn query_supplies_works() {
     let (suite, ..) = setup_test_naive(Default::default());
 
     suite

--- a/dango/testing/tests/dex/audit.rs
+++ b/dango/testing/tests/dex/audit.rs
@@ -39,8 +39,8 @@ use {
 /// Prior to the fix, liquidity depth from orders placed by the passive pool wasn't
 /// decreased if the order is filled. Only liquidity from user orders were properly
 /// decreased.
-#[test]
-fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
+#[tokio::test]
+async fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Supply oracle prices. DANGO = $200, USDC = $1.
@@ -62,6 +62,7 @@ fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Configure DANGO-USD pool type to geometric with spacing 1. It's easier to
@@ -91,6 +92,7 @@ fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
             }])),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Add liquidity to the DANGO-USDC pool: 10 dango, 2,000 USDC (2_000_000_000 uusdc)
@@ -108,6 +110,7 @@ fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
                 usdc::DENOM.clone() => 2_000_000_000,
             },
         )
+        .await
         .should_succeed();
 
     // Query the liquidity depth before placing any order. There should be an
@@ -184,7 +187,7 @@ fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
                 cancels: None,
             },
             coins! { usdc::DENOM.clone() => 200_600_000 * 3 },
-        )
+        ).await
         .should_succeed();
 
     // The ask side liquidity should be reduced from 10 base to 10 - 3 = 7.
@@ -234,8 +237,8 @@ fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled() {
         });
 }
 
-#[test]
-fn issue_6_cannot_mint_zero_lp_tokens() {
+#[tokio::test]
+async fn issue_6_cannot_mint_zero_lp_tokens() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Provide liquidity with zero amount of one side
@@ -252,11 +255,12 @@ fn issue_6_cannot_mint_zero_lp_tokens() {
                 dango::DENOM.clone() => 100_000,
             },
         )
+        .await
         .should_fail_with_error("LP token mint amount is less than `MINIMUM_LIQUIDITY`");
 }
 
-#[test]
-fn issue_10_rounding_up_in_xyk_swap_exact_amount_out() {
+#[tokio::test]
+async fn issue_10_rounding_up_in_xyk_swap_exact_amount_out() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Provide liquidity with owner account
@@ -274,6 +278,7 @@ fn issue_10_rounding_up_in_xyk_swap_exact_amount_out() {
                 usdc::DENOM.clone() => 100_000,
             },
         )
+        .await
         .should_succeed();
 
     // Record user balance
@@ -298,6 +303,7 @@ fn issue_10_rounding_up_in_xyk_swap_exact_amount_out() {
                 eth::DENOM.clone() => 103,
             },
         )
+        .await
         .should_succeed();
 
     // Assert that the user's balance has changed correctly
@@ -307,8 +313,8 @@ fn issue_10_rounding_up_in_xyk_swap_exact_amount_out() {
     });
 }
 
-#[test]
-fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
+#[tokio::test]
+async fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     suite
@@ -318,6 +324,7 @@ fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
             &dex::ExecuteMsg::Owner(dex::OwnerMsg::SetPaused(true)),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -331,6 +338,7 @@ fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("can't provide liquidity when trading is paused");
 
     suite
@@ -344,6 +352,7 @@ fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("can't withdraw liquidity when trading is paused");
 
     suite
@@ -362,6 +371,7 @@ fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("can't swap when trading is paused");
 
     suite
@@ -380,6 +390,7 @@ fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("can't swap when trading is paused");
 
     suite
@@ -392,13 +403,14 @@ fn issue_30_liquidity_operations_are_not_allowed_when_dex_is_paused() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error("can't update orders when trading is paused");
 }
 
 /// Prior to the fix, the depth quote amount was subject to rounding errors when
 /// a limit order was partially filled and the error kept increasing over time.
-#[test]
-fn issue_156_depth_quote_rounding_error() {
+#[tokio::test]
+async fn issue_156_depth_quote_rounding_error() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption {
         bridge_ops: |accounts| {
             vec![
@@ -472,6 +484,7 @@ fn issue_156_depth_quote_rounding_error() {
                 quote_denom.clone() => Uint128::new(1_000_000),
             ),
         )
+        .await
         .should_succeed();
 
     // Create some matching orders:
@@ -536,6 +549,7 @@ fn issue_156_depth_quote_rounding_error() {
                     quote_denom.clone() => buy_amount * Uint128::new(2),
                 ),
             )
+            .await
             .should_succeed();
 
         // Check the liquidity depth.
@@ -626,8 +640,8 @@ fn issue_156_depth_quote_rounding_error() {
 /// In `cancel_all_orders`, we refund all orders. However, actually, passive
 /// orders don't need to be refunded. Refunding it leads to error because the
 /// DEX contract doesn't implement the `receive` entry point.
-#[test]
-fn issue_194_cancel_all_orders_works_properly_with_passive_orders() {
+#[tokio::test]
+async fn issue_194_cancel_all_orders_works_properly_with_passive_orders() {
     // ------------------------------- 1. Setup --------------------------------
 
     // Set up DANGO-USDC pair with geometric pool and oracle feed.
@@ -684,6 +698,7 @@ fn issue_194_cancel_all_orders_works_properly_with_passive_orders() {
                 usdc::DENOM.clone() => 1000,
             },
         )
+        .await
         .should_succeed();
 
     // For realism, also create some user orders.
@@ -715,6 +730,7 @@ fn issue_194_cancel_all_orders_works_properly_with_passive_orders() {
                 usdc::DENOM.clone() => 195,
             },
         )
+        .await
         .should_succeed();
 
     // Pause trading. We want to ensure that forced order cancelations works
@@ -727,6 +743,7 @@ fn issue_194_cancel_all_orders_works_properly_with_passive_orders() {
             &dex::ExecuteMsg::Owner(dex::OwnerMsg::SetPaused(true)),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------- 2. Ensure contract state before cancelation --------------
@@ -811,6 +828,7 @@ fn issue_194_cancel_all_orders_works_properly_with_passive_orders() {
             &dex::ExecuteMsg::Owner(dex::OwnerMsg::Reset {}),
             Coins::new(),
         )
+        .await
         .should_succeed(); // Prior to the fix, this errors.
 
     // --------------- 4. Check contract state after cancelation ---------------
@@ -853,8 +871,8 @@ fn issue_194_cancel_all_orders_works_properly_with_passive_orders() {
         .should_succeed_and(|orders| orders.is_empty());
 }
 
-#[test]
-fn issue_233_minimum_order_size_cannot_be_circumvented_for_ask_orders() {
+#[tokio::test]
+async fn issue_233_minimum_order_size_cannot_be_circumvented_for_ask_orders() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Create an ask order of one base unit with a price equal to the minimum order size.
@@ -874,11 +892,12 @@ fn issue_233_minimum_order_size_cannot_be_circumvented_for_ask_orders() {
             },
             coins! { dango::DENOM.clone() => 1 },
         )
+        .await
         .should_fail();
 }
 
-#[test]
-fn issue_296_provide_liquidity_query_uses_max_staleness_for_oracle_price() {
+#[tokio::test]
+async fn issue_296_provide_liquidity_query_uses_max_staleness_for_oracle_price() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Provide some liquidity with owner account
@@ -896,6 +915,7 @@ fn issue_296_provide_liquidity_query_uses_max_staleness_for_oracle_price() {
                 usdc::DENOM.clone() => 5,
             },
         )
+        .await
         .should_succeed();
 
     // Feed oracle prices. Use 0 as Timestamp to ensure that the order price is stale.
@@ -917,6 +937,7 @@ fn issue_296_provide_liquidity_query_uses_max_staleness_for_oracle_price() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Query simulate provide liquidity with stale oracle price
@@ -953,8 +974,8 @@ fn issue_296_provide_liquidity_query_uses_max_staleness_for_oracle_price() {
 
 /// Prior to the fix, a zero length swap route was allowed, which resulted in charging a fee
 /// despite not having any swaps performed.
-#[test]
-fn issue_429_zero_length_or_three_length_swap_routes_are_not_allowed() {
+#[tokio::test]
+async fn issue_429_zero_length_or_three_length_swap_routes_are_not_allowed() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Provide liquidity to the pool.
@@ -972,6 +993,7 @@ fn issue_429_zero_length_or_three_length_swap_routes_are_not_allowed() {
                 usdc::DENOM.clone() => 100_000,
             },
         )
+        .await
         .should_succeed();
 
     // Attempt to swap with a zero length route.
@@ -985,6 +1007,7 @@ fn issue_429_zero_length_or_three_length_swap_routes_are_not_allowed() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(StdError::length_out_of_range::<UniqueVec<PairId>>(
             0, "<", 1,
         ));
@@ -1013,6 +1036,7 @@ fn issue_429_zero_length_or_three_length_swap_routes_are_not_allowed() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(StdError::length_out_of_range::<UniqueVec<PairId>>(
             3, ">", 2,
         ));

--- a/dango/testing/tests/dex/audit.rs
+++ b/dango/testing/tests/dex/audit.rs
@@ -187,7 +187,8 @@ async fn liquidity_depth_from_passive_pool_decreased_properly_when_order_filled(
                 cancels: None,
             },
             coins! { usdc::DENOM.clone() => 200_600_000 * 3 },
-        ).await
+        )
+        .await
         .should_succeed();
 
     // The ask side liquidity should be reduced from 10 base to 10 - 3 = 7.

--- a/dango/testing/tests/dex/clearing.rs
+++ b/dango/testing/tests/dex/clearing.rs
@@ -604,7 +604,8 @@ async fn volume_tracking_works_with_multiple_orders_from_same_user() {
                 cancels: None,
             },
             coins! { usdc::DENOM.clone() => 301_000_000 },
-        ).await
+        )
+        .await
         .should_succeed();
 
     // Submit matching orders with user2
@@ -716,7 +717,8 @@ async fn volume_tracking_works_with_multiple_orders_from_same_user() {
             coins! {
                 usdc::DENOM.clone() => 411_000_000,
             },
-        ).await
+        )
+        .await
         .should_succeed();
 
     // Submit matching orders with user2

--- a/dango/testing/tests/dex/clearing.rs
+++ b/dango/testing/tests/dex/clearing.rs
@@ -250,7 +250,8 @@ use {
     };
     "example 5"
 )]
-fn dex_works(
+#[tokio::test]
+async fn dex_works(
     // A list of orders to submit: direction, price, amount.
     orders_to_submit: Vec<(Direction, u128, u128)>,
     // Orders that should remain not fully filled: order_id => remaining amount.
@@ -274,6 +275,7 @@ fn dex_works(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -288,6 +290,7 @@ fn dex_works(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Find which accounts will submit the orders, so we can track their balances.
@@ -351,6 +354,7 @@ fn dex_works(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -379,7 +383,7 @@ fn dex_works(
 }
 
 /// Submit a standard limit order. Used for volume tracking tests.
-fn submit_standard_order(
+async fn submit_standard_order(
     suite: &mut TestSuite<NaiveProposalPreparer>,
     user: &mut TestAccount,
     contracts: &Contracts,
@@ -406,11 +410,12 @@ fn submit_standard_order(
             },
             funds,
         )
+        .await
         .should_succeed();
 }
 
-#[test]
-fn volume_tracking_works() {
+#[tokio::test]
+async fn volume_tracking_works() {
     let (mut suite, accounts, _, contracts, _) = setup_test_naive(TestOption {
         // Taxman now tracks volumes with the granularity of 1 day. This test
         // was written before this change was introduced. To make this test work
@@ -427,6 +432,7 @@ fn volume_tracking_works() {
             contracts.account_factory,
             Coins::one(usdc::DENOM.clone(), 100_000_000).unwrap(),
         )
+        .await
         .unwrap();
 
     let mut user2_addr_1 = accounts.user2;
@@ -436,6 +442,7 @@ fn volume_tracking_works() {
             contracts.account_factory,
             Coins::one(dango::DENOM.clone(), 100_000_000).unwrap(),
         )
+        .await
         .unwrap();
 
     // Query volumes before, should be 0
@@ -454,19 +461,19 @@ fn volume_tracking_works() {
         .should_succeed_and_equal(Udec128::ZERO);
 
     // Submit a new order with user1 address 1
-    submit_standard_order(&mut suite, &mut user1_addr_1, &contracts, Direction::Bid);
+    submit_standard_order(&mut suite, &mut user1_addr_1, &contracts, Direction::Bid).await;
 
     // User2 submit an opposite matching order with address 1
-    submit_standard_order(&mut suite, &mut user2_addr_1, &contracts, Direction::Ask);
+    submit_standard_order(&mut suite, &mut user2_addr_1, &contracts, Direction::Ask).await;
 
     // Get timestamp after trade
     let timestamp_after_first_trade = suite.block.timestamp;
 
     // Submit a new order with user1 address 1
-    submit_standard_order(&mut suite, &mut user1_addr_1, &contracts, Direction::Bid);
+    submit_standard_order(&mut suite, &mut user1_addr_1, &contracts, Direction::Bid).await;
 
     // User2 submit an opposite matching order with address 1
-    submit_standard_order(&mut suite, &mut user2_addr_1, &contracts, Direction::Ask);
+    submit_standard_order(&mut suite, &mut user2_addr_1, &contracts, Direction::Ask).await;
 
     // Get timestamp after trade
     let timestamp_after_second_trade = suite.block.timestamp;
@@ -488,10 +495,10 @@ fn volume_tracking_works() {
         .should_succeed_and_equal(Udec128::new(200_000_000));
 
     // Submit a new order with user1 address 2
-    submit_standard_order(&mut suite, &mut user1_addr_2, &contracts, Direction::Bid);
+    submit_standard_order(&mut suite, &mut user1_addr_2, &contracts, Direction::Bid).await;
 
     // Submit a new opposite matching order with user2 address 2
-    submit_standard_order(&mut suite, &mut user2_addr_2, &contracts, Direction::Ask);
+    submit_standard_order(&mut suite, &mut user2_addr_2, &contracts, Direction::Ask).await;
 
     let timestamp_after_third_trade = suite.block.timestamp;
 
@@ -557,8 +564,8 @@ fn volume_tracking_works() {
     });
 }
 
-#[test]
-fn volume_tracking_works_with_multiple_orders_from_same_user() {
+#[tokio::test]
+async fn volume_tracking_works_with_multiple_orders_from_same_user() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption {
         // See comment in `volume_tracking_works` for the rationale of this.
         block_time: Duration::from_days(1),
@@ -597,7 +604,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                 cancels: None,
             },
             coins! { usdc::DENOM.clone() => 301_000_000 },
-        )
+        ).await
         .should_succeed();
 
     // Submit matching orders with user2
@@ -629,6 +636,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                 eth::DENOM.clone() => 117304,
             },
         )
+        .await
         .should_succeed();
 
     // Get timestamp after trade
@@ -708,7 +716,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
             coins! {
                 usdc::DENOM.clone() => 411_000_000,
             },
-        )
+        ).await
         .should_succeed();
 
     // Submit matching orders with user2
@@ -742,6 +750,7 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
                 eth::DENOM.clone() => 117304 * 2,
             },
         )
+        .await
         .should_succeed();
 
     // Get timestamp after second trade
@@ -2332,7 +2341,8 @@ fn volume_tracking_works_with_multiple_orders_from_same_user() {
     BTreeMap::new();
     "One limit ask price 1.0, one market bid matched two market bids from other address one partially matched one unmatched are refunded correctly, limit order same size, 1% maker fee, 5% taker fee, no slippage"
 )]
-fn market_order_clearing(
+#[tokio::test]
+async fn market_order_clearing(
     limit_orders_and_funds: Vec<(Vec<CreateOrderRequest>, Coins)>,
     market_orders_and_funds: Vec<(Vec<CreateOrderRequest>, Coins)>,
     limits_and_markets_in_same_block: bool,
@@ -2355,6 +2365,7 @@ fn market_order_clearing(
             None,                // No chain config update
             Some(app_config),    // App config update
         )
+        .await
         .should_succeed();
 
     // Register oracle price source for USDC and DANGO. Needed for volume tracking in cron_execute
@@ -2376,6 +2387,7 @@ fn market_order_clearing(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Record balances for users
@@ -2434,6 +2446,7 @@ fn market_order_clearing(
                     .chain(create_market_order_txs)
                     .collect(),
             )
+            .await
             .block_outcome
             .tx_outcomes
             .into_iter()
@@ -2443,6 +2456,7 @@ fn market_order_clearing(
     } else {
         suite
             .make_block(submit_limit_order_txs)
+            .await
             .block_outcome
             .tx_outcomes
             .into_iter()
@@ -2451,6 +2465,7 @@ fn market_order_clearing(
             });
         suite
             .make_block(create_market_order_txs)
+            .await
             .block_outcome
             .tx_outcomes
             .into_iter()
@@ -2552,7 +2567,8 @@ fn market_order_clearing(
     }
     ; "limit bid matched with market ask limit size too small market order is consumed with zero output"
 )]
-fn market_order_matched_results_in_zero_output(
+#[tokio::test]
+async fn market_order_matched_results_in_zero_output(
     limit_order: CreateOrderRequest,
     limit_funds: Coins,
     market_order: CreateOrderRequest,
@@ -2581,6 +2597,7 @@ fn market_order_matched_results_in_zero_output(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite.balances().record_many(accounts.users());
@@ -2596,6 +2613,7 @@ fn market_order_matched_results_in_zero_output(
             },
             limit_funds,
         )
+        .await
         .should_succeed();
 
     // Create a market order with a small amount and price,
@@ -2609,6 +2627,7 @@ fn market_order_matched_results_in_zero_output(
             },
             market_funds,
         )
+        .await
         .should_succeed();
 
     // No matching could take place so both users should have unchanged balances
@@ -2621,8 +2640,8 @@ fn market_order_matched_results_in_zero_output(
         .should_change(&accounts.user2, expected_balance_changes_market_order_user);
 }
 
-#[test]
-fn cron_execute_gracefully_handles_oracle_price_failure() {
+#[tokio::test]
+async fn cron_execute_gracefully_handles_oracle_price_failure() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     suite.balances().record_many(accounts.users());
@@ -2646,6 +2665,7 @@ fn cron_execute_gracefully_handles_oracle_price_failure() {
                 dango::DENOM.clone() => 1000000,
             },
         )
+        .await
         .should_succeed();
 
     // Submit another limit from user2
@@ -2667,6 +2687,7 @@ fn cron_execute_gracefully_handles_oracle_price_failure() {
                 usdc::DENOM.clone() => 1000000,
             },
         )
+        .await
         .should_succeed();
 
     // ------ Assert that the orders were matched and filled correctly ------
@@ -2692,8 +2713,8 @@ fn cron_execute_gracefully_handles_oracle_price_failure() {
     });
 }
 
-#[test]
-fn market_orders_are_sorted_by_price_ascending() {
+#[tokio::test]
+async fn market_orders_are_sorted_by_price_ascending() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Set maker and taker fee rates to 0 for simplicity
@@ -2707,6 +2728,7 @@ fn market_orders_are_sorted_by_price_ascending() {
             None,                // No chain config update
             Some(app_config),    // App config update
         )
+        .await
         .should_succeed();
 
     // Register oracle price source for USDC and DANGO. Needed for volume tracking in cron_execute
@@ -2723,6 +2745,7 @@ fn market_orders_are_sorted_by_price_ascending() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -2737,6 +2760,7 @@ fn market_orders_are_sorted_by_price_ascending() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // No matter which user places the orders they outcome should be the same.
@@ -2772,6 +2796,7 @@ fn market_orders_are_sorted_by_price_ascending() {
                     dango::DENOM.clone() => 1000000,
                 },
             )
+            .await
             .should_succeed();
 
         // Submit two market orders from different users in the same block. First user
@@ -2834,6 +2859,7 @@ fn market_orders_are_sorted_by_price_ascending() {
         // successful.
         suite
             .make_block(txs)
+            .await
             .block_outcome
             .tx_outcomes
             .into_iter()
@@ -2868,8 +2894,8 @@ fn market_orders_are_sorted_by_price_ascending() {
 /// Since order 2 has the better price, it will be matched against 1.
 /// Market order 3 will be popped out of the iterator, but not finding a match.
 /// In this case, we need to handle the cancelation and refund of this order.
-#[test]
-fn refund_left_over_market_bid() {
+#[tokio::test]
+async fn refund_left_over_market_bid() {
     let (mut suite, mut accounts, _, contracts, _) =
         setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
             dex: DexOption {
@@ -2904,6 +2930,7 @@ fn refund_left_over_market_bid() {
             None,                // No chain config update
             Some(app_config),    // App config update
         )
+        .await
         .should_succeed();
 
     // Block 1: we make it such that a mid price of 100 is recorded.
@@ -2935,6 +2962,7 @@ fn refund_left_over_market_bid() {
                 usdc::DENOM.clone() => 100,
             },
         )
+        .await
         .should_succeed();
 
     // Query the mid price to make sure it's accurate.
@@ -3016,6 +3044,7 @@ fn refund_left_over_market_bid() {
                 )
                 .unwrap(),
         ])
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -3051,8 +3080,8 @@ fn refund_left_over_market_bid() {
 /// - resting order book: limit bid, price 100, amount 1
 /// - limit ask, price 99, amount 1
 /// - market ask, price 100, amount 1
-#[test]
-fn refund_left_over_market_ask() {
+#[tokio::test]
+async fn refund_left_over_market_ask() {
     let (mut suite, mut accounts, _, contracts, _) =
         setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
             dex: DexOption {
@@ -3087,6 +3116,7 @@ fn refund_left_over_market_ask() {
             None,                // No chain config update
             Some(app_config),    // App config update
         )
+        .await
         .should_succeed();
 
     // Block 1: we make it such that a mid price of 100 is recorded.
@@ -3118,6 +3148,7 @@ fn refund_left_over_market_ask() {
                 usdc::DENOM.clone() => 200,
             },
         )
+        .await
         .should_succeed();
 
     // Query the mid price to make sure it's accurate.
@@ -3196,6 +3227,7 @@ fn refund_left_over_market_ask() {
                 )
                 .unwrap(),
         ])
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -3223,8 +3255,8 @@ fn refund_left_over_market_ask() {
     });
 }
 
-#[test]
-fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
+#[tokio::test]
+async fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let txs = vec![
@@ -3284,6 +3316,7 @@ fn resting_order_book_is_updated_correctly_orders_remain_on_both_sides() {
 
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()

--- a/dango/testing/tests/dex/handle_error.rs
+++ b/dango/testing/tests/dex/handle_error.rs
@@ -95,7 +95,8 @@ fn do_nothing(_ctx: SudoCtx, _msg: Empty) -> StdResult<Response> {
     };
     "intentional error in taxman fee payment"
 )]
-fn handling_error_in_auction(f: fn(&Contracts) -> (Addr, ContractWrapper)) {
+#[tokio::test]
+async fn handling_error_in_auction(f: fn(&Contracts) -> (Addr, ContractWrapper)) {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let (contract_to_migrate, bugged_code) = f(&contracts);
@@ -148,7 +149,7 @@ fn handling_error_in_auction(f: fn(&Contracts) -> (Addr, ContractWrapper)) {
         )
         .unwrap();
 
-    suite.make_block(vec![tx]);
+    suite.make_block(vec![tx]).await;
 
     // Ensure trading is halted.
     suite

--- a/dango/testing/tests/dex/liquidity.rs
+++ b/dango/testing/tests/dex/liquidity.rs
@@ -26,8 +26,8 @@ use {
     test_case::test_case,
 };
 
-#[test]
-fn only_owner_can_create_passive_pool() {
+#[tokio::test]
+async fn only_owner_can_create_passive_pool() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let lp_denom = Denom::try_from("dex/pool/xrp/usdc").unwrap();
@@ -55,6 +55,7 @@ fn only_owner_can_create_passive_pool() {
             }])),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("you don't have the right, O you don't have the right");
 
     // Attempt to create pair as owner. Should succeed.
@@ -80,6 +81,7 @@ fn only_owner_can_create_passive_pool() {
             }])),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
@@ -209,7 +211,8 @@ fn only_owner_can_create_passive_pool() {
     Uint128::new(199_899_999)
     ; "geometric pool provision at different ratio 2"
 )]
-fn provide_liquidity(
+#[tokio::test]
+async fn provide_liquidity(
     provision: Coins,
     swap_fee: Udec128,
     pool_type: PassiveLiquidity,
@@ -226,34 +229,32 @@ fn provide_liquidity(
         usdc::DENOM.clone()  => 100,
     };
 
-    suite
+    let pair_params = suite
         .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
         })
-        .should_succeed_and(|pair_params: &PairParams| {
-            // Update pair params
-            suite
-                .execute(
-                    &mut accounts.owner,
-                    contracts.dex,
-                    &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                        params: PairParams {
-                            lp_denom: pair_params.lp_denom.clone(),
-                            bucket_sizes: BTreeSet::new(),
-                            swap_fee_rate: Bounded::new_unchecked(swap_fee),
-                            pool_type,
-                            min_order_size_quote: Uint128::ZERO,
-                            min_order_size_base: Uint128::ZERO,
-                        },
-                    }])),
-                    Coins::new(),
-                )
-                .should_succeed();
-            true
-        });
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.dex,
+            &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                base_denom: dango::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+                params: PairParams {
+                    lp_denom: pair_params.lp_denom.clone(),
+                    bucket_sizes: BTreeSet::new(),
+                    swap_fee_rate: Bounded::new_unchecked(swap_fee),
+                    pool_type,
+                    min_order_size_quote: Uint128::ZERO,
+                    min_order_size_base: Uint128::ZERO,
+                },
+            }])),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
 
     // Register the oracle prices
     for (denom, price) in oracle_prices {
@@ -270,6 +271,7 @@ fn provide_liquidity(
                 }),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -284,6 +286,7 @@ fn provide_liquidity(
             },
             initial_reserves.clone(),
         )
+        .await
         .should_succeed();
 
     // Record the users initial balances.
@@ -307,6 +310,7 @@ fn provide_liquidity(
             },
             provision.clone(),
         )
+        .await
         .should_succeed();
 
     // Ensure that the dex balance has increased by the expected amount.
@@ -340,43 +344,41 @@ fn provide_liquidity(
         );
 }
 
-#[test]
-fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
+#[tokio::test]
+async fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Update pair params
-    suite
+    let pair_params = suite
         .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
         })
-        .should_succeed_and(|pair_params: &PairParams| {
-            // Update pair params
-            suite
-                .execute(
-                    &mut accounts.owner,
-                    contracts.dex,
-                    &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                        params: PairParams {
-                            lp_denom: pair_params.lp_denom.clone(),
-                            bucket_sizes: BTreeSet::new(),
-                            swap_fee_rate: pair_params.swap_fee_rate,
-                            pool_type: PassiveLiquidity::Geometric(Geometric {
-                                spacing: Udec128::ONE,
-                                ratio: Bounded::new_unchecked(Udec128::ONE),
-                                limit: 10,
-                            }),
-                            min_order_size_quote: Uint128::ZERO,
-                            min_order_size_base: Uint128::ZERO,
-                        },
-                    }])),
-                    Coins::new(),
-                )
-                .should_succeed();
-            true
-        });
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.dex,
+            &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                base_denom: dango::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+                params: PairParams {
+                    lp_denom: pair_params.lp_denom.clone(),
+                    bucket_sizes: BTreeSet::new(),
+                    swap_fee_rate: pair_params.swap_fee_rate,
+                    pool_type: PassiveLiquidity::Geometric(Geometric {
+                        spacing: Udec128::ONE,
+                        ratio: Bounded::new_unchecked(Udec128::ONE),
+                        limit: 10,
+                    }),
+                    min_order_size_quote: Uint128::ZERO,
+                    min_order_size_base: Uint128::ZERO,
+                },
+            }])),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
 
     // Since there is no oracle price, liquidity provision should fail.
     suite
@@ -393,6 +395,7 @@ fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
                 usdc::DENOM.clone() => 100_000,
             },
         )
+        .await
         .should_fail_with_error(StdError::data_not_found::<PrecisionlessPrice>(
             PYTH_PRICES.path(USDC_USD_ID.id).storage_key(),
         ));
@@ -416,7 +419,12 @@ fn provide_liquidity_to_geometric_pool_should_fail_without_oracle_price() {
     };
     "withdraw half"
 )]
-fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds_returned: Coins) {
+#[tokio::test]
+async fn withdraw_liquidity(
+    lp_burn_amount: Uint128,
+    swap_fee: Udec128,
+    expected_funds_returned: Coins,
+) {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let lp_denom = Denom::try_from("dex/pool/dango/usdc").unwrap();
@@ -427,34 +435,32 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
         usdc::DENOM.clone()  => 100,
     };
 
-    suite
+    let pair_params = suite
         .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
         })
-        .should_succeed_and(|pair_params: &PairParams| {
-            // Update pair params
-            suite
-                .execute(
-                    &mut accounts.owner,
-                    contracts.dex,
-                    &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                        params: PairParams {
-                            lp_denom: pair_params.lp_denom.clone(),
-                            bucket_sizes: BTreeSet::new(),
-                            swap_fee_rate: Bounded::new_unchecked(swap_fee),
-                            pool_type: pair_params.pool_type.clone(),
-                            min_order_size_quote: Uint128::ZERO,
-                            min_order_size_base: Uint128::ZERO,
-                        },
-                    }])),
-                    Coins::new(),
-                )
-                .should_succeed();
-            true
-        });
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.dex,
+            &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                base_denom: dango::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+                params: PairParams {
+                    lp_denom: pair_params.lp_denom.clone(),
+                    bucket_sizes: BTreeSet::new(),
+                    swap_fee_rate: Bounded::new_unchecked(swap_fee),
+                    pool_type: pair_params.pool_type.clone(),
+                    min_order_size_quote: Uint128::ZERO,
+                    min_order_size_base: Uint128::ZERO,
+                },
+            }])),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
 
     // Register the oracle prices
     suite
@@ -470,6 +476,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -485,6 +492,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Owner provides some initial liquidity.
@@ -499,6 +507,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
             },
             initial_reserves.clone(),
         )
+        .await
         .should_succeed();
 
     // User provides some liquidity.
@@ -517,6 +526,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
             },
             provided_funds.clone(),
         )
+        .await
         .should_succeed();
 
     // record user and dex balances
@@ -536,6 +546,7 @@ fn withdraw_liquidity(lp_burn_amount: Uint128, swap_fee: Udec128, expected_funds
             },
             coins! { lp_denom.clone() => lp_burn_amount },
         )
+        .await
         .should_succeed();
 
     // Assert that the user's balances have changed as expected.
@@ -981,7 +992,8 @@ fn balance_changes_from_coins(
     ];
     "xyk pool balance 1:200 tick size 1 one percent fee three users with multiple orders"
 )]
-fn curve_on_orderbook(
+#[tokio::test]
+async fn curve_on_orderbook(
     pool_type: PassiveLiquidity,
     swap_fee_rate: Udec128,
     pool_liquidity: Coins,
@@ -1004,37 +1016,36 @@ fn curve_on_orderbook(
             None,                // No chain config update
             Some(app_config),    // App config update
         )
+        .await
         .should_succeed();
 
     // Update pair params
-    suite
+    let pair_params = suite
         .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
             base_denom: eth::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
         })
-        .should_succeed_and(|pair_params: &PairParams| {
-            // Provide liquidity with owner account
-            suite
-                .execute(
-                    &mut accounts.owner,
-                    contracts.dex,
-                    &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
-                        base_denom: eth::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                        params: PairParams {
-                            lp_denom: pair_params.lp_denom.clone(),
-                            pool_type,
-                            bucket_sizes: BTreeSet::new(),
-                            swap_fee_rate: Bounded::new_unchecked(swap_fee_rate),
-                            min_order_size_quote: Uint128::ZERO,
-                            min_order_size_base: Uint128::ZERO,
-                        },
-                    }])),
-                    pool_liquidity.clone(),
-                )
-                .should_succeed();
-            true
-        });
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.dex,
+            &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                base_denom: eth::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+                params: PairParams {
+                    lp_denom: pair_params.lp_denom.clone(),
+                    pool_type,
+                    bucket_sizes: BTreeSet::new(),
+                    swap_fee_rate: Bounded::new_unchecked(swap_fee_rate),
+                    min_order_size_quote: Uint128::ZERO,
+                    min_order_size_base: Uint128::ZERO,
+                },
+            }])),
+            pool_liquidity.clone(),
+        )
+        .await
+        .should_succeed();
 
     // Register oracle price source for USDC
     suite
@@ -1050,6 +1061,7 @@ fn curve_on_orderbook(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Register oracle price source for ETH
@@ -1066,6 +1078,7 @@ fn curve_on_orderbook(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Provide liquidity with owner account
@@ -1080,6 +1093,7 @@ fn curve_on_orderbook(
             },
             pool_liquidity.clone(),
         )
+        .await
         .should_succeed();
 
     // Record dex and user balances
@@ -1110,6 +1124,7 @@ fn curve_on_orderbook(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -1756,7 +1771,8 @@ fn curve_on_orderbook(
     });
     "multiple orders on both sides, two orders per bucket, bucket size 20, cancel some orders"
 )]
-fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancellation(
+#[tokio::test]
+async fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancellation(
     limit_orders: Vec<(Direction, Price, Uint128)>, // direction, price, amount
     cancels: Option<CancelOrderRequest>,
     bucket_size: Price,
@@ -1787,6 +1803,7 @@ fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancell
             }])),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Register oracle price sources for ETH and USDC
@@ -1803,6 +1820,7 @@ fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancell
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1818,6 +1836,7 @@ fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancell
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Calculate required funds for market orders
@@ -1878,6 +1897,7 @@ fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancell
             },
             funds,
         )
+        .await
         .should_succeed();
 
     // Query the liquidity depth
@@ -1901,6 +1921,7 @@ fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancell
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Query the liquidity depth
@@ -1917,8 +1938,8 @@ fn test_liquidity_depth_is_correctly_calculated_after_order_clearing_and_cancell
         );
 }
 
-#[test]
-fn decrease_liquidity_depths_minimal_failing_test() {
+#[tokio::test]
+async fn decrease_liquidity_depths_minimal_failing_test() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Register oracle price sources for ETH and USDC
@@ -1935,6 +1956,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Submit new orders with user1
@@ -1964,7 +1986,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
             coins! {
                 usdc::DENOM.clone() => 411_000_000,
             },
-        )
+        ).await
         .should_succeed();
 
     // Submit matching orders with user2
@@ -1988,6 +2010,7 @@ fn decrease_liquidity_depths_minimal_failing_test() {
                 eth::DENOM.clone() => 117304 * 2,
             },
         )
+        .await
         .should_succeed();
 
     // Assert that orderbook is empty
@@ -2001,8 +2024,8 @@ fn decrease_liquidity_depths_minimal_failing_test() {
         .should_succeed_and_equal(BTreeMap::new());
 }
 
-#[test]
-fn provide_liquidity_fails_when_minimum_output_is_not_met() {
+#[tokio::test]
+async fn provide_liquidity_fails_when_minimum_output_is_not_met() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let expected_mint_amount = Uint128::new(100_000_000) - MINIMUM_LIQUIDITY;
@@ -2021,6 +2044,7 @@ fn provide_liquidity_fails_when_minimum_output_is_not_met() {
                 usdc::DENOM.clone() => 100,
             },
         )
+        .await
         .should_fail_with_error(format!(
             "LP mint amount is less than the minimum output: {} < {}",
             expected_mint_amount,
@@ -2028,8 +2052,8 @@ fn provide_liquidity_fails_when_minimum_output_is_not_met() {
         ));
 }
 
-#[test]
-fn withdraw_liquidity_fails_when_minimum_output_is_not_met() {
+#[tokio::test]
+async fn withdraw_liquidity_fails_when_minimum_output_is_not_met() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let lp_denom = Denom::try_from("dex/pool/dango/usdc").unwrap();
@@ -2048,6 +2072,7 @@ fn withdraw_liquidity_fails_when_minimum_output_is_not_met() {
                 usdc::DENOM.clone() => 100,
             },
         )
+        .await
         .should_succeed();
 
     let lp_balance = suite
@@ -2071,6 +2096,7 @@ fn withdraw_liquidity_fails_when_minimum_output_is_not_met() {
             },
             Coins::one(lp_denom.clone(), lp_balance).unwrap(),
         )
+        .await
         .should_fail_with_error(format!(
             "withdrawn assets are less than the minimum output: {:?} < {:?}",
             CoinPair::try_from(coins! {

--- a/dango/testing/tests/dex/liquidity.rs
+++ b/dango/testing/tests/dex/liquidity.rs
@@ -1986,7 +1986,8 @@ async fn decrease_liquidity_depths_minimal_failing_test() {
             coins! {
                 usdc::DENOM.clone() => 411_000_000,
             },
-        ).await
+        )
+        .await
         .should_succeed();
 
     // Submit matching orders with user2

--- a/dango/testing/tests/dex/orders.rs
+++ b/dango/testing/tests/dex/orders.rs
@@ -23,8 +23,8 @@ use {
 /// deserialize. However, let's just assume an attacker somehow circumvents that
 /// (which would require him to collude with a validator), then the contract
 /// would still reject the order.
-#[test]
-fn cannot_submit_order_with_zero_amount() {
+#[tokio::test]
+async fn cannot_submit_order_with_zero_amount() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Attempt to submit a limit order with zero amount.
@@ -44,6 +44,7 @@ fn cannot_submit_order_with_zero_amount() {
             },
             Coins::one(usdc::DENOM.clone(), 1).unwrap(),
         )
+        .await
         .should_fail_with_error(StdError::zero_value::<Uint128>());
 
     // Attempt to submit a market order with zero amount.
@@ -63,11 +64,12 @@ fn cannot_submit_order_with_zero_amount() {
             },
             Coins::one(usdc::DENOM.clone(), 1).unwrap(),
         )
+        .await
         .should_fail_with_error(StdError::zero_value::<Uint128>());
 }
 
-#[test]
-fn cannot_submit_orders_in_non_existing_pairs() {
+#[tokio::test]
+async fn cannot_submit_orders_in_non_existing_pairs() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     suite
@@ -86,6 +88,7 @@ fn cannot_submit_orders_in_non_existing_pairs() {
             },
             Coins::one(usdc::DENOM.clone(), 1).unwrap(),
         )
+        .await
         .should_fail_with_error(format!(
             "pair not found with base `{}` and quote `{}`",
             atom::DENOM.clone(),
@@ -234,7 +237,8 @@ fn cannot_submit_orders_in_non_existing_pairs() {
     => panics "insufficient funds for batch updating orders";
     "two submission insufficient funds"
 )]
-fn submit_and_cancel_orders(
+#[tokio::test]
+async fn submit_and_cancel_orders(
     creates: Vec<CreateOrderRequest>,
     cancels: Option<CancelOrderRequest>,
     funds: Coins,
@@ -257,6 +261,7 @@ fn submit_and_cancel_orders(
             },
             funds,
         )
+        .await
         .should_succeed();
 
     // Cancel the order.
@@ -270,6 +275,7 @@ fn submit_and_cancel_orders(
             },
             coins! { dango::DENOM.clone() => 1 },
         )
+        .await
         .should_succeed();
 
     // Check that the user balance has not changed.
@@ -458,7 +464,8 @@ fn submit_and_cancel_orders(
     };
     "submit one order then cancel it and place a new order excess funds are returned"
 )]
-fn submit_orders_then_cancel_and_submit_in_same_message(
+#[tokio::test]
+async fn submit_orders_then_cancel_and_submit_in_same_message(
     initial_orders: Vec<CreateOrderRequest>,
     initial_funds: Coins,
     cancellations: Option<CancelOrderRequest>,
@@ -480,6 +487,7 @@ fn submit_orders_then_cancel_and_submit_in_same_message(
             },
             initial_funds,
         )
+        .await
         .should_succeed();
 
     // Record the user's balance
@@ -496,6 +504,7 @@ fn submit_orders_then_cancel_and_submit_in_same_message(
             },
             second_funds,
         )
+        .await
         .should_succeed();
 
     // Check that the user balance has changed
@@ -523,8 +532,8 @@ fn submit_orders_then_cancel_and_submit_in_same_message(
         });
 }
 
-#[test]
-fn submit_and_cancel_order_in_same_block() {
+#[tokio::test]
+async fn submit_and_cancel_order_in_same_block() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Record the user's balance
@@ -572,6 +581,7 @@ fn submit_and_cancel_order_in_same_block() {
     // Execute the transaction in a block
     suite
         .make_block(vec![tx])
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -685,7 +695,8 @@ fn submit_and_cancel_order_in_same_block() {
     };
     "dango/usdc with start after and limit"
 )]
-fn query_orders_by_pair(
+#[tokio::test]
+async fn query_orders_by_pair(
     orders_to_submit: Vec<((Denom, Denom), Direction, u128, u128)>,
     (base_denom, quote_denom): (Denom, Denom),
     start_after: Option<OrderId>,
@@ -764,6 +775,7 @@ fn query_orders_by_pair(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -849,7 +861,8 @@ fn query_orders_by_pair(
     Some("order size (99 bridge/usdc) is less than the minimum (100 bridge/usdc)");
     "ask smaller than minimum order size"
 )]
-fn limit_order_minimum_order_size(
+#[tokio::test]
+async fn limit_order_minimum_order_size(
     order: CreateOrderRequest,
     funds: Coins,
     min_order_size_quote: Uint128,
@@ -860,33 +873,32 @@ fn limit_order_minimum_order_size(
 
     // Update the pair params with the minimum order size
 
-    suite
+    let pair_params = suite
         .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
         })
-        .should_succeed_and(|pair_params: &PairParams| {
-            suite
-                .execute(
-                    &mut accounts.owner,
-                    contracts.dex,
-                    &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                        params: PairParams {
-                            lp_denom: pair_params.lp_denom.clone(),
-                            bucket_sizes: BTreeSet::new(),
-                            swap_fee_rate: pair_params.swap_fee_rate,
-                            pool_type: pair_params.pool_type.clone(),
-                            min_order_size_quote,
-                            min_order_size_base,
-                        },
-                    }])),
-                    Coins::new(),
-                )
-                .should_succeed();
-            true
-        });
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.dex,
+            &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                base_denom: dango::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+                params: PairParams {
+                    lp_denom: pair_params.lp_denom.clone(),
+                    bucket_sizes: BTreeSet::new(),
+                    swap_fee_rate: pair_params.swap_fee_rate,
+                    pool_type: pair_params.pool_type.clone(),
+                    min_order_size_quote,
+                    min_order_size_base,
+                },
+            }])),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
 
     // Submit the order
     match expected_error {
@@ -901,6 +913,7 @@ fn limit_order_minimum_order_size(
                     },
                     funds,
                 )
+                .await
                 .should_succeed();
         },
 
@@ -915,6 +928,7 @@ fn limit_order_minimum_order_size(
                     },
                     funds,
                 )
+                .await
                 .should_fail_with_error(error);
         },
     }
@@ -1070,7 +1084,8 @@ fn limit_order_minimum_order_size(
     Some("order size (99 bridge/usdc) is less than the minimum (100 bridge/usdc)");
     "ask smaller than minimum order size no slippage"
 )]
-fn market_order_minimum_order_size(
+#[tokio::test]
+async fn market_order_minimum_order_size(
     limit_order: CreateOrderRequest,
     market_order: CreateOrderRequest,
     limit_order_funds: Coins,
@@ -1082,30 +1097,29 @@ fn market_order_minimum_order_size(
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Update the pair params with the minimum order size
-    suite
+    let pair_params = suite
         .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
         })
-        .should_succeed_and(|pair_params: &PairParams| {
-            suite
-                .execute(
-                    &mut accounts.owner,
-                    contracts.dex,
-                    &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                        params: PairParams {
-                            min_order_size_quote,
-                            min_order_size_base,
-                            ..pair_params.clone()
-                        },
-                    }])),
-                    Coins::new(),
-                )
-                .should_succeed();
-            true
-        });
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.dex,
+            &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                base_denom: dango::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+                params: PairParams {
+                    min_order_size_quote,
+                    min_order_size_base,
+                    ..pair_params.clone()
+                },
+            }])),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
 
     // Submit the limit order to create a resting order book
     suite
@@ -1118,6 +1132,7 @@ fn market_order_minimum_order_size(
             },
             limit_order_funds,
         )
+        .await
         .should_succeed();
 
     // Submit the order
@@ -1133,6 +1148,7 @@ fn market_order_minimum_order_size(
                     },
                     market_order_funds,
                 )
+                .await
                 .should_succeed();
         },
         Some(error) => {
@@ -1146,13 +1162,14 @@ fn market_order_minimum_order_size(
                     },
                     market_order_funds,
                 )
+                .await
                 .should_fail_with_error(error);
         },
     }
 }
 
-#[test]
-fn orders_cannot_be_created_for_non_existing_pair() {
+#[tokio::test]
+async fn orders_cannot_be_created_for_non_existing_pair() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Submit limit order
@@ -1172,6 +1189,7 @@ fn orders_cannot_be_created_for_non_existing_pair() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(format!(
             "pair not found with base `{}` and quote `{}`",
             dango::DENOM.clone(),
@@ -1195,6 +1213,7 @@ fn orders_cannot_be_created_for_non_existing_pair() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(format!(
             "pair not found with base `{}` and quote `{}`",
             dango::DENOM.clone(),
@@ -1212,8 +1231,8 @@ fn orders_cannot_be_created_for_non_existing_pair() {
 /// of 1 * 100 = 100 quote asset deposit, and refund the excess 50, at the time
 /// of order creation. Then, if the user cancels the order, he gets the remaining
 /// 100 back.
-#[test]
-fn create_and_cancel_order_with_remainder() {
+#[tokio::test]
+async fn create_and_cancel_order_with_remainder() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     suite.balances().record(&accounts.user1);
@@ -1234,6 +1253,7 @@ fn create_and_cancel_order_with_remainder() {
             },
             Coins::one(usdc::DENOM.clone(), 150).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1246,6 +1266,7 @@ fn create_and_cancel_order_with_remainder() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     suite.balances().should_change(&accounts.user1, btree_map! {

--- a/dango/testing/tests/dex/proptests.rs
+++ b/dango/testing/tests/dex/proptests.rs
@@ -295,7 +295,7 @@ pub enum DexAction {
 }
 
 impl DexAction {
-    fn execute(
+    async fn execute(
         &self,
         suite: &mut TestSuite<NaiveProposalPreparer>,
         accounts: &mut TestAccounts,
@@ -343,7 +343,7 @@ impl DexAction {
                     .sign_transaction(NonEmpty::new_unchecked(vec![msg]), &suite.chain_id, 100_000)
                     .unwrap();
 
-                let block_outcome = suite.make_block(vec![tx]).block_outcome;
+                let block_outcome = suite.make_block(vec![tx]).await.block_outcome;
 
                 if let Err(_err) = &block_outcome.tx_outcomes.first().unwrap().result {
                     // println!("CreateLimitOrder error: {_err}");
@@ -427,7 +427,7 @@ impl DexAction {
                     .sign_transaction(NonEmpty::new_unchecked(vec![msg]), &suite.chain_id, 100_000)
                     .unwrap();
 
-                let block_outcome = suite.make_block(vec![tx]).block_outcome;
+                let block_outcome = suite.make_block(vec![tx]).await.block_outcome;
 
                 assert!(
                     block_outcome
@@ -459,7 +459,7 @@ impl DexAction {
                     .sign_transaction(NonEmpty::new_unchecked(vec![msg]), &suite.chain_id, 100_000)
                     .unwrap();
 
-                let block_outcome = suite.make_block(vec![tx]).block_outcome;
+                let block_outcome = suite.make_block(vec![tx]).await.block_outcome;
 
                 if let Err(_err) = &block_outcome.tx_outcomes.first().unwrap().result {
                     // println!("ProvideLiquidity error: {_err}");
@@ -511,7 +511,7 @@ impl DexAction {
                     .sign_transaction(NonEmpty::new_unchecked(vec![msg]), &suite.chain_id, 100_000)
                     .unwrap();
 
-                let block_outcome = suite.make_block(vec![tx]).block_outcome;
+                let block_outcome = suite.make_block(vec![tx]).await.block_outcome;
 
                 assert!(
                     block_outcome
@@ -538,7 +538,7 @@ impl DexAction {
                     .sign_transaction(NonEmpty::new_unchecked(vec![msg]), &suite.chain_id, 100_000)
                     .unwrap();
 
-                let block_outcome = suite.make_block(vec![tx]).block_outcome;
+                let block_outcome = suite.make_block(vec![tx]).await.block_outcome;
 
                 block_outcome
                     .tx_outcomes
@@ -593,7 +593,7 @@ impl DexAction {
                     .sign_transaction(NonEmpty::new_unchecked(vec![msg]), &suite.chain_id, 100_000)
                     .unwrap();
 
-                let block_outcome = suite.make_block(vec![tx]).block_outcome;
+                let block_outcome = suite.make_block(vec![tx]).await.block_outcome;
 
                 block_outcome
                     .tx_outcomes
@@ -991,7 +991,7 @@ fn limit_orders(min_size: usize, max_size: usize) -> impl Strategy<Value = Vec<D
 }
 
 /// Feed fixed oracle prices for all denoms.
-fn feed_prices(
+async fn feed_prices(
     timestamp: Timestamp,
     suite: &mut TestSuite<NaiveProposalPreparer>,
     accounts: &mut TestAccounts,
@@ -1011,6 +1011,7 @@ fn feed_prices(
                 }),
                 Coins::default(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1018,7 +1019,7 @@ fn feed_prices(
 }
 
 /// Test a list of DexActions. Execute the actions and check balances after each action.
-fn test_dex_actions(
+async fn test_dex_actions(
     dex_actions: Vec<DexAction>,
     pool_types: Vec<PassiveLiquidity>,
 ) -> Result<(TestSuite<NaiveProposalPreparer>, TestAccounts, Contracts), TestCaseError> {
@@ -1066,7 +1067,7 @@ fn test_dex_actions(
 
     // Register fixed prices for all denoms.
     let timestamp = Timestamp::from_nanos(u128::MAX); // Maximum time in the future to prevent oracle price from being outdated.
-    feed_prices(timestamp, &mut suite, &mut accounts, &contracts)?;
+    feed_prices(timestamp, &mut suite, &mut accounts, &contracts).await?;
 
     let bucket_sizes = bucket_sizes();
 
@@ -1099,6 +1100,7 @@ fn test_dex_actions(
             )),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Check dex contract's balances. Should be empty.
@@ -1108,7 +1110,9 @@ fn test_dex_actions(
     // Execute the actions and check balances after each action.
     for action in dex_actions {
         // Execute the action.
-        let block_outcome = action.execute(&mut suite, &mut accounts, &contracts)?;
+        let block_outcome = action
+            .execute(&mut suite, &mut accounts, &contracts)
+            .await?;
 
         // Query dex paused status.
         let is_paused = suite
@@ -1161,12 +1165,23 @@ proptest! {
 
     #[test]
     fn dex_contract_balances_equals_open_orders_plus_passive_liquidity(dex_actions in dex_actions(5, 10), pool_types in pool_types(3)) {
-        test_dex_actions(dex_actions, pool_types)?;
+        // proptest doesn't support `async fn` test bodies, so build a runtime
+        // and `block_on` the async helper. Safe here because there's no
+        // outer tokio runtime to deadlock against.
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(test_dex_actions(dex_actions, pool_types))?;
     }
 
     #[test]
     fn provide_liq_and_market_order(dex_actions in provide_liquidity_and_market_order(), pool_types in pool_types(3)) {
-        test_dex_actions(dex_actions, pool_types)?;
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(test_dex_actions(dex_actions, pool_types))?;
     }
 }
 
@@ -1180,8 +1195,8 @@ proptest! {
 /// hold and use to place order. E.g. if reserve ratio is 5%, then the pool will
 /// only use 95% of its funds to place order, thus its liquidity never reduces
 /// to zero.
-#[test]
-fn xyk_liquidity_should_not_reduce_to_zero_by_market_order() {
+#[tokio::test]
+async fn xyk_liquidity_should_not_reduce_to_zero_by_market_order() {
     let (suite, _, contracts) = test_dex_actions(
         vec![
             DexAction::ProvideLiquidity {
@@ -1205,6 +1220,7 @@ fn xyk_liquidity_should_not_reduce_to_zero_by_market_order() {
             limit: 30,
         })],
     )
+    .await
     .unwrap();
 
     // Query the reserve of ETH-USDC pool. Neither tokens should be zero.

--- a/dango/testing/tests/dex/swaps.rs
+++ b/dango/testing/tests/dex/swaps.rs
@@ -271,7 +271,8 @@ fn balance_changes_from_coins(
     };
     "1:1 pool 0.01% swap fee one step route input 100% of pool liquidity"
 )]
-fn swap_exact_amount_in(
+#[tokio::test]
+async fn swap_exact_amount_in(
     pool_reserves: BTreeMap<(Denom, Denom), Coins>,
     route: Vec<PairId>,
     swap_funds: Coins,
@@ -284,36 +285,32 @@ fn swap_exact_amount_in(
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     for ((base_denom, quote_denom), swap_fee_rate) in swap_fee_rates {
-        suite
+        let pair_params = suite
             .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
                 base_denom: base_denom.clone(),
                 quote_denom: quote_denom.clone(),
             })
-            .should_succeed_and(|pair_params: &PairParams| {
-                // Update pair params
-                suite
-                    .execute(
-                        &mut accounts.owner,
-                        contracts.dex,
-                        &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![
-                            PairUpdate {
-                                base_denom: base_denom.clone(),
-                                quote_denom: quote_denom.clone(),
-                                params: PairParams {
-                                    lp_denom: pair_params.lp_denom.clone(),
-                                    bucket_sizes: BTreeSet::new(),
-                                    swap_fee_rate: Bounded::new_unchecked(swap_fee_rate),
-                                    pool_type: pair_params.pool_type.clone(),
-                                    min_order_size_quote: Uint128::ZERO,
-                                    min_order_size_base: Uint128::ZERO,
-                                },
-                            },
-                        ])),
-                        Coins::new(),
-                    )
-                    .should_succeed();
-                true
-            });
+            .should_succeed();
+        suite
+            .execute(
+                &mut accounts.owner,
+                contracts.dex,
+                &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                    base_denom: base_denom.clone(),
+                    quote_denom: quote_denom.clone(),
+                    params: PairParams {
+                        lp_denom: pair_params.lp_denom.clone(),
+                        bucket_sizes: BTreeSet::new(),
+                        swap_fee_rate: Bounded::new_unchecked(swap_fee_rate),
+                        pool_type: pair_params.pool_type.clone(),
+                        min_order_size_quote: Uint128::ZERO,
+                        min_order_size_base: Uint128::ZERO,
+                    },
+                }])),
+                Coins::new(),
+            )
+            .await
+            .should_succeed();
     }
 
     // Provide liquidity with owner account
@@ -329,6 +326,7 @@ fn swap_exact_amount_in(
                 },
                 reserve.clone(),
             )
+            .await
             .should_succeed();
     }
 
@@ -348,6 +346,7 @@ fn swap_exact_amount_in(
             },
             swap_funds.clone(),
         )
+        .await
         .should_succeed();
 
     // Assert that the user's balances have changed as expected.
@@ -627,7 +626,8 @@ fn swap_exact_amount_in(
     };
     "1:1 pool 0.01% swap fee one step route output 49.995% of pool liquidity"
 )]
-fn swap_exact_amount_out(
+#[tokio::test]
+async fn swap_exact_amount_out(
     pool_reserves: BTreeMap<(Denom, Denom), Coins>,
     route: Vec<PairId>,
     exact_out: Coin,
@@ -662,6 +662,7 @@ fn swap_exact_amount_out(
                     }])),
                     Coins::new(),
                 )
+                .await
                 .should_succeed();
         }
     }
@@ -679,6 +680,7 @@ fn swap_exact_amount_out(
                 },
                 reserve.clone(),
             )
+            .await
             .should_succeed();
     }
 
@@ -698,6 +700,7 @@ fn swap_exact_amount_out(
             },
             swap_funds.clone(),
         )
+        .await
         .should_succeed();
 
     // Assert that the user's balances have changed as expected.
@@ -739,8 +742,8 @@ fn swap_exact_amount_out(
     }
 }
 
-#[test]
-fn geometric_pool_swaps_fail_without_oracle_price() {
+#[tokio::test]
+async fn geometric_pool_swaps_fail_without_oracle_price() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // Provide liquidity to pair before changing the pool type since XYK does not require an oracle price
@@ -758,41 +761,40 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 usdc::DENOM.clone() => 1000000,
             },
         )
+        .await
         .should_succeed();
 
     // Update pair params to change pool type to geometric
-    suite
+    let pair_params = suite
         .query_wasm_smart(contracts.dex, dex::QueryPairRequest {
             base_denom: dango::DENOM.clone(),
             quote_denom: usdc::DENOM.clone(),
         })
-        .should_succeed_and(|pair_params: &PairParams| {
-            // Update pair params
-            suite
-                .execute(
-                    &mut accounts.owner,
-                    contracts.dex,
-                    &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
-                        base_denom: dango::DENOM.clone(),
-                        quote_denom: usdc::DENOM.clone(),
-                        params: PairParams {
-                            lp_denom: pair_params.lp_denom.clone(),
-                            bucket_sizes: BTreeSet::new(),
-                            swap_fee_rate: pair_params.swap_fee_rate,
-                            pool_type: PassiveLiquidity::Geometric(Geometric {
-                                spacing: Udec128::ONE,
-                                ratio: Bounded::new_unchecked(Udec128::ONE),
-                                limit: 10,
-                            }),
-                            min_order_size_quote: Uint128::ZERO,
-                            min_order_size_base: Uint128::ZERO,
-                        },
-                    }])),
-                    Coins::new(),
-                )
-                .should_succeed();
-            true
-        });
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.dex,
+            &dex::ExecuteMsg::Owner(dex::OwnerMsg::BatchUpdatePairs(vec![PairUpdate {
+                base_denom: dango::DENOM.clone(),
+                quote_denom: usdc::DENOM.clone(),
+                params: PairParams {
+                    lp_denom: pair_params.lp_denom.clone(),
+                    bucket_sizes: BTreeSet::new(),
+                    swap_fee_rate: pair_params.swap_fee_rate,
+                    pool_type: PassiveLiquidity::Geometric(Geometric {
+                        spacing: Udec128::ONE,
+                        ratio: Bounded::new_unchecked(Udec128::ONE),
+                        limit: 10,
+                    }),
+                    min_order_size_quote: Uint128::ZERO,
+                    min_order_size_base: Uint128::ZERO,
+                },
+            }])),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
 
     // Ensure swap exact amount in fails
     suite
@@ -810,6 +812,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 dango::DENOM.clone() => 1000000,
             },
         )
+        .await
         .should_fail_with_error(StdError::data_not_found::<PriceSource>(
             PRICE_SOURCES.path(&dango::DENOM).storage_key(),
         ));
@@ -830,6 +833,7 @@ fn geometric_pool_swaps_fail_without_oracle_price() {
                 usdc::DENOM.clone() => 1000000,
             },
         )
+        .await
         .should_fail_with_error(StdError::data_not_found::<PriceSource>(
             PRICE_SOURCES.path(&dango::DENOM).storage_key(),
         ));

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -552,8 +552,8 @@ async fn new_user_gets_default_username() {
 }
 
 /// Genesis users should also have a default `user_{index}` username.
-#[tokio::test]
-async fn genesis_users_have_default_username() {
+#[test]
+fn genesis_users_have_default_username() {
     let (suite, accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let user_index = accounts.user1.user_index();
@@ -688,8 +688,8 @@ async fn cannot_claim_taken_username() {
 }
 
 /// `Username::is_default` correctly identifies system-generated usernames.
-#[tokio::test]
-async fn username_is_default_detection() {
+#[test]
+fn username_is_default_detection() {
     assert!(Username::default_for_index(0).is_default());
     assert!(Username::default_for_index(42).is_default());
     assert!(Username::default_for_index(u32::MAX).is_default());
@@ -701,8 +701,8 @@ async fn username_is_default_detection() {
 }
 
 /// `ForgotUsername` query returns `User` structs with populated `index`.
-#[tokio::test]
-async fn forgot_username_returns_users_with_index() {
+#[test]
+fn forgot_username_returns_users_with_index() {
     let (suite, accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let user_index = accounts.user1.user_index();

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -24,8 +24,8 @@ use {
 /// message. Sending the `RegisterUser` message without a deposit resulting in
 /// the transaction failing. This design has drawbacks; see the PR's description.
 /// Since PR #1460, this test now reflects the intended onboarding procedure.
-#[test]
-fn onboarding_without_deposit() {
+#[tokio::test]
+async fn onboarding_without_deposit() {
     let (suite, mut accounts, codes, contracts, validator_sets) =
         setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
             account: AccountOption {
@@ -43,7 +43,7 @@ fn onboarding_without_deposit() {
     // that would be block 0, in other words the genesis block. The single-signature
     // account won't claim orphaned transfers during genesis. For a realistic test,
     // we do `CheckTx` at a post-genesis block.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     let chain_id = suite.chain_id.clone();
 
@@ -76,6 +76,7 @@ fn onboarding_without_deposit() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // The account should have been created in the `Inactive` state.
@@ -108,6 +109,7 @@ fn onboarding_without_deposit() {
             &user,
             10_000_000, // Minimum deposit is 10_000_000. Need to send at this that amount.
         )
+        .await
         .should_succeed();
 
     // Account should have been activated.
@@ -128,6 +130,7 @@ fn onboarding_without_deposit() {
             &account_factory::ExecuteMsg::RegisterAccount {},
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Ensure the user now has two accounts and they are both active.
@@ -149,8 +152,8 @@ fn onboarding_without_deposit() {
 
 /// If minimum deposit is zero, then the account is automatically activated.
 /// No need to make a deposit.
-#[test]
-fn onboarding_without_deposit_when_minimum_deposit_is_zero() {
+#[tokio::test]
+async fn onboarding_without_deposit_when_minimum_deposit_is_zero() {
     // Set up the test with minimum deposit set to zero.
     let (mut suite, mut accounts, codes, contracts, _) = setup_test_naive(Default::default());
 
@@ -185,6 +188,7 @@ fn onboarding_without_deposit_when_minimum_deposit_is_zero() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Now that the user has been created, query it's index.
@@ -238,8 +242,8 @@ fn onboarding_without_deposit_when_minimum_deposit_is_zero() {
 /// However, we keep this test for the edge case -- what if someone sends a
 /// transfer before creating the account? The user needs to be able to recover
 /// the funds.
-#[test]
-fn onboarding_with_deposit_when_minimum_deposit_is_zero() {
+#[tokio::test]
+async fn onboarding_with_deposit_when_minimum_deposit_is_zero() {
     // Set up the test with minimum deposit set to zero.
     let (suite, mut accounts, codes, contracts, validator_sets) =
         setup_test_naive(Default::default());
@@ -263,6 +267,7 @@ fn onboarding_with_deposit_when_minimum_deposit_is_zero() {
             &user,
             10_000_000,
         )
+        .await
         .should_succeed();
 
     // Sign the `RegisterUserData`.
@@ -291,6 +296,7 @@ fn onboarding_with_deposit_when_minimum_deposit_is_zero() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Now that the user has been created, he can claim the orphaned transfer.
@@ -307,6 +313,7 @@ fn onboarding_with_deposit_when_minimum_deposit_is_zero() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Make sure a single-signature account is created with the deposited balance.
@@ -315,8 +322,8 @@ fn onboarding_with_deposit_when_minimum_deposit_is_zero() {
         .should_succeed_and_equal(Uint128::new(10_000_000));
 }
 
-#[test]
-fn update_key() {
+#[tokio::test]
+async fn update_key() {
     let (mut suite, _, codes, contracts, _) = setup_test_naive(Default::default());
 
     let chain_id = suite.chain_id.clone();
@@ -353,6 +360,7 @@ fn update_key() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Now that the user has been created, query it's index.
@@ -370,6 +378,7 @@ fn update_key() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(format!(
             "can't delete the last key associated with user index {}",
             user.user_index()
@@ -397,6 +406,7 @@ fn update_key() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Query keys should return two keys.
@@ -422,6 +432,7 @@ fn update_key() {
             },
             Coins::new(),
         )
+        .await
         .should_fail_with_error(format!(
             "key is already associated with user index {}",
             user.user_index()
@@ -438,6 +449,7 @@ fn update_key() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Query keys should return only one key.
@@ -450,8 +462,8 @@ fn update_key() {
         .should_succeed_and_equal(btree_map! { key_hash => pk });
 }
 
-#[test]
-fn single_signature_account_count_limit() {
+#[tokio::test]
+async fn single_signature_account_count_limit() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let user_index = accounts.user1.user_index();
@@ -465,6 +477,7 @@ fn single_signature_account_count_limit() {
                 &account_factory::ExecuteMsg::RegisterAccount {},
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -482,12 +495,13 @@ fn single_signature_account_count_limit() {
             &account_factory::ExecuteMsg::RegisterAccount {},
             Coins::new(),
         )
+        .await
         .should_fail_with_error(format!("user {user_index} has reached max account count"));
 }
 
 /// New users should automatically get a `user_{index}` default username.
-#[test]
-fn new_user_gets_default_username() {
+#[tokio::test]
+async fn new_user_gets_default_username() {
     let (mut suite, _, codes, contracts, _) = setup_test_naive(Default::default());
 
     let chain_id = suite.chain_id.clone();
@@ -520,6 +534,7 @@ fn new_user_gets_default_username() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let user = user.query_user_index(suite.querier());
@@ -537,8 +552,8 @@ fn new_user_gets_default_username() {
 }
 
 /// Genesis users should also have a default `user_{index}` username.
-#[test]
-fn genesis_users_have_default_username() {
+#[tokio::test]
+async fn genesis_users_have_default_username() {
     let (suite, accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let user_index = accounts.user1.user_index();
@@ -554,8 +569,8 @@ fn genesis_users_have_default_username() {
 }
 
 /// A user with a default username can change it to a custom one.
-#[test]
-fn update_default_username() {
+#[tokio::test]
+async fn update_default_username() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let user_index = accounts.user1.user_index();
@@ -568,6 +583,7 @@ fn update_default_username() {
             &account_factory::ExecuteMsg::UpdateUsername(custom_name.clone()),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify the username was updated.
@@ -588,8 +604,8 @@ fn update_default_username() {
 }
 
 /// A user with a custom username cannot change it again.
-#[test]
-fn cannot_change_custom_username() {
+#[tokio::test]
+async fn cannot_change_custom_username() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let user_index = accounts.user1.user_index();
@@ -603,6 +619,7 @@ fn cannot_change_custom_username() {
             &account_factory::ExecuteMsg::UpdateUsername(custom_name),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Second change: custom → another custom. Should fail.
@@ -614,14 +631,15 @@ fn cannot_change_custom_username() {
             &account_factory::ExecuteMsg::UpdateUsername(another_name),
             Coins::new(),
         )
+        .await
         .should_fail_with_error(format!(
             "a custom username is already set for user {user_index}"
         ));
 }
 
 /// Users cannot set a reserved `user_N` pattern as their custom username.
-#[test]
-fn cannot_set_reserved_username() {
+#[tokio::test]
+async fn cannot_set_reserved_username() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let reserved_name = Username::from_str("user_999").unwrap();
@@ -633,12 +651,13 @@ fn cannot_set_reserved_username() {
             &account_factory::ExecuteMsg::UpdateUsername(reserved_name),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("usernames matching 'user_N' are reserved");
 }
 
 /// Two users cannot claim the same username.
-#[test]
-fn cannot_claim_taken_username() {
+#[tokio::test]
+async fn cannot_claim_taken_username() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let name = Username::from_str("alice").unwrap();
@@ -651,6 +670,7 @@ fn cannot_claim_taken_username() {
             &account_factory::ExecuteMsg::UpdateUsername(name.clone()),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User 2 tries to claim "alice". Should fail.
@@ -661,14 +681,15 @@ fn cannot_claim_taken_username() {
             &account_factory::ExecuteMsg::UpdateUsername(name.clone()),
             Coins::new(),
         )
+        .await
         .should_fail_with_error(format!(
             "the username `{name}` is already associated with a user index"
         ));
 }
 
 /// `Username::is_default` correctly identifies system-generated usernames.
-#[test]
-fn username_is_default_detection() {
+#[tokio::test]
+async fn username_is_default_detection() {
     assert!(Username::default_for_index(0).is_default());
     assert!(Username::default_for_index(42).is_default());
     assert!(Username::default_for_index(u32::MAX).is_default());
@@ -680,8 +701,8 @@ fn username_is_default_detection() {
 }
 
 /// `ForgotUsername` query returns `User` structs with populated `index`.
-#[test]
-fn forgot_username_returns_users_with_index() {
+#[tokio::test]
+async fn forgot_username_returns_users_with_index() {
     let (suite, accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     let user_index = accounts.user1.user_index();

--- a/dango/testing/tests/gateway.rs
+++ b/dango/testing/tests/gateway.rs
@@ -113,7 +113,8 @@ async fn rate_limit() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Inflows must no longer replenish the outbound quota. Receive 100M more
@@ -155,7 +156,8 @@ async fn rate_limit() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Advance one day so the cron seeds a fresh quota of 10% × 370M = 37M.
@@ -217,7 +219,8 @@ async fn rate_limit() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Raise the rate limit to 99%. In phase 1 this still only takes effect
@@ -290,14 +293,16 @@ async fn native_denom() {
             .execute(
                 &mut accounts.owner,
                 contracts.gateway,
-                &gateway::ExecuteMsg::SetRoutes(btree_set!((
-                    Origin::Local(dango::DENOM.clone(),),
-                    contracts.warp,
-                    Remote::Warp {
-                        domain: remote_domain,
-                        contract: remote_warp.into(),
-                    }
-                ))),
+                &gateway::ExecuteMsg::SetRoutes(btree_set! {
+                    (
+                        Origin::Local(dango::DENOM.clone()),
+                        contracts.warp,
+                        Remote::Warp {
+                            domain: remote_domain,
+                            contract: remote_warp.into(),
+                        },
+                    ),
+                }),
                 Coins::default(),
             )
             .await
@@ -463,7 +468,8 @@ async fn set_rate_limits_resets_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Owner raises the rate limit to 50% without advancing time. Raising
@@ -495,7 +501,8 @@ async fn set_rate_limits_resets_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Advance one day so the cron fires and reseeds. Supply is 90M (after
@@ -955,7 +962,8 @@ async fn personal_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // ---- Expired personal quota is ignored ----
@@ -994,7 +1002,8 @@ async fn personal_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // The expired entry is left in storage; the handler doesn't scrub it. The
@@ -1141,7 +1150,8 @@ async fn personal_quota_revoke_via_op_delete() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 20_000_000 + usdc_sol_fee).unwrap(),
-        ).await
+        )
+        .await
         .should_fail_with_error(
             "insufficient outbound quota! denom: bridge/usdc, requested: 20000000, remaining after personal quota: 20000000",
         );

--- a/dango/testing/tests/gateway.rs
+++ b/dango/testing/tests/gateway.rs
@@ -16,8 +16,8 @@ use {
     hyperlane_types::{Addr32, isms},
 };
 
-#[test]
-fn rate_limit() {
+#[tokio::test]
+async fn rate_limit() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -47,6 +47,7 @@ fn rate_limit() {
         ] {
             suite
                 .receive_warp_transfer(relayer, domain, origin_warp, receiver, amount)
+                .await
                 .should_succeed();
         }
 
@@ -72,10 +73,11 @@ fn rate_limit() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Make 1 day pass letting the cron job to reset the rate limits.
-    advance_to_next_day(&mut suite);
+    advance_to_next_day(&mut suite).await;
 
     // Try send back exact tokens to don't trigger rate limit.
     // Current limit = 10% of 300 = 30
@@ -95,6 +97,7 @@ fn rate_limit() {
             },
             Coin::new(usdc::DENOM.clone(), 30_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Trigger the rate limit sending 1 more token.
@@ -110,7 +113,7 @@ fn rate_limit() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Inflows must no longer replenish the outbound quota. Receive 100M more
@@ -123,6 +126,7 @@ fn rate_limit() {
             receiver,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     // Supply is now 300M + 100M = 400M minus the 30M already sent back to
@@ -151,11 +155,11 @@ fn rate_limit() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Advance one day so the cron seeds a fresh quota of 10% × 370M = 37M.
-    advance_to_next_day(&mut suite);
+    advance_to_next_day(&mut suite).await;
 
     // Reserves: ethereum received 100M twice (no outflow) → 200M.
     //           solana received 200M, sent 30M back → 170M.
@@ -197,6 +201,7 @@ fn rate_limit() {
             },
             Coin::new(usdc::DENOM.clone(), 37_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // One more token fails — quota is depleted and inflow can't refill it.
@@ -212,7 +217,7 @@ fn rate_limit() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Raise the rate limit to 99%. In phase 1 this still only takes effect
@@ -226,10 +231,11 @@ fn rate_limit() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Another day. Supply is 370M - 37M = 333M; quota is 333M × 99%.
-    advance_to_next_day(&mut suite);
+    advance_to_next_day(&mut suite).await;
 
     // Solana reserve after the previous 37M withdraw is 170M - 37M = 133M.
     // Drain it completely in a single transfer (well under the new quota).
@@ -246,6 +252,7 @@ fn rate_limit() {
             },
             Coin::new(usdc::DENOM.clone(), 133_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Solana reserve is now empty; the next transfer fails on reserve, not
@@ -263,11 +270,12 @@ fn rate_limit() {
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_fail_with_error("insufficient reserve!");
 }
 
-#[test]
-fn native_denom() {
+#[tokio::test]
+async fn native_denom() {
     let (mut suite, mut accounts, _, contracts, mut valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -292,6 +300,7 @@ fn native_denom() {
                 ))),
                 Coins::default(),
             )
+            .await
             .should_succeed();
     }
 
@@ -310,6 +319,7 @@ fn native_denom() {
                 },
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         valset.insert(remote_domain, validator_set);
@@ -328,6 +338,7 @@ fn native_denom() {
                 &accounts.user2,
                 100,
             )
+            .await
             .should_fail_with_error(MathError::overflow_sub(0_u128, 100_u128));
     }
 
@@ -350,6 +361,7 @@ fn native_denom() {
                 },
                 coins! { dango::DENOM.clone() => 100 },
             )
+            .await
             .should_succeed();
     }
 
@@ -363,6 +375,7 @@ fn native_denom() {
                 &accounts.user2,
                 100,
             )
+            .await
             .should_succeed();
     }
 
@@ -376,8 +389,8 @@ fn native_denom() {
     });
 }
 
-#[test]
-fn set_rate_limits_resets_quota() {
+#[tokio::test]
+async fn set_rate_limits_resets_quota() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -403,6 +416,7 @@ fn set_rate_limits_resets_quota() {
             receiver,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     // Set a 10% rate limit. Supply is 100M, so the quota should be seeded to
@@ -416,6 +430,7 @@ fn set_rate_limits_resets_quota() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Drain the full 10M quota.
@@ -432,6 +447,7 @@ fn set_rate_limits_resets_quota() {
             },
             Coin::new(usdc::DENOM.clone(), 10_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Next token fails — the quota is now exhausted.
@@ -447,7 +463,7 @@ fn set_rate_limits_resets_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Owner raises the rate limit to 50% without advancing time. Raising
@@ -463,6 +479,7 @@ fn set_rate_limits_resets_quota() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Quota is still 0 (raise is deferred to next cron). 1 more token fails.
@@ -478,12 +495,12 @@ fn set_rate_limits_resets_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // Advance one day so the cron fires and reseeds. Supply is 90M (after
     // the 10M drain), so the new quota is 45M.
-    advance_to_next_day(&mut suite);
+    advance_to_next_day(&mut suite).await;
 
     // The call that failed above now succeeds — quota has 45M headroom.
     suite
@@ -499,6 +516,7 @@ fn set_rate_limits_resets_quota() {
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Removing USDC from the rate limits map should drop its entry in
@@ -511,6 +529,7 @@ fn set_rate_limits_resets_quota() {
             &gateway::ExecuteMsg::SetRateLimits(btree_map! {}),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -526,13 +545,14 @@ fn set_rate_limits_resets_quota() {
             },
             Coin::new(usdc::DENOM.clone(), 50_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Advance a day so the cron fires. The cron iterates RATE_LIMITS, which
     // no longer contains USDC, so no OUTBOUND_QUOTAS entry should be
     // resurrected for it. A subsequent large transfer must still succeed —
     // reserves remain the only constraint.
-    advance_to_next_day(&mut suite);
+    advance_to_next_day(&mut suite).await;
 
     suite
         .execute(
@@ -547,6 +567,7 @@ fn set_rate_limits_resets_quota() {
             },
             Coin::new(usdc::DENOM.clone(), 20_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 }
 
@@ -555,8 +576,8 @@ fn set_rate_limits_resets_quota() {
 /// cron tick lets the same user drain `supply × limit` twice in a row.
 /// Covers the four cases the tighten helper has to get right: no-op,
 /// lower, raise, and cron reseed.
-#[test]
-fn set_rate_limits_only_tightens_existing_quotas() {
+#[tokio::test]
+async fn set_rate_limits_only_tightens_existing_quotas() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -582,6 +603,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             receiver,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     // Seed a 50% rate limit. Quota = 50M.
@@ -594,6 +616,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Drain 30M → quota 20M, supply 70M.
@@ -610,6 +633,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             },
             Coin::new(usdc::DENOM.clone(), 30_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Case 1: same limit re-set. min(20M, 70M × 50% = 35M) = 20M. No change
@@ -623,6 +647,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Transfer 20M + 1 must still fail. If the same-limit call had reset the
@@ -640,6 +665,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             },
             Coin::new(usdc::DENOM.clone(), 20_000_001 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_fail_with_error("insufficient outbound quota!");
 
     // Case 2: lower the limit to 10%. Tightens to min(20M, 70M × 10% = 7M)
@@ -653,6 +679,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // 7M + 1 fails, 7M succeeds.
@@ -669,6 +696,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             },
             Coin::new(usdc::DENOM.clone(), 7_000_001 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_fail_with_error("insufficient outbound quota!");
 
     suite
@@ -684,6 +712,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             },
             Coin::new(usdc::DENOM.clone(), 7_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Quota is now 0. Supply 63M.
@@ -699,6 +728,7 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Even 1 more token fails — no quota has been freed by the raise.
@@ -715,10 +745,11 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_fail_with_error("insufficient outbound quota!");
 
     // Case 4: cron tick reseeds to the raised level. 63M × 80% = 50.4M.
-    advance_to_next_day(&mut suite);
+    advance_to_next_day(&mut suite).await;
 
     suite
         .execute(
@@ -733,11 +764,12 @@ fn set_rate_limits_only_tightens_existing_quotas() {
             },
             Coin::new(usdc::DENOM.clone(), 50_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 }
 
-#[test]
-fn personal_quota() {
+#[tokio::test]
+async fn personal_quota() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -766,6 +798,7 @@ fn personal_quota() {
             receiver,
             200_000_000,
         )
+        .await
         .should_succeed();
 
     // Tight 1% rate limit. Supply is 200M → global quota = 2M.
@@ -778,6 +811,7 @@ fn personal_quota() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // ---- Auth ----
@@ -795,6 +829,7 @@ fn personal_quota() {
             },
             Coins::default(),
         )
+        .await
         .should_fail_with_error("only the owner can set personal quotas");
 
     // ---- Overwrite + query ----
@@ -813,6 +848,7 @@ fn personal_quota() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Overwrite with a smaller, permanent allowance.
@@ -830,6 +866,7 @@ fn personal_quota() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     let pq = suite
@@ -861,6 +898,7 @@ fn personal_quota() {
             },
             Coin::new(usdc::DENOM.clone(), 40_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     let pq = suite
@@ -892,6 +930,7 @@ fn personal_quota() {
             },
             Coin::new(usdc::DENOM.clone(), 12_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Fully consumed personal quotas are removed from storage.
@@ -916,7 +955,7 @@ fn personal_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // ---- Expired personal quota is ignored ----
@@ -935,10 +974,11 @@ fn personal_quota() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // 2h later — under the 24h cron interval, so the global quota stays at 0.
-    advance_by(&mut suite, Duration::from_hours(2));
+    advance_by(&mut suite, Duration::from_hours(2)).await;
 
     // The personal quota is now expired and must be skipped. Withdrawing 1
     // token falls through to the global quota (still 0) and fails.
@@ -954,7 +994,7 @@ fn personal_quota() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 1, remaining after personal quota: 1");
 
     // The expired entry is left in storage; the handler doesn't scrub it. The
@@ -988,8 +1028,8 @@ fn personal_quota() {
 /// `Op::Delete` must remove the personal quota entry outright — not just
 /// flip its amount to zero — so subsequent withdrawals see no personal
 /// allowance at all and fall straight to the global quota.
-#[test]
-fn personal_quota_revoke_via_op_delete() {
+#[tokio::test]
+async fn personal_quota_revoke_via_op_delete() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -1017,6 +1057,7 @@ fn personal_quota_revoke_via_op_delete() {
             receiver,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     suite
@@ -1028,6 +1069,7 @@ fn personal_quota_revoke_via_op_delete() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Grant a 50M personal allowance.
@@ -1045,6 +1087,7 @@ fn personal_quota_revoke_via_op_delete() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     let pq = suite
@@ -1070,6 +1113,7 @@ fn personal_quota_revoke_via_op_delete() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Entry is gone — not just zeroed.
@@ -1097,7 +1141,7 @@ fn personal_quota_revoke_via_op_delete() {
                 recipient: mock_solana_recipient,
             },
             Coin::new(usdc::DENOM.clone(), 20_000_000 + usdc_sol_fee).unwrap(),
-        )
+        ).await
         .should_fail_with_error(
             "insufficient outbound quota! denom: bridge/usdc, requested: 20000000, remaining after personal quota: 20000000",
         );
@@ -1116,6 +1160,7 @@ fn personal_quota_revoke_via_op_delete() {
             },
             Coin::new(usdc::DENOM.clone(), 10_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 }
 
@@ -1123,8 +1168,8 @@ fn personal_quota_revoke_via_op_delete() {
 /// must still behave correctly: the personal allowance is consumed first,
 /// and any overflow falls through to an absent global entry (which means
 /// unrestricted, not "blocked").
-#[test]
-fn personal_quota_on_un_rate_limited_denom() {
+#[tokio::test]
+async fn personal_quota_on_un_rate_limited_denom() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -1153,6 +1198,7 @@ fn personal_quota_on_un_rate_limited_denom() {
             receiver,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     // Grant a 50M personal allowance.
@@ -1170,6 +1216,7 @@ fn personal_quota_on_un_rate_limited_denom() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Consume 30M — fully from the personal quota.
@@ -1186,6 +1233,7 @@ fn personal_quota_on_un_rate_limited_denom() {
             },
             Coin::new(usdc::DENOM.clone(), 30_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     let pq = suite
@@ -1215,6 +1263,7 @@ fn personal_quota_on_un_rate_limited_denom() {
             },
             Coin::new(usdc::DENOM.clone(), 50_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Personal quota is now fully consumed and removed from storage.
@@ -1240,6 +1289,7 @@ fn personal_quota_on_un_rate_limited_denom() {
             },
             Coin::new(usdc::DENOM.clone(), 10_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 }
 
@@ -1247,8 +1297,8 @@ fn personal_quota_on_un_rate_limited_denom() {
 /// record wholesale — no carry-over of the leftover balance, no
 /// preservation of the old expiry. The stored amount and expiry reflect
 /// the admin's most recent decision.
-#[test]
-fn personal_quota_mid_consumption_overwrite() {
+#[tokio::test]
+async fn personal_quota_mid_consumption_overwrite() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -1276,6 +1326,7 @@ fn personal_quota_mid_consumption_overwrite() {
             receiver,
             200_000_000,
         )
+        .await
         .should_succeed();
 
     // Tight global rate limit (1%) so the test leans on the personal quota.
@@ -1288,6 +1339,7 @@ fn personal_quota_mid_consumption_overwrite() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Grant 100M with no expiry.
@@ -1305,6 +1357,7 @@ fn personal_quota_mid_consumption_overwrite() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Consume 40M — fully within personal. 60M remains.
@@ -1321,6 +1374,7 @@ fn personal_quota_mid_consumption_overwrite() {
             },
             Coin::new(usdc::DENOM.clone(), 40_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     let pq = suite
@@ -1351,6 +1405,7 @@ fn personal_quota_mid_consumption_overwrite() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     let stored = suite
@@ -1374,8 +1429,8 @@ fn personal_quota_mid_consumption_overwrite() {
 /// Paginated queries must return entries in ascending `(Addr, Denom)`
 /// order and the `start_after` bound must correctly skip past the end of
 /// the previous page.
-#[test]
-fn personal_quotas_pagination() {
+#[tokio::test]
+async fn personal_quotas_pagination() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -1410,6 +1465,7 @@ fn personal_quotas_pagination() {
                 },
                 Coins::default(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1482,8 +1538,8 @@ fn personal_quotas_pagination() {
 /// The `is_none_or(|t| block.timestamp < t)` predicate is strict. Cover
 /// both sides of the boundary: at exactly `block.timestamp == expire_at`
 /// the quota is already expired; 1ns before that it is still active.
-#[test]
-fn personal_quota_expire_at_boundary() {
+#[tokio::test]
+async fn personal_quota_expire_at_boundary() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -1511,6 +1567,7 @@ fn personal_quota_expire_at_boundary() {
             receiver,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     // ---- Active: 1ns before expiry ----
@@ -1528,6 +1585,7 @@ fn personal_quota_expire_at_boundary() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Advance to 1ns before the expiry. The predicate `now < expire_at` is
@@ -1535,7 +1593,8 @@ fn personal_quota_expire_at_boundary() {
     advance_by(
         &mut suite,
         Duration::from_hours(1) - Duration::from_nanos(1),
-    );
+    )
+    .await;
 
     suite
         .execute(
@@ -1550,6 +1609,7 @@ fn personal_quota_expire_at_boundary() {
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     // The active path consumed 1 token from the personal quota.
@@ -1580,9 +1640,10 @@ fn personal_quota_expire_at_boundary() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
-    advance_by(&mut suite, Duration::from_hours(1));
+    advance_by(&mut suite, Duration::from_hours(1)).await;
 
     // The transfer should succeed (the denom is un-rate-limited), but the
     // personal quota must NOT be consumed — the predicate treats
@@ -1600,6 +1661,7 @@ fn personal_quota_expire_at_boundary() {
             },
             Coin::new(usdc::DENOM.clone(), 1 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     let pq = suite
@@ -1616,8 +1678,8 @@ fn personal_quota_expire_at_boundary() {
 /// scrubbed it), re-granting must replace the stale entry cleanly —
 /// fresh amount, fresh expire_at, fresh granted_at. No carry-over of the
 /// old expired record.
-#[test]
-fn personal_quota_regrant_after_expiry() {
+#[tokio::test]
+async fn personal_quota_regrant_after_expiry() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -1645,6 +1707,7 @@ fn personal_quota_regrant_after_expiry() {
             receiver,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     // Grant 10M with a 1h lifetime.
@@ -1662,6 +1725,7 @@ fn personal_quota_regrant_after_expiry() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     let pq_before = suite
@@ -1675,7 +1739,7 @@ fn personal_quota_regrant_after_expiry() {
 
     // Advance 2h so the entry is expired but has not been scrubbed by any
     // transfer attempt.
-    advance_by(&mut suite, Duration::from_hours(2));
+    advance_by(&mut suite, Duration::from_hours(2)).await;
 
     // Re-grant a fresh 20M with a new 1h lifetime. Under no carry-over, the
     // old expired record is replaced wholesale.
@@ -1693,6 +1757,7 @@ fn personal_quota_regrant_after_expiry() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     let pq_after = suite
@@ -1729,6 +1794,7 @@ fn personal_quota_regrant_after_expiry() {
             },
             Coin::new(usdc::DENOM.clone(), 1_000_000 + usdc_sol_fee).unwrap(),
         )
+        .await
         .should_succeed();
 
     let pq_consumed = suite
@@ -1745,8 +1811,8 @@ fn personal_quota_regrant_after_expiry() {
 /// PERSONAL_QUOTAS, even if the entry is already expired. The expired
 /// record should survive unchanged until the admin explicitly overwrites
 /// or deletes it, or the user triggers consumption.
-#[test]
-fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
+#[tokio::test]
+async fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
     let (mut suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
         bridge_ops: |_| vec![],
         ..TestOption::default()
@@ -1770,6 +1836,7 @@ fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
             &accounts.user2,
             100_000_000,
         )
+        .await
         .should_succeed();
 
     // Global rate limit so cron_execute has something to reseed. This
@@ -1784,6 +1851,7 @@ fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
             }),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Grant a 1h personal allowance.
@@ -1801,6 +1869,7 @@ fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     let pq_before_cron = suite
@@ -1813,7 +1882,7 @@ fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
 
     // Advance a full day. The personal quota expired 23h ago at this point.
     // The cron has fired at least once during this advance (24h tick).
-    advance_to_next_day(&mut suite);
+    advance_to_next_day(&mut suite).await;
 
     let pq_after_cron = suite
         .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
@@ -1830,14 +1899,14 @@ fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
     assert_eq!(pq_after_cron.granted_at, pq_before_cron.granted_at);
 }
 
-fn advance_to_next_day(suite: &mut TestSuite) {
+async fn advance_to_next_day(suite: &mut TestSuite) {
     suite.block_time = Duration::from_days(1);
-    suite.make_empty_block();
+    suite.make_empty_block().await;
     suite.block_time = Duration::ZERO;
 }
 
-fn advance_by(suite: &mut TestSuite, d: Duration) {
+async fn advance_by(suite: &mut TestSuite, d: Duration) {
     suite.block_time = d;
-    suite.make_empty_block();
+    suite.make_empty_block().await;
     suite.block_time = Duration::ZERO;
 }

--- a/dango/testing/tests/httpd/accounts.rs
+++ b/dango/testing/tests/httpd/accounts.rs
@@ -44,8 +44,8 @@ async fn query_accounts() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let user1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
-    let user2 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let user1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
+    let user2 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -91,7 +91,7 @@ async fn query_accounts_with_user_index() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -143,7 +143,7 @@ async fn query_accounts_with_wrong_user_index() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -193,8 +193,10 @@ async fn query_user_multiple_single_signature_accounts() -> anyhow::Result<()> {
 
     // Create two accounts under the same user. The two `TestAccount`'s should
     // have the same user index.
-    let mut test_account1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
-    let test_account2 = add_account_with_existing_user(&mut suite, &contracts, &mut test_account1);
+    let mut test_account1 =
+        create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
+    let test_account2 =
+        add_account_with_existing_user(&mut suite, &contracts, &mut test_account1).await;
     assert_eq!(test_account1.user_index(), test_account2.user_index());
 
     suite.app.indexer.wait_for_finish().await?;
@@ -281,7 +283,7 @@ async fn graphql_paginate_accounts() -> anyhow::Result<()> {
 
     // Create 10 accounts to paginate through
     for _ in 0..10 {
-        let _user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+        let _user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
     }
 
     suite.app.indexer.wait_for_finish().await?;
@@ -393,7 +395,8 @@ async fn graphql_subscribe_to_accounts() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let _test_account = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let _test_account =
+        create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -410,7 +413,7 @@ async fn graphql_subscribe_to_accounts() -> anyhow::Result<()> {
     tokio::spawn(async move {
         while let Some(_idx) = rx.recv().await {
             let _test_account =
-                create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+                create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
         }
         Ok::<(), anyhow::Error>(())
     });
@@ -477,7 +480,8 @@ async fn graphql_subscribe_to_accounts_with_user_index() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let mut test_account1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let mut test_account1 =
+        create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
     let user_index = test_account1.user_index() as i64;
 
     suite.app.indexer.wait_for_finish().await?;
@@ -499,11 +503,11 @@ async fn graphql_subscribe_to_accounts_with_user_index() -> anyhow::Result<()> {
         while let Some(_idx) = rx.recv().await {
             // Create a new account with a new user index, to see if the subscription filters it out
             let _test_account =
-                create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+                create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
             // Create a new account with the original user
             let _test_account2 =
-                add_account_with_existing_user(&mut suite, &contracts, &mut test_account1);
+                add_account_with_existing_user(&mut suite, &contracts, &mut test_account1).await;
 
             suite.app.indexer.wait_for_finish().await?;
         }
@@ -559,6 +563,7 @@ async fn graphql_returns_account_owner_nonces() -> anyhow::Result<()> {
                 accounts.user1.address(),
                 Coins::one(dango::DENOM.clone(), 123).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -619,6 +624,7 @@ async fn graphql_returns_address_balance() -> anyhow::Result<()> {
                 accounts.user1.address(),
                 Coins::one(dango::DENOM.clone(), 123).unwrap(),
             )
+            .await
             .should_succeed();
     }
 

--- a/dango/testing/tests/httpd/candles.rs
+++ b/dango/testing/tests/httpd/candles.rs
@@ -431,6 +431,7 @@ async fn graphql_subscribe_to_candles_on_no_new_pair_prices() -> anyhow::Result<
                     50_000_000,
                     NonEmpty::new_unchecked(msgs),
                 )
+                .await
                 .should_succeed();
         }
 
@@ -562,6 +563,7 @@ async fn create_pair_prices(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders_to_submit: Vec<(Direction, u128, u128)> = vec![
@@ -613,6 +615,7 @@ async fn create_pair_prices(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -641,6 +644,7 @@ async fn create_pair_prices_with_tiny_price(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let tiny_price =
@@ -686,6 +690,7 @@ async fn create_pair_prices_with_tiny_price(
 
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()

--- a/dango/testing/tests/httpd/pair_stats.rs
+++ b/dango/testing/tests/httpd/pair_stats.rs
@@ -220,6 +220,7 @@ async fn query_pair_stats_formats_small_prices_without_scientific_notation() -> 
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Submit matching bid/ask orders at a very small price so GraphQL must
@@ -255,6 +256,7 @@ async fn query_pair_stats_formats_small_prices_without_scientific_notation() -> 
                 Coin::new(usdc::DENOM.clone(), Uint128::new(200_000))?,
             ])?,
         )
+        .await
         .should_succeed();
 
     suite.app.indexer.wait_for_finish().await?;
@@ -316,6 +318,7 @@ async fn create_pair_prices(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders_to_submit: Vec<(Direction, u128, u128)> = vec![
@@ -367,6 +370,7 @@ async fn create_pair_prices(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()

--- a/dango/testing/tests/httpd/perps_candles.rs
+++ b/dango/testing/tests/httpd/perps_candles.rs
@@ -28,9 +28,9 @@ async fn query_perps_candles() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -77,10 +77,10 @@ async fn graphql_subscribe_to_perps_candles() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -108,7 +108,8 @@ async fn graphql_subscribe_to_perps_candles() -> anyhow::Result<()> {
                 &pair_id(),
                 2_000,
                 1,
-            );
+            )
+            .await;
         }
         Ok::<(), anyhow::Error>(())
     });

--- a/dango/testing/tests/httpd/perps_events.rs
+++ b/dango/testing/tests/httpd/perps_events.rs
@@ -20,12 +20,12 @@ async fn query_perps_events_user_lifecycle() -> anyhow::Result<()> {
         setup_test_with_indexer(TestOption::default()).await;
 
     let pair = pair_id();
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
     // user2 places a limit ask → user1 fills it via market buy.
     //   user2 sees: order_filled
     //   user1 sees: order_filled
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 3);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 3).await;
 
     suite.app.indexer.wait_for_finish().await?;
 

--- a/dango/testing/tests/httpd/perps_pair_stats.rs
+++ b/dango/testing/tests/httpd/perps_pair_stats.rs
@@ -19,8 +19,8 @@ async fn query_perps_pair_stats() -> anyhow::Result<()> {
         setup_test_with_indexer(TestOption::default()).await;
 
     let pair = pair_id();
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 5);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -113,8 +113,8 @@ async fn query_all_perps_pair_stats() -> anyhow::Result<()> {
         setup_test_with_indexer(TestOption::default()).await;
 
     let pair = pair_id();
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 5);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -164,8 +164,8 @@ async fn query_perps_pair_stats_partial_fields() -> anyhow::Result<()> {
         setup_test_with_indexer(TestOption::default()).await;
 
     let pair = pair_id();
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 5);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 

--- a/dango/testing/tests/httpd/trades.rs
+++ b/dango/testing/tests/httpd/trades.rs
@@ -408,6 +408,7 @@ async fn create_pair_prices(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders_to_submit: Vec<(Direction, u128, u128)> = vec![
@@ -459,6 +460,7 @@ async fn create_pair_prices(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -487,6 +489,7 @@ async fn create_pair_prices_with_tiny_price(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let tiny_price =
@@ -532,6 +535,7 @@ async fn create_pair_prices_with_tiny_price(
 
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()

--- a/dango/testing/tests/httpd/transfers.rs
+++ b/dango/testing/tests/httpd/transfers.rs
@@ -37,6 +37,7 @@ async fn graphql_returns_transfer_and_accounts() -> anyhow::Result<()> {
             50_000_000,
             NonEmpty::new_unchecked(msgs),
         )
+        .await
         .should_succeed();
 
     suite.app.indexer.wait_for_finish().await?;
@@ -110,8 +111,8 @@ async fn graphql_transfers_with_user_index() -> anyhow::Result<()> {
 
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let mut user1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
-    let user2 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let mut user1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
+    let user2 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite
         .transfer(
@@ -119,6 +120,7 @@ async fn graphql_transfers_with_user_index() -> anyhow::Result<()> {
             user2.address(),
             Coins::one(usdc::DENOM.clone(), 100).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite.app.indexer.wait_for_finish().await?;
@@ -217,8 +219,8 @@ async fn graphql_transfers_with_wrong_user_index() -> anyhow::Result<()> {
 
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let mut user1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
-    let user2 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let mut user1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
+    let user2 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite
         .transfer(
@@ -226,6 +228,7 @@ async fn graphql_transfers_with_wrong_user_index() -> anyhow::Result<()> {
             user2.address(),
             Coins::one(usdc::DENOM.clone(), 100).unwrap(),
         )
+        .await
         .should_succeed();
 
     let local_set = tokio::task::LocalSet::new();
@@ -280,6 +283,7 @@ async fn graphql_paginate_transfers() -> anyhow::Result<()> {
                 recipient,
                 Coins::one(usdc::DENOM.clone(), 100_000_000).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -389,6 +393,7 @@ async fn graphql_subscribe_to_transfers() -> anyhow::Result<()> {
             50_000_000,
             NonEmpty::new_unchecked(msgs),
         )
+        .await
         .should_succeed();
 
     suite.app.indexer.wait_for_finish().await?;
@@ -416,6 +421,7 @@ async fn graphql_subscribe_to_transfers() -> anyhow::Result<()> {
                     50_000_000,
                     NonEmpty::new_unchecked(msgs),
                 )
+                .await
                 .should_succeed();
         }
         Ok::<(), anyhow::Error>(())
@@ -503,6 +509,7 @@ async fn graphql_subscribe_to_transfers_with_filter() -> anyhow::Result<()> {
             50_000_000,
             NonEmpty::new_unchecked(msgs),
         )
+        .await
         .should_succeed();
 
     // Use typed subscription from dango-sdk
@@ -533,6 +540,7 @@ async fn graphql_subscribe_to_transfers_with_filter() -> anyhow::Result<()> {
                     50_000_000,
                     NonEmpty::new_unchecked(msgs),
                 )
+                .await
                 .should_succeed();
         }
         Ok::<(), anyhow::Error>(())

--- a/dango/testing/tests/httpd/users.rs
+++ b/dango/testing/tests/httpd/users.rs
@@ -25,7 +25,7 @@ async fn query_user() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -75,9 +75,10 @@ async fn query_single_user_multiple_public_keys() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let mut test_account = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let mut test_account =
+        create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
-    let (pk, key_hash) = add_user_public_key(&mut suite, &contracts, &mut test_account);
+    let (pk, key_hash) = add_user_public_key(&mut suite, &contracts, &mut test_account).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -137,7 +138,7 @@ async fn query_public_keys_by_user_index() -> anyhow::Result<()> {
     ) = setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let test_account = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let test_account = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 

--- a/dango/testing/tests/indexing/accounts.rs
+++ b/dango/testing/tests/indexing/accounts.rs
@@ -16,7 +16,7 @@ async fn index_account_creations() -> anyhow::Result<()> {
         setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -61,7 +61,7 @@ async fn index_previous_blocks() -> anyhow::Result<()> {
         setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let user = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -92,9 +92,11 @@ async fn index_single_user_multiple_single_signature_accounts() -> anyhow::Resul
         setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let mut test_account1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let mut test_account1 =
+        create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
-    let test_account2 = add_account_with_existing_user(&mut suite, &contracts, &mut test_account1);
+    let test_account2 =
+        add_account_with_existing_user(&mut suite, &contracts, &mut test_account1).await;
 
     suite.app.indexer.wait_for_finish().await?;
 

--- a/dango/testing/tests/indexing/candles.rs
+++ b/dango/testing/tests/indexing/candles.rs
@@ -56,6 +56,7 @@ async fn index_candles_with_mocked_clickhouse() -> anyhow::Result<()> {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders_to_submit: Vec<(Direction, u128, u128)> = vec![
@@ -107,6 +108,7 @@ async fn index_candles_with_mocked_clickhouse() -> anyhow::Result<()> {
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()
@@ -408,15 +410,16 @@ async fn index_candles_changing_prices() -> anyhow::Result<()> {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Make an empty block at timestamps 41.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     // This function makes a block containing a single limit buy order and a
     // limit sell order of the same price and size. This produces a clearing
     // price that is to be indexed.
-    let mut make_block_with_price = |suite: &mut TestSuite<_, _, _, _>, price, amount| {
+    let mut make_block_with_price = async |suite: &mut TestSuite<_, _, _, _>, price, amount| {
         suite
             .execute(
                 &mut accounts.user1,
@@ -445,6 +448,7 @@ async fn index_candles_changing_prices() -> anyhow::Result<()> {
                     usdc::DENOM.clone() => amount.checked_mul_dec_ceil(price).unwrap(),
                 },
             )
+            .await
             .should_succeed();
     };
 
@@ -472,7 +476,7 @@ async fn index_candles_changing_prices() -> anyhow::Result<()> {
     // Price: 100_000
     // Volume in DANGO: 1
     // Volume in USDC: 1 * 100_000 = 100_000
-    make_block_with_price(&mut suite, Udec128_24::new(100_000), Uint128::new(1));
+    make_block_with_price(&mut suite, Udec128_24::new(100_000), Uint128::new(1)).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -499,7 +503,7 @@ async fn index_candles_changing_prices() -> anyhow::Result<()> {
     // Price: 99_999
     // Volume in DANGO: 1 + 1 (from previous block) = 2
     // Volume in USDC: 99_999 + 100_000 (from previous block) = 199_999
-    make_block_with_price(&mut suite, Udec128_24::new(99_999), Uint128::new(1));
+    make_block_with_price(&mut suite, Udec128_24::new(99_999), Uint128::new(1)).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -526,7 +530,7 @@ async fn index_candles_changing_prices() -> anyhow::Result<()> {
     // Price: 100_001
     // Volume in DANGO: 1 + 2 (from previous blocks) = 3
     // Volume in USDC: 100_001 + 199_999 (from previous blocks) = 300_000
-    make_block_with_price(&mut suite, Udec128_24::new(100_001), Uint128::new(1));
+    make_block_with_price(&mut suite, Udec128_24::new(100_001), Uint128::new(1)).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -551,7 +555,7 @@ async fn index_candles_changing_prices() -> anyhow::Result<()> {
     // Block 4
     // Block time: 121 seconds
     // Do nothing.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -620,10 +624,11 @@ async fn index_pair_prices_with_small_amounts() -> anyhow::Result<()> {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Make an empty block at timestamps 41.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     // -------------------------------- block 1 --------------------------------
 
@@ -665,6 +670,7 @@ async fn index_pair_prices_with_small_amounts() -> anyhow::Result<()> {
                 usdc::DENOM.clone() => Uint128::new(200_000),
             },
         )
+        .await
         .should_succeed();
 
     suite.app.indexer.wait_for_finish().await?;
@@ -749,6 +755,7 @@ async fn create_pair_prices(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -30,7 +30,7 @@ use {
 };
 
 /// Place a resting limit ask for user2 (no immediate fill).
-fn place_limit_ask(
+async fn place_limit_ask(
     suite: &mut TestSuiteWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
@@ -55,11 +55,12 @@ fn place_limit_ask(
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
 /// Submit a market buy for user1 (crosses resting asks).
-fn market_buy(
+async fn market_buy(
     suite: &mut TestSuiteWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
@@ -81,6 +82,7 @@ fn market_buy(
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
@@ -128,9 +130,9 @@ async fn index_perps_candles_basic() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -172,13 +174,13 @@ async fn index_perps_candles_multiple_fills_same_block() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
     // Place two limit asks at different prices, then a large market buy that
     // fills both in the same block.
-    place_limit_ask(&mut suite, &mut accounts, &contracts, 2_000, 3);
-    place_limit_ask(&mut suite, &mut accounts, &contracts, 2_100, 2);
-    market_buy(&mut suite, &mut accounts, &contracts, 5);
+    place_limit_ask(&mut suite, &mut accounts, &contracts, 2_000, 3).await;
+    place_limit_ask(&mut suite, &mut accounts, &contracts, 2_100, 2).await;
+    market_buy(&mut suite, &mut accounts, &contracts, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -215,11 +217,11 @@ async fn index_perps_candles_changing_prices() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 1_999, 1);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_001, 1);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 1_999, 1).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_001, 1).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -262,17 +264,17 @@ async fn index_perps_candles_across_minute_boundary() -> anyhow::Result<()> {
         )
         .await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 1_999, 1);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_001, 1);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 1_999, 1).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_001, 1).await;
 
     // Several empty blocks to force candle boundary crossing
     for _ in 0..5 {
-        suite.make_empty_block();
+        suite.make_empty_block().await;
     }
 
     suite.app.indexer.wait_for_finish().await?;
@@ -311,10 +313,10 @@ async fn index_perps_candles_many_fills_one_minute() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
     for _ in 0..10 {
-        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
+        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1).await;
     }
 
     suite.app.indexer.wait_for_finish().await?;
@@ -356,10 +358,10 @@ async fn index_perps_candles_cache_consistency() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -393,10 +395,10 @@ async fn index_perps_candles_one_second_interval() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
     for _ in 0..10 {
-        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
+        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1).await;
     }
 
     suite.app.indexer.wait_for_finish().await?;
@@ -458,7 +460,7 @@ async fn index_perps_candles_full_timeline() -> anyhow::Result<()> {
         )
         .await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
     // 30 fills with varying prices in the $1990–$2020 range.
     // Capped at 14 due to a deadlock in the block processing pipeline.
@@ -473,12 +475,12 @@ async fn index_perps_candles_full_timeline() -> anyhow::Result<()> {
     let expected_low = *prices.iter().min().unwrap();
 
     for &price in &prices {
-        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), price, 1);
+        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), price, 1).await;
     }
 
     // Push past another 5-minute boundary so we get an extra empty candle.
     for _ in 0..10 {
-        suite.make_empty_block();
+        suite.make_empty_block().await;
     }
 
     suite.app.indexer.wait_for_finish().await?;
@@ -611,6 +613,7 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Register the BTC pair via MaintainerMsg::Configure (ETH pair already
@@ -653,6 +656,7 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Deposit margin for both users.
@@ -664,12 +668,13 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), grug::Uint128::new(100_000 * 1_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
     // Create fills on both pairs.
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &eth_pair, 2_000, 3);
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &btc_pair, 60_000, 1);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &eth_pair, 2_000, 3).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &btc_pair, 60_000, 1).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -743,10 +748,10 @@ async fn index_perps_candles_preload_rebuilds_current_bucket_from_clickhouse() -
         )
         .await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
     for _ in 0..5 {
-        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1);
+        create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 1).await;
     }
 
     suite.app.indexer.wait_for_finish().await?;

--- a/dango/testing/tests/indexing/perps_events.rs
+++ b/dango/testing/tests/indexing/perps_events.rs
@@ -15,9 +15,9 @@ async fn index_perps_events() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_context, _, _db_guard) =
         setup_test_with_indexer(TestOption::default()).await;
 
-    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
-    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5);
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 5).await;
 
     suite.app.indexer.wait_for_finish().await?;
 

--- a/dango/testing/tests/indexing/trades.rs
+++ b/dango/testing/tests/indexing/trades.rs
@@ -101,6 +101,7 @@ async fn create_pair_prices(
     // successful.
     suite
         .make_block(txs)
+        .await
         .block_outcome
         .tx_outcomes
         .into_iter()

--- a/dango/testing/tests/indexing/transfers.rs
+++ b/dango/testing/tests/indexing/transfers.rs
@@ -28,6 +28,7 @@ async fn index_transfer_events() -> anyhow::Result<()> {
             50_000_000,
             NonEmpty::new_unchecked(msgs),
         )
+        .await
         .should_succeed();
 
     suite.app.indexer.wait_for_finish().await?;
@@ -66,6 +67,7 @@ async fn index_transfer_events() -> anyhow::Result<()> {
             50_000_000,
             NonEmpty::new_unchecked(vec![msg]),
         )
+        .await
         .should_succeed();
 
     // Force the runtime to wait for the async indexer task to finish

--- a/dango/testing/tests/indexing/users.rs
+++ b/dango/testing/tests/indexing/users.rs
@@ -15,9 +15,10 @@ async fn index_single_user_multiple_public_keys() -> anyhow::Result<()> {
         setup_test_with_indexer(TestOption::default()).await;
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
-    let mut test_account1 = create_user_and_account(&mut suite, &mut accounts, &contracts, &codes);
+    let mut test_account1 =
+        create_user_and_account(&mut suite, &mut accounts, &contracts, &codes).await;
 
-    let (pk, key_hash) = add_user_public_key(&mut suite, &contracts, &mut test_account1);
+    let (pk, key_hash) = add_user_public_key(&mut suite, &contracts, &mut test_account1).await;
 
     suite.app.indexer.wait_for_finish().await?;
 

--- a/dango/testing/tests/nonce.rs
+++ b/dango/testing/tests/nonce.rs
@@ -39,8 +39,8 @@ fn prepare_tx_with_nonce(accounts: &TestAccounts, nonce: u32, expiry: Option<Dur
     }
 }
 
-#[test]
-fn tracked_nonces_works() {
+#[tokio::test]
+async fn tracked_nonces_works() {
     let (mut suite, mut accounts, ..) = setup_test_naive(Default::default());
 
     for _ in 0..20 {
@@ -50,6 +50,7 @@ fn tracked_nonces_works() {
                 accounts.user1.address(),
                 Coins::one(dango::DENOM.clone(), 123).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -59,34 +60,34 @@ fn tracked_nonces_works() {
         .should_succeed_and(|seen_nonces| seen_nonces.last() == Some(&19));
 
     let tx = prepare_tx_with_nonce(&accounts, 20, None);
-    suite.send_transaction(tx).should_succeed();
+    suite.send_transaction(tx).await.should_succeed();
 
     // Transfer should fail because the nonce is already tracked.
     let tx = prepare_tx_with_nonce(&accounts, 9, None);
-    suite.send_transaction(tx).should_fail();
+    suite.send_transaction(tx).await.should_fail();
 
     for i in 21..44 {
         if ![23, 25, 27, 29].contains(&i) {
             let tx = prepare_tx_with_nonce(&accounts, i, None);
-            suite.send_transaction(tx).should_succeed();
+            suite.send_transaction(tx).await.should_succeed();
         }
     }
 
     // A nonce in range and not used should still be valid.
     for i in [25, 27, 29] {
         let tx = prepare_tx_with_nonce(&accounts, i, None);
-        suite.send_transaction(tx).should_succeed();
+        suite.send_transaction(tx).await.should_succeed();
     }
 
     // A nonce not used but not in range shouldn't be valid.
     let tx = prepare_tx_with_nonce(&accounts, 23, None);
-    suite.send_transaction(tx).should_fail();
+    suite.send_transaction(tx).await.should_fail();
 
     // A transaction with a valid nonce but expired shouldn't be valid.
     let tx = prepare_tx_with_nonce(&accounts, 45, Some(Duration::from_days(0)));
-    suite.send_transaction(tx).should_fail();
+    suite.send_transaction(tx).await.should_fail();
 
     // Same tx but without expire should be valid.
     let tx = prepare_tx_with_nonce(&accounts, 45, None);
-    suite.send_transaction(tx).should_succeed();
+    suite.send_transaction(tx).await.should_succeed();
 }

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -18,8 +18,8 @@ fn setup_oracle_test() -> (TestSuite<NaiveProposalPreparer>, TestAccounts, Addr)
     (suite, accounts, contracts.oracle)
 }
 
-#[test]
-fn pyth_lazer() {
+#[tokio::test]
+async fn pyth_lazer() {
     let (mut suite, mut accounts, oracle) = setup_oracle_test();
 
     let message = LeEcdsaMessage {
@@ -49,7 +49,7 @@ fn pyth_lazer() {
                 eth::DENOM.clone() => PriceSource::Pyth { id: 2, precision: 18 , channel:Channel::RealTime },
             }),
             Coins::default(),
-        )
+        ).await
         .should_succeed();
 
     // The trusted signer was set in genesis. For the purpose of this test,
@@ -64,6 +64,7 @@ fn pyth_lazer() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Try to feed price from Pyth Lazer. Should fail because the signer is not trusted.
@@ -74,6 +75,7 @@ fn pyth_lazer() {
             &ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message.clone()])),
             Coins::default(),
         )
+        .await
         .should_fail_with_error("signer is not trusted");
 
     // Get current time
@@ -90,6 +92,7 @@ fn pyth_lazer() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Query the trusted signers
@@ -116,6 +119,7 @@ fn pyth_lazer() {
             &ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message.clone()])),
             Coins::default(),
         )
+        .await
         .should_fail_with_error("signer is no longer trusted");
 
     // Set the signer as trusted but with a timestamp in the future.
@@ -129,6 +133,7 @@ fn pyth_lazer() {
             },
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Try to feed price from Pyth Lazer. Should succeed because the signer is trusted.
@@ -139,6 +144,7 @@ fn pyth_lazer() {
             &ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message])),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
     // Query the BTC price

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -49,7 +49,8 @@ async fn pyth_lazer() {
                 eth::DENOM.clone() => PriceSource::Pyth { id: 2, precision: 18 , channel:Channel::RealTime },
             }),
             Coins::default(),
-        ).await
+        )
+        .await
         .should_succeed();
 
     // The trusted signer was set in genesis. For the purpose of this test,

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -67,12 +67,12 @@ use {
 /// | 4    | Oracle → $2,300                               | user1 equity=-$460, MM=$575 → liquidatable     |
 /// | 5    | Liquidate user1                               | 1 ETH fills at $100k, 4 ETH ADL'd at ~-$22,240 |
 /// | 6    | Verify                                        | user3 margin deeply negative (bug)             |
-#[test]
-fn adl_bug_absurd_book_price() {
+#[tokio::test]
+async fn adl_bug_absurd_book_price() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Oracle = $2,000.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -98,6 +98,7 @@ fn adl_bug_absurd_book_price() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -111,6 +112,7 @@ fn adl_bug_absurd_book_price() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -131,6 +133,7 @@ fn adl_bug_absurd_book_price() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -148,6 +151,7 @@ fn adl_bug_absurd_book_price() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(1_050_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -166,6 +170,7 @@ fn adl_bug_absurd_book_price() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify positions.
@@ -204,6 +209,7 @@ fn adl_bug_absurd_book_price() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -224,6 +230,7 @@ fn adl_bug_absurd_book_price() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -240,7 +247,7 @@ fn adl_bug_absurd_book_price() {
     //   → close entire SHORT position
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_300);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_300).await;
 
     // -------------------------------------------------------------------------
     // Step 5: Liquidate user1.
@@ -287,6 +294,7 @@ fn adl_bug_absurd_book_price() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -52,10 +52,10 @@ fn limit_ask(price: i128, size: i128, cid: Option<u64>) -> SubmitOrderRequest {
 
 /// Happy path: batch of [PostOnly bid, PostOnly ask, Cancel(One(bid))].
 /// Assert exactly one resting order remains (the ask).
-#[test]
-fn batch_submit_then_cancel() {
+#[tokio::test]
+async fn batch_submit_then_cancel() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -64,6 +64,7 @@ fn batch_submit_then_cancel() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Submit bid first to learn its OrderId, then run the batch.
@@ -85,6 +86,7 @@ fn batch_submit_then_cancel() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -100,10 +102,10 @@ fn batch_submit_then_cancel() {
 /// Atomic replacement: user rests 3 orders, then issues a batch that
 /// cancels all and re-submits 3 new ones. Assert the new orders are on
 /// the book and the old ones are gone.
-#[test]
-fn batch_atomic_replace() {
+#[tokio::test]
+async fn batch_atomic_replace() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -112,6 +114,7 @@ fn batch_atomic_replace() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Rest 3 bids at descending prices.
@@ -123,6 +126,7 @@ fn batch_atomic_replace() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(limit_bid(price, 1, None))),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -150,6 +154,7 @@ fn batch_atomic_replace() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let new_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -170,10 +175,10 @@ fn batch_atomic_replace() {
 /// client id so a subsequent `Submit` carrying the same client id
 /// succeeds — the two actions see each other's writes via grug's
 /// in-call `Buffer`.
-#[test]
-fn batch_reuse_client_order_id() {
+#[tokio::test]
+async fn batch_reuse_client_order_id() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let cid = 42u64;
 
@@ -184,6 +189,7 @@ fn batch_reuse_client_order_id() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Resting bid with client_order_id = 42.
@@ -198,6 +204,7 @@ fn batch_reuse_client_order_id() {
             ))),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Batch: cancel by cid, then submit a new order carrying the same cid.
@@ -216,6 +223,7 @@ fn batch_reuse_client_order_id() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -231,10 +239,10 @@ fn batch_reuse_client_order_id() {
 /// A duplicate `client_order_id` within a batch fails the second submit
 /// and rolls back the first. Snapshot `UserState` and `orders` before
 /// the batch; assert they're byte-identical after the failure.
-#[test]
-fn batch_atomicity_on_submit_failure() {
+#[tokio::test]
+async fn batch_atomicity_on_submit_failure() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -243,6 +251,7 @@ fn batch_atomicity_on_submit_failure() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     let state_before: perps::UserState = suite
@@ -273,6 +282,7 @@ fn batch_atomicity_on_submit_failure() {
             )),
             Coins::new(),
         )
+        .await
         .should_fail();
 
     let state_after: perps::UserState = suite
@@ -294,10 +304,10 @@ fn batch_atomicity_on_submit_failure() {
 /// A bogus `Cancel(One(...))` mid-batch rolls back an earlier successful
 /// submit. Same snapshot-and-compare assertion as the submit-failure
 /// case above.
-#[test]
-fn batch_atomicity_on_cancel_failure() {
+#[tokio::test]
+async fn batch_atomicity_on_cancel_failure() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -306,6 +316,7 @@ fn batch_atomicity_on_cancel_failure() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     let state_before: perps::UserState = suite
@@ -335,6 +346,7 @@ fn batch_atomicity_on_cancel_failure() {
             )),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("order not found");
 
     let state_after: perps::UserState = suite
@@ -363,10 +375,10 @@ fn batch_atomicity_on_cancel_failure() {
 /// cid fails the second action. After the revert, user1's resting ask
 /// is still on the book and user1's UserState (margin, position) is
 /// byte-identical to before the batch.
-#[test]
-fn batch_fill_reverts_on_later_failure() {
+#[tokio::test]
+async fn batch_fill_reverts_on_later_failure() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // Both users deposit margin.
     for user in [&mut accounts.user1, &mut accounts.user2] {
@@ -377,6 +389,7 @@ fn batch_fill_reverts_on_later_failure() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -388,6 +401,7 @@ fn batch_fill_reverts_on_later_failure() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(limit_ask(2_000, 1, None))),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Snapshot maker (user1) and taker (user2) state plus their order books
@@ -443,6 +457,7 @@ fn batch_fill_reverts_on_later_failure() {
             )),
             Coins::new(),
         )
+        .await
         .should_fail();
 
     // Both maker and taker state must be byte-identical — the fill against
@@ -494,10 +509,10 @@ fn batch_fill_reverts_on_later_failure() {
 
 /// Sanity: a single-action batch produces observable state equivalent
 /// to the corresponding direct `SubmitOrder` message.
-#[test]
-fn batch_single_action() {
+#[tokio::test]
+async fn batch_single_action() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -506,6 +521,7 @@ fn batch_single_action() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -520,6 +536,7 @@ fn batch_single_action() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -533,10 +550,10 @@ fn batch_single_action() {
 /// `Param::max_action_batch_size` is enforced. Lower the cap to 3 via
 /// `Configure`; a 4-action batch is rejected without touching any
 /// storage.
-#[test]
-fn batch_size_cap_enforced() {
+#[tokio::test]
+async fn batch_size_cap_enforced() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // Lower the cap to 3.
     suite
@@ -554,6 +571,7 @@ fn batch_size_cap_enforced() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -563,6 +581,7 @@ fn batch_size_cap_enforced() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     let state_before: perps::UserState = suite
@@ -588,6 +607,7 @@ fn batch_size_cap_enforced() {
             )),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("`max_action_batch_size` (3), found: 4");
 
     let state_after: perps::UserState = suite
@@ -613,6 +633,7 @@ fn batch_size_cap_enforced() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
@@ -622,8 +643,8 @@ fn batch_size_cap_enforced() {
 /// succeeds if the cid-index write from the first action is visible
 /// through the in-call `Buffer`, which proves cross-pair reads
 /// inside a batch see earlier in-batch writes.
-#[test]
-fn batch_across_two_pairs() {
+#[tokio::test]
+async fn batch_across_two_pairs() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     let eth_pair = pair_id();
@@ -653,6 +674,7 @@ fn batch_across_two_pairs() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Add the BTC pair (the ETH pair is already configured at genesis;
@@ -670,6 +692,7 @@ fn batch_across_two_pairs() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -679,6 +702,7 @@ fn batch_across_two_pairs() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     let eth_cid = 1u64;
@@ -721,6 +745,7 @@ fn batch_across_two_pairs() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Only the BTC bid remains; the ETH bid was cancelled by its
@@ -742,10 +767,10 @@ fn batch_across_two_pairs() {
 /// cancelled order emits an `OrderRemoved` event with reason
 /// `SelfTradePrevention` carrying the original `client_order_id`.
 /// The taker's remaining GTC ask rests since no other makers exist.
-#[test]
-fn batch_stp_fires_for_self_match() {
+#[tokio::test]
+async fn batch_stp_fires_for_self_match() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -754,6 +779,7 @@ fn batch_stp_fires_for_self_match() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     let bid_cid = 42u64;
@@ -787,6 +813,7 @@ fn batch_stp_fires_for_self_match() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed()
         .events;
 
@@ -825,10 +852,10 @@ fn batch_stp_fires_for_self_match() {
 /// so the cancel's cid-index lookup returns "order not found".
 /// Both maker and taker state must be byte-identical to the
 /// pre-batch snapshot.
-#[test]
-fn batch_cancel_fails_for_filled_order() {
+#[tokio::test]
+async fn batch_cancel_fails_for_filled_order() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -838,6 +865,7 @@ fn batch_cancel_fails_for_filled_order() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -849,6 +877,7 @@ fn batch_cancel_fails_for_filled_order() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(limit_ask(2_000, 1, None))),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let user1_state_before: perps::UserState = suite
@@ -901,6 +930,7 @@ fn batch_cancel_fails_for_filled_order() {
             )),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("order not found");
 
     // Full rollback: maker's resting ask and both users' states are
@@ -938,10 +968,10 @@ fn batch_cancel_fails_for_filled_order() {
 /// The third action collides on the cid and fails → batch reverts.
 /// `USER_REFERRAL_DATA` for both referrer and referee must be
 /// unchanged.
-#[test]
-fn batch_referral_commissions_rollback() {
+#[tokio::test]
+async fn batch_referral_commissions_rollback() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // user1 activates their referrer slot by setting a fee share
     // ratio; user2 then points to user1 as their referrer.
@@ -954,6 +984,7 @@ fn batch_referral_commissions_rollback() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -965,6 +996,7 @@ fn batch_referral_commissions_rollback() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // user2 (taker/payer) and user3 (maker/counterparty) deposit.
@@ -976,6 +1008,7 @@ fn batch_referral_commissions_rollback() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -986,6 +1019,7 @@ fn batch_referral_commissions_rollback() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(limit_ask(2_000, 1, None))),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Snapshot cumulative referral data for both referrer and referee
@@ -1033,6 +1067,7 @@ fn batch_referral_commissions_rollback() {
             )),
             Coins::new(),
         )
+        .await
         .should_fail();
 
     let user1_data_after: UserReferralData = suite

--- a/dango/testing/tests/perps/client_order_id.rs
+++ b/dango/testing/tests/perps/client_order_id.rs
@@ -16,11 +16,11 @@ use {
 ///
 /// Covers the full execute-message round trip the algo-trader use case
 /// depends on.
-#[test]
-fn submit_cancel_resubmit_by_client_order_id() {
+#[tokio::test]
+async fn submit_cancel_resubmit_by_client_order_id() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
     let cid: ClientOrderId = Uint64::new(42);
@@ -33,6 +33,7 @@ fn submit_cancel_resubmit_by_client_order_id() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Submit a resting GTC limit bid carrying `cid`. The price ($1,500) is
@@ -55,6 +56,7 @@ fn submit_cancel_resubmit_by_client_order_id() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Sanity: exactly one resting order, carrying `cid`.
@@ -76,6 +78,7 @@ fn submit_cancel_resubmit_by_client_order_id() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // The order is gone.
@@ -107,6 +110,7 @@ fn submit_cancel_resubmit_by_client_order_id() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -123,11 +127,11 @@ fn submit_cancel_resubmit_by_client_order_id() {
 
 /// Cancelling a `client_order_id` that the sender never used (or has
 /// already cancelled / had filled) bails with a clear error message.
-#[test]
-fn cancel_by_unknown_client_order_id_fails() {
+#[tokio::test]
+async fn cancel_by_unknown_client_order_id_fails() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -138,5 +142,6 @@ fn cancel_by_unknown_client_order_id_fails() {
             )),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("order not found");
 }

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -18,11 +18,11 @@ use {
 
 /// Full lifecycle: deposit → open position → place TP → oracle rises →
 /// cron triggers TP → position closed.
-#[test]
-fn conditional_order_tp_triggers_on_price_rise() {
+#[tokio::test]
+async fn conditional_order_tp_triggers_on_price_rise() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -34,6 +34,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Step 2: Maker places ask: 10 ETH @ $2,000.
@@ -44,6 +45,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -64,6 +66,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 3: Trader market buys 10 ETH. Fee = 10 * $2,000 * 0.1% = $20.
@@ -83,6 +86,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let state: UserState = suite
@@ -112,6 +116,7 @@ fn conditional_order_tp_triggers_on_price_rise() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 5: Verify conditional order exists on the position.
@@ -149,13 +154,14 @@ fn conditional_order_tp_triggers_on_price_rise() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 7: Oracle updated to $2,500.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
 
     // Step 8: Advance time so perps cron fires (interval = 1 min).
-    suite.increase_time(Duration::from_minutes(2));
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     // Step 9: Verify trader state — position closed.
     let state: UserState = suite
@@ -188,11 +194,11 @@ fn conditional_order_tp_triggers_on_price_rise() {
 
 /// SL triggers on price drop: deposit → buy → place SL → oracle drops →
 /// cron triggers SL → position closed with loss.
-#[test]
-fn conditional_order_sl_triggers_on_price_drop() {
+#[tokio::test]
+async fn conditional_order_sl_triggers_on_price_drop() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -204,6 +210,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Maker deposits and places ask.
@@ -214,6 +221,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -234,6 +242,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -252,6 +261,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 2: Trader submits SL: sell 5 @ trigger $1,800 Below, 2% slippage.
@@ -268,6 +278,7 @@ fn conditional_order_sl_triggers_on_price_drop() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 3: Bidder places bid: 5 ETH @ $1,800.
@@ -289,11 +300,12 @@ fn conditional_order_sl_triggers_on_price_drop() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 4: Oracle drops to $1,800, advance time so perps cron fires.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800);
-    suite.increase_time(Duration::from_minutes(2));
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     // Step 5: Verify trader state — position closed, PnL = 5*($1,800-$2,000) = -$1,000.
     let state: UserState = suite
@@ -333,11 +345,11 @@ fn conditional_order_sl_triggers_on_price_drop() {
 /// $1,800 and the cron fires, the $1,900 SL (closer to market) must execute
 /// first and consume the better $1,790 bid, leaving the $1,770 bid for the
 /// $1,800 SL.
-#[test]
-fn conditional_orders_follow_price_time_priority() {
+#[tokio::test]
+async fn conditional_orders_follow_price_time_priority() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -352,6 +364,7 @@ fn conditional_orders_follow_price_time_priority() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -361,6 +374,7 @@ fn conditional_orders_follow_price_time_priority() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -370,6 +384,7 @@ fn conditional_orders_follow_price_time_priority() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -394,6 +409,7 @@ fn conditional_orders_follow_price_time_priority() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -416,6 +432,7 @@ fn conditional_orders_follow_price_time_priority() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -438,6 +455,7 @@ fn conditional_orders_follow_price_time_priority() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -457,6 +475,7 @@ fn conditional_orders_follow_price_time_priority() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -476,6 +495,7 @@ fn conditional_orders_follow_price_time_priority() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -502,6 +522,7 @@ fn conditional_orders_follow_price_time_priority() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -522,6 +543,7 @@ fn conditional_orders_follow_price_time_priority() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -536,8 +558,8 @@ fn conditional_orders_follow_price_time_priority() {
     // Both $1,790 and $1,770 are above $1,764 → within tolerance.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800);
-    suite.increase_time(Duration::from_minutes(2));
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     // -------------------------------------------------------------------------
     // Assertions: Both positions closed, both conditional orders consumed.
@@ -601,11 +623,11 @@ fn conditional_orders_follow_price_time_priority() {
 /// This test places two BELOW conditional orders: one sell (no bids on book →
 /// will fail) and one buy (ask available → will succeed). It verifies that
 /// the first order's failure does not prevent the second from executing.
-#[test]
-fn conditional_order_failure_does_not_block_others() {
+#[tokio::test]
+async fn conditional_order_failure_does_not_block_others() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -620,6 +642,7 @@ fn conditional_order_failure_does_not_block_others() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -629,6 +652,7 @@ fn conditional_order_failure_does_not_block_others() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -638,6 +662,7 @@ fn conditional_order_failure_does_not_block_others() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -662,6 +687,7 @@ fn conditional_order_failure_does_not_block_others() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -680,6 +706,7 @@ fn conditional_order_failure_does_not_block_others() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -704,6 +731,7 @@ fn conditional_order_failure_does_not_block_others() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -722,6 +750,7 @@ fn conditional_order_failure_does_not_block_others() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify positions: User1 = 5 long, User3 = 5 short.
@@ -767,6 +796,7 @@ fn conditional_order_failure_does_not_block_others() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -787,6 +817,7 @@ fn conditional_order_failure_does_not_block_others() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -812,6 +843,7 @@ fn conditional_order_failure_does_not_block_others() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -824,8 +856,8 @@ fn conditional_order_failure_does_not_block_others() {
     //      → succeeds.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800);
-    suite.increase_time(Duration::from_minutes(2));
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     // -------------------------------------------------------------------------
     // Assertions
@@ -896,11 +928,11 @@ fn conditional_order_failure_does_not_block_others() {
 ///  6. With the fix: the pre-call snapshot of `user_state` is restored, so
 ///     `open_order_count == 1` and the resting bid is still in the book.
 ///  7. A subsequent market sell from User3 fills User1's bid without panicking.
-#[test]
-fn conditional_order_self_trade_failure_preserves_user_state() {
+#[tokio::test]
+async fn conditional_order_self_trade_failure_preserves_user_state() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -917,6 +949,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(amount)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -939,6 +972,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User1 market-buys 5 ETH → long 5 @ $2,000.
@@ -958,6 +992,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User1 places a resting bid at $1,950 (would add to long if filled).
@@ -980,6 +1015,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Snapshot User1's state: should have 1 resting bid, reserved_margin > 0.
@@ -1015,6 +1051,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Oracle drops to $1,960 → SL triggers. No other bids in range ($1,862+) —
@@ -1022,8 +1059,8 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
     // memory, `match_order` has no more liquidity, `ensure!` fails, and
     // `process_triggered_order` gracefully cancels the conditional order via
     // `SlippageExceeded`.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_960);
-    suite.increase_time(Duration::from_minutes(2));
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_960).await;
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     // --- Post-trigger assertions ---
 
@@ -1094,6 +1131,7 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // After the fill, User1's resting bid should be gone and
@@ -1114,13 +1152,13 @@ fn conditional_order_self_trade_failure_preserves_user_state() {
 
 /// Market buy with TP child order → position has conditional_order_above →
 /// oracle rises → cron triggers TP → position closed with profit.
-#[test]
-fn child_order_market_with_tp_triggers() {
+#[tokio::test]
+async fn child_order_market_with_tp_triggers() {
     let (mut suite, mut accounts, _codes, contracts, _mock_validators) =
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // Deposit for user1 (trader) and user2 (maker).
     for user in [&mut accounts.user1, &mut accounts.user2] {
@@ -1131,6 +1169,7 @@ fn child_order_market_with_tp_triggers() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1153,6 +1192,7 @@ fn child_order_market_with_tp_triggers() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trader market buys 10 ETH with TP @ $2,500.
@@ -1176,6 +1216,7 @@ fn child_order_market_with_tp_triggers() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify TP is on the position.
@@ -1191,7 +1232,7 @@ fn child_order_market_with_tp_triggers() {
     assert!(pos.conditional_order_below.is_none(), "no SL");
 
     // Oracle rises to $2,500 → trigger TP.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
 
     // Maker places bid to fill the TP market sell.
     suite
@@ -1212,10 +1253,11 @@ fn child_order_market_with_tp_triggers() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Advance time to trigger cron.
-    suite.increase_time(Duration::from_minutes(2));
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     // Verify position is closed.
     let state: UserState = suite
@@ -1235,13 +1277,13 @@ fn child_order_market_with_tp_triggers() {
 }
 
 /// Market buy with SL child order → oracle drops → SL triggers → closed with loss.
-#[test]
-fn child_order_market_with_sl_triggers() {
+#[tokio::test]
+async fn child_order_market_with_sl_triggers() {
     let (mut suite, mut accounts, _codes, contracts, _mock_validators) =
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -1251,6 +1293,7 @@ fn child_order_market_with_sl_triggers() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1273,6 +1316,7 @@ fn child_order_market_with_sl_triggers() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trader market buys 5 ETH with SL @ $1,800.
@@ -1296,6 +1340,7 @@ fn child_order_market_with_sl_triggers() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify SL is on the position.
@@ -1311,7 +1356,7 @@ fn child_order_market_with_sl_triggers() {
     assert!(pos.conditional_order_above.is_none(), "no TP");
 
     // Oracle drops to $1,800 → trigger SL.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
 
     // Maker places bid to fill SL.
     suite
@@ -1332,9 +1377,10 @@ fn child_order_market_with_sl_triggers() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    suite.increase_time(Duration::from_minutes(2));
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     let state: UserState = suite
         .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
@@ -1352,13 +1398,13 @@ fn child_order_market_with_sl_triggers() {
 
 /// Market sell that closes existing long position, with TP/SL child order →
 /// no conditional orders remain.
-#[test]
-fn child_order_ignored_when_position_closed() {
+#[tokio::test]
+async fn child_order_ignored_when_position_closed() {
     let (mut suite, mut accounts, _codes, contracts, _mock_validators) =
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -1368,6 +1414,7 @@ fn child_order_ignored_when_position_closed() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1390,6 +1437,7 @@ fn child_order_ignored_when_position_closed() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1408,6 +1456,7 @@ fn child_order_ignored_when_position_closed() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Now maker places bid, trader sells to close with TP/SL attached.
@@ -1429,6 +1478,7 @@ fn child_order_ignored_when_position_closed() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1455,6 +1505,7 @@ fn child_order_ignored_when_position_closed() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Position should be closed, no conditional orders.
@@ -1470,13 +1521,13 @@ fn child_order_ignored_when_position_closed() {
 
 /// Position has existing TP/SL. New market order with different child orders fills
 /// → old TP/SL replaced.
-#[test]
-fn child_order_overwrites_existing() {
+#[tokio::test]
+async fn child_order_overwrites_existing() {
     let (mut suite, mut accounts, _codes, contracts, _mock_validators) =
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -1486,6 +1537,7 @@ fn child_order_overwrites_existing() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1508,6 +1560,7 @@ fn child_order_overwrites_existing() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1526,6 +1579,7 @@ fn child_order_overwrites_existing() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Set existing TP/SL via SubmitConditionalOrder.
@@ -1542,6 +1596,7 @@ fn child_order_overwrites_existing() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Buy more with different TP/SL child orders → overwrites.
@@ -1569,6 +1624,7 @@ fn child_order_overwrites_existing() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let state: UserState = suite
@@ -1590,13 +1646,13 @@ fn child_order_overwrites_existing() {
 }
 
 /// SubmitConditionalOrder twice with same direction → second overwrites first.
-#[test]
-fn conditional_order_overwrite_same_direction() {
+#[tokio::test]
+async fn conditional_order_overwrite_same_direction() {
     let (mut suite, mut accounts, _codes, contracts, _mock_validators) =
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -1605,6 +1661,7 @@ fn conditional_order_overwrite_same_direction() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1614,6 +1671,7 @@ fn conditional_order_overwrite_same_direction() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Establish long position.
@@ -1635,6 +1693,7 @@ fn conditional_order_overwrite_same_direction() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1653,6 +1712,7 @@ fn conditional_order_overwrite_same_direction() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // First TP.
@@ -1669,6 +1729,7 @@ fn conditional_order_overwrite_same_direction() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Second TP (same direction) → should overwrite, not error.
@@ -1685,6 +1746,7 @@ fn conditional_order_overwrite_same_direction() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let state: UserState = suite
@@ -1704,13 +1766,13 @@ fn conditional_order_overwrite_same_direction() {
 }
 
 /// SubmitConditionalOrder with size > position → now allowed (previously errored).
-#[test]
-fn conditional_order_size_exceeds_position_allowed() {
+#[tokio::test]
+async fn conditional_order_size_exceeds_position_allowed() {
     let (mut suite, mut accounts, _codes, contracts, _mock_validators) =
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     suite
         .execute(
@@ -1719,6 +1781,7 @@ fn conditional_order_size_exceeds_position_allowed() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1728,6 +1791,7 @@ fn conditional_order_size_exceeds_position_allowed() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Establish small long.
@@ -1749,6 +1813,7 @@ fn conditional_order_size_exceeds_position_allowed() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1767,6 +1832,7 @@ fn conditional_order_size_exceeds_position_allowed() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Submit TP with size > position (was -5 but position is only 3).
@@ -1783,6 +1849,7 @@ fn conditional_order_size_exceeds_position_allowed() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify it was placed.
@@ -1804,11 +1871,11 @@ fn conditional_order_size_exceeds_position_allowed() {
 /// `SlippageCapTightened` — distinct from `SlippageExceeded` which
 /// signals a book-liquidity shortfall. The position stays open; no
 /// market order is attempted.
-#[test]
-fn conditional_order_cancelled_when_slippage_cap_tightened() {
+#[tokio::test]
+async fn conditional_order_cancelled_when_slippage_cap_tightened() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1829,6 +1896,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trader deposits and opens a long via a market fill against a
@@ -1840,6 +1908,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1849,6 +1918,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1869,6 +1939,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1887,6 +1958,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trader places TP with 10% slippage — legal against the 50% cap.
@@ -1903,6 +1975,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Governance tightens the cap to 5% — the stored 10% TP slippage
@@ -1922,6 +1995,7 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Provide a bid the TP could legally fill at, so the only reason
@@ -1944,13 +2018,14 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Oracle rises to the TP trigger.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
 
     // Advance time so the perps cron fires.
-    suite.increase_time(Duration::from_minutes(2));
+    suite.increase_time(Duration::from_minutes(2)).await;
 
     // Position is still open (TP was not executed; order was cancelled
     // for cap tightening).
@@ -1977,11 +2052,11 @@ fn conditional_order_cancelled_when_slippage_cap_tightened() {
 /// match. Verifies the cron path of `compute_submit_order_outcome` → `match_order` →
 /// `settle_fill` correctly threads `next_fill_id` the same way the
 /// user-submitted path does.
-#[test]
-fn conditional_order_trigger_fills_carry_fill_id() {
+#[tokio::test]
+async fn conditional_order_trigger_fills_carry_fill_id() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1993,6 +2068,7 @@ fn conditional_order_trigger_fills_carry_fill_id() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -2002,6 +2078,7 @@ fn conditional_order_trigger_fills_carry_fill_id() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(50_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -2022,6 +2099,7 @@ fn conditional_order_trigger_fills_carry_fill_id() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -2040,6 +2118,7 @@ fn conditional_order_trigger_fills_carry_fill_id() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -2055,6 +2134,7 @@ fn conditional_order_trigger_fills_carry_fill_id() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Resting bid that the TP will cross when triggered.
@@ -2076,16 +2156,17 @@ fn conditional_order_trigger_fills_carry_fill_id() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Move oracle above the TP trigger and advance time to fire cron.
     // `increase_time` discards the block outcome, so inline its body to
     // keep access to the cron-emitted events.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
 
     let old_block_time = suite.block_time;
     suite.block_time = Duration::from_minutes(2);
-    let outcome = suite.make_empty_block();
+    let outcome = suite.make_empty_block().await;
     suite.block_time = old_block_time;
 
     let fills = outcome
@@ -2131,11 +2212,11 @@ fn conditional_order_trigger_fills_carry_fill_id() {
 /// after the first triggered order saves its advanced `NEXT_FILL_ID`,
 /// the second triggered order must load the updated value rather than
 /// the pre-cron one.
-#[test]
-fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
+#[tokio::test]
+async fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -2148,6 +2229,7 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -2160,6 +2242,7 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Two opening asks, one per trader.
@@ -2184,6 +2267,7 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
                 )),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -2206,6 +2290,7 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
                 )),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -2227,6 +2312,7 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
                 }),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -2252,15 +2338,16 @@ fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
                 )),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
     // Move the oracle so both TPs trigger, then fire cron.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
 
     let old_block_time = suite.block_time;
     suite.block_time = Duration::from_minutes(2);
-    let outcome = suite.make_empty_block();
+    let outcome = suite.make_empty_block().await;
     suite.block_time = old_block_time;
 
     let fills = outcome

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -56,12 +56,12 @@ fn default_param_no_liq_fee() -> Param {
 /// | 4    | Oracle drops to $1,450                          | PnL = 5x($1,450-$2,000) = -$2,750; equity = $240; MM = 5x$1,450x5% = $362.50                                       | equity < MM -> liquidatable                                                            |
 /// | 5    | Bidder places bid: 5 ETH @ $1,450               | —                                                                                                                  | —                                                                                      |
 /// | 6    | Liquidate trader                                | deficit = $122.50; close ~1.689655 ETH via book; liq_fee ~$24.50; margin after ~$2,036.19; ~3.31 ETH position stays | trader position reduced; trader margin ~$2,036; vault margin += ~$24.50; bidder filled |
-#[test]
-fn liquidation_on_order_book() {
+#[tokio::test]
+async fn liquidation_on_order_book() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -78,6 +78,7 @@ fn liquidation_on_order_book() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -90,6 +91,7 @@ fn liquidation_on_order_book() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -99,6 +101,7 @@ fn liquidation_on_order_book() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(3_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -112,6 +115,7 @@ fn liquidation_on_order_book() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -132,6 +136,7 @@ fn liquidation_on_order_book() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -155,6 +160,7 @@ fn liquidation_on_order_book() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify position: 5 ETH long @ $2,000, margin = $2,990.
@@ -182,7 +188,7 @@ fn liquidation_on_order_book() {
     // MM = 5 * $1,450 * 5% = $362.50; equity < MM -> liquidatable.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
 
     // -------------------------------------------------------------------------
     // Step 5: Bidder (user3) deposits $10,000 USDC and places bid: 5 ETH @ $1,450.
@@ -195,6 +201,7 @@ fn liquidation_on_order_book() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -215,6 +222,7 @@ fn liquidation_on_order_book() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -250,6 +258,7 @@ fn liquidation_on_order_book() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trader position should be reduced from 5 to ~3.310345 ETH (partial close).
@@ -342,12 +351,12 @@ fn liquidation_on_order_book() {
 /// | 8    | Oracle → $1,450                           | Trader A: PnL=-$2,750, equity=-$1,660               |
 /// | 9    | Liquidate Trader A                        | No bids → ADL against Trader B at bankruptcy price  |
 /// | 10   | Verify results                            | Trader B position reduced; insurance fund updated   |
-#[test]
-fn liquidation_with_adl() {
+#[tokio::test]
+async fn liquidation_with_adl() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -362,6 +371,7 @@ fn liquidation_with_adl() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(1_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -374,6 +384,7 @@ fn liquidation_with_adl() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -387,6 +398,7 @@ fn liquidation_with_adl() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(1_100_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -400,6 +412,7 @@ fn liquidation_with_adl() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -420,6 +433,7 @@ fn liquidation_with_adl() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -443,6 +457,7 @@ fn liquidation_with_adl() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let state: Option<UserState> = suite
@@ -463,6 +478,7 @@ fn liquidation_with_adl() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -486,6 +502,7 @@ fn liquidation_with_adl() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -508,6 +525,7 @@ fn liquidation_with_adl() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let state = suite
@@ -525,7 +543,7 @@ fn liquidation_with_adl() {
     // PnL = 5 * ($1,450 - $2,000) = -$2,750; equity = $1,090 - $2,750 = -$1,660.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
 
     // -------------------------------------------------------------------------
     // Step 9: Liquidate Trader A.
@@ -556,6 +574,7 @@ fn liquidation_with_adl() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed()
         .events;
 
@@ -674,11 +693,11 @@ fn liquidation_with_adl() {
 
 /// Liquidation cancels conditional orders alongside regular orders.
 /// Follows the pattern from `liquidation_on_order_book`.
-#[test]
-fn liquidation_cancels_conditional_orders() {
+#[tokio::test]
+async fn liquidation_cancels_conditional_orders() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -690,6 +709,7 @@ fn liquidation_cancels_conditional_orders() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -702,6 +722,7 @@ fn liquidation_cancels_conditional_orders() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -711,6 +732,7 @@ fn liquidation_cancels_conditional_orders() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(3_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Step 2: Maker (user2) deposits and places ask: 5 ETH @ $2,000.
@@ -721,6 +743,7 @@ fn liquidation_cancels_conditional_orders() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -741,6 +764,7 @@ fn liquidation_cancels_conditional_orders() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trader buys 5 ETH.
@@ -760,6 +784,7 @@ fn liquidation_cancels_conditional_orders() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 3: Trader submits TP and SL conditional orders.
@@ -776,6 +801,7 @@ fn liquidation_cancels_conditional_orders() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -791,6 +817,7 @@ fn liquidation_cancels_conditional_orders() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify both conditional orders were placed.
@@ -811,7 +838,7 @@ fn liquidation_cancels_conditional_orders() {
     );
 
     // Step 4: Oracle drops to $1,450.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
 
     // Step 5: Bidder (user3) deposits and places bid: 5 ETH @ $1,450.
     suite
@@ -821,6 +848,7 @@ fn liquidation_cancels_conditional_orders() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -841,6 +869,7 @@ fn liquidation_cancels_conditional_orders() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 6: Liquidate trader.
@@ -853,6 +882,7 @@ fn liquidation_cancels_conditional_orders() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Step 7: Verify state after liquidation.
@@ -910,13 +940,13 @@ fn liquidation_cancels_conditional_orders() {
 ///   6. Liquidation closes vault's long against the bid
 ///   7. Assert: vault positions cleared, insurance fund received fee,
 ///      vault margin adjusted by PnL
-#[test]
-fn vault_liquidation_on_order_book() {
+#[tokio::test]
+async fn vault_liquidation_on_order_book() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     let pair = pair_id();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // -------------------------------------------------------------------------
     // Step 1: LP (user1) deposits $5,000 USDC and adds all as vault liquidity.
@@ -929,6 +959,7 @@ fn vault_liquidation_on_order_book() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(5_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -941,6 +972,7 @@ fn vault_liquidation_on_order_book() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -967,6 +999,7 @@ fn vault_liquidation_on_order_book() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -980,6 +1013,7 @@ fn vault_liquidation_on_order_book() {
             &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -1007,6 +1041,7 @@ fn vault_liquidation_on_order_book() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1025,6 +1060,7 @@ fn vault_liquidation_on_order_book() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify vault is long.
@@ -1050,7 +1086,7 @@ fn vault_liquidation_on_order_book() {
     //   $250 < $1,000 → liquidatable
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_600);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_600).await;
 
     // Sanity: verify vault is liquidatable (equity < MM).
     let vault_ext: perps::UserStateExtended = suite
@@ -1101,6 +1137,7 @@ fn vault_liquidation_on_order_book() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1121,6 +1158,7 @@ fn vault_liquidation_on_order_book() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1136,6 +1174,7 @@ fn vault_liquidation_on_order_book() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1245,11 +1284,11 @@ fn vault_liquidation_on_order_book() {
 ///
 /// This pins the BitMEX-style separation: order-book matches get a
 /// `fill_id`, position transfers at the bankruptcy price do not.
-#[test]
-fn liquidation_book_fills_have_fill_id_adl_does_not() {
+#[tokio::test]
+async fn liquidation_book_fills_have_fill_id_adl_does_not() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1261,6 +1300,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(1_100_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Maker (user2) deposits enough to seed the book with plenty of asks,
@@ -1272,6 +1312,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(20_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Maker places ask: 5 ETH @ $2,000. Trader A fills it, ending long 5 ETH.
@@ -1293,6 +1334,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1311,6 +1353,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trader B (user3) will be the ADL counter-party: short 5 ETH @ $2,000.
@@ -1322,6 +1365,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Maker places a bid so Trader B can short into it.
@@ -1343,6 +1387,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1361,12 +1406,13 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Oracle drops to $1,450. Trader A is deeply underwater and forced
     // to close the full position; equity is negative so target_price for
     // book matching is the oracle ($1,450).
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
 
     // Partial book liquidity for the liquidation: Maker places a bid for
     // 2 ETH @ $1,450. Trader A's liquidation will fill this, then ADL
@@ -1389,6 +1435,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Liquidate Trader A. Expect book fills + ADL remainder.
@@ -1401,6 +1448,7 @@ fn liquidation_book_fills_have_fill_id_adl_does_not() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed()
         .events;
 

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -52,7 +52,7 @@ pub fn default_pair_param() -> PairParam {
 }
 
 /// Register fixed oracle prices for the perps pair and settlement currency.
-pub fn register_oracle_prices(
+pub async fn register_oracle_prices(
     suite: &mut dango_testing::TestSuite<grug_app::NaiveProposalPreparer>,
     accounts: &mut dango_testing::TestAccounts,
     contracts: &Contracts,
@@ -76,5 +76,6 @@ pub fn register_oracle_prices(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }

--- a/dango/testing/tests/perps/price_band.rs
+++ b/dango/testing/tests/perps/price_band.rs
@@ -22,8 +22,7 @@ use {
 /// with $10,000 margin.
 macro_rules! setup_band_suite {
     () => {{
-        let (mut suite, mut accounts, _, contracts, _) =
-            setup_test_naive(TestOption::default());
+        let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
         register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
         let pair = pair_id();
 
@@ -41,7 +40,8 @@ macro_rules! setup_band_suite {
                     },
                 }),
                 Coins::new(),
-            ).await
+            )
+            .await
             .should_succeed();
 
         suite
@@ -50,7 +50,8 @@ macro_rules! setup_band_suite {
                 contracts.perps,
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
-            ).await
+            )
+            .await
             .should_succeed();
 
         (suite, accounts, contracts, pair)
@@ -60,23 +61,25 @@ macro_rules! setup_band_suite {
 /// Send a limit order from user1 at the given price and time-in-force.
 macro_rules! submit_limit {
     ($suite:expr, $accounts:expr, $contracts:expr, $pair:expr, $size:expr, $price:expr, $tif:expr) => {
-        $suite.execute(
-            &mut $accounts.user1,
-            $contracts.perps,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
-                pair_id: $pair.clone(),
-                size: Quantity::new_int($size),
-                kind: OrderKind::Limit {
-                    limit_price: UsdPrice::new_int($price),
-                    time_in_force: $tif,
-                    client_order_id: None,
-                },
-                reduce_only: false,
-                tp: None,
-                sl: None,
-            })),
-            Coins::new(),
-        ).await
+        $suite
+            .execute(
+                &mut $accounts.user1,
+                $contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                    pair_id: $pair.clone(),
+                    size: Quantity::new_int($size),
+                    kind: OrderKind::Limit {
+                        limit_price: UsdPrice::new_int($price),
+                        time_in_force: $tif,
+                        client_order_id: None,
+                    },
+                    reduce_only: false,
+                    tp: None,
+                    sl: None,
+                })),
+                Coins::new(),
+            )
+            .await
     };
 }
 

--- a/dango/testing/tests/perps/price_band.rs
+++ b/dango/testing/tests/perps/price_band.rs
@@ -24,7 +24,7 @@ macro_rules! setup_band_suite {
     () => {{
         let (mut suite, mut accounts, _, contracts, _) =
             setup_test_naive(TestOption::default());
-        register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+        register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
         let pair = pair_id();
 
         suite
@@ -41,7 +41,7 @@ macro_rules! setup_band_suite {
                     },
                 }),
                 Coins::new(),
-            )
+            ).await
             .should_succeed();
 
         suite
@@ -50,7 +50,7 @@ macro_rules! setup_band_suite {
                 contracts.perps,
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
-            )
+            ).await
             .should_succeed();
 
         (suite, accounts, contracts, pair)
@@ -76,13 +76,13 @@ macro_rules! submit_limit {
                 sl: None,
             })),
             Coins::new(),
-        )
+        ).await
     };
 }
 
 /// GTC limit buy exactly at the upper band bound is accepted.
-#[test]
-fn banding_gtc_at_upper_bound_accepted() {
+#[tokio::test]
+async fn banding_gtc_at_upper_bound_accepted() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     // oracle * (1 + 10%) = $2,200.
@@ -99,8 +99,8 @@ fn banding_gtc_at_upper_bound_accepted() {
 }
 
 /// GTC limit buy just above the upper bound is rejected.
-#[test]
-fn banding_gtc_just_above_upper_bound_rejected() {
+#[tokio::test]
+async fn banding_gtc_just_above_upper_bound_rejected() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     submit_limit!(
@@ -116,8 +116,8 @@ fn banding_gtc_just_above_upper_bound_rejected() {
 }
 
 /// GTC limit sell below the lower bound is rejected.
-#[test]
-fn banding_gtc_below_lower_bound_rejected() {
+#[tokio::test]
+async fn banding_gtc_below_lower_bound_rejected() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     submit_limit!(
@@ -133,8 +133,8 @@ fn banding_gtc_below_lower_bound_rejected() {
 }
 
 /// IOC limit with out-of-band price is rejected before any fill is attempted.
-#[test]
-fn banding_ioc_out_of_band_rejected() {
+#[tokio::test]
+async fn banding_ioc_out_of_band_rejected() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     submit_limit!(
@@ -151,8 +151,8 @@ fn banding_ioc_out_of_band_rejected() {
 
 /// PostOnly with out-of-band price is rejected at Step 0, never reaching the
 /// crossing check inside `store_post_only_limit_order`.
-#[test]
-fn banding_post_only_out_of_band_rejected() {
+#[tokio::test]
+async fn banding_post_only_out_of_band_rejected() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     submit_limit!(
@@ -170,8 +170,8 @@ fn banding_post_only_out_of_band_rejected() {
 /// Market orders use `max_slippage`, not `limit_price`, so the band does not
 /// apply. A market order with wide slippage against an empty book fails only
 /// for lack of liquidity, not for banding reasons.
-#[test]
-fn banding_does_not_affect_market_orders() {
+#[tokio::test]
+async fn banding_does_not_affect_market_orders() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     suite
@@ -190,6 +190,7 @@ fn banding_does_not_affect_market_orders() {
             })),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("no liquidity at acceptable price");
 }
 
@@ -197,8 +198,8 @@ fn banding_does_not_affect_market_orders() {
 /// bid far below oracle — the precondition for the bad-debt-minting self-match
 /// attack — is rejected at submission. Without banding, this order would rest
 /// on the book and serve as the bad-price maker in the attack.
-#[test]
-fn banding_blocks_pathological_post_only_trap() {
+#[tokio::test]
+async fn banding_blocks_pathological_post_only_trap() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     // Oracle = $2,000, band = 10%. A PostOnly bid at $200 (90% below
@@ -228,8 +229,8 @@ fn banding_blocks_pathological_post_only_trap() {
 /// cancels it, and then fills against an in-band maker deeper in the book.
 /// This verifies `continue` semantics (walk past the cancelled maker,
 /// rather than `break`-ing and leaving in-band liquidity unreached).
-#[test]
-fn banding_drift_maker_cancelled_at_match_time() {
+#[tokio::test]
+async fn banding_drift_maker_cancelled_at_match_time() {
     let (mut suite, mut accounts, contracts, pair) = setup_band_suite!();
 
     // Oracle at T1 = $2,000, band = 10% → allowed range [$1,800, $2,200].
@@ -250,7 +251,7 @@ fn banding_drift_maker_cancelled_at_match_time() {
     // Oracle moves to $2,500 → new allowed range [$2,250, $2,750].
     //   - user1's $2,199 ask: now below the lower bound ($2,199 < $2,250).
     //     OUT of band.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
 
     // user3 deposits and (at T2, in the new band) places a PostOnly ask
     // at $2,400 — this one stays in-band.
@@ -261,6 +262,7 @@ fn banding_drift_maker_cancelled_at_match_time() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -280,6 +282,7 @@ fn banding_drift_maker_cancelled_at_match_time() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // user2 market-buys size 2 with wide slippage. Walks asks ascending:
@@ -293,6 +296,7 @@ fn banding_drift_maker_cancelled_at_match_time() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -310,6 +314,7 @@ fn banding_drift_maker_cancelled_at_match_time() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // user1's stale ask was cancelled by the match-time check.

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -26,12 +26,12 @@ use {
 
 /// Register a referral relationship during user registration via the account
 /// factory (the `referrer` field on `RegisterUser`).
-#[test]
-fn referral_during_user_register() {
+#[tokio::test]
+async fn referral_during_user_register() {
     let (mut suite, mut accounts, codes, contracts, ..) =
         setup_test_naive(TestOption::preset_test());
 
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     // User1 (index 1) sets a fee share ratio so they can be a referrer.
     set_fee_share_ratio(
@@ -40,6 +40,7 @@ fn referral_during_user_register() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     let chain_id = suite.chain_id.clone();
@@ -74,6 +75,7 @@ fn referral_during_user_register() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Look up the new user's index.
@@ -100,8 +102,8 @@ fn referral_during_user_register() {
 
 /// Set a referral relationship after the user has already registered, and
 /// verify immutability + multiple referees.
-#[test]
-fn referral_after_user_register() {
+#[tokio::test]
+async fn referral_after_user_register() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // User1, User2, and User3 all set fee share ratios.
@@ -111,6 +113,7 @@ fn referral_after_user_register() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     set_fee_share_ratio(
@@ -119,6 +122,7 @@ fn referral_after_user_register() {
         &mut accounts.user2,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     set_fee_share_ratio(
@@ -127,6 +131,7 @@ fn referral_after_user_register() {
         &mut accounts.user3,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     // User2 sets User1 as referrer.
@@ -140,6 +145,7 @@ fn referral_after_user_register() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify User2's referrer is User1.
@@ -161,6 +167,7 @@ fn referral_after_user_register() {
             }),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("referee 2 already has a referrer");
 
     // User3 also sets User1 as referrer.
@@ -174,6 +181,7 @@ fn referral_after_user_register() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     assert_eq!(
@@ -194,6 +202,7 @@ fn referral_after_user_register() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     assert_eq!(
@@ -205,8 +214,8 @@ fn referral_after_user_register() {
 }
 
 /// A user cannot refer themselves.
-#[test]
-fn referral_self_refer_fails() {
+#[tokio::test]
+async fn referral_self_refer_fails() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     set_fee_share_ratio(
@@ -215,6 +224,7 @@ fn referral_self_refer_fails() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     suite
@@ -227,12 +237,13 @@ fn referral_self_refer_fails() {
             }),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("a user cannot refer themselves");
 }
 
 /// A referral cannot be set if the referrer has no fee share ratio.
-#[test]
-fn referral_without_share_ratio_fails() {
+#[tokio::test]
+async fn referral_without_share_ratio_fails() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // User1 has NOT set a share ratio. Trying to set User1 as referrer should fail.
@@ -246,12 +257,13 @@ fn referral_without_share_ratio_fails() {
             }),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("referrer 1 has no fee share ratio set");
 }
 
 /// Only the referee (or the account factory) can set the referral relationship.
-#[test]
-fn referral_wrong_caller_fails() {
+#[tokio::test]
+async fn referral_wrong_caller_fails() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     set_fee_share_ratio(
@@ -260,6 +272,7 @@ fn referral_wrong_caller_fails() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     // User3 tries to set the referral for User2 — should fail.
@@ -273,14 +286,15 @@ fn referral_wrong_caller_fails() {
             }),
             Coins::new(),
         )
+        .await
         .should_fail_with_error(
             "caller is not the account factory, chain owner, or an account owned by the referee",
         );
 }
 
 /// The fee share ratio can only increase, never decrease.
-#[test]
-fn modify_share_ratio() {
+#[tokio::test]
+async fn modify_share_ratio() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // Set initial share ratio to 20%.
@@ -290,6 +304,7 @@ fn modify_share_ratio() {
         &mut accounts.user1,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     // Verify the stored ratio.
@@ -307,6 +322,7 @@ fn modify_share_ratio() {
         &mut accounts.user1,
         Dimensionless::new_percent(10),
     )
+    .await
     .should_fail_with_error("fee share ratio can only increase");
 
     // Increase the share ratio — should succeed.
@@ -316,6 +332,7 @@ fn modify_share_ratio() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     assert_eq!(
@@ -327,8 +344,8 @@ fn modify_share_ratio() {
 }
 
 /// Fee share ratio cannot exceed the maximum (50%).
-#[test]
-fn share_ratio_exceeds_max_fails() {
+#[tokio::test]
+async fn share_ratio_exceeds_max_fails() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // 51% should fail.
@@ -338,6 +355,7 @@ fn share_ratio_exceeds_max_fails() {
         &mut accounts.user1,
         Dimensionless::new_percent(51),
     )
+    .await
     .should_fail_with_error("fee share ratio cannot exceed");
 
     // 50% should succeed.
@@ -347,6 +365,7 @@ fn share_ratio_exceeds_max_fails() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 }
 
@@ -355,8 +374,8 @@ fn share_ratio_exceeds_max_fails() {
 /// Without this guard a malicious referrer could set e.g. -50%, causing
 /// `credit_commission(referee, negative)` on every trade — silently draining
 /// the referee's margin while inflating the referrer's commission.
-#[test]
-fn negative_share_ratio_fails() {
+#[tokio::test]
+async fn negative_share_ratio_fails() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // -1% should fail.
@@ -366,12 +385,13 @@ fn negative_share_ratio_fails() {
         &mut accounts.user1,
         Dimensionless::new_percent(-1),
     )
+    .await
     .should_fail_with_error("fee share ratio cannot be negative");
 }
 
 /// Zero is a valid share ratio (referrer takes no commission from the referee).
-#[test]
-fn zero_share_ratio_accepted() {
+#[tokio::test]
+async fn zero_share_ratio_accepted() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     set_fee_share_ratio(
@@ -380,13 +400,14 @@ fn zero_share_ratio_accepted() {
         &mut accounts.user1,
         Dimensionless::ZERO,
     )
+    .await
     .should_succeed();
 }
 
 /// Setting the fee share ratio requires sufficient perps trading volume
 /// when `volume_to_be_referrer` is non-zero.
-#[test]
-fn set_share_ratio_requires_volume() {
+#[tokio::test]
+async fn set_share_ratio_requires_volume() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // Configure the perps contract to require $10,000 volume to become a
@@ -407,6 +428,7 @@ fn set_share_ratio_requires_volume() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User2 has zero volume — should fail.
@@ -416,14 +438,15 @@ fn set_share_ratio_requires_volume() {
         &mut accounts.user2,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_fail_with_error("insufficient perps volume to become a referrer");
 }
 
 /// Volume for referrer eligibility is aggregated across all accounts of a user.
 /// User1 has two accounts that each trade below the threshold individually,
 /// but together meet the $10,000 minimum.
-#[test]
-fn set_share_ratio_aggregates_volume_across_accounts() {
+#[tokio::test]
+async fn set_share_ratio_aggregates_volume_across_accounts() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // Configure the perps contract to require $10,000 volume to become a referrer.
@@ -443,10 +466,11 @@ fn set_share_ratio_aggregates_volume_across_accounts() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Register oracle prices: ETH = $1,000.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_000).await;
 
     // Create a second account for user1 (same user_index, different address).
     let mut user1_account2 = accounts
@@ -456,12 +480,13 @@ fn set_share_ratio_aggregates_volume_across_accounts() {
             contracts.account_factory,
             Coins::one(usdc::DENOM.clone(), 50_000_000_000).unwrap(),
         )
+        .await
         .unwrap();
 
     // Deposit margin: user1 accounts and user2 (counterparty).
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 10_000);
-    deposit_margin(&mut suite, contracts.perps, &mut user1_account2, 10_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 50_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 10_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut user1_account2, 10_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 50_000).await;
 
     // Trade 1: user2 sells 7 ETH at $1,000, user1 account1 buys → $7,000 notional.
     place_ask_order(
@@ -470,8 +495,9 @@ fn set_share_ratio_aggregates_volume_across_accounts() {
         &mut accounts.user2,
         UsdPrice::new_int(1_000),
         7,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user1, 7);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user1, 7).await;
 
     // With only $7,000 volume, user1 cannot become a referrer.
     set_fee_share_ratio(
@@ -480,6 +506,7 @@ fn set_share_ratio_aggregates_volume_across_accounts() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_fail_with_error("insufficient perps volume to become a referrer");
 
     // Trade 2: user2 sells 3 ETH at $1,000, user1 account2 buys → $3,000 notional.
@@ -489,8 +516,9 @@ fn set_share_ratio_aggregates_volume_across_accounts() {
         &mut accounts.user2,
         UsdPrice::new_int(1_000),
         3,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut user1_account2, 3);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut user1_account2, 3).await;
 
     // Now the combined volume across both accounts is $10,000 — should succeed.
     set_fee_share_ratio(
@@ -499,18 +527,19 @@ fn set_share_ratio_aggregates_volume_across_accounts() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 }
 
 /// When `referral.active` is false, no fee commissions are applied.
-#[test]
-fn referral_active_flag() {
+#[tokio::test]
+async fn referral_active_flag() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000).await;
 
     // User1 becomes a referrer, User2 is the referee.
     set_fee_share_ratio(
@@ -519,6 +548,7 @@ fn referral_active_flag() {
         &mut accounts.user1,
         Dimensionless::new_percent(50),
     )
+    .await
     .should_succeed();
 
     suite
@@ -531,6 +561,7 @@ fn referral_active_flag() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Set commission rate override so we know the exact commission amount.
@@ -544,6 +575,7 @@ fn referral_active_flag() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Disable referral system.
@@ -563,6 +595,7 @@ fn referral_active_flag() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Record initial margins.
@@ -581,8 +614,9 @@ fn referral_active_flag() {
         &mut accounts.user8,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user2, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user2, 1).await;
 
     // User1 (referrer) should NOT have received any commission.
     let user1_margin_after = suite
@@ -608,6 +642,7 @@ fn referral_active_flag() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Trade again.
@@ -617,8 +652,9 @@ fn referral_active_flag() {
         &mut accounts.user8,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user2, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user2, 1).await;
 
     // User1 (referrer) should now have received a commission.
     let user1_margin_final: UsdValue = suite
@@ -634,8 +670,8 @@ fn referral_active_flag() {
 
 /// Commission rate override: only owner can set, overrides volume tiers,
 /// removing the override falls back to volume-based calculation.
-#[test]
-fn commission_rate_override() {
+#[tokio::test]
+async fn commission_rate_override() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // Configure commission rate tiers.
@@ -660,11 +696,12 @@ fn commission_rate_override() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
 
     // User1 becomes a referrer.
     set_fee_share_ratio(
@@ -673,6 +710,7 @@ fn commission_rate_override() {
         &mut accounts.user1,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     // User2 sets User1 as referrer.
@@ -686,6 +724,7 @@ fn commission_rate_override() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Default commission rate is 10%.
@@ -703,6 +742,7 @@ fn commission_rate_override() {
             }),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("you don't have the right");
 
     // Owner sets override to 50%.
@@ -716,13 +756,14 @@ fn commission_rate_override() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let settings = query_referral_settings(&suite, contracts.perps, 1).unwrap();
     assert_eq!(settings.commission_rate, CommissionRate::new_percent(50));
 
     // Trade to generate volume past the 100 USD tier.
-    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1);
+    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1).await;
 
     // Override still applies (ignores volume tier).
     let settings = query_referral_settings(&suite, contracts.perps, 1).unwrap();
@@ -739,6 +780,7 @@ fn commission_rate_override() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Falls back to volume-based tier (>= 100 → 20%).
@@ -747,14 +789,14 @@ fn commission_rate_override() {
 }
 
 /// Query per-referee statistics sorted by volume.
-#[test]
-fn referrer_stats() {
+#[tokio::test]
+async fn referrer_stats() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
 
     // User1 becomes a referrer.
     set_fee_share_ratio(
@@ -763,6 +805,7 @@ fn referrer_stats() {
         &mut accounts.user1,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     // User2 and User3 set User1 as referrer.
@@ -776,6 +819,7 @@ fn referrer_stats() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -788,10 +832,11 @@ fn referrer_stats() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User2 trades (volume = 1 * 2000 = $2,000).
-    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1);
+    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1).await;
 
     // User3 trades more (volume = 2 * 2000 = $4,000).
     // Need user3 as taker — swap user1 as maker, user3 as taker.
@@ -801,8 +846,9 @@ fn referrer_stats() {
         &mut accounts.user1,
         UsdPrice::new_int(2_000),
         2,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user3, 2);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user3, 2).await;
 
     // Query stats sorted by volume descending.
     let stats: Vec<(Referee, perps::RefereeStats)> = suite
@@ -889,29 +935,29 @@ fn referrer_stats() {
 ///   - user3 (4th referrer): 10% < max(20%) → $0
 ///   - user2 (5th referrer): vault_fee × (60% - 20%) = $0.80 (marginal)
 ///   - user1 (6th referrer): outside chain depth → $0
-#[test]
-fn commission_rate_margins() {
+#[tokio::test]
+async fn commission_rate_margins() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     let params = suite
         .query_wasm_smart(contracts.perps, QueryParamRequest {})
         .unwrap();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // Deposit margin for user8 (maker) and all referee/referrer users.
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user5, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user6, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user7, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user5, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user6, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user7, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000).await;
 
     // All users become referrers with 20% share ratio.
     for user in [
-        &mut accounts.user1 as &mut dyn Signer,
+        &mut accounts.user1 as &mut (dyn Signer + Send + Sync),
         &mut accounts.user2,
         &mut accounts.user3,
         &mut accounts.user4,
@@ -924,12 +970,13 @@ fn commission_rate_margins() {
             user,
             Dimensionless::new_percent(20),
         )
+        .await
         .should_succeed();
     }
 
     // Build referral chain: user1 ← user2 ← user3 ← user4 ← user5 ← user6 ← user7.
     for (referrer, referee) in [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)] {
-        let sender: &mut dyn Signer = match referee {
+        let sender: &mut (dyn Signer + Send + Sync) = match referee {
             2 => &mut accounts.user2,
             3 => &mut accounts.user3,
             4 => &mut accounts.user4,
@@ -945,6 +992,7 @@ fn commission_rate_margins() {
                 &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetReferral { referrer, referee }),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -960,6 +1008,7 @@ fn commission_rate_margins() {
                 }),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -994,8 +1043,8 @@ fn commission_rate_margins() {
     let price = UsdPrice::new_int(2_000);
     let size = 1;
     let trade_value = price.checked_mul(Quantity::new_int(size)).unwrap();
-    place_ask_order(&mut suite, contracts.perps, &mut accounts.user8, price, 1);
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user7, 1);
+    place_ask_order(&mut suite, contracts.perps, &mut accounts.user8, price, 1).await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user7, 1).await;
 
     // Read post-trade margins.
     let post_margins: Vec<UsdValue> = [
@@ -1172,8 +1221,8 @@ fn commission_rate_margins() {
 }
 
 /// Referee count increments when referral relationships are set.
-#[test]
-fn referee_count() {
+#[tokio::test]
+async fn referee_count() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // User1 becomes a referrer.
@@ -1183,6 +1232,7 @@ fn referee_count() {
         &mut accounts.user1,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     // Initially, referee_count is 0.
@@ -1200,6 +1250,7 @@ fn referee_count() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let data = query_referral_data(&suite, contracts.perps, 1, None);
@@ -1216,6 +1267,7 @@ fn referee_count() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let data = query_referral_data(&suite, contracts.perps, 1, None);
@@ -1228,6 +1280,7 @@ fn referee_count() {
         &mut accounts.user2,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     suite
@@ -1240,6 +1293,7 @@ fn referee_count() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let data_user1 = query_referral_data(&suite, contracts.perps, 1, None);
@@ -1250,14 +1304,14 @@ fn referee_count() {
 }
 
 /// Active users count increments once per referee per day.
-#[test]
-fn active_referral() {
+#[tokio::test]
+async fn active_referral() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
 
     // User1 becomes a referrer.
     set_fee_share_ratio(
@@ -1266,6 +1320,7 @@ fn active_referral() {
         &mut accounts.user1,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     // User2 and User3 set User1 as referrer.
@@ -1279,6 +1334,7 @@ fn active_referral() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1291,17 +1347,18 @@ fn active_referral() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User2 trades — cumulative_daily_active_referees should be 1, cumulative_global_active_referees should be 1.
-    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1);
+    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1).await;
 
     let data = query_referral_data(&suite, contracts.perps, 1, None);
     assert_eq!(data.cumulative_daily_active_referees, 1);
     assert_eq!(data.cumulative_global_active_referees, 1);
 
     // User2 trades again same day — both counters unchanged.
-    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1);
+    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1).await;
 
     let data = query_referral_data(&suite, contracts.perps, 1, None);
     assert_eq!(data.cumulative_daily_active_referees, 1);
@@ -1314,8 +1371,9 @@ fn active_referral() {
         &mut accounts.user1,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user3, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user3, 1).await;
 
     let data = query_referral_data(&suite, contracts.perps, 1, None);
     assert_eq!(data.cumulative_daily_active_referees, 2);
@@ -1324,9 +1382,9 @@ fn active_referral() {
     // Next day, User2 trades — cumulative_daily_active_referees should be 3 (cumulative),
     // but cumulative_global_active_referees stays at 2 (User2 already traded before).
     suite.block_time = grug::Duration::from_days(1);
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
-    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1);
+    create_perps_fill(&mut suite, &mut accounts, contracts.perps, 2_000, 1).await;
 
     let data = query_referral_data(&suite, contracts.perps, 1, None);
     assert_eq!(data.cumulative_daily_active_referees, 3);
@@ -1337,11 +1395,11 @@ fn active_referral() {
 /// debited, and the taker's referrer must earn commission computed from
 /// the **net** vault fee — not from the taker's gross fee (which would
 /// overpay commissions beyond what the protocol actually collected).
-#[test]
-fn negative_maker_fee_does_not_debit_referrers() {
+#[tokio::test]
+async fn negative_maker_fee_does_not_debit_referrers() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1374,13 +1432,14 @@ fn negative_maker_fee_does_not_debit_referrers() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Deposit for users 1-4.
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
 
     // user1 is the taker's referrer; user2 is the maker's referrer. Both
     // become referrers by setting a 20% fee share ratio.
@@ -1390,6 +1449,7 @@ fn negative_maker_fee_does_not_debit_referrers() {
         &mut accounts.user1,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
     set_fee_share_ratio(
         &mut suite,
@@ -1397,13 +1457,14 @@ fn negative_maker_fee_does_not_debit_referrers() {
         &mut accounts.user2,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     // Wire the referral relationships:
     //   user4 (taker) ← user1 (referrer)
     //   user3 (maker) ← user2 (referrer)
     for (sender, referrer, referee) in [(4u32, 1u32, 4u32), (3, 2, 3)] {
-        let signer: &mut dyn Signer = match sender {
+        let signer: &mut (dyn Signer + Send + Sync) = match sender {
             3 => &mut accounts.user3,
             4 => &mut accounts.user4,
             _ => unreachable!(),
@@ -1415,6 +1476,7 @@ fn negative_maker_fee_does_not_debit_referrers() {
                 &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetReferral { referrer, referee }),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1454,8 +1516,9 @@ fn negative_maker_fee_does_not_debit_referrers() {
         &mut accounts.user3,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1).await;
 
     // Snapshot margins after.
     let margin_after: Vec<UsdValue> = user_addrs
@@ -1520,8 +1583,8 @@ fn negative_maker_fee_does_not_debit_referrers() {
 
 /// A payer without a referrer still gets a `FeeDistributed` event with
 /// correct protocol_fee, vault_fee, and empty commissions.
-#[test]
-fn fee_distributed_event_without_referrer() {
+#[tokio::test]
+async fn fee_distributed_event_without_referrer() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // Set protocol fee to 50%.
@@ -1541,11 +1604,12 @@ fn fee_distributed_event_without_referrer() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
 
     // Trade without any referral relationship.
     place_ask_order(
@@ -1554,8 +1618,10 @@ fn fee_distributed_event_without_referrer() {
         &mut accounts.user1,
         UsdPrice::new_int(2_000),
         1,
-    );
-    let events = place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1);
+    )
+    .await;
+    let events =
+        place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1).await;
 
     let fee_events: Vec<FeeDistributed> = events
         .search_event::<CheckedContractEvent>()
@@ -1599,8 +1665,8 @@ fn fee_distributed_event_without_referrer() {
 
 /// A payer with a referrer gets a `FeeDistributed` event with correct
 /// protocol_fee, vault_fee (reduced by commissions), and commissions.
-#[test]
-fn fee_distributed_event_with_referrer() {
+#[tokio::test]
+async fn fee_distributed_event_with_referrer() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // Set protocol fee to 50%.
@@ -1620,12 +1686,13 @@ fn fee_distributed_event_with_referrer() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000).await;
 
     // User1 becomes a referrer with 20% share ratio.
     set_fee_share_ratio(
@@ -1634,6 +1701,7 @@ fn fee_distributed_event_with_referrer() {
         &mut accounts.user1,
         Dimensionless::new_percent(20),
     )
+    .await
     .should_succeed();
 
     // User2 sets User1 as referrer.
@@ -1647,6 +1715,7 @@ fn fee_distributed_event_with_referrer() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Set a known commission rate override for deterministic math.
@@ -1660,6 +1729,7 @@ fn fee_distributed_event_with_referrer() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User8 places ask (maker), User2 (referee) buys (taker).
@@ -1670,8 +1740,10 @@ fn fee_distributed_event_with_referrer() {
         &mut accounts.user8,
         UsdPrice::new_int(2_000),
         1,
-    );
-    let events = place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1);
+    )
+    .await;
+    let events =
+        place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1).await;
 
     let fee_events: Vec<FeeDistributed> = events
         .search_event::<CheckedContractEvent>()
@@ -1722,8 +1794,8 @@ fn fee_distributed_event_with_referrer() {
 /// opted in (no `FEE_SHARE_RATIO` entry), the referee's trades must still
 /// settle. The referrer's share ratio defaults to zero, so the full
 /// commission flows to the referrer and the referee receives no rebate.
-#[test]
-fn fee_distributed_event_with_referrer_without_share_ratio() {
+#[tokio::test]
+async fn fee_distributed_event_with_referrer_without_share_ratio() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     // Set protocol fee to 50%.
@@ -1743,12 +1815,13 @@ fn fee_distributed_event_with_referrer_without_share_ratio() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000).await;
 
     // Note: deliberately do NOT call `set_fee_share_ratio` for user1 — the
     // chain owner is wiring up the relationship via the bypass below.
@@ -1764,6 +1837,7 @@ fn fee_distributed_event_with_referrer_without_share_ratio() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Set a known commission rate override for deterministic math.
@@ -1777,6 +1851,7 @@ fn fee_distributed_event_with_referrer_without_share_ratio() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // User8 places ask (maker), User2 (referee) buys (taker).
@@ -1787,8 +1862,10 @@ fn fee_distributed_event_with_referrer_without_share_ratio() {
         &mut accounts.user8,
         UsdPrice::new_int(2_000),
         1,
-    );
-    let events = place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1);
+    )
+    .await;
+    let events =
+        place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user2, 1).await;
 
     let fee_events: Vec<FeeDistributed> = events
         .search_event::<CheckedContractEvent>()
@@ -1848,18 +1925,18 @@ fn fee_distributed_event_with_referrer_without_share_ratio() {
 ///   referrer_commission = vault_fee × 100% × 1  = vault_fee
 ///
 /// All of vault_fee flows to A; the vault's net cut is zero.
-#[test]
-fn cr_100_direct_referrer_taker() {
+#[tokio::test]
+async fn cr_100_direct_referrer_taker() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     let params = suite
         .query_wasm_smart(contracts.perps, QueryParamRequest {})
         .unwrap();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
 
     // A opts in as a referrer with share_ratio = 0.
     set_fee_share_ratio(
@@ -1868,6 +1945,7 @@ fn cr_100_direct_referrer_taker() {
         &mut accounts.user1,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
 
     // Trader (user3) is referee of A (user1).
@@ -1881,9 +1959,11 @@ fn cr_100_direct_referrer_taker() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 1, 100)
+        .await
         .should_succeed();
 
     let user_addrs = [accounts.user1.address(), accounts.user3.address()];
@@ -1896,8 +1976,9 @@ fn cr_100_direct_referrer_taker() {
         &mut accounts.user4,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user3, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user3, 1).await;
 
     let margin_after = snapshot_margins(&suite, contracts.perps, &user_addrs);
 
@@ -1932,19 +2013,19 @@ fn cr_100_direct_referrer_taker() {
 ///
 /// Also asserts the `FeeDistributed` event reflects this (vault_fee in the
 /// event drops to zero post-commission, commissions = [0, 0.90, 1.10]).
-#[test]
-fn cr_100_indirect_referrer_taker() {
+#[tokio::test]
+async fn cr_100_indirect_referrer_taker() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     let params = suite
         .query_wasm_smart(contracts.perps, QueryParamRequest {})
         .unwrap();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
 
     // A and B both opt in as referrers with share_ratio = 0.
     set_fee_share_ratio(
@@ -1953,6 +2034,7 @@ fn cr_100_indirect_referrer_taker() {
         &mut accounts.user1,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
     set_fee_share_ratio(
         &mut suite,
@@ -1960,6 +2042,7 @@ fn cr_100_indirect_referrer_taker() {
         &mut accounts.user2,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
 
     // Wire chain: user1 (A) ← user2 (B) ← user3 (trader).
@@ -1973,6 +2056,7 @@ fn cr_100_indirect_referrer_taker() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -1984,11 +2068,14 @@ fn cr_100_indirect_referrer_taker() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 1, 100)
+        .await
         .should_succeed();
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 2, 45)
+        .await
         .should_succeed();
 
     let user_addrs = [
@@ -2005,8 +2092,10 @@ fn cr_100_indirect_referrer_taker() {
         &mut accounts.user4,
         UsdPrice::new_int(2_000),
         1,
-    );
-    let events = place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user3, 1);
+    )
+    .await;
+    let events =
+        place_market_buy_with_events(&mut suite, contracts.perps, &mut accounts.user3, 1).await;
 
     let margin_after = snapshot_margins(&suite, contracts.perps, &user_addrs);
 
@@ -2079,8 +2168,8 @@ fn cr_100_indirect_referrer_taker() {
 /// With taker = maker = 5 bps and protocol = 0, total_positive splits the
 /// vault_fee 50/50, so the maker's vault_fee portion = trade_value × 5 bps
 /// = $1.00. A receives that full $1.00 (cr=100%, sr=0).
-#[test]
-fn cr_100_direct_referrer_maker_positive_fee() {
+#[tokio::test]
+async fn cr_100_direct_referrer_maker_positive_fee() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     let pair = pair_id();
@@ -2110,12 +2199,13 @@ fn cr_100_direct_referrer_maker_positive_fee() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
 
     set_fee_share_ratio(
         &mut suite,
@@ -2123,6 +2213,7 @@ fn cr_100_direct_referrer_maker_positive_fee() {
         &mut accounts.user1,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
     suite
         .execute(
@@ -2134,8 +2225,10 @@ fn cr_100_direct_referrer_maker_positive_fee() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 1, 100)
+        .await
         .should_succeed();
 
     let user_addrs = [accounts.user1.address(), accounts.user3.address()];
@@ -2148,8 +2241,9 @@ fn cr_100_direct_referrer_maker_positive_fee() {
         &mut accounts.user3,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1).await;
 
     let margin_after = snapshot_margins(&suite, contracts.perps, &user_addrs);
 
@@ -2185,8 +2279,8 @@ fn cr_100_direct_referrer_maker_positive_fee() {
 /// Maker's vault_fee portion = $1.00 (as in the direct case). Of that:
 ///   level 1 (B): $1.00 × 45% = $0.45
 ///   level 2 (A): $1.00 × 55% = $0.55
-#[test]
-fn cr_100_indirect_referrer_maker_positive_fee() {
+#[tokio::test]
+async fn cr_100_indirect_referrer_maker_positive_fee() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     let pair = pair_id();
@@ -2215,13 +2309,14 @@ fn cr_100_indirect_referrer_maker_positive_fee() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
 
     set_fee_share_ratio(
         &mut suite,
@@ -2229,6 +2324,7 @@ fn cr_100_indirect_referrer_maker_positive_fee() {
         &mut accounts.user1,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
     set_fee_share_ratio(
         &mut suite,
@@ -2236,6 +2332,7 @@ fn cr_100_indirect_referrer_maker_positive_fee() {
         &mut accounts.user2,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
     suite
         .execute(
@@ -2247,6 +2344,7 @@ fn cr_100_indirect_referrer_maker_positive_fee() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -2258,10 +2356,13 @@ fn cr_100_indirect_referrer_maker_positive_fee() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 1, 100)
+        .await
         .should_succeed();
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 2, 45)
+        .await
         .should_succeed();
 
     let user_addrs = [
@@ -2277,8 +2378,9 @@ fn cr_100_indirect_referrer_maker_positive_fee() {
         &mut accounts.user3,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1).await;
 
     let margin_after = snapshot_margins(&suite, contracts.perps, &user_addrs);
 
@@ -2315,8 +2417,8 @@ fn cr_100_indirect_referrer_maker_positive_fee() {
 /// fill where the maker fee is *negative* (rebate). The trader's vault_fee
 /// portion clamps to zero (per the proportional split in submit_order.rs),
 /// so A's commission must be zero — and crucially A must NOT be debited.
-#[test]
-fn cr_100_direct_referrer_maker_rebate() {
+#[tokio::test]
+async fn cr_100_direct_referrer_maker_rebate() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     let pair = pair_id();
@@ -2346,12 +2448,13 @@ fn cr_100_direct_referrer_maker_rebate() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
 
     set_fee_share_ratio(
         &mut suite,
@@ -2359,6 +2462,7 @@ fn cr_100_direct_referrer_maker_rebate() {
         &mut accounts.user1,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
     suite
         .execute(
@@ -2370,8 +2474,10 @@ fn cr_100_direct_referrer_maker_rebate() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 1, 100)
+        .await
         .should_succeed();
 
     let user_addrs = [accounts.user1.address(), accounts.user3.address()];
@@ -2384,8 +2490,9 @@ fn cr_100_direct_referrer_maker_rebate() {
         &mut accounts.user3,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1).await;
 
     let margin_after = snapshot_margins(&suite, contracts.perps, &user_addrs);
 
@@ -2409,8 +2516,8 @@ fn cr_100_direct_referrer_maker_rebate() {
 
 /// Indirect chain A → B → trader. A.cr = 100%, B.cr = 45%, both sr = 0.
 /// Trader is the maker on a rebate fill. Both A and B must NOT be debited.
-#[test]
-fn cr_100_indirect_referrer_maker_rebate() {
+#[tokio::test]
+async fn cr_100_indirect_referrer_maker_rebate() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
     let pair = pair_id();
@@ -2439,13 +2546,14 @@ fn cr_100_indirect_referrer_maker_rebate() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000);
-    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
+    deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
 
     set_fee_share_ratio(
         &mut suite,
@@ -2453,6 +2561,7 @@ fn cr_100_indirect_referrer_maker_rebate() {
         &mut accounts.user1,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
     set_fee_share_ratio(
         &mut suite,
@@ -2460,6 +2569,7 @@ fn cr_100_indirect_referrer_maker_rebate() {
         &mut accounts.user2,
         Dimensionless::new_percent(0),
     )
+    .await
     .should_succeed();
     suite
         .execute(
@@ -2471,6 +2581,7 @@ fn cr_100_indirect_referrer_maker_rebate() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     suite
         .execute(
@@ -2482,10 +2593,13 @@ fn cr_100_indirect_referrer_maker_rebate() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 1, 100)
+        .await
         .should_succeed();
     set_commission_rate_override(&mut suite, contracts.perps, &mut accounts.owner, 2, 45)
+        .await
         .should_succeed();
 
     let user_addrs = [
@@ -2501,8 +2615,9 @@ fn cr_100_indirect_referrer_maker_rebate() {
         &mut accounts.user3,
         UsdPrice::new_int(2_000),
         1,
-    );
-    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1);
+    )
+    .await;
+    place_market_buy(&mut suite, contracts.perps, &mut accounts.user4, 1).await;
 
     let margin_after = snapshot_margins(&suite, contracts.perps, &user_addrs);
 
@@ -2529,36 +2644,42 @@ fn cr_100_indirect_referrer_maker_rebate() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn set_fee_share_ratio(
+async fn set_fee_share_ratio(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     perps: Addr,
-    user: &mut dyn Signer,
+    user: &mut (dyn Signer + Send + Sync),
     ratio: FeeShareRatio,
 ) -> TxOutcome {
-    suite.execute(
-        user,
-        perps,
-        &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetFeeShareRatio { share_ratio: ratio }),
-        Coins::new(),
-    )
+    suite
+        .execute(
+            user,
+            perps,
+            &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetFeeShareRatio {
+                share_ratio: ratio,
+            }),
+            Coins::new(),
+        )
+        .await
 }
 
-fn set_commission_rate_override(
+async fn set_commission_rate_override(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     perps: Addr,
-    owner: &mut dyn Signer,
+    owner: &mut (dyn Signer + Send + Sync),
     user: u32,
     rate_percent: i128,
 ) -> TxOutcome {
-    suite.execute(
-        owner,
-        perps,
-        &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetCommissionRateOverride {
-            user,
-            commission_rate: Op::Insert(CommissionRate::new_percent(rate_percent)),
-        }),
-        Coins::new(),
-    )
+    suite
+        .execute(
+            owner,
+            perps,
+            &perps::ExecuteMsg::Referral(perps::ReferralMsg::SetCommissionRateOverride {
+                user,
+                commission_rate: Op::Insert(CommissionRate::new_percent(rate_percent)),
+            }),
+            Coins::new(),
+        )
+        .await
 }
 
 fn snapshot_margins(
@@ -2578,7 +2699,7 @@ fn snapshot_margins(
         .collect()
 }
 
-fn register_oracle_prices(
+async fn register_oracle_prices(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     accounts: &mut dango_testing::TestAccounts,
     contracts: &dango_genesis::Contracts,
@@ -2602,13 +2723,14 @@ fn register_oracle_prices(
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
-fn deposit_margin(
+async fn deposit_margin(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     perps: Addr,
-    user: &mut dyn Signer,
+    user: &mut (dyn Signer + Send + Sync),
     usd_amount: u128,
 ) {
     let amount = Uint128::new(usd_amount * 1_000_000);
@@ -2619,13 +2741,14 @@ fn deposit_margin(
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), amount).unwrap(),
         )
+        .await
         .should_succeed();
 }
 
-fn place_ask_order(
+async fn place_ask_order(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     perps: Addr,
-    user: &mut dyn Signer,
+    user: &mut (dyn Signer + Send + Sync),
     price: UsdPrice,
     size: u128,
 ) {
@@ -2647,13 +2770,14 @@ fn place_ask_order(
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
-fn place_market_buy(
+async fn place_market_buy(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     perps: Addr,
-    user: &mut dyn Signer,
+    user: &mut (dyn Signer + Send + Sync),
     size: u128,
 ) {
     suite
@@ -2672,11 +2796,12 @@ fn place_market_buy(
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
 /// Place a limit ask (user1) then a market buy (user2) to produce a fill.
-fn create_perps_fill(
+async fn create_perps_fill(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     accounts: &mut dango_testing::TestAccounts,
     perps: Addr,
@@ -2689,14 +2814,15 @@ fn create_perps_fill(
         &mut accounts.user1,
         UsdPrice::new_int(price as i128),
         size,
-    );
-    place_market_buy(suite, perps, &mut accounts.user2, size);
+    )
+    .await;
+    place_market_buy(suite, perps, &mut accounts.user2, size).await;
 }
 
-fn place_market_buy_with_events(
+async fn place_market_buy_with_events(
     suite: &mut dango_testing::TestSuite<NaiveProposalPreparer>,
     perps: Addr,
-    user: &mut dyn Signer,
+    user: &mut (dyn Signer + Send + Sync),
     size: u128,
 ) -> grug::TxEvents {
     suite
@@ -2715,6 +2841,7 @@ fn place_market_buy_with_events(
             })),
             Coins::new(),
         )
+        .await
         .should_succeed()
         .events
 }

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -1169,7 +1169,8 @@ macro_rules! setup_slippage_cap_suite {
                     },
                 }),
                 Coins::new(),
-            ).await
+            )
+            .await
             .should_succeed();
 
         suite
@@ -1178,7 +1179,8 @@ macro_rules! setup_slippage_cap_suite {
                 contracts.perps,
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
-            ).await
+            )
+            .await
             .should_succeed();
 
         (suite, accounts, contracts, pair)

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -25,12 +25,12 @@ use {
 /// | 3    | Trader market buys 10 ETH           | fee = 10 × $2,000 × 0.1% = $20                                | position: 10 ETH long @ $2,000; margin = $9,980; ask removed |
 /// | 4    | Trader withdraws $7,000             | equity=$9,980, used_IM=10×$2,000×10%=$2,000, available=$7,980 | succeeds; margin = $2,980                                    |
 /// | 5    | Trader withdraws $2,000             | available = $2,980 - $2,000 = $980                            | fails: "exceeds available margin"                            |
-#[test]
-fn trading_lifecycle() {
+#[tokio::test]
+async fn trading_lifecycle() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -46,6 +46,7 @@ fn trading_lifecycle() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Verify trader's margin = $10,000.
@@ -69,6 +70,7 @@ fn trading_lifecycle() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -89,6 +91,7 @@ fn trading_lifecycle() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify ask exists on the book.
@@ -121,6 +124,7 @@ fn trading_lifecycle() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify position and margin.
@@ -169,6 +173,7 @@ fn trading_lifecycle() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify margin = $9,980 - $7,000 = $2,980.
@@ -195,6 +200,7 @@ fn trading_lifecycle() {
             }),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("exceeds available margin");
 }
 
@@ -206,12 +212,12 @@ fn trading_lifecycle() {
 /// | 2    | Maker A places ask: 5 ETH @ $2,000  | —                                  | —                                                                                                                                                      |
 /// | 3    | Trader limit buys 10 ETH @ $2,000   | 5 filled vs maker, 5 rests as bid  | position: 5 ETH long @ $2,000; fee = $10; margin = $9,990; reserved_margin = 5x$2,000x10% = $1,000 (for resting 5); open_order_count = 1; bid on book  |
 /// | 4    | Trader cancels the resting order    | —                                  | reserved_margin = $0; open_order_count = 0; bid removed from book; position unchanged (still 5 ETH)                                                    |
-#[test]
-fn limit_order_partial_fill_and_cancel() {
+#[tokio::test]
+async fn limit_order_partial_fill_and_cancel() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -226,6 +232,7 @@ fn limit_order_partial_fill_and_cancel() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -239,6 +246,7 @@ fn limit_order_partial_fill_and_cancel() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -259,6 +267,7 @@ fn limit_order_partial_fill_and_cancel() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -285,6 +294,7 @@ fn limit_order_partial_fill_and_cancel() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify position: 5 ETH long @ $2,000, margin = $9,990.
@@ -341,6 +351,7 @@ fn limit_order_partial_fill_and_cancel() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify reserved_margin = $0 and open_order_count = 0.
@@ -380,11 +391,11 @@ fn limit_order_partial_fill_and_cancel() {
 /// Verify that liquidity depth bookkeeping tracks resting orders correctly
 /// across four code paths: order placement, self-trade prevention (EXPIRE_MAKER),
 /// fill, and cancel-all.
-#[test]
-fn liquidity_depth_tracking() {
+#[tokio::test]
+async fn liquidity_depth_tracking() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -404,6 +415,7 @@ fn liquidity_depth_tracking() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Deposit margin for both users.
@@ -414,6 +426,7 @@ fn liquidity_depth_tracking() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -423,6 +436,7 @@ fn liquidity_depth_tracking() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     let query_depth = |suite: &dango_testing::TestSuite<_>| -> LiquidityDepthResponse {
@@ -466,6 +480,7 @@ fn liquidity_depth_tracking() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let depth = query_depth(&suite);
@@ -505,6 +520,7 @@ fn liquidity_depth_tracking() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let depth = query_depth(&suite);
@@ -548,6 +564,7 @@ fn liquidity_depth_tracking() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let depth = query_depth(&suite);
@@ -580,6 +597,7 @@ fn liquidity_depth_tracking() {
             )),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let depth = query_depth(&suite);
@@ -610,11 +628,11 @@ fn liquidity_depth_tracking() {
 /// | 3    | Taker market buys 10 ETH               | fee=$20, protocol=$4 → State.treasury == $4             |
 /// | 4    | Maker places another ask 10 ETH @ $2k  | —                                                       |
 /// | 5    | Taker market buys 10 ETH               | another $4 → State.treasury == $8 (accumulated!)        |
-#[test]
-fn protocol_fee_accumulates_across_fills() {
+#[tokio::test]
+async fn protocol_fee_accumulates_across_fills() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -634,6 +652,7 @@ fn protocol_fee_accumulates_across_fills() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Deposit for maker (user2) and taker (user1).
@@ -644,6 +663,7 @@ fn protocol_fee_accumulates_across_fills() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -653,6 +673,7 @@ fn protocol_fee_accumulates_across_fills() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // --- Fill 1: Maker places ask 10 ETH @ $2,000, taker market buys ---
@@ -675,6 +696,7 @@ fn protocol_fee_accumulates_across_fills() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -693,6 +715,7 @@ fn protocol_fee_accumulates_across_fills() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // fee = 10 * $2,000 * 0.1% = $20
@@ -727,6 +750,7 @@ fn protocol_fee_accumulates_across_fills() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -745,6 +769,7 @@ fn protocol_fee_accumulates_across_fills() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // another $4 → total should be $8 (accumulated, not overwritten!)
@@ -768,11 +793,11 @@ fn protocol_fee_accumulates_across_fills() {
 /// | 3    | Maker places post_only ask: 50 ETH @ $2,000    | resting on book                                                    | ask exists                               |
 /// | 4    | Taker market buys 50 ETH                        | notional=$100k, taker fee=$30, maker fee=-$10                      | taker margin=$99,970; maker margin=$100,010 |
 /// | 5    | Check treasury                                  | proto: taker $6 + maker -$2 = $4                                   | treasury=$4                              |
-#[test]
-fn negative_maker_fee_rebate_lifecycle() {
+#[tokio::test]
+async fn negative_maker_fee_rebate_lifecycle() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -803,6 +828,7 @@ fn negative_maker_fee_rebate_lifecycle() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -816,6 +842,7 @@ fn negative_maker_fee_rebate_lifecycle() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -825,6 +852,7 @@ fn negative_maker_fee_rebate_lifecycle() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -849,6 +877,7 @@ fn negative_maker_fee_rebate_lifecycle() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -875,6 +904,7 @@ fn negative_maker_fee_rebate_lifecycle() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -936,11 +966,11 @@ fn negative_maker_fee_rebate_lifecycle() {
 /// | 2    | Maker (user2) places post-only ask: 5 ETH     | ask on book                                     |
 /// | 3    | Taker (user1) IOC limit buy 10 ETH @ $2,000   | 5 fill, 5 cancelled                             |
 /// | 4    | Verify taker state                            | position=5, open_order_count=0, reserved=$0     |
-#[test]
-fn ioc_limit_order_partial_fill() {
+#[tokio::test]
+async fn ioc_limit_order_partial_fill() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -955,6 +985,7 @@ fn ioc_limit_order_partial_fill() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -964,6 +995,7 @@ fn ioc_limit_order_partial_fill() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -988,6 +1020,7 @@ fn ioc_limit_order_partial_fill() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1014,6 +1047,7 @@ fn ioc_limit_order_partial_fill() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1064,11 +1098,11 @@ fn ioc_limit_order_partial_fill() {
 /// |------|-------------------------------------------------|--------------------------------|
 /// | 1    | Taker deposits $10,000 USDC                     | margin established             |
 /// | 2    | Taker IOC limit buy 10 ETH @ $1,900 (empty book)| error: no liquidity            |
-#[test]
-fn ioc_limit_order_no_fill_rejected() {
+#[tokio::test]
+async fn ioc_limit_order_no_fill_rejected() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1080,6 +1114,7 @@ fn ioc_limit_order_no_fill_rejected() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Step 2: IOC limit buy against empty book → should fail.
@@ -1101,6 +1136,7 @@ fn ioc_limit_order_no_fill_rejected() {
             })),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("no liquidity at acceptable price");
 }
 
@@ -1116,7 +1152,7 @@ macro_rules! setup_slippage_cap_suite {
     () => {{
         let (mut suite, mut accounts, _, contracts, _) =
             setup_test_naive(TestOption::default());
-        register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+        register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
         let pair = pair_id();
 
         suite
@@ -1133,7 +1169,7 @@ macro_rules! setup_slippage_cap_suite {
                     },
                 }),
                 Coins::new(),
-            )
+            ).await
             .should_succeed();
 
         suite
@@ -1142,7 +1178,7 @@ macro_rules! setup_slippage_cap_suite {
                 contracts.perps,
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
-            )
+            ).await
             .should_succeed();
 
         (suite, accounts, contracts, pair)
@@ -1152,8 +1188,8 @@ macro_rules! setup_slippage_cap_suite {
 /// Market order with slippage exactly at the pair cap is accepted at
 /// submission. (It fails later for lack of liquidity — that's fine; the
 /// point of the test is the submission-time check.)
-#[test]
-fn slippage_cap_market_at_cap_accepted_at_submission() {
+#[tokio::test]
+async fn slippage_cap_market_at_cap_accepted_at_submission() {
     let (mut suite, mut accounts, contracts, pair) = setup_slippage_cap_suite!();
 
     // max_slippage = 5% (exactly the cap). The order passes the cap
@@ -1174,14 +1210,15 @@ fn slippage_cap_market_at_cap_accepted_at_submission() {
             })),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("no liquidity at acceptable price");
 }
 
 /// Market order with slippage just above the pair cap is rejected at
 /// submission with the cap error (not "no liquidity"). This proves the
 /// cap check runs before matching.
-#[test]
-fn slippage_cap_market_above_cap_rejected() {
+#[tokio::test]
+async fn slippage_cap_market_above_cap_rejected() {
     let (mut suite, mut accounts, contracts, pair) = setup_slippage_cap_suite!();
 
     // max_slippage = 6% against 5% cap.
@@ -1201,13 +1238,14 @@ fn slippage_cap_market_above_cap_rejected() {
             })),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("exceeds the pair cap");
 }
 
 /// TP/SL child order slippage is capped by the same per-pair parameter
 /// as the top-level market order.
-#[test]
-fn slippage_cap_tpsl_child_order_above_cap_rejected() {
+#[tokio::test]
+async fn slippage_cap_tpsl_child_order_above_cap_rejected() {
     let (mut suite, mut accounts, contracts, pair) = setup_slippage_cap_suite!();
 
     // Parent market order with slippage within cap, but the TP child
@@ -1232,14 +1270,15 @@ fn slippage_cap_tpsl_child_order_above_cap_rejected() {
             })),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("exceeds the pair cap");
 }
 
 /// Limit orders do not carry `max_slippage` and are unaffected by the
 /// market-order slippage cap. Their `limit_price` is bounded instead by
 /// `max_limit_price_deviation` (PR1 banding).
-#[test]
-fn slippage_cap_does_not_affect_limit_orders() {
+#[tokio::test]
+async fn slippage_cap_does_not_affect_limit_orders() {
     let (mut suite, mut accounts, contracts, pair) = setup_slippage_cap_suite!();
 
     // Limit buy at oracle = $2,000. Always within the 10% band of
@@ -1263,6 +1302,7 @@ fn slippage_cap_does_not_affect_limit_orders() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 }
 
@@ -1270,11 +1310,11 @@ fn slippage_cap_does_not_affect_limit_orders() {
 /// events — two per match — and the two events of a given match share a
 /// `fill_id`. Successive matches use consecutive fill ids, and
 /// `NEXT_FILL_ID` in storage advances by one per match.
-#[test]
-fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
+#[tokio::test]
+async fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1287,6 +1327,7 @@ fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
                 &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
                 Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
             )
+            .await
             .should_succeed();
     }
     suite
@@ -1296,6 +1337,7 @@ fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Two resting asks at different prices. The taker's market buy will
@@ -1322,6 +1364,7 @@ fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
                 )),
                 Coins::new(),
             )
+            .await
             .should_succeed();
     }
 
@@ -1342,6 +1385,7 @@ fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed()
         .events;
 
@@ -1412,11 +1456,11 @@ fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
 /// This test places a maker bid for 5 ETH, then submits a market sell for 10.
 /// The 5 available should fill and the remaining 5 should be discarded.
 /// With the bug, the entire order is rejected.
-#[test]
-fn sell_side_market_order_partial_fill() {
+#[tokio::test]
+async fn sell_side_market_order_partial_fill() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1431,6 +1475,7 @@ fn sell_side_market_order_partial_fill() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1440,6 +1485,7 @@ fn sell_side_market_order_partial_fill() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1464,6 +1510,7 @@ fn sell_side_market_order_partial_fill() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1491,6 +1538,7 @@ fn sell_side_market_order_partial_fill() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify taker has a 10 ETH short position from the 5 that filled.
@@ -1531,11 +1579,11 @@ fn sell_side_market_order_partial_fill() {
 ///
 ///   Buy 10: fillable_size = 10, after 5 filled unfilled = 5.
 ///   5 < 10 → true → passes.
-#[test]
-fn buy_side_market_order_partial_fill() {
+#[tokio::test]
+async fn buy_side_market_order_partial_fill() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1550,6 +1598,7 @@ fn buy_side_market_order_partial_fill() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -1559,6 +1608,7 @@ fn buy_side_market_order_partial_fill() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1583,6 +1633,7 @@ fn buy_side_market_order_partial_fill() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -1607,6 +1658,7 @@ fn buy_side_market_order_partial_fill() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify taker has a 5 ETH long position from the partial fill.

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -35,12 +35,12 @@ use {
 /// | 9    | LP removes remaining shares                      | unlock reflects realized PnL                    |
 /// | 10   | Advance time past cooldown                       | unlocks credited to LP margin                   |
 /// | 11   | Verify total withdrawn ≈ $5k + vault profit      | —                                               |
-#[test]
-fn vault_lp_lifecycle() {
+#[tokio::test]
+async fn vault_lp_lifecycle() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     let pair = pair_id();
 
@@ -55,6 +55,7 @@ fn vault_lp_lifecycle() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -67,6 +68,7 @@ fn vault_lp_lifecycle() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let lp_state = suite
@@ -123,13 +125,14 @@ fn vault_lp_lifecycle() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
     // Step 3: Call OnOracleUpdate so the vault places bid+ask.
     // -------------------------------------------------------------------------
 
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     suite
         .execute(
@@ -138,6 +141,7 @@ fn vault_lp_lifecycle() {
             &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Vault should have orders on the book.
@@ -181,6 +185,7 @@ fn vault_lp_lifecycle() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -199,6 +204,7 @@ fn vault_lp_lifecycle() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Vault should now have a long position.
@@ -222,13 +228,13 @@ fn vault_lp_lifecycle() {
     // Step 5: Oracle → $2,200. Vault's long has unrealized profit.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_200);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_200).await;
 
     // -------------------------------------------------------------------------
     // Step 6: OnOracleUpdate at $2,200 → vault refreshes orders.
     // -------------------------------------------------------------------------
 
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     suite
         .execute(
@@ -237,6 +243,7 @@ fn vault_lp_lifecycle() {
             &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -260,6 +267,7 @@ fn vault_lp_lifecycle() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Vault should have realized PnL → margin increased above pre-trade level.
@@ -290,6 +298,7 @@ fn vault_lp_lifecycle() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let lp_state = suite
@@ -322,6 +331,7 @@ fn vault_lp_lifecycle() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let lp_state = suite
@@ -343,7 +353,7 @@ fn vault_lp_lifecycle() {
     // Step 10: Advance time past cooldown (1 day) so cron processes unlocks.
     // -------------------------------------------------------------------------
 
-    suite.increase_time(Duration::from_days(2));
+    suite.increase_time(Duration::from_days(2)).await;
 
     // -------------------------------------------------------------------------
     // Step 11: Verify total withdrawn reflects original $5k + vault profits.
@@ -383,8 +393,8 @@ fn vault_lp_lifecycle() {
 /// orders), and that when `OnOracleUpdate` fails the oracle price update is
 /// **not** reverted while the perps state changes from the failed call are
 /// rolled back.
-#[test]
-fn oracle_triggers_on_oracle_update() {
+#[tokio::test]
+async fn oracle_triggers_on_oracle_update() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     let pair = pair_id();
@@ -413,6 +423,7 @@ fn oracle_triggers_on_oracle_update() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -426,6 +437,7 @@ fn oracle_triggers_on_oracle_update() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -438,6 +450,7 @@ fn oracle_triggers_on_oracle_update() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -464,6 +477,7 @@ fn oracle_triggers_on_oracle_update() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Vault should have no orders before any price is fed.
@@ -502,6 +516,7 @@ fn oracle_triggers_on_oracle_update() {
             &oracle::ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message1])),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Oracle price should be set for the perps pair.
@@ -602,6 +617,7 @@ fn oracle_triggers_on_oracle_update() {
             &oracle::ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message2])),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Oracle price should have been updated (new timestamp or value).
@@ -667,14 +683,14 @@ fn oracle_triggers_on_oracle_update() {
 ///
 /// This test asserts the vault is healthy at step 6 and is expected to FAIL
 /// under the current code. Once the bug is fixed, this test should pass.
-#[test]
-fn vault_overcommits_margin_after_position_and_price_drop() {
+#[tokio::test]
+async fn vault_overcommits_margin_after_position_and_price_drop() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     let pair = pair_id();
 
     // Register oracle: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // -------------------------------------------------------------------------
     // Step 1: LP (user1) deposits $5,000 USDC and adds all of it as vault
@@ -688,6 +704,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(5_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -700,6 +717,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let vault_state = suite
@@ -738,6 +756,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
@@ -754,6 +773,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
             &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -783,6 +803,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -801,6 +822,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify vault has a long position.
@@ -827,7 +849,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
     //   Vault is STILL HEALTHY ($1,500 >= $1,062.50) but has $0 available.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_700);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_700).await;
 
     // Sanity check: vault should be healthy at this point.
     let vault_ext: perps::UserStateExtended = suite
@@ -879,6 +901,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
             &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // With the fix, available margin is $0, so the vault places NO orders.
@@ -926,7 +949,7 @@ fn vault_overcommits_margin_after_position_and_price_drop() {
                 sl: None,
             })),
             Coins::new(),
-        )
+        ).await
         // OLD (incorrect) behavior: the vault had a bid, so this would succeed.
         // .should_succeed();
         .should_fail_with_error("no liquidity");

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -949,7 +949,8 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
                 sl: None,
             })),
             Coins::new(),
-        ).await
+        )
+        .await
         // OLD (incorrect) behavior: the vault had a bid, so this would succeed.
         // .should_succeed();
         .should_fail_with_error("no liquidity");

--- a/dango/testing/tests/perps/vault_snapshots.rs
+++ b/dango/testing/tests/perps/vault_snapshots.rs
@@ -18,11 +18,11 @@ use {
 /// `dango/genesis/src/builder.rs`), so back-to-back tx blocks (250ms apart)
 /// do not trigger it. We rely on `increase_time(1 day)` to push past the
 /// scheduling boundary and produce one snapshot per call.
-#[test]
-fn vault_snapshots_accrue_daily() {
+#[tokio::test]
+async fn vault_snapshots_accrue_daily() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // LP deposits collateral and adds liquidity. None of these short-interval
     // blocks trigger the perps cron (interval = 1 min, block time = 250ms),
@@ -34,6 +34,7 @@ fn vault_snapshots_accrue_daily() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -46,6 +47,7 @@ fn vault_snapshots_accrue_daily() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let snapshots: BTreeMap<Timestamp, VaultSnapshot> = suite
@@ -65,7 +67,7 @@ fn vault_snapshots_accrue_daily() {
     // deposit ($5,000 equity, share_supply > 0).
     // ---------------------------------------------------------------------
 
-    suite.increase_time(Duration::from_days(1));
+    suite.increase_time(Duration::from_days(1)).await;
     let day_1 = round_to_day(suite.block.timestamp);
 
     let snapshots: BTreeMap<Timestamp, VaultSnapshot> = suite
@@ -96,11 +98,11 @@ fn vault_snapshots_accrue_daily() {
     // Cross day 2 and day 3: one snapshot each.
     // ---------------------------------------------------------------------
 
-    suite.increase_time(Duration::from_days(1));
+    suite.increase_time(Duration::from_days(1)).await;
     let day_2 = round_to_day(suite.block.timestamp);
     assert_eq!(day_2, day_1 + Duration::from_days(1));
 
-    suite.increase_time(Duration::from_days(1));
+    suite.increase_time(Duration::from_days(1)).await;
     let day_3 = round_to_day(suite.block.timestamp);
     assert_eq!(day_3, day_2 + Duration::from_days(1));
 

--- a/dango/testing/tests/perps/vault_withdrawal_health.rs
+++ b/dango/testing/tests/perps/vault_withdrawal_health.rs
@@ -36,14 +36,14 @@ use {
 /// | 4    | Taker sells into vault bid                      | vault goes long; margin ~$5,000                               | vault has long position          |
 /// | 5    | Oracle drops to $1,900 (breakeven)              | PnL=0; equity≈$5,000; MM≈$1,188                               | vault healthy (equity > MM)      |
 /// | 6    | LP burns ~85% of shares                         | release≈$4,250; old margin check passes; equity→≈$750         | withdraw rejected (fix)          |
-#[test]
-fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
+#[tokio::test]
+async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
     // ---- Step 0: Setup ----
 
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
     let pair = pair_id();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
 
     // -------------------------------------------------------------------------
     // Step 1: LP (user1) deposits $5,000 USDC and adds $5,000 as vault liquidity.
@@ -56,6 +56,7 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(5_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -68,6 +69,7 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let lp_state: perps::UserState = suite
@@ -103,13 +105,14 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
             }),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // -------------------------------------------------------------------------
     // Step 3: Refresh vault orders. Expect bid at $1,900 (= $2,000 * 0.95).
     // -------------------------------------------------------------------------
 
-    suite.make_empty_block();
+    suite.make_empty_block().await;
     suite
         .execute(
             &mut accounts.owner,
@@ -117,6 +120,7 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
             &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
@@ -154,6 +158,7 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
             &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
             Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -172,6 +177,7 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
             })),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Verify vault has a long position.
@@ -197,7 +203,7 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
     // Vault is healthy: $5,000 > $1,900.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_900);
+    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_900).await;
 
     let vault_ext: perps::UserStateExtended = suite
         .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
@@ -250,5 +256,6 @@ fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
             &perps::ExecuteMsg::Vault(perps::VaultMsg::RemoveLiquidity { shares_to_burn }),
             Coins::new(),
         )
+        .await
         .should_fail_with_error("insufficient vault available margin to cover withdrawal");
 }

--- a/dango/testing/tests/proposal_preparer.rs
+++ b/dango/testing/tests/proposal_preparer.rs
@@ -26,8 +26,8 @@ const NOT_USED_ID_LAZER: PythLazerSubscriptionDetails = PythLazerSubscriptionDet
     channel: Channel::FixedRate(FixedRate::RATE_200_MS),
 };
 
-#[test]
-fn proposal_pyth() {
+#[tokio::test]
+async fn proposal_pyth() {
     // Ensure there are all cache file for the PythIds in oracle and also for
     // the NOT_USED_ID and retrieve them if not presents. This is needed since
     // the PythPPHandler create a thread to get the data from Pyth and if the
@@ -83,6 +83,7 @@ fn proposal_pyth() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -92,11 +93,12 @@ fn proposal_pyth() {
             &ExecuteMsg::RegisterPriceSources(price_source),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Assert the price of btc exists.
     sleep(Duration::from_secs(2));
-    assert_price_exists(&mut suite, contracts.oracle, btc::DENOM.clone());
+    assert_price_exists(&mut suite, contracts.oracle, btc::DENOM.clone()).await;
 
     // Retrieve the prices and sequences.
     let prices1 = suite
@@ -108,7 +110,7 @@ fn proposal_pyth() {
     // Await some time and assert that the timestamps are updated.
     sleep(Duration::from_secs(1));
 
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     let prices2 = suite
         .query_wasm_smart(oracle, QueryPriceRequest {
@@ -161,16 +163,20 @@ fn proposal_pyth() {
 
         suite
             .execute(&mut accounts.owner, contracts.oracle, &msg, Coins::new())
+            .await
             .should_succeed();
 
         // Verify that the price exists.
         sleep(Duration::from_secs(1));
-        assert_price_exists(&mut suite, oracle, test_denom);
+        assert_price_exists(&mut suite, oracle, test_denom).await;
     }
 }
 
-fn assert_price_exists<P>(suite: &mut TestSuite<ProposalPreparer<P>>, oracle: Addr, denom: Denom)
-where
+async fn assert_price_exists<P>(
+    suite: &mut TestSuite<ProposalPreparer<P>>,
+    oracle: Addr,
+    denom: Denom,
+) where
     P: PythClientTrait + QueryPythId + Send + 'static,
     P::Error: std::fmt::Debug,
 {
@@ -180,7 +186,7 @@ where
     for _ in 0..10 {
         thread::sleep(Duration::from_millis(200));
 
-        let txs = suite.make_empty_block().block_outcome.tx_outcomes;
+        let txs = suite.make_empty_block().await.block_outcome.tx_outcomes;
 
         // Ensure all tx passed.
         for tx in txs {

--- a/dango/testing/tests/pyth_handler.rs
+++ b/dango/testing/tests/pyth_handler.rs
@@ -11,8 +11,8 @@ use {
     std::{thread::sleep, time::Duration},
 };
 
-#[test]
-fn handler() {
+#[tokio::test]
+async fn handler() {
     let (mut suite, mut accounts, codes, contracts, _) = setup_test(Default::default());
 
     // Oracle from the setup_test has some PythIds already uploaded.
@@ -33,6 +33,7 @@ fn handler() {
             None,
             Coins::new(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -51,6 +52,7 @@ fn handler() {
             &ExecuteMsg::RegisterPriceSources(price_source),
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     let querier = QuerierWrapper::new(&suite);

--- a/dango/testing/tests/session_key.rs
+++ b/dango/testing/tests/session_key.rs
@@ -182,8 +182,8 @@ mod session_account {
     }
 }
 
-#[test]
-fn session_key() {
+#[tokio::test]
+async fn session_key() {
     let (mut suite, accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     suite.block_time = Duration::from_seconds(10);
@@ -203,6 +203,7 @@ fn session_key() {
                 accounts.user1.address(),
                 Coin::new(usdc::DENOM.clone(), 100).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -215,6 +216,7 @@ fn session_key() {
                 accounts.user1.address(),
                 Coin::new(usdc::DENOM.clone(), 100).unwrap(),
             )
+            .await
             .should_fail_with_error("session expired at Duration(Dec(Int(31536100000000000))");
         owner.nonce -= 1;
 
@@ -236,6 +238,7 @@ fn session_key() {
                 accounts.user1.address(),
                 Coin::new(usdc::DENOM.clone(), 100).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -246,6 +249,7 @@ fn session_key() {
     {
         let owner2 = owner
             .register_new_account(&mut suite, contracts.account_factory, Coins::default())
+            .await
             .unwrap();
 
         // Refresh the session key signature
@@ -267,6 +271,7 @@ fn session_key() {
                 owner2.address(),
                 Coin::new(usdc::DENOM.clone(), 100).unwrap(),
             )
+            .await
             .should_succeed();
 
         // The new account should be able to send coins to the relayer
@@ -276,6 +281,7 @@ fn session_key() {
                 accounts.user1.address(),
                 Coin::new(usdc::DENOM.clone(), 100).unwrap(),
             )
+            .await
             .should_succeed();
     }
 
@@ -297,6 +303,7 @@ fn session_key() {
                 accounts.user1.address(),
                 Coin::new(usdc::DENOM.clone(), 100).unwrap(),
             )
+            .await
             .should_succeed();
     }
 }

--- a/dango/testing/tests/taxman.rs
+++ b/dango/testing/tests/taxman.rs
@@ -10,8 +10,8 @@ use {
 const OLD_FEE_RATE: Udec128 = Udec128::new_percent(1); // 0.01 uusdc per gas unit
 const NEW_FEE_RATE: Udec128 = Udec128::new_percent(2); // 0.02 uusdc per gas unit
 
-#[test]
-fn fee_rate_update_works() {
+#[tokio::test]
+async fn fee_rate_update_works() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(Default::default());
 
     // --------------------------------- tx 1 ----------------------------------
@@ -32,6 +32,7 @@ fn fee_rate_update_works() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // This transaction was run when fee rate was zero.
@@ -57,6 +58,7 @@ fn fee_rate_update_works() {
             },
             Coins::new(),
         )
+        .await
         .should_succeed();
 
     // Owner should have been charged a gas fee, but at the old rate.
@@ -75,6 +77,7 @@ fn fee_rate_update_works() {
     // Someone else sends a transaction.
     let success = suite
         .transfer(&mut accounts.user1, accounts.owner.address(), Coins::new())
+        .await
         .should_succeed();
 
     // Gas fee should be calculated using the new rate.

--- a/dango/testing/tests/va.rs
+++ b/dango/testing/tests/va.rs
@@ -378,8 +378,8 @@ async fn test_announce() {
     }
 }
 
-#[tokio::test]
-async fn test_query() {
+#[test]
+fn test_query() {
     let (suite, _, _, contracts, _) = setup_test(Default::default());
 
     // Assert mailbox is correct.

--- a/dango/testing/tests/va.rs
+++ b/dango/testing/tests/va.rs
@@ -58,8 +58,8 @@ impl MockAnnouncement {
     }
 }
 
-#[test]
-fn test_announce() {
+#[tokio::test]
+async fn test_announce() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test(Default::default());
 
     let mut validators_expected = BTreeSet::new();
@@ -86,6 +86,7 @@ fn test_announce() {
                 },
                 Coins::new(),
             )
+            .await
             .should_fail_with_error("invalid payment");
     }
 
@@ -102,6 +103,7 @@ fn test_announce() {
                 },
                 coins! { dango::DENOM.clone() => announce_fee },
             )
+            .await
             .should_fail_with_error("invalid payment");
     }
 
@@ -121,6 +123,7 @@ fn test_announce() {
                     usdc::DENOM.clone()  => announce_fee,
                 },
             )
+            .await
             .should_fail_with_error("invalid payment");
     }
 
@@ -137,6 +140,7 @@ fn test_announce() {
                 },
                 coins! { usdc::DENOM.clone() => announce_fee - 1 },
             )
+            .await
             .should_fail_with_error("insufficient validator announce fee");
     }
 
@@ -153,6 +157,7 @@ fn test_announce() {
                 },
                 coins! { usdc::DENOM.clone() => announce_fee },
             )
+            .await
             .should_succeed()
             .events
             .search_event::<CheckedContractEvent>()
@@ -210,6 +215,7 @@ fn test_announce() {
                 },
                 coins! { usdc::DENOM.clone() => announce_fee },
             )
+            .await
             .should_fail_with_error("duplicate data found!");
     }
 
@@ -235,6 +241,7 @@ fn test_announce() {
                 },
                 coins! { usdc::DENOM.clone() => announce_fee2 },
             )
+            .await
             .should_succeed()
             .events
             .search_event::<CheckedContractEvent>()
@@ -299,6 +306,7 @@ fn test_announce() {
                 },
                 coins! { usdc::DENOM.clone() => announce_fee3 },
             )
+            .await
             .should_succeed()
             .events
             .search_event::<CheckedContractEvent>()
@@ -365,12 +373,13 @@ fn test_announce() {
                 },
                 coins! { usdc::DENOM.clone() => announce_fee },
             )
+            .await
             .should_fail_with_error("pubkey mismatch");
     }
 }
 
-#[test]
-fn test_query() {
+#[tokio::test]
+async fn test_query() {
     let (suite, _, _, contracts, _) = setup_test(Default::default());
 
     // Assert mailbox is correct.

--- a/dango/testing/tests/vesting.rs
+++ b/dango/testing/tests/vesting.rs
@@ -26,8 +26,8 @@ fn setup_test() -> (TestSuite<NaiveProposalPreparer>, TestAccounts, Addr) {
     (suite, accounts, contracts.vesting)
 }
 
-#[test]
-fn missing_funds() {
+#[tokio::test]
+async fn missing_funds() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -44,11 +44,12 @@ fn missing_funds() {
             },
             Coins::default(),
         )
+        .await
         .should_fail_with_error("invalid payment: expecting 1, found 0");
 }
 
-#[test]
-fn non_owner_creating_position() {
+#[tokio::test]
+async fn non_owner_creating_position() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -65,11 +66,12 @@ fn non_owner_creating_position() {
             },
             Coins::one(dango::DENOM.clone(), 100).unwrap(),
         )
+        .await
         .should_fail_with_error("you don't have the right");
 }
 
-#[test]
-fn not_dango_token() {
+#[tokio::test]
+async fn not_dango_token() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -86,14 +88,15 @@ fn not_dango_token() {
             },
             Coins::one(usdc::DENOM.clone(), 100).unwrap(),
         )
+        .await
         .should_fail_with_error(StdError::invalid_payment(
             dango::DENOM.clone(),
             usdc::DENOM.clone(),
         ));
 }
 
-#[test]
-fn before_unlocking_starting_time() {
+#[tokio::test]
+async fn before_unlocking_starting_time() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -110,6 +113,7 @@ fn before_unlocking_starting_time() {
             },
             TEST_AMOUNT.clone(),
         )
+        .await
         .should_succeed();
 
     let initial_balance = suite
@@ -127,6 +131,7 @@ fn before_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_fail_with_error("nothing to claim");
     }
 
@@ -141,6 +146,7 @@ fn before_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         suite
@@ -165,6 +171,7 @@ fn before_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         suite
@@ -189,6 +196,7 @@ fn before_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         suite
@@ -204,8 +212,8 @@ fn before_unlocking_starting_time() {
     }
 }
 
-#[test]
-fn after_unlocking_starting_time() {
+#[tokio::test]
+async fn after_unlocking_starting_time() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -222,6 +230,7 @@ fn after_unlocking_starting_time() {
             },
             TEST_AMOUNT.clone(),
         )
+        .await
         .should_succeed();
 
     let initial_balance = suite
@@ -239,6 +248,7 @@ fn after_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_fail_with_error("nothing to claim");
     }
 
@@ -253,6 +263,7 @@ fn after_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_fail_with_error("nothing to claim");
     }
 
@@ -268,6 +279,7 @@ fn after_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         suite
@@ -292,6 +304,7 @@ fn after_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         suite
@@ -316,6 +329,7 @@ fn after_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         suite
@@ -331,8 +345,8 @@ fn after_unlocking_starting_time() {
     }
 }
 
-#[test]
-fn terminate_before_unlocking_starting_time_never_claimed() {
+#[tokio::test]
+async fn terminate_before_unlocking_starting_time_never_claimed() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -349,6 +363,7 @@ fn terminate_before_unlocking_starting_time_never_claimed() {
             },
             TEST_AMOUNT.clone(),
         )
+        .await
         .should_succeed();
 
     let epoch = epoch(ONE_MONTH * 27, TEST_AMOUNT.amount);
@@ -375,6 +390,7 @@ fn terminate_before_unlocking_starting_time_never_claimed() {
                 },
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check the status of the position after terminate
@@ -397,6 +413,7 @@ fn terminate_before_unlocking_starting_time_never_claimed() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check the balance of the user
@@ -415,6 +432,7 @@ fn terminate_before_unlocking_starting_time_never_claimed() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check if the position is removed
@@ -434,8 +452,8 @@ fn terminate_before_unlocking_starting_time_never_claimed() {
     }
 }
 
-#[test]
-fn terminate_before_unlocking_starting_time_with_claimed() {
+#[tokio::test]
+async fn terminate_before_unlocking_starting_time_with_claimed() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -452,6 +470,7 @@ fn terminate_before_unlocking_starting_time_with_claimed() {
             },
             TEST_AMOUNT.clone(),
         )
+        .await
         .should_succeed();
 
     let epoch = epoch(ONE_MONTH * 27, TEST_AMOUNT.amount);
@@ -477,6 +496,7 @@ fn terminate_before_unlocking_starting_time_with_claimed() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check the balance of the user
@@ -503,6 +523,7 @@ fn terminate_before_unlocking_starting_time_with_claimed() {
                 },
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check the status of the position after terminate
@@ -528,6 +549,7 @@ fn terminate_before_unlocking_starting_time_with_claimed() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check if the position is removed
@@ -547,8 +569,8 @@ fn terminate_before_unlocking_starting_time_with_claimed() {
     }
 }
 
-#[test]
-fn terminate_after_unlocking_starting_time() {
+#[tokio::test]
+async fn terminate_after_unlocking_starting_time() {
     let (mut suite, mut accounts, vesting_addr) = setup_test();
 
     suite
@@ -565,6 +587,7 @@ fn terminate_after_unlocking_starting_time() {
             },
             TEST_AMOUNT.clone(),
         )
+        .await
         .should_succeed();
 
     let initial_balance = suite
@@ -589,6 +612,7 @@ fn terminate_after_unlocking_starting_time() {
                 },
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check the status of the position after terminate
@@ -611,6 +635,7 @@ fn terminate_after_unlocking_starting_time() {
                 &vesting::ExecuteMsg::Claim {},
                 Coins::default(),
             )
+            .await
             .should_succeed();
 
         // Check if the position is removed

--- a/dango/testing/tests/warp.rs
+++ b/dango/testing/tests/warp.rs
@@ -24,8 +24,8 @@ use {
     sea_orm::EntityTrait,
 };
 
-#[test]
-fn receiving_remote() {
+#[tokio::test]
+async fn receiving_remote() {
     let (suite, mut accounts, _, contracts, validator_sets) = setup_test(Default::default());
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
@@ -39,6 +39,7 @@ fn receiving_remote() {
             &accounts.user1,
             Uint128::new(MOCK_RECEIVE_AMOUNT),
         )
+        .await
         .should_succeed();
 
     // The message should have been recorded as received.
@@ -87,6 +88,7 @@ async fn sending_remote() {
             },
             coins! { usdc::DENOM.clone() => SEND_AMOUNT },
         )
+        .await
         .should_succeed();
 
     // Message should have been inserted into the Merkle tree.
@@ -170,8 +172,8 @@ async fn sending_remote() {
     ]);
 }
 
-#[test]
-fn sending_remote_incorrect_route() {
+#[tokio::test]
+async fn sending_remote_incorrect_route() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test(Default::default());
 
     const RECIPIENT: Addr32 =
@@ -196,6 +198,7 @@ fn sending_remote_incorrect_route() {
             },
             coins! { usdc::DENOM.clone() => SEND_AMOUNT },
         )
+        .await
         .should_fail_with_error(StdError::data_not_found::<Addr>(
             REVERSE_ROUTES
                 .path((&usdc::DENOM, ETHEREUM_WETH_REMOTE))
@@ -203,8 +206,8 @@ fn sending_remote_incorrect_route() {
         ));
 }
 
-#[test]
-fn sending_remote_insufficient_reserve() {
+#[tokio::test]
+async fn sending_remote_insufficient_reserve() {
     let (suite, mut accounts, _, contracts, validator_sets) = setup_test(Default::default());
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
@@ -234,6 +237,7 @@ fn sending_remote_insufficient_reserve() {
             },
             coins! { usdc::DENOM.clone() => SEND_AMOUNT },
         )
+        .await
         .should_fail_with_error(format!(
             "insufficient reserve! bridge: {}, remote: {:?}, reserve: {}, amount: {}",
             contracts.warp, SOLANA_USDC_REMOTE, 0, SEND_AMOUNT_AFTER_FEE
@@ -248,6 +252,7 @@ fn sending_remote_insufficient_reserve() {
             &accounts.user2,
             Uint128::new(SEND_AMOUNT + 100), // A little more than sufficient amount.
         )
+        .await
         .should_succeed();
 
     // User1 tries to withdraw again. Should succeed.
@@ -261,5 +266,6 @@ fn sending_remote_insufficient_reserve() {
             },
             coins! { usdc::DENOM.clone() => SEND_AMOUNT },
         )
+        .await
         .should_succeed();
 }

--- a/grug/std/Cargo.toml
+++ b/grug/std/Cargo.toml
@@ -30,3 +30,6 @@ grug-ffi = { workspace = true }
 # The testing crate is only included when _not_ building for WebAssembly.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 grug-testing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/grug/std/tests/index_list.rs
+++ b/grug/std/tests/index_list.rs
@@ -13,8 +13,8 @@ const TEST: IndexedMap<(u8, u64), (i8, i64), TestIndexes> = IndexedMap::new("tes
     bar: UniqueIndex::new(|_k, v| v.1, "test", "test__bar"),
 });
 
-#[tokio::test]
-async fn index_list_macro_works() {
+#[test]
+fn index_list_macro_works() {
     let mut storage = MockStorage::new();
 
     TEST.save(&mut storage, (1, 2), &(3, 4)).unwrap();

--- a/grug/std/tests/index_list.rs
+++ b/grug/std/tests/index_list.rs
@@ -13,8 +13,8 @@ const TEST: IndexedMap<(u8, u64), (i8, i64), TestIndexes> = IndexedMap::new("tes
     bar: UniqueIndex::new(|_k, v| v.1, "test", "test__bar"),
 });
 
-#[test]
-fn index_list_macro_works() {
+#[tokio::test]
+async fn index_list_macro_works() {
     let mut storage = MockStorage::new();
 
     TEST.save(&mut storage, (1, 2), &(3, 4)).unwrap();

--- a/grug/std/tests/queries.rs
+++ b/grug/std/tests/queries.rs
@@ -37,8 +37,8 @@ mod query_maker {
     }
 }
 
-#[test]
-fn query_super_smart() {
+#[tokio::test]
+async fn query_super_smart() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("larry", Coins::one("uusdc", 123).unwrap())
         .set_chain_id("kebab")
@@ -59,6 +59,7 @@ fn query_super_smart() {
             None,
             Coins::new(),
         )
+        .await
         .should_succeed()
         .address;
 

--- a/grug/testing/src/client.rs
+++ b/grug/testing/src/client.rs
@@ -324,7 +324,7 @@ where
     ID: Indexer,
     AppError: From<DB::Error> + From<VM::Error> + From<PP::Error>,
 {
-    let outcome = suite.make_block(tx);
+    let outcome = suite.make_block(tx).await;
     index(index_txs, index_blocks, outcome, suite.block).await
 }
 

--- a/grug/testing/src/suite.rs
+++ b/grug/testing/src/suite.rs
@@ -219,32 +219,32 @@ where
     }
 
     /// Increase the chain's time by the given duration.
-    pub fn increase_time(&mut self, duration: Duration) {
+    pub async fn increase_time(&mut self, duration: Duration) {
         let old_block_time = self.block_time;
         self.block_time = duration;
-        self.make_empty_block();
+        self.make_empty_block().await;
         self.block_time = old_block_time;
     }
 
     /// Make a new block without any transaction. Panic if any error happens.
-    pub fn make_empty_block(&mut self) -> MakeBlockOutcome {
-        self.make_block(vec![])
+    pub async fn make_empty_block(&mut self) -> MakeBlockOutcome {
+        self.make_block(vec![]).await
     }
 
     /// Make a new block without any transaction.
-    pub fn try_make_empty_block(&mut self) -> AppResult<MakeBlockOutcome> {
-        self.try_make_block(vec![])
+    pub async fn try_make_empty_block(&mut self) -> AppResult<MakeBlockOutcome> {
+        self.try_make_block(vec![]).await
     }
 
     /// Make a new block with the given transactions. Panic if any error happens.
-    pub fn make_block(&mut self, txs: Vec<Tx>) -> MakeBlockOutcome {
-        self.try_make_block(txs).unwrap_or_else(|err| {
+    pub async fn make_block(&mut self, txs: Vec<Tx>) -> MakeBlockOutcome {
+        self.try_make_block(txs).await.unwrap_or_else(|err| {
             panic!("fatal error while making block: {err}");
         })
     }
 
     /// Make a new block with the given transactions.
-    pub fn try_make_block(&mut self, txs: Vec<Tx>) -> AppResult<MakeBlockOutcome> {
+    pub async fn try_make_block(&mut self, txs: Vec<Tx>) -> AppResult<MakeBlockOutcome> {
         // Advance block height and time
         let mut new_block = self.block;
         new_block.height += 1;
@@ -268,13 +268,9 @@ where
         };
 
         // Call ABCI `FinalizeBlock` then `Commit`. The `App` methods are async
-        // so they can `.await` the indexer trait directly; we bridge them to
-        // the sync `TestSuite` API with a single `block_on`.
-        let block_outcome = futures::executor::block_on(async {
-            let outcome = self.app.do_finalize_block(block).await?; // TODO: drop uncommitted changes if errors
-            self.app.do_commit().await?;
-            AppResult::Ok(outcome)
-        })?;
+        // so they can `.await` the indexer trait directly.
+        let block_outcome = self.app.do_finalize_block(block).await?; // TODO: drop uncommitted changes if errors
+        self.app.do_commit().await?;
 
         self.block = new_block;
 
@@ -282,21 +278,25 @@ where
     }
 
     /// Execute a single transaction.
-    pub fn send_transaction(&mut self, tx: Tx) -> TxOutcome {
-        let mut block_outcome = self.make_block(vec![tx]);
+    pub async fn send_transaction(&mut self, tx: Tx) -> TxOutcome {
+        let mut block_outcome = self.make_block(vec![tx]).await;
 
         block_outcome.block_outcome.tx_outcomes.pop().unwrap()
     }
 
     /// Sign a transaction with the default gas limit.
-    pub fn sign_transaction(&self, signer: &mut dyn Signer, msgs: NonEmpty<Vec<Message>>) -> Tx {
+    pub fn sign_transaction(
+        &self,
+        signer: &mut (dyn Signer + Send + Sync),
+        msgs: NonEmpty<Vec<Message>>,
+    ) -> Tx {
         self.sign_transaction_with_gas(signer, self.default_gas_limit, msgs)
     }
 
     /// Sign a transaction with the given gas limit.
     pub fn sign_transaction_with_gas(
         &self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         msgs: NonEmpty<Vec<Message>>,
     ) -> Tx {
@@ -308,43 +308,51 @@ where
     }
 
     /// Execute a single message.
-    pub fn send_message(&mut self, signer: &mut dyn Signer, msg: Message) -> TxOutcome {
+    pub async fn send_message(
+        &mut self,
+        signer: &mut (dyn Signer + Send + Sync),
+        msg: Message,
+    ) -> TxOutcome {
         self.send_message_with_gas(signer, self.default_gas_limit, msg)
+            .await
     }
 
     /// Execute a single message under the given gas limit.
-    pub fn send_message_with_gas(
+    pub async fn send_message_with_gas(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         msg: Message,
     ) -> TxOutcome {
         self.send_messages_with_gas(signer, gas_limit, NonEmpty::new_unchecked(vec![msg]))
+            .await
     }
 
     /// Execute one or more messages.
-    pub fn send_messages(
+    pub async fn send_messages(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         msgs: NonEmpty<Vec<Message>>,
     ) -> TxOutcome {
         self.send_messages_with_gas(signer, self.default_gas_limit, msgs)
+            .await
     }
 
     /// Execute one or more messages under the given gas limit.
-    pub fn send_messages_with_gas(
+    pub async fn send_messages_with_gas(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         msgs: NonEmpty<Vec<Message>>,
     ) -> TxOutcome {
         self.send_transaction(self.sign_transaction_with_gas(signer, gas_limit, msgs))
+            .await
     }
 
     /// Update the chain's config.
-    pub fn configure<T>(
+    pub async fn configure<T>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         new_cfg: Option<Config>,
         new_app_cfg: Option<T>,
     ) -> TxOutcome
@@ -352,12 +360,13 @@ where
         T: Serialize,
     {
         self.configure_with_gas(signer, self.default_gas_limit, new_cfg, new_app_cfg)
+            .await
     }
 
     /// Update the chain's config under the given gas limit.
-    pub fn configure_with_gas<T>(
+    pub async fn configure_with_gas<T>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         new_cfg: Option<Config>,
         new_app_cfg: Option<T>,
@@ -370,12 +379,13 @@ where
             gas_limit,
             Message::configure(new_cfg, new_app_cfg).unwrap(),
         )
+        .await
     }
 
     /// Schedule a chain upgrade.
-    pub fn upgrade<T, U, V>(
+    pub async fn upgrade<T, U, V>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         height: u64,
         cargo_version: T,
         git_tag: Option<U>,
@@ -394,12 +404,13 @@ where
             git_tag,
             url,
         )
+        .await
     }
 
     /// Schedule a chain upgrade under the given gas limit.
-    pub fn upgrade_with_gas<T, U, V>(
+    pub async fn upgrade_with_gas<T, U, V>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         height: u64,
         cargo_version: T,
@@ -416,21 +427,28 @@ where
             gas_limit,
             Message::upgrade(height, cargo_version, git_tag, url),
         )
+        .await
     }
 
     /// Make a transfer of tokens.
-    pub fn transfer<C>(&mut self, signer: &mut dyn Signer, to: Addr, coins: C) -> TxOutcome
+    pub async fn transfer<C>(
+        &mut self,
+        signer: &mut (dyn Signer + Send + Sync),
+        to: Addr,
+        coins: C,
+    ) -> TxOutcome
     where
         C: TryInto<Coins>,
         StdError: From<C::Error>,
     {
         self.transfer_with_gas(signer, self.default_gas_limit, to, coins)
+            .await
     }
 
     /// Make a transfer of tokens under the given gas limit.
-    pub fn transfer_with_gas<C>(
+    pub async fn transfer_with_gas<C>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         to: Addr,
         coins: C,
@@ -440,22 +458,24 @@ where
         StdError: From<C::Error>,
     {
         self.send_message_with_gas(signer, gas_limit, Message::transfer(to, coins).unwrap())
+            .await
     }
 
     /// Make a batched transfer of tokens to multiple recipients.
-    pub fn batch_transfer(
+    pub async fn batch_transfer(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         transfers: BTreeMap<Addr, Coins>,
     ) -> TxOutcome {
         self.batch_transfer_with_gas(signer, self.default_gas_limit, transfers)
+            .await
     }
 
     /// Make a batched transfer of tokens to multiple recipients, under the
     /// given gas limit.
-    pub fn batch_transfer_with_gas(
+    pub async fn batch_transfer_with_gas(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         transfers: BTreeMap<Addr, Coins>,
     ) -> TxOutcome {
@@ -464,20 +484,26 @@ where
             gas_limit,
             Message::batch_transfer(transfers).unwrap(),
         )
+        .await
     }
 
     /// Upload a code. Return the code's hash.
-    pub fn upload<B>(&mut self, signer: &mut dyn Signer, code: B) -> UploadOutcome
+    pub async fn upload<B>(
+        &mut self,
+        signer: &mut (dyn Signer + Send + Sync),
+        code: B,
+    ) -> UploadOutcome
     where
         B: Into<Binary>,
     {
         self.upload_with_gas(signer, self.default_gas_limit, code)
+            .await
     }
 
     /// Upload a code under the given gas limit. Return the code's hash.
-    pub fn upload_with_gas<B>(
+    pub async fn upload_with_gas<B>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         code: B,
     ) -> UploadOutcome
@@ -487,15 +513,17 @@ where
         let code = code.into();
         let code_hash = code.hash256();
 
-        let outcome = self.send_message_with_gas(signer, gas_limit, Message::upload(code));
+        let outcome = self
+            .send_message_with_gas(signer, gas_limit, Message::upload(code))
+            .await;
 
         UploadOutcome { code_hash, outcome }
     }
 
     /// Instantiate a contract. Return the contract's address.
-    pub fn instantiate<M, S, C>(
+    pub async fn instantiate<M, S, C>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         code_hash: Hash256,
         msg: &M,
         salt: S,
@@ -519,13 +547,14 @@ where
             admin,
             funds,
         )
+        .await
     }
 
     /// Instantiate a contract under the given gas limit. Return the contract's
     /// address.
-    pub fn instantiate_with_gas<M, S, C>(
+    pub async fn instantiate_with_gas<M, S, C>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         code_hash: Hash256,
         msg: &M,
@@ -543,20 +572,22 @@ where
         let salt = salt.into();
         let address = Addr::derive(signer.address(), code_hash, &salt);
 
-        let outcome = self.send_message_with_gas(
-            signer,
-            gas_limit,
-            Message::instantiate(code_hash, msg, salt, label, admin, funds).unwrap(),
-        );
+        let outcome = self
+            .send_message_with_gas(
+                signer,
+                gas_limit,
+                Message::instantiate(code_hash, msg, salt, label, admin, funds).unwrap(),
+            )
+            .await;
 
         InstantiateOutcome { address, outcome }
     }
 
     /// Upload a code and instantiate a contract with it in one go. Return the
     /// code hash as well as the contract's address.
-    pub fn upload_and_instantiate<M, B, S, L, C>(
+    pub async fn upload_and_instantiate<M, B, S, L, C>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         code: B,
         msg: &M,
         salt: S,
@@ -582,13 +613,14 @@ where
             admin,
             funds,
         )
+        .await
     }
 
     /// Upload a code and instantiate a contract with it in one go under the
     /// given gas limit. Return the code hash as well as the contract's address.
-    pub fn upload_and_instantiate_with_gas<M, B, S, L, C>(
+    pub async fn upload_and_instantiate_with_gas<M, B, S, L, C>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         code: B,
         msg: &M,
@@ -610,14 +642,16 @@ where
         let salt = salt.into();
         let address = Addr::derive(signer.address(), code_hash, &salt);
 
-        let outcome = self.send_messages_with_gas(
-            signer,
-            gas_limit,
-            NonEmpty::new_unchecked(vec![
-                Message::upload(code),
-                Message::instantiate(code_hash, msg, salt, label, admin, funds).unwrap(),
-            ]),
-        );
+        let outcome = self
+            .send_messages_with_gas(
+                signer,
+                gas_limit,
+                NonEmpty::new_unchecked(vec![
+                    Message::upload(code),
+                    Message::instantiate(code_hash, msg, salt, label, admin, funds).unwrap(),
+                ]),
+            )
+            .await;
 
         UploadAndInstantiateOutcome {
             address,
@@ -627,9 +661,9 @@ where
     }
 
     /// Execute a contrat.
-    pub fn execute<M, C>(
+    pub async fn execute<M, C>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         contract: Addr,
         msg: &M,
         funds: C,
@@ -640,12 +674,13 @@ where
         StdError: From<C::Error>,
     {
         self.execute_with_gas(signer, self.default_gas_limit, contract, msg, funds)
+            .await
     }
 
     /// Execute a contrat under the given gas limit.
-    pub fn execute_with_gas<M, C>(
+    pub async fn execute_with_gas<M, C>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         contract: Addr,
         msg: &M,
@@ -661,12 +696,13 @@ where
             gas_limit,
             Message::execute(contract, msg, funds).unwrap(),
         )
+        .await
     }
 
     /// Migrate a contract to a new code hash.
-    pub fn migrate<M>(
+    pub async fn migrate<M>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         contract: Addr,
         new_code_hash: Hash256,
         msg: &M,
@@ -675,12 +711,13 @@ where
         M: Serialize,
     {
         self.migrate_with_gas(signer, self.default_gas_limit, contract, new_code_hash, msg)
+            .await
     }
 
     /// Migrate a contract to a new code hash, under the given gas limit.
-    pub fn migrate_with_gas<M>(
+    pub async fn migrate_with_gas<M>(
         &mut self,
-        signer: &mut dyn Signer,
+        signer: &mut (dyn Signer + Send + Sync),
         gas_limit: u64,
         contract: Addr,
         new_code_hash: Hash256,
@@ -694,6 +731,7 @@ where
             gas_limit,
             Message::migrate(contract, new_code_hash, msg).unwrap(),
         )
+        .await
     }
 
     /// Return a `QuerierWrapper` object.

--- a/grug/testing/tests/account.rs
+++ b/grug/testing/tests/account.rs
@@ -5,8 +5,8 @@ use {
     grug_types::{Coins, Duration, JsonDeExt, Message, NonEmpty, ResultExt, Timestamp, Tx},
 };
 
-#[test]
-fn check_tx_and_finalize() {
+#[tokio::test]
+async fn check_tx_and_finalize() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("rhaki", Coins::one("uatom", 100).unwrap())
         .add_account("larry", Coins::new())
@@ -22,6 +22,7 @@ fn check_tx_and_finalize() {
     // Create a tx to set sequence to 1.
     suite
         .send_message(&mut accounts["rhaki"], transfer_msg.clone())
+        .await
         .should_succeed();
 
     // Create a tx with sequence 0, 1, 2, 4.
@@ -85,7 +86,7 @@ fn check_tx_and_finalize() {
     // The tx with sequence 1 should succeed.
     // The tx with sequence 2 should succeed.
     // The tx with sequence 4 should fail.
-    let result = suite.make_block(txs).block_outcome;
+    let result = suite.make_block(txs).await.block_outcome;
 
     result.tx_outcomes[0].clone().should_succeed();
     result.tx_outcomes[1].clone().should_succeed();
@@ -108,7 +109,7 @@ fn check_tx_and_finalize() {
         )
         .unwrap();
 
-    suite.make_block(vec![tx]).block_outcome.tx_outcomes[0]
+    suite.make_block(vec![tx]).await.block_outcome.tx_outcomes[0]
         .clone()
         .should_succeed();
 

--- a/grug/testing/tests/cron.rs
+++ b/grug/testing/tests/cron.rs
@@ -70,8 +70,8 @@ struct Balances {
     umars: u128,
 }
 
-#[test]
-fn cronjob_works() {
+#[tokio::test]
+async fn cronjob_works() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("larry", [("uatom", 100), ("uosmo", 100), ("umars", 100)])
         .add_account("jake", Coins::new())
@@ -91,6 +91,7 @@ fn cronjob_works() {
     // Upload the tester contract code.
     let tester_code_hash = suite
         .upload(&mut accounts["larry"], tester_code)
+        .await
         .should_succeed()
         .code_hash;
 
@@ -111,6 +112,7 @@ fn cronjob_works() {
             None,
             Coins::one("uatom", 3).unwrap(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -128,6 +130,7 @@ fn cronjob_works() {
             None,
             Coins::one("uosmo", 3).unwrap(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -145,6 +148,7 @@ fn cronjob_works() {
             None,
             Coins::one("umars", 3).unwrap(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -164,6 +168,7 @@ fn cronjob_works() {
     // cron3 scheduled at 8
     suite
         .configure::<Json>(&mut accounts["larry"], Some(new_cfg), None)
+        .await
         .should_succeed();
 
     // Make some blocks.
@@ -265,12 +270,12 @@ fn cronjob_works() {
             .should_succeed_and_equal(expect);
 
         // Advance block
-        suite.make_empty_block();
+        suite.make_empty_block().await;
     }
 }
 
-#[test]
-fn cronjob_fails() {
+#[tokio::test]
+async fn cronjob_fails() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("larry", Coins::new())
         .set_genesis_time(Timestamp::from_nanos(0))
@@ -284,6 +289,7 @@ fn cronjob_fails() {
 
     let tester_code_hash = suite
         .upload(&mut accounts["larry"], tester_code)
+        .await
         .should_succeed()
         .code_hash;
 
@@ -297,6 +303,7 @@ fn cronjob_fails() {
             None,
             Coins::default(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -308,6 +315,7 @@ fn cronjob_fails() {
 
     suite
         .configure::<Json>(&mut accounts["larry"], Some(new_cfg), None)
+        .await
         .should_succeed();
 
     // Before the block, storage key `b"foo"` should have the value `b"init"`.
@@ -316,7 +324,7 @@ fn cronjob_fails() {
         .should_succeed_and_equal(Some(Binary::from(*b"init")));
 
     // Advance block and trigger the cronjob
-    let res = suite.make_empty_block().block_outcome;
+    let res = suite.make_empty_block().await.block_outcome;
     assert_eq!(res.cron_outcomes.len(), 1);
 
     // The cronjob attempts to overwrite the value with `b"cron_execute"`.

--- a/grug/testing/tests/migrate.rs
+++ b/grug/testing/tests/migrate.rs
@@ -93,8 +93,8 @@ mod tester {
     }
 }
 
-#[test]
-fn migrate() {
+#[tokio::test]
+async fn migrate() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("owner", Coins::new())
         .add_account("sender", Coins::new())
@@ -129,14 +129,20 @@ fn migrate() {
             Some(admin_addr),
             Coins::default(),
         )
+        .await
         .should_succeed();
 
-    let v2_code_hash = suite.upload(&mut admin, v2).should_succeed().code_hash;
+    let v2_code_hash = suite
+        .upload(&mut admin, v2)
+        .await
+        .should_succeed()
+        .code_hash;
 
     // Try migrate from non_owner
     {
         suite
             .migrate(&mut attacker, contract, v2_code_hash, &MigrateMsg::Fail)
+            .await
             .should_fail_with_error("sender does not have permission to perform this action");
     }
 
@@ -144,6 +150,7 @@ fn migrate() {
     {
         suite
             .migrate(&mut admin, contract, v2_code_hash, &MigrateMsg::Fail)
+            .await
             .should_fail_with_error("host returned error: migrate failed");
 
         // Check the code_hash is still the old one
@@ -161,6 +168,7 @@ fn migrate() {
 
         suite
             .migrate(&mut admin, contract, v2_code_hash, &MigrateMsg::Ok)
+            .await
             .should_succeed();
 
         // Check the code_hash is still the old one
@@ -178,8 +186,8 @@ fn migrate() {
     }
 }
 
-#[test]
-fn migrate_no_admin() {
+#[tokio::test]
+async fn migrate_no_admin() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("owner", Coins::new())
         .add_account("sender", Coins::new())
@@ -209,12 +217,18 @@ fn migrate_no_admin() {
             None,
             Coins::default(),
         )
+        .await
         .should_succeed();
 
-    let v2_code_hash = suite.upload(&mut admin, v2).should_succeed().code_hash;
+    let v2_code_hash = suite
+        .upload(&mut admin, v2)
+        .await
+        .should_succeed()
+        .code_hash;
 
     // Admin not set, migrate fails
     suite
         .migrate(&mut admin, contract, v2_code_hash, &MigrateMsg::Ok)
+        .await
         .should_fail_with_error("sender does not have permission to perform this action");
 }

--- a/grug/testing/tests/prepare_proposal.rs
+++ b/grug/testing/tests/prepare_proposal.rs
@@ -165,8 +165,8 @@ impl ProposalPreparer for CoingeckoPriceFeeder {
     }
 }
 
-#[test]
-fn prepare_proposal_works() {
+#[tokio::test]
+async fn prepare_proposal_works() {
     let (mut suite, mut accounts) = TestBuilder::new_with_pp(CoingeckoPriceFeeder)
         .add_account("larry", Coins::new())
         .set_owner("larry")
@@ -189,12 +189,14 @@ fn prepare_proposal_works() {
             None,
             Coins::new(),
         )
+        .await
         .should_succeed()
         .address;
 
     // Set oracle contract address as app config.
     suite
         .configure(&mut accounts["larry"], None, Some(oracle))
+        .await
         .should_succeed();
 
     // At this point, the feeder shouldn't have fed any price yet, because the
@@ -206,7 +208,7 @@ fn prepare_proposal_works() {
     // Make an "empty" block.
     // The block should contain 1 transaction, the price feed inserted by the
     // proposal preparer.
-    let outcomes = suite.make_empty_block().block_outcome.tx_outcomes;
+    let outcomes = suite.make_empty_block().await.block_outcome.tx_outcomes;
     assert_eq!(outcomes.len(), 1);
     assert!(outcomes[0].result.is_ok());
 

--- a/grug/testing/tests/queries.rs
+++ b/grug/testing/tests/queries.rs
@@ -25,8 +25,8 @@ mod query_maker {
     }
 }
 
-#[test]
-fn handling_multi_query() {
+#[tokio::test]
+async fn handling_multi_query() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("larry", Coins::one("uusdc", 123).unwrap())
         .set_chain_id("kebab")
@@ -46,5 +46,6 @@ fn handling_multi_query() {
             None,
             Coins::new(),
         )
+        .await
         .should_succeed();
 }

--- a/grug/testing/tests/reply.rs
+++ b/grug/testing/tests/reply.rs
@@ -153,7 +153,7 @@ mod replier {
     }
 }
 
-fn setup() -> (TestSuite, TestAccounts, Addr) {
+async fn setup() -> (TestSuite, TestAccounts, Addr) {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("owner", Coin::new("usdc", 100_000).unwrap())
         .add_account("sender", Coins::new())
@@ -176,6 +176,7 @@ fn setup() -> (TestSuite, TestAccounts, Addr) {
             None,
             Coins::default(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -430,10 +431,13 @@ fn setup() -> (TestSuite, TestAccounts, Addr) {
     false;
     "reply_error_1pe_2ok_reply_1.1fail"
 )]
-fn reply<const S: usize>(msg: ExecuteMsg, mut data: [&str; S], should_tx_fail: bool) {
-    let (mut suite, mut accounts, replier_addr) = setup();
+#[tokio::test]
+async fn reply<const S: usize>(msg: ExecuteMsg, mut data: [&str; S], should_tx_fail: bool) {
+    let (mut suite, mut accounts, replier_addr) = setup().await;
 
-    let result = suite.execute(&mut accounts["owner"], replier_addr, &msg, Coins::default());
+    let result = suite
+        .execute(&mut accounts["owner"], replier_addr, &msg, Coins::default())
+        .await;
 
     if should_tx_fail {
         result.should_fail();

--- a/grug/testing/tests/taxman.rs
+++ b/grug/testing/tests/taxman.rs
@@ -151,7 +151,8 @@ mod taxman {
     None;
     "successful tx"
 )]
-fn withholding_and_finalizing_fee_works(
+#[tokio::test]
+async fn withholding_and_finalizing_fee_works(
     sender_balance_before: u128,
     send_amount: u128,
     gas_limit: u64,
@@ -178,15 +179,17 @@ fn withholding_and_finalizing_fee_works(
 
     let to = accounts["receiver"].address;
 
-    let outcome = suite.send_message_with_gas(
-        &mut accounts["sender"],
-        gas_limit,
-        Message::transfer(
-            to,
-            Coins::one(taxman::FEE_DENOM.clone(), send_amount).unwrap(),
+    let outcome = suite
+        .send_message_with_gas(
+            &mut accounts["sender"],
+            gas_limit,
+            Message::transfer(
+                to,
+                Coins::one(taxman::FEE_DENOM.clone(), send_amount).unwrap(),
+            )
+            .unwrap(),
         )
-        .unwrap(),
-    );
+        .await;
 
     match maybe_err {
         Some(err) => {
@@ -216,8 +219,8 @@ fn withholding_and_finalizing_fee_works(
 // If it does fail though, we simply discard all state changes and events emitted
 // by the transaction, as if it never happened. We also print a log to the CLI
 // at the ERROR tracing level to raise developer's awareness.
-#[test]
-fn finalizing_fee_erroring() {
+#[tokio::test]
+async fn finalizing_fee_erroring() {
     let bugged_taxman_code = ContractBuilder::new(Box::new(taxman::instantiate))
         .with_withhold_fee(Box::new(taxman::withhold_fee))
         .with_finalize_fee(Box::new(taxman::bugged_finalize_fee))
@@ -238,11 +241,13 @@ fn finalizing_fee_erroring() {
     // Send a transaction with a single message.
     // `withhold_fee` must pass, which should be the case as we're requesting
     // zero gas limit.
-    let outcome = suite.send_message_with_gas(
-        &mut accounts["sender"],
-        2000,
-        Message::transfer(to, Coins::new()).unwrap(),
-    );
+    let outcome = suite
+        .send_message_with_gas(
+            &mut accounts["sender"],
+            2000,
+            Message::transfer(to, Coins::new()).unwrap(),
+        )
+        .await;
 
     // Result should be an error.
     let failing = outcome.should_fail_with_error("division by zero: 1 / 0");

--- a/grug/testing/tests/upgrade.rs
+++ b/grug/testing/tests/upgrade.rs
@@ -10,8 +10,8 @@ use {
     std::{str::FromStr, sync::Arc},
 };
 
-#[test]
-fn error_cases() {
+#[tokio::test]
+async fn error_cases() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("owner", Coins::new())
         .add_account("jake", Coins::new())
@@ -27,6 +27,7 @@ fn error_cases() {
             Some("v0.1.0"),
             Some("https://github.com"),
         )
+        .await
         .should_fail_with_error(AppError::not_owner(
             accounts["jake"].address,
             accounts["owner"].address,
@@ -41,14 +42,15 @@ fn error_cases() {
             Some("v0.1.0"),
             Some("https://github.com"),
         )
+        .await
         .should_fail_with_error(AppError::upgrade_height_not_in_future(2, 2));
 }
 
 /// In this test, we attempt to change the chain ID through a chain upgrade.
 /// This is otherwise not possible through normal transactions.
 /// This upgrade doesn't involve any contract calls.
-#[test]
-fn upgrading_without_calling_contract() {
+#[tokio::test]
+async fn upgrading_without_calling_contract() {
     const OLD_CHAIN_ID: &str = "oonga";
     const NEW_CHAIN_ID: &str = "boonga";
 
@@ -72,6 +74,7 @@ fn upgrading_without_calling_contract() {
             Some("v0.1.0"),
             Some("https://github.com"),
         )
+        .await
         .should_succeed();
 
     suite.query_status().should_succeed_and(|status| {
@@ -90,7 +93,7 @@ fn upgrading_without_calling_contract() {
     // -------------------------------- Block 2 --------------------------------
 
     // Upgrade doesn't happen yet.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     suite.query_status().should_succeed_and(|status| {
         status.chain_id == OLD_CHAIN_ID && status.last_finalized_block.height == 2
@@ -101,6 +104,7 @@ fn upgrading_without_calling_contract() {
     // Block 3. The chain halts as planned.
     suite
         .try_make_empty_block()
+        .await
         .should_fail_with_error(AppError::upgrade_incorrect_version(
             "0.0.0".to_string(),
             "0.1.0".to_string(),
@@ -116,7 +120,7 @@ fn upgrading_without_calling_contract() {
     );
 
     // Make block 3 again with the new app. Upgrade happens.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     suite.query_status().should_succeed_and(|status| {
         status.chain_id == NEW_CHAIN_ID && status.last_finalized_block.height == 3
@@ -145,8 +149,8 @@ fn upgrading_without_calling_contract() {
 ///
 /// In practice, this can be easily done with a simple contract migration, but
 /// here for testing purpose, we go with a full chain upgrade.
-#[test]
-fn upgrading_with_calling_contract() {
+#[tokio::test]
+async fn upgrading_with_calling_contract() {
     mod new_mock_bank {
         use {
             grug_math::{NextNumber, Uint256},
@@ -199,12 +203,13 @@ fn upgrading_with_calling_contract() {
             None::<String>,
             None::<String>,
         )
+        .await
         .should_succeed();
 
     // -------------------------------- Block 2 --------------------------------
 
     // Upgrade doesn't happen yet. The balance should be 128-bit.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     suite
         .query_wasm_raw(
@@ -222,6 +227,7 @@ fn upgrading_with_calling_contract() {
     // The chain halts as planned.
     suite
         .try_make_empty_block()
+        .await
         .should_fail_with_error(AppError::upgrade_incorrect_version(
             "0.0.0".into(),
             "0.1.0".into(),
@@ -269,7 +275,7 @@ fn upgrading_with_calling_contract() {
 
     // Make block 3 again with the new app. Upgrade happens.
     // The balance should be 256-bit now.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
 
     suite
         .query_wasm_raw(
@@ -293,8 +299,8 @@ fn upgrading_with_calling_contract() {
 /// This test exercises (2): we attach a `watch` channel, drive the chain
 /// through the halt block, and assert the trigger fired with the expected
 /// halt reason.
-#[test]
-fn upgrade_incorrect_version_fires_shutdown_trigger() {
+#[tokio::test]
+async fn upgrade_incorrect_version_fires_shutdown_trigger() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .set_genesis_time(Timestamp::from_nanos(0))
         .set_block_time(Duration::from_seconds(1))
@@ -314,11 +320,12 @@ fn upgrade_incorrect_version_fires_shutdown_trigger() {
             None::<String>,
             None::<String>,
         )
+        .await
         .should_succeed();
 
     // -------------------------------- Block 2 --------------------------------
     // Upgrade height not yet reached: trigger must stay silent.
-    suite.make_empty_block();
+    suite.make_empty_block().await;
     assert!(
         halt_rx.borrow().is_none(),
         "shutdown trigger fired before upgrade height",
@@ -329,6 +336,7 @@ fn upgrade_incorrect_version_fires_shutdown_trigger() {
     // trigger fires with the mismatched versions.
     suite
         .try_make_empty_block()
+        .await
         .should_fail_with_error(AppError::upgrade_incorrect_version(
             "0.0.0".to_string(),
             "0.1.0".to_string(),

--- a/grug/vm/hybrid/Cargo.toml
+++ b/grug/vm/hybrid/Cargo.toml
@@ -28,4 +28,5 @@ grug-db-memory = { workspace = true }
 grug-math      = { workspace = true }
 grug-tester    = { workspace = true, features = ["library"] }
 grug-vm-hybrid = { workspace = true, features = ["testing"] }
+tokio          = { workspace = true }
 tracing        = { workspace = true }

--- a/grug/vm/hybrid/tests/backtrace.rs
+++ b/grug/vm/hybrid/tests/backtrace.rs
@@ -28,7 +28,7 @@ fn read_wasm_file(filename: &str) -> Binary {
 
 static DENOM: LazyLock<Denom> = LazyLock::new(|| Denom::from_str("ugrug").unwrap());
 
-pub fn setup_test() -> (TestSuite<MemDb, HybridVm>, TestAccounts, Addr, Addr) {
+pub async fn setup_test() -> (TestSuite<MemDb, HybridVm>, TestAccounts, Addr, Addr) {
     let rust_tester: Binary = ContractBuilder::new(Box::new(grug_tester::instantiate))
         .with_query(Box::new(grug_tester::query))
         .build()
@@ -54,7 +54,7 @@ pub fn setup_test() -> (TestSuite<MemDb, HybridVm>, TestAccounts, Addr, Addr) {
             Some("tester"),
             None,
             Coins::new(),
-        )
+        ).await
         .should_succeed()
         .address;
 
@@ -68,16 +68,16 @@ pub fn setup_test() -> (TestSuite<MemDb, HybridVm>, TestAccounts, Addr, Addr) {
             Some("tester"),
             None,
             Coins::new(),
-        )
+        ).await
         .should_succeed()
         .address;
 
     (suite, accounts, wasm_tester, rust_tester)
 }
 
-#[test]
-fn backtrace() {
-    let (suite, _, wasm_tester, rust_tester) = setup_test();
+#[tokio::test]
+async fn backtrace() {
+    let (suite, _, wasm_tester, rust_tester) = setup_test().await;
 
     let res = suite
         .query_wasm_smart(wasm_tester, QueryBacktraceRequest {

--- a/grug/vm/hybrid/tests/backtrace.rs
+++ b/grug/vm/hybrid/tests/backtrace.rs
@@ -54,7 +54,8 @@ pub async fn setup_test() -> (TestSuite<MemDb, HybridVm>, TestAccounts, Addr, Ad
             Some("tester"),
             None,
             Coins::new(),
-        ).await
+        )
+        .await
         .should_succeed()
         .address;
 
@@ -68,7 +69,8 @@ pub async fn setup_test() -> (TestSuite<MemDb, HybridVm>, TestAccounts, Addr, Ad
             Some("tester"),
             None,
             Coins::new(),
-        ).await
+        )
+        .await
         .should_succeed()
         .address;
 

--- a/grug/vm/rust/Cargo.toml
+++ b/grug/vm/rust/Cargo.toml
@@ -22,3 +22,4 @@ thiserror       = { workspace = true }
 grug-math    = { workspace = true }
 grug-testing = { workspace = true }
 test-case    = { workspace = true }
+tokio        = { workspace = true }

--- a/grug/vm/rust/tests/transfer.rs
+++ b/grug/vm/rust/tests/transfer.rs
@@ -7,8 +7,8 @@ use {
 
 static DENOM: LazyLock<Denom> = LazyLock::new(|| Denom::from_str("ugrug").unwrap());
 
-#[test]
-fn transfers() {
+#[tokio::test]
+async fn transfers() {
     let (mut suite, mut accounts) = TestBuilder::new()
         .add_account("sender", Coins::one(DENOM.clone(), 100).unwrap())
         .add_account("receiver", Coins::new())
@@ -36,6 +36,7 @@ fn transfers() {
                 Message::transfer(to, Coins::one(DENOM.clone(), 25).unwrap()).unwrap(),
             ]),
         )
+        .await
         .should_succeed();
 
     // Check balances again

--- a/grug/vm/wasm/Cargo.toml
+++ b/grug/vm/wasm/Cargo.toml
@@ -44,6 +44,7 @@ k256           = { workspace = true }
 p256           = { workspace = true }
 rand           = { workspace = true }
 test-case      = { workspace = true }
+tokio          = { workspace = true }
 
 [[bench]]
 harness = false

--- a/grug/vm/wasm/tests/tester.rs
+++ b/grug/vm/wasm/tests/tester.rs
@@ -32,7 +32,7 @@ fn read_wasm_file(filename: &str) -> Binary {
     fs::read(path).unwrap().into()
 }
 
-fn setup_test() -> (TestSuite<MemDb, WasmVm>, TestAccounts, Addr) {
+async fn setup_test() -> (TestSuite<MemDb, WasmVm>, TestAccounts, Addr) {
     let (mut suite, mut accounts) = TestBuilder::new_with_vm(WasmVm::new(WASM_CACHE_CAPACITY))
         .add_account("owner", Coins::new())
         .add_account("sender", Coins::one(DENOM.clone(), 32_100_000).unwrap())
@@ -51,15 +51,16 @@ fn setup_test() -> (TestSuite<MemDb, WasmVm>, TestAccounts, Addr) {
             None,
             Coins::new(),
         )
+        .await
         .should_succeed()
         .address;
 
     (suite, accounts, tester)
 }
 
-#[test]
-fn infinite_loop() {
-    let (mut suite, mut accounts, tester) = setup_test();
+#[tokio::test]
+async fn infinite_loop() {
+    let (mut suite, mut accounts, tester) = setup_test().await;
 
     suite
         .send_message_with_gas(
@@ -72,12 +73,13 @@ fn infinite_loop() {
             )
             .unwrap(),
         )
+        .await
         .should_fail_with_error("out of gas");
 }
 
-#[test]
-fn immutable_state() {
-    let (mut suite, mut accounts, tester) = setup_test();
+#[tokio::test]
+async fn immutable_state() {
+    let (mut suite, mut accounts, tester) = setup_test().await;
 
     // Query the tester contract.
     //
@@ -114,12 +116,13 @@ fn immutable_state() {
             )
             .unwrap(),
         )
+        .await
         .should_fail_with_error(VmError::immutable_state());
 }
 
-#[test]
-fn query_stack_overflow() {
-    let (suite, _, tester) = setup_test();
+#[tokio::test]
+async fn query_stack_overflow() {
+    let (suite, _, tester) = setup_test().await;
 
     // The contract attempts to call with `QueryMsg::StackOverflow` to itself in
     // a loop. Should raise the "exceeded max query depth" error.
@@ -128,9 +131,9 @@ fn query_stack_overflow() {
         .should_fail_with_error(VmError::exceed_max_query_depth());
 }
 
-#[test]
-fn message_stack_overflow() {
-    let (mut suite, mut accounts, tester) = setup_test();
+#[tokio::test]
+async fn message_stack_overflow() {
+    let (mut suite, mut accounts, tester) = setup_test().await;
 
     // The contract attempts to return a Response with `Execute::StackOverflow`
     // to itself in a loop. Should raise the "exceeded max message depth" error.
@@ -145,6 +148,7 @@ fn message_stack_overflow() {
             )
             .unwrap(),
         )
+        .await
         .should_fail_with_error(AppError::exceed_max_message_depth());
 }
 
@@ -360,7 +364,8 @@ fn generate_ed25519_verify_request() -> QueryVerifyEd25519Request {
     GenericResult::Err(VerificationError::unauthentic().into_generic_backtraced_error());
     "invalid ed25519: different msg"
 )]
-fn verifying_signature<G, M, R>(
+#[tokio::test]
+async fn verifying_signature<G, M, R>(
     generate_request: G,
     malleate: M,
     expect: GenericResult<R::Response>,
@@ -371,7 +376,7 @@ fn verifying_signature<G, M, R>(
     R::Message: Serialize,
     R::Response: DeserializeOwned + Debug + PartialEq,
 {
-    let (suite, _, tester) = setup_test();
+    let (suite, _, tester) = setup_test().await;
 
     // Generate and malleate query request
     let req = generate_request();
@@ -380,9 +385,9 @@ fn verifying_signature<G, M, R>(
     suite.query_wasm_smart(tester, req).should_match(expect);
 }
 
-#[test]
-fn recovering_secp256k1_pubkey() {
-    let (suite, _, tester) = setup_test();
+#[tokio::test]
+async fn recovering_secp256k1_pubkey() {
+    let (suite, _, tester) = setup_test().await;
 
     // Generate a valid signature
     let (vk, req) = {
@@ -443,9 +448,9 @@ fn ed25519_sign(msg: &str) -> (Binary, Binary, Binary) {
     )
 }
 
-#[test]
-fn wasm_ed25519_batch_verify() {
-    let (suite, _, tester) = setup_test();
+#[tokio::test]
+async fn wasm_ed25519_batch_verify() {
+    let (suite, _, tester) = setup_test().await;
 
     let mut req = {
         let (prehash_msg1, sig1, vk1) = ed25519_sign("Jake");

--- a/grug/vm/wasm/tests/transfer.rs
+++ b/grug/vm/wasm/tests/transfer.rs
@@ -12,8 +12,8 @@ const FEE_RATE: Udec128 = Udec128::new_percent(10);
 
 static DENOM: LazyLock<Denom> = LazyLock::new(|| Denom::from_str("ugrug").unwrap());
 
-#[test]
-fn transfers() {
+#[tokio::test]
+async fn transfers() {
     let (mut suite, mut accounts) = TestBuilder::new_with_vm(WasmVm::new(WASM_CACHE_CAPACITY))
         .add_account("owner", Coins::new())
         .add_account("sender", Coins::one(DENOM.clone(), 300_000).unwrap())
@@ -35,16 +35,18 @@ fn transfers() {
         .should_succeed_and_equal(Uint128::ZERO);
 
     // Sender sends 70 ugrug to the receiver across multiple messages
-    let outcome = suite.send_messages_with_gas(
-        &mut accounts["sender"],
-        2_500_000,
-        NonEmpty::new_unchecked(vec![
-            Message::transfer(to, Coins::one(DENOM.clone(), 10).unwrap()).unwrap(),
-            Message::transfer(to, Coins::one(DENOM.clone(), 15).unwrap()).unwrap(),
-            Message::transfer(to, Coins::one(DENOM.clone(), 20).unwrap()).unwrap(),
-            Message::transfer(to, Coins::one(DENOM.clone(), 25).unwrap()).unwrap(),
-        ]),
-    );
+    let outcome = suite
+        .send_messages_with_gas(
+            &mut accounts["sender"],
+            2_500_000,
+            NonEmpty::new_unchecked(vec![
+                Message::transfer(to, Coins::one(DENOM.clone(), 10).unwrap()).unwrap(),
+                Message::transfer(to, Coins::one(DENOM.clone(), 15).unwrap()).unwrap(),
+                Message::transfer(to, Coins::one(DENOM.clone(), 20).unwrap()).unwrap(),
+                Message::transfer(to, Coins::one(DENOM.clone(), 25).unwrap()).unwrap(),
+            ]),
+        )
+        .await;
 
     outcome.clone().should_succeed();
 
@@ -79,8 +81,8 @@ fn transfers() {
         ]));
 }
 
-#[test]
-fn transfers_with_insufficient_gas_limit() {
+#[tokio::test]
+async fn transfers_with_insufficient_gas_limit() {
     let (mut suite, mut accounts) = TestBuilder::new_with_vm(WasmVm::new(WASM_CACHE_CAPACITY))
         .add_account("owner", Coins::new())
         .add_account("sender", Coins::one(DENOM.clone(), 200_000).unwrap())
@@ -95,11 +97,13 @@ fn transfers_with_insufficient_gas_limit() {
     // For this test to work, the tx should request enough gas to pass `withhold_fee`,
     // but not enough to cover the actual transfer.
     // In experience, 200k gas works.
-    let outcome = suite.send_message_with_gas(
-        &mut accounts["sender"],
-        200_000,
-        Message::transfer(to, Coins::one(DENOM.clone(), 10).unwrap()).unwrap(),
-    );
+    let outcome = suite
+        .send_message_with_gas(
+            &mut accounts["sender"],
+            200_000,
+            Message::transfer(to, Coins::one(DENOM.clone(), 10).unwrap()).unwrap(),
+        )
+        .await;
 
     outcome.clone().should_fail();
 

--- a/indexer/testing/tests/indexing/hooked/block.rs
+++ b/indexer/testing/tests/indexing/hooked/block.rs
@@ -36,6 +36,7 @@ async fn index_block() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Force the runtime to wait for the async indexer task to finish
@@ -103,6 +104,7 @@ async fn parse_previous_block_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -161,6 +163,7 @@ async fn parse_previous_block_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // 5 bis. Force the runtime to wait for the async indexer task to finish
@@ -204,6 +207,7 @@ async fn no_sql_index_error_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     suite
@@ -277,6 +281,7 @@ async fn no_sql_index_error_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // 5 bis. Force the runtime to wait for the async indexer task to finish
@@ -328,6 +333,7 @@ async fn index_block_events() {
             None,
             Coins::default(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -339,6 +345,7 @@ async fn index_block_events() {
 
     suite
         .execute(&mut accounts["owner"], replier_addr, &msg, Coins::default())
+        .await
         .should_succeed();
 
     // Force the runtime to wait for the async indexer task to finish

--- a/indexer/testing/tests/indexing/sql/block.rs
+++ b/indexer/testing/tests/indexing/sql/block.rs
@@ -35,6 +35,7 @@ async fn index_block() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Force the runtime to wait for the async indexer task to finish
@@ -102,6 +103,7 @@ async fn parse_previous_block_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Force the runtime to shutdown or when reusing this `start` would fail
@@ -149,6 +151,7 @@ async fn parse_previous_block_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // 5 bis. Force the runtime to wait for the async indexer task to finish
@@ -192,6 +195,7 @@ async fn no_sql_index_error_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // Force the runtime to shutdown or when reusing this `start` would fail
@@ -256,6 +260,7 @@ async fn no_sql_index_error_after_restart() {
             2000,
             Message::transfer(to, Coins::one(denom.clone(), 2_000).unwrap()).unwrap(),
         )
+        .await
         .should_succeed();
 
     // 5 bis. Force the runtime to wait for the async indexer task to finish
@@ -444,6 +449,7 @@ async fn index_block_events() {
             None,
             Coins::default(),
         )
+        .await
         .should_succeed()
         .address;
 
@@ -455,6 +461,7 @@ async fn index_block_events() {
 
     suite
         .execute(&mut accounts["owner"], replier_addr, &msg, Coins::default())
+        .await
         .should_succeed();
 
     // Force the runtime to wait for the async indexer task to finish
@@ -535,6 +542,7 @@ async fn blocks_on_disk_compressed() {
             None,
             Coins::default(),
         )
+        .await
         .should_succeed()
         .address;
 


### PR DESCRIPTION
A follow-up to #1982.

`TestSuite::try_make_block` and friends previously bridged the async `App::do_finalize_block` / `do_commit` to a sync API via `futures::executor::block_on`. When called from inside `#[tokio::test]` contexts that touch a `tokio::Mutex` (e.g. via the indexer hooks), the bare-bones poller would block the only tokio worker and the lock holder could never make progress, deadlocking the test.

Convert the entire mutating API surface (~28 methods: `try_make_block`, `make_block`, `send_transaction`, `send_message{,s}{,_with_gas}`, `configure`, `upgrade`, `transfer`, `batch_transfer`, `upload`, `instantiate`, `upload_and_instantiate`, `execute`, `migrate`, `increase_time`, plus their `_with_gas` variants) to `async fn` so they can `.await` the underlying app methods directly. Tests now use `#[tokio::test]` (current_thread runtime by default — light overhead).

Also bump `&mut dyn Signer` to `&mut (dyn Signer + Send + Sync)` so generated futures are `Send` and can be moved across tokio workers (needed when tests use `tokio::spawn`).

Cascading changes:
- Add `tokio` dev-dependency to grug-vm-rust, grug-vm-wasm, grug-vm-hybrid, grug crates whose tests didn't already pull it in.
- Update ~210 test functions across grug/dango/indexer to `#[tokio::test] async fn`, with `.await` on every mutating call.
- Helper functions in test files transitively converted to async.
- Proptest tests can't be async (proptest macro doesn't support it), so they build a current_thread runtime and `block_on` the async body. Same approach for criterion benchmarks.
- `should_succeed_and(|x| { suite.method().await })` patterns restructured to extract the value first, then await outside the closure (closures can't be sync wrappers around async work).
- One closure converted to `async ||` (Rust 2024).
- TestAccount helpers (`register_new_account`, `receive_warp_transfer`) bumped to require `Send + Sync` on signer args.

Construction (`TestSuite::new_with_db_vm_indexer_and_pp`) keeps the `futures::executor::block_on` call for `Indexer::start` since it runs once at test setup before any tokio runtime is at risk.