### PR TITLE
refactor(indexer): phase 4 — replace `HookedIndexer` with concrete struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5300,7 +5300,6 @@ dependencies = [
  "futures",
  "grug-storage",
  "grug-types",
- "http 1.4.0",
  "ics23",
  "metrics",
  "prost 0.14.3",
@@ -6317,7 +6316,6 @@ version = "0.0.0"
 dependencies = [
  "assertor",
  "async-stream",
- "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
@@ -6414,29 +6412,15 @@ dependencies = [
 name = "indexer-hooked"
 version = "0.0.0"
 dependencies = [
- "anyhow",
- "async-graphql",
- "async-stream",
  "async-trait",
- "borsh",
- "futures",
  "grug-app",
  "grug-types",
- "http 1.4.0",
+ "indexer-cache",
+ "indexer-clickhouse",
+ "indexer-sql",
  "metrics",
- "sea-orm",
- "serde",
- "serde_json",
- "sqlx",
- "strum 0.28.0",
- "strum_macros 0.28.0",
- "tempfile",
- "test-case",
- "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tracing",
- "uuid",
 ]
 
 [[package]]

--- a/book/overview/4-indexer-and-node.md
+++ b/book/overview/4-indexer-and-node.md
@@ -15,12 +15,14 @@ commitment.
 ```rust
 // grug/app/src/traits/indexer.rs
 #[async_trait]
-pub trait Indexer {
+pub trait Indexer: Send + Sync {
     async fn start(&mut self, storage: &dyn Storage) -> IndexerResult<()>;
-    async fn pre_indexing(&self, block_height: u64, ctx: &mut IndexerContext) -> IndexerResult<()>;
-    async fn index_block(&self, block: ..., outcome: ..., ctx: &mut IndexerContext) -> IndexerResult<()>;
-    async fn post_indexing(&self, block_height: u64, ..., ctx: &mut IndexerContext) -> IndexerResult<()>;
-    async fn shutdown(&self) -> IndexerResult<()>;
+    async fn shutdown(&mut self) -> IndexerResult<()>;
+    async fn pre_indexing(&self, block_height: u64) -> IndexerResult<()>;
+    async fn index_block(&self, block: &Block, outcome: &BlockOutcome) -> IndexerResult<()>;
+    async fn post_indexing(&self, block_height: u64, cfg: Config, app_cfg: Json) -> IndexerResult<()>;
+    async fn wait_for_finish(&self) -> IndexerResult<()>;
+    async fn last_indexed_block_height(&self) -> IndexerResult<Option<u64>>;
 }
 ```
 
@@ -46,17 +48,20 @@ pub trait Indexer {
 
 ### HookedIndexer (composition)
 
-`indexer/hooked/` provides a composite pattern for chaining multiple indexers:
+`indexer/hooked/` is the single `Indexer` impl that the chain wires into `App`. It owns the three production indexer components by value and orchestrates their per-block work:
 
 ```rust
 pub struct HookedIndexer {
-    indexers: Arc<RwLock<Vec<Box<dyn Indexer + Send + Sync>>>>,
+    pub file:       indexer_cache::Cache,
+    pub sql:        indexer_sql::Indexer,
+    pub clickhouse: indexer_clickhouse::Indexer,
+    // …plus an `is_running` flag and a per-block `post_indexing` task map.
 }
 ```
 
-Indexers are added in order and each receives a shared `IndexerContext` (type-safe
-key-value store using `http::Extensions`). Earlier indexers can produce data consumed
-by later ones.
+The data flow is expressed through typed method arguments: `Cache::post_indexing` returns a `BlockAndBlockOutcomeWithHttpDetails` payload, which `HookedIndexer` then hands to `SqlIndexer::post_indexing` and `ClickhouseIndexer::post_indexing` in sequence. Each block's `post_indexing` runs on its own tokio task so SQL and Clickhouse writes do not block consensus; `wait_for_finish` drains the task map before shutdown.
+
+The "Hooked" name is historical — earlier revisions held a dynamic `Arc<RwLock<Vec<Box<dyn Indexer>>>>` and passed data between entries through an opaque `http::Extensions`-based context. The current shape is the three concrete fields above, but the crate and struct name are kept so deploy scripts and imports do not need to churn.
 
 ## 2. SQL Indexer (`indexer/sql/`)
 
@@ -107,18 +112,20 @@ Persists complete block + outcome data to disk for recovery:
 
 Optional S3 sync with bitmap tracking of uploaded blocks.
 
-## 4. Dango-Specific Indexer (`indexer/sql/`)
+## 4. Dango-Specific Writes (`indexer/sql/src/write/`)
 
-Extends the base SQL indexer with domain-specific data extraction:
+The SQL indexer crate also performs Dango-specific data extraction in the same `post_indexing` pass, after the generic block/tx/message/event rows have been written:
 
 ```rust
-// Runs in post_indexing (async, non-blocking)
+// Runs in SqlIndexer::post_indexing (async, non-blocking)
 let (transfers, accounts, perps) = tokio::join!(
-    transfers::save_transfers(&ctx, block_height),
-    accounts::save_accounts(&ctx, block, app_cfg),
-    perps_events::save_perps_events(&ctx, block, app_cfg),
+    crate::write::transfers::save_transfers(&self.context, block_height),
+    crate::write::accounts::save_accounts(&self.context, block, app_cfg.clone()),
+    crate::write::perps_events::save_perps_events(&self.context, block, app_cfg),
 );
 ```
+
+Two sea-orm migration tables are kept side by side in the same database (`grug_seaql_migrations` and `dango_seaql_migrations`) so existing prod data does not need to be migrated.
 
 Extracts:
 
@@ -175,11 +182,10 @@ The `dango start` command initializes and runs the full node:
 4.  Open DiskDb (RocksDB)
 5.  Create RustVm
 6.  Create base App
-7.  Setup indexer stack:
-    ├── CacheIndexer (disk persistence)
-    ├── SqlIndexer (PostgreSQL)
-    ├── DangoIndexer (domain-specific extraction)
-    └── ClickHouseIndexer (analytics)
+7.  Setup indexer stack (HookedIndexer with three components):
+    ├── Cache (disk persistence + optional S3 sync)
+    ├── SqlIndexer (PostgreSQL — generic + Dango-specific tables)
+    └── ClickhouseIndexer (analytics)
 8.  Run DB migrations + catch-up reindexing
 9.  Spawn:
     ├── Dango HTTP server (GraphQL)
@@ -218,10 +224,9 @@ The app is split into four ABCI service components:
                     │ Block + Outcome
 ┌───────────────────┴────────────────────────────────────┐
 │ Non-Consensus (Indexer Stack)                          │
-│  CacheIndexer → disk                                   │
-│  SqlIndexer → PostgreSQL                               │
-│  DangoIndexer → domain tables                          │
-│  ClickHouseIndexer → analytics DB                      │
+│  Cache → disk (+ optional S3 sync)                     │
+│  SqlIndexer → PostgreSQL (generic + Dango tables)      │
+│  ClickhouseIndexer → analytics DB                      │
 └────────────────── ▼ ───────────────────────────────────┘
                     │
 ┌───────────────────┴────────────────────────────────────┐

--- a/dango/cli/src/start.rs
+++ b/dango/cli/src/start.rs
@@ -273,8 +273,6 @@ impl StartCmd {
         app: Arc<App<DiskDb<SimpleCommitment>, RustVm, NaiveProposalPreparer, NullIndexer>>,
         tendermint_rpc_addr: &str,
     ) -> anyhow::Result<(HookedIndexer, indexer_httpd::context::FullContext)> {
-        let mut hooked_indexer = HookedIndexer::new();
-
         let sql_indexer = indexer_sql::IndexerBuilder::default()
             .with_database_url(&cfg.indexer.database.url)
             .with_database_max_connections(cfg.indexer.database.max_connections)
@@ -293,15 +291,11 @@ impl StartCmd {
 
         let clickhouse_indexer = indexer_clickhouse::Indexer::new(clickhouse_context.clone());
 
-        // Create cache indexer (RuntimeHandler no longer needed)
         let mut indexer_cache = indexer_cache::Cache::new_with_dir(app_dir.indexer_dir());
-        // Pass S3 config to the cache indexer context
         indexer_cache.context.s3 = cfg.indexer.s3.clone();
         let indexer_cache_context = indexer_cache.context.clone();
 
-        hooked_indexer.add_indexer(indexer_cache).await?;
-        hooked_indexer.add_indexer(sql_indexer).await?;
-        hooked_indexer.add_indexer(clickhouse_indexer).await?;
+        let mut hooked_indexer = HookedIndexer::new(indexer_cache, sql_indexer, clickhouse_indexer);
 
         let dango_httpd_context = indexer_httpd::context::FullContext::new(
             indexer_cache_context,

--- a/dango/mocks/httpd/Cargo.toml
+++ b/dango/mocks/httpd/Cargo.toml
@@ -21,7 +21,7 @@ grug-types              = { workspace = true }
 grug-vm-rust            = { workspace = true }
 hyperlane-testing       = { workspace = true }
 indexer-cache           = { workspace = true }
-indexer-clickhouse      = { workspace = true, features = ["tracing"] }
+indexer-clickhouse      = { workspace = true, features = ["testing", "tracing"] }
 indexer-hooked          = { workspace = true }
 indexer-httpd           = { workspace = true, features = ["tracing"] }
 indexer-sql             = { workspace = true, features = ["tracing"] }

--- a/dango/mocks/httpd/src/lib.rs
+++ b/dango/mocks/httpd/src/lib.rs
@@ -106,12 +106,21 @@ where
     let indexer_cache = indexer_cache::Cache::new_with_tempdir();
     let indexer_cache_context = indexer_cache.context.clone();
 
-    let mut hooked_indexer = HookedIndexer::new();
-
     let indexer_context_callback = indexer.context.clone();
 
-    hooked_indexer.add_indexer(indexer_cache).await.unwrap();
-    hooked_indexer.add_indexer(indexer).await.unwrap();
+    // The mock httpd doesn't talk to a real Clickhouse — wire up a mocked
+    // context so `HookedIndexer` can hold a real `ClickhouseIndexer` value.
+    let indexer_clickhouse_context = indexer_clickhouse::context::Context::new(
+        "http://localhost:8123".to_string(),
+        "default".to_string(),
+        "default".to_string(),
+        "default".to_string(),
+    )
+    .with_mock();
+    let clickhouse_indexer =
+        indexer_clickhouse::indexer::Indexer::new(indexer_clickhouse_context.clone());
+
+    let hooked_indexer = HookedIndexer::new(indexer_cache, indexer, clickhouse_indexer);
 
     let (suite, test, codes, contracts, mock_validator_sets) = setup_suite_with_db_and_vm(
         MemDb::<SimpleCommitment>::new(),
@@ -136,13 +145,6 @@ where
     let mock_client = MockClient::new_shared(suite.clone(), block_creation);
 
     let app = suite.read().await.app.clone_without_indexer();
-
-    let indexer_clickhouse_context = indexer_clickhouse::context::Context::new(
-        "http://localhost:8123".to_string(),
-        "default".to_string(),
-        "default".to_string(),
-        "default".to_string(),
-    );
 
     let dango_httpd_context = indexer_httpd::context::FullContext::new(
         indexer_cache_context,

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -186,8 +186,6 @@ pub async fn setup_test_with_indexer_and_custom_genesis(
 
     let sql_context = indexer.context.clone();
 
-    let mut hooked_indexer = HookedIndexer::new();
-
     let indexer_cache = indexer_cache::Cache::new_with_tempdir();
     let indexer_cache_context = indexer_cache.context.clone();
 
@@ -208,14 +206,9 @@ pub async fn setup_test_with_indexer_and_custom_genesis(
         clickhouse_context = clickhouse_context.with_mock();
     }
 
-    hooked_indexer.add_indexer(indexer_cache).await.unwrap();
-    hooked_indexer.add_indexer(indexer).await.unwrap();
-
     let clickhouse_indexer = indexer_clickhouse::indexer::Indexer::new(clickhouse_context.clone());
-    hooked_indexer
-        .add_indexer(clickhouse_indexer)
-        .await
-        .unwrap();
+
+    let hooked_indexer = HookedIndexer::new(indexer_cache, indexer, clickhouse_indexer);
 
     let db = MemDb::new();
     let vm = RustVm::new();

--- a/grug/app/Cargo.toml
+++ b/grug/app/Cargo.toml
@@ -25,7 +25,6 @@ error-backtrace = { workspace = true }
 futures         = { workspace = true }
 grug-storage    = { workspace = true }
 grug-types      = { workspace = true }
-http            = { workspace = true }
 ics23           = { workspace = true, optional = true }
 metrics         = { workspace = true, optional = true }
 prost           = { workspace = true }

--- a/grug/app/src/app.rs
+++ b/grug/app/src/app.rs
@@ -7,12 +7,12 @@ use grug_types::{HashExt, JsonDeExt};
 use {
     crate::{
         APP_CONFIG, AppError, AppResult, CHAIN_ID, CODES, CONFIG, Db, EventResult, GasTracker,
-        Indexer, IndexerContext, LAST_FINALIZED_BLOCK, NEXT_CRONJOBS, NEXT_UPGRADE,
-        NaiveProposalPreparer, NaiveQuerier, NullIndexer, PAST_UPGRADES, ProposalPreparer,
-        QuerierProviderImpl, TraceOption, Vm, catch_and_push_event, do_authenticate, do_configure,
-        do_cron_execute, do_execute, do_finalize_fee, do_instantiate, do_migrate, do_transfer,
-        do_upgrade, do_upload, do_withhold_fee, query_app_config, query_balance, query_balances,
-        query_code, query_codes, query_config, query_contract, query_contracts, query_next_upgrade,
+        Indexer, LAST_FINALIZED_BLOCK, NEXT_CRONJOBS, NEXT_UPGRADE, NaiveProposalPreparer,
+        NaiveQuerier, NullIndexer, PAST_UPGRADES, ProposalPreparer, QuerierProviderImpl,
+        TraceOption, Vm, catch_and_push_event, do_authenticate, do_configure, do_cron_execute,
+        do_execute, do_finalize_fee, do_instantiate, do_migrate, do_transfer, do_upgrade,
+        do_upload, do_withhold_fee, query_app_config, query_balance, query_balances, query_code,
+        query_codes, query_config, query_contract, query_contracts, query_next_upgrade,
         query_past_upgrades, query_status, query_supplies, query_supply, query_wasm_raw,
         query_wasm_scan, query_wasm_smart,
     },
@@ -492,7 +492,7 @@ where
         let mut tx_outcomes = vec![];
 
         self.indexer
-            .pre_indexing(block.info.height, &mut IndexerContext::new())
+            .pre_indexing(block.info.height)
             .await
             .inspect_err(|_err| {
                 #[cfg(feature = "tracing")]
@@ -668,7 +668,7 @@ where
         };
 
         self.indexer
-            .index_block(&block, &block_outcome, &mut IndexerContext::new())
+            .index_block(&block, &block_outcome)
             .await
             .inspect_err(|_err| {
                 #[cfg(feature = "tracing")]
@@ -707,7 +707,7 @@ where
         let app_cfg = APP_CONFIG.load(&storage)?;
 
         self.indexer
-            .post_indexing(version, cfg, app_cfg, &mut IndexerContext::new())
+            .post_indexing(version, cfg, app_cfg)
             .await
             .inspect_err(|_err| {
                 #[cfg(feature = "tracing")]

--- a/grug/app/src/traits/indexer.rs
+++ b/grug/app/src/traits/indexer.rs
@@ -8,61 +8,6 @@ use {
 /// Result type for indexer operations
 pub type IndexerResult<T> = Result<T, IndexerError>;
 
-/// Context for passing data between indexers in a composite pattern.
-/// Uses http::Extensions to allow storing arbitrary typed data that can be
-/// shared between different indexer implementations.
-///
-/// # Example
-/// ```ignore
-/// // In an earlier indexer implementation:
-/// ctx.insert("shared_data".to_string());
-///
-/// // In a later indexer implementation:
-/// if let Some(data) = ctx.get::<String>() {
-///     println!("Received: {}", data);
-/// }
-/// ```
-///
-/// Note: Types must implement `Clone + Send + Sync + 'static` to be stored.
-#[derive(Debug, Default, Clone)]
-pub struct IndexerContext {
-    extensions: http::Extensions,
-}
-
-impl IndexerContext {
-    /// Create a new empty context
-    pub fn new() -> Self {
-        Self {
-            extensions: http::Extensions::new(),
-        }
-    }
-
-    /// Insert a value into the context
-    pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, value: T) -> Option<T> {
-        self.extensions.insert(value)
-    }
-
-    /// Get a reference to a value from the context
-    pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
-        self.extensions.get::<T>()
-    }
-
-    /// Get a mutable reference to a value from the context
-    pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
-        self.extensions.get_mut::<T>()
-    }
-
-    /// Remove a value from the context
-    pub fn remove<T: Send + Sync + 'static>(&mut self) -> Option<T> {
-        self.extensions.remove::<T>()
-    }
-
-    /// Check if the context contains a value of type T
-    pub fn contains<T: Send + Sync + 'static>(&self) -> bool {
-        self.extensions.get::<T>().is_some()
-    }
-}
-
 /// This is the trait that the indexer must implement. It is used by the Grug core to index blocks
 #[async_trait]
 pub trait Indexer: Send + Sync {
@@ -81,11 +26,7 @@ pub trait Indexer: Send + Sync {
     }
 
     /// Called when indexing a block, allowing to create a new DB transaction
-    async fn pre_indexing(
-        &self,
-        _block_height: u64,
-        _ctx: &mut IndexerContext,
-    ) -> IndexerResult<()> {
+    async fn pre_indexing(&self, _block_height: u64) -> IndexerResult<()> {
         Ok(())
     }
 
@@ -94,7 +35,6 @@ pub trait Indexer: Send + Sync {
         &self,
         _block: &Block,
         _block_outcome: &BlockOutcome,
-        _ctx: &mut IndexerContext,
     ) -> IndexerResult<()> {
         Ok(())
     }
@@ -105,7 +45,6 @@ pub trait Indexer: Send + Sync {
         _block_height: u64,
         _cfg: Config,
         _app_cfg: Json,
-        _ctx: &mut IndexerContext,
     ) -> IndexerResult<()> {
         Ok(())
     }

--- a/indexer/cache/Cargo.toml
+++ b/indexer/cache/Cargo.toml
@@ -20,7 +20,6 @@ tracing              = ["dep:tracing"]
 
 [dependencies]
 async-stream         = { workspace = true }
-async-trait          = { workspace = true }
 aws-config           = { workspace = true, optional = true }
 aws-credential-types = { workspace = true, optional = true }
 aws-sdk-s3           = { workspace = true, optional = true }

--- a/indexer/cache/src/indexer.rs
+++ b/indexer/cache/src/indexer.rs
@@ -1,6 +1,5 @@
 use {
     crate::{Context, cache_file::CacheFile, error::Result, indexer_path::IndexerPath},
-    async_trait::async_trait,
     grug_types::BlockAndBlockOutcomeWithHttpDetails,
     serde::{Deserialize, Serialize},
     std::{
@@ -44,7 +43,7 @@ const INTERVAL_BETWEEN_S3_BITMAP_STORES: u64 = 60;
 // or not, to save disk space. `app.toml` could also add a u64 field to limit the
 // number of blocks to keep, deleting the oldest ones when exceeding that number.
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Cache {
     pub context: Context,
     // This because the way indexer methods are called, we need to store the blocks
@@ -435,9 +434,11 @@ impl Cache {
     }
 }
 
-#[async_trait]
-impl grug_app::Indexer for Cache {
-    async fn start(&mut self, _storage: &dyn grug_types::Storage) -> grug_app::IndexerResult<()> {
+impl Cache {
+    pub async fn start(
+        &mut self,
+        _storage: &dyn grug_types::Storage,
+    ) -> grug_app::IndexerResult<()> {
         #[cfg(feature = "s3")]
         if self.context.s3.enabled {
             let context = self.context.clone();
@@ -502,19 +503,24 @@ impl grug_app::Indexer for Cache {
         Ok(())
     }
 
-    #[cfg(feature = "s3")]
-    async fn shutdown(&mut self) -> grug_app::IndexerResult<()> {
+    pub async fn shutdown(&mut self) -> grug_app::IndexerResult<()> {
+        #[cfg(feature = "s3")]
         Self::store_bitmap(&self.context, self.s3_bitmap.clone())?;
 
         Ok(())
     }
 
+    /// No-op kept for symmetry with the other indexers' `wait_for_finish`.
+    pub async fn wait_for_finish(&self) -> grug_app::IndexerResult<()> {
+        Ok(())
+    }
+
+    /// Load a cached block from disk into the in-memory map, if a file exists
+    /// at `block_path(block_height)`. Called during the indexer pipeline's
+    /// `pre_indexing` phase, and during `reindex` to populate the in-memory
+    /// hop that `post_indexing` later drains.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn pre_indexing(
-        &self,
-        block_height: u64,
-        ctx: &mut grug_app::IndexerContext,
-    ) -> grug_app::IndexerResult<()> {
+    pub async fn pre_indexing(&self, block_height: u64) -> grug_app::IndexerResult<()> {
         let file_path = self.context.indexer_path.block_path(block_height);
 
         // This is used when reindexing existing blocks, since `index_block` won't be called.
@@ -524,20 +530,20 @@ impl grug_app::Indexer for Cache {
             self.blocks
                 .lock()
                 .map_err(|_| grug_app::IndexerError::mutex_poisoned())?
-                .insert(block_height, cache_file.data.clone());
-
-            ctx.insert(cache_file.data);
+                .insert(block_height, cache_file.data);
         }
 
         Ok(())
     }
 
+    /// Persist a freshly minted block to disk (or reload it from disk if it
+    /// was already there), and store the payload in the in-memory map for
+    /// `post_indexing` to consume.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn index_block(
+    pub async fn index_block(
         &self,
         block: &grug_types::Block,
         block_outcome: &grug_types::BlockOutcome,
-        ctx: &mut grug_app::IndexerContext,
     ) -> grug_app::IndexerResult<()> {
         let file_path = self.context.indexer_path.block_path(block.info.height);
 
@@ -555,9 +561,7 @@ impl grug_app::Indexer for Cache {
             self.blocks
                 .lock()
                 .map_err(|_| grug_app::IndexerError::mutex_poisoned())?
-                .insert(block.info.height, cache_file.data.clone());
-
-            ctx.insert(cache_file.data);
+                .insert(block.info.height, cache_file.data);
         } else {
             #[cfg(feature = "tracing")]
             tracing::info!(
@@ -578,22 +582,20 @@ impl grug_app::Indexer for Cache {
             self.blocks
                 .lock()
                 .map_err(|_| grug_app::IndexerError::mutex_poisoned())?
-                .insert(block.info.height, cache_file.data.clone());
-
-            ctx.insert(cache_file.data);
+                .insert(block.info.height, cache_file.data);
         }
 
         Ok(())
     }
 
+    /// Drain the in-memory map for `block_height`, finalize the on-disk file
+    /// (compress + record last-block-height), and return the payload so
+    /// downstream consumers (`SqlIndexer`, `ClickhouseIndexer`) can process it.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn post_indexing(
+    pub async fn post_indexing(
         &self,
         block_height: u64,
-        _cfg: grug_types::Config,
-        _app_cfg: grug_types::Json,
-        ctx: &mut grug_app::IndexerContext,
-    ) -> grug_app::IndexerResult<()> {
+    ) -> grug_app::IndexerResult<BlockAndBlockOutcomeWithHttpDetails> {
         let Some(data) = self
             .blocks
             .lock()
@@ -605,14 +607,6 @@ impl grug_app::Indexer for Cache {
             )));
         };
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!(
-            block_height,
-            "Added block data to indexer context in post_indexing",
-        );
-
-        ctx.insert(data);
-
         let file_path = self.context.indexer_path.block_path(block_height);
 
         if CacheFile::exists(file_path.clone()) {
@@ -621,7 +615,7 @@ impl grug_app::Indexer for Cache {
             Self::store_last_block_height(&self.context, block_height, HIGHEST_BLOCK_FILENAME)?;
         }
 
-        Ok(())
+        Ok(data)
     }
 }
 

--- a/indexer/clickhouse/src/error.rs
+++ b/indexer/clickhouse/src/error.rs
@@ -17,9 +17,6 @@ pub enum IndexerError {
     #[backtrace(new)]
     Clickhouse(clickhouse::error::Error),
 
-    #[error("missing block or block outcome")]
-    MissingBlockOrBlockOutcome,
-
     #[error("candle timeout")]
     CandleTimeout,
 

--- a/indexer/clickhouse/src/indexer.rs
+++ b/indexer/clickhouse/src/indexer.rs
@@ -85,6 +85,11 @@ impl Indexer {
             return Ok(());
         }
 
+        #[cfg(feature = "testing")]
+        if self.context.is_mocked() {
+            return Ok(());
+        }
+
         let candle_generator = candles::generator::CandleGenerator::new(self.context.clone());
 
         if let Err(_err) = candle_generator.save_all_candles().await {
@@ -136,6 +141,15 @@ impl Indexer {
     ) -> grug_app::IndexerResult<()> {
         if !self.indexing {
             return Err(grug_app::IndexerError::not_running());
+        }
+
+        // Symmetric with `start` / `wait_for_finish`: a mocked Clickhouse
+        // context has no installed handlers, so any write attempt would
+        // explode. Test harnesses opt in by calling `.with_mock()` on the
+        // context; in that mode `post_indexing` is a no-op.
+        #[cfg(feature = "testing")]
+        if self.context.is_mocked() {
+            return Ok(());
         }
 
         #[cfg(feature = "tracing")]

--- a/indexer/clickhouse/src/indexer.rs
+++ b/indexer/clickhouse/src/indexer.rs
@@ -1,9 +1,8 @@
 use {
     crate::context::Context,
-    async_trait::async_trait,
     dango_types::config::AppConfig,
     futures::try_join,
-    grug::{Config, Json, JsonDeExt},
+    grug::{BlockAndBlockOutcomeWithHttpDetails, Config, Json, JsonDeExt},
 };
 #[cfg(feature = "metrics")]
 use {
@@ -18,6 +17,7 @@ pub mod perps_fees;
 pub mod perps_pair_stats;
 pub mod trades;
 
+#[derive(Clone)]
 pub struct Indexer {
     pub context: Context,
     indexing: bool,
@@ -30,17 +30,17 @@ impl Indexer {
             indexing: false,
         }
     }
-}
 
-#[async_trait]
-impl grug_app::Indexer for Indexer {
-    async fn last_indexed_block_height(&self) -> grug_app::IndexerResult<Option<u64>> {
+    pub async fn last_indexed_block_height(&self) -> grug_app::IndexerResult<Option<u64>> {
         // TODO: Implement last_indexed_block_height using `pair_prices` table.
         Ok(None)
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn start(&mut self, _storage: &dyn grug_types::Storage) -> grug_app::IndexerResult<()> {
+    pub async fn start(
+        &mut self,
+        _storage: &dyn grug_types::Storage,
+    ) -> grug_app::IndexerResult<()> {
         #[cfg(feature = "testing")]
         if self.context.is_mocked() {
             #[cfg(feature = "tracing")]
@@ -80,7 +80,7 @@ impl grug_app::Indexer for Indexer {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn wait_for_finish(&self) -> grug_app::IndexerResult<()> {
+    pub async fn wait_for_finish(&self) -> grug_app::IndexerResult<()> {
         if !self.indexing {
             return Ok(());
         }
@@ -104,7 +104,7 @@ impl grug_app::Indexer for Indexer {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn shutdown(&mut self) -> grug_app::IndexerResult<()> {
+    pub async fn shutdown(&mut self) -> grug_app::IndexerResult<()> {
         // Avoid running this twice when called manually and from `Drop`
         if !self.indexing {
             return Ok(());
@@ -127,12 +127,12 @@ impl grug_app::Indexer for Indexer {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn post_indexing(
+    pub async fn post_indexing(
         &self,
         #[allow(unused_variables)] block_height: u64,
         _cfg: Config,
         app_cfg: Json,
-        ctx: &mut grug_app::IndexerContext,
+        block: &BlockAndBlockOutcomeWithHttpDetails,
     ) -> grug_app::IndexerResult<()> {
         if !self.indexing {
             return Err(grug_app::IndexerError::not_running());
@@ -141,7 +141,6 @@ impl grug_app::Indexer for Indexer {
         #[cfg(feature = "tracing")]
         tracing::debug!(block_height, "`post_indexing` work started");
 
-        let ctx = ctx.clone();
         let context = self.context.clone();
 
         #[cfg(feature = "metrics")]
@@ -152,10 +151,10 @@ impl grug_app::Indexer for Indexer {
             .map_err(|e| grug_app::IndexerError::hook(e.to_string()))?;
 
         try_join!(
-            Self::store_candles(&app_cfg.addresses.dex, &ctx, &context),
-            Self::store_trades(&app_cfg.addresses.dex, &ctx, &context),
-            Self::store_perps_candles(&app_cfg.addresses.perps, &ctx, &context),
-            Self::store_perps_fees(&app_cfg.addresses.perps, &ctx, &context)
+            Self::store_candles(&app_cfg.addresses.dex, block, &context),
+            Self::store_trades(&app_cfg.addresses.dex, block, &context),
+            Self::store_perps_candles(&app_cfg.addresses.perps, block, &context),
+            Self::store_perps_fees(&app_cfg.addresses.perps, block, &context)
         )
         .map_err(|e| grug_app::IndexerError::hook(e.to_string()))?;
 

--- a/indexer/clickhouse/src/indexer/candles.rs
+++ b/indexer/clickhouse/src/indexer/candles.rs
@@ -1,10 +1,5 @@
 use {
-    crate::{
-        context::Context,
-        entities::pair_price::PairPrice,
-        error::{IndexerError, Result},
-        indexer::Indexer,
-    },
+    crate::{context::Context, entities::pair_price::PairPrice, error::Result, indexer::Indexer},
     chrono::{DateTime, Utc},
     dango_types::dex::OrdersMatched,
     grug::{
@@ -20,13 +15,9 @@ pub mod generator;
 impl Indexer {
     pub(crate) async fn store_candles(
         dex_addr: &Addr,
-        ctx: &grug_app::IndexerContext,
+        block_and_block_outcome: &BlockAndBlockOutcomeWithHttpDetails,
         context: &Context,
     ) -> Result<()> {
-        let block_and_block_outcome = ctx
-            .get::<BlockAndBlockOutcomeWithHttpDetails>()
-            .ok_or(IndexerError::missing_block_or_block_outcome())?;
-
         let created_at = DateTime::<Utc>::from_naive_utc_and_offset(
             block_and_block_outcome
                 .block

--- a/indexer/clickhouse/src/indexer/perps_candles/mod.rs
+++ b/indexer/clickhouse/src/indexer/perps_candles/mod.rs
@@ -1,8 +1,6 @@
 use {
     crate::{
-        context::Context,
-        entities::perps_pair_price::PerpsPairPrice,
-        error::{IndexerError, Result},
+        context::Context, entities::perps_pair_price::PerpsPairPrice, error::Result,
         indexer::Indexer,
     },
     chrono::{DateTime, Utc},
@@ -21,13 +19,9 @@ pub mod generator;
 impl Indexer {
     pub(crate) async fn store_perps_candles(
         perps_addr: &Addr,
-        ctx: &grug_app::IndexerContext,
+        block_and_block_outcome: &BlockAndBlockOutcomeWithHttpDetails,
         context: &Context,
     ) -> Result<()> {
-        let block_and_block_outcome = ctx
-            .get::<BlockAndBlockOutcomeWithHttpDetails>()
-            .ok_or(IndexerError::missing_block_or_block_outcome())?;
-
         let created_at = DateTime::<Utc>::from_naive_utc_and_offset(
             block_and_block_outcome
                 .block

--- a/indexer/clickhouse/src/indexer/perps_fees.rs
+++ b/indexer/clickhouse/src/indexer/perps_fees.rs
@@ -1,10 +1,5 @@
 use {
-    crate::{
-        context::Context,
-        entities::perps_fees::PerpsFees,
-        error::{IndexerError, Result},
-        indexer::Indexer,
-    },
+    crate::{context::Context, entities::perps_fees::PerpsFees, error::Result, indexer::Indexer},
     chrono::{DateTime, Utc},
     dango_order_book::{Quantity, UsdPrice, UsdValue},
     dango_types::perps::{Deleveraged, FeeDistributed, OrderFilled},
@@ -18,13 +13,9 @@ use {
 impl Indexer {
     pub(crate) async fn store_perps_fees(
         perps_addr: &Addr,
-        ctx: &grug_app::IndexerContext,
+        block_and_block_outcome: &BlockAndBlockOutcomeWithHttpDetails,
         context: &Context,
     ) -> Result<()> {
-        let block_and_block_outcome = ctx
-            .get::<BlockAndBlockOutcomeWithHttpDetails>()
-            .ok_or(IndexerError::missing_block_or_block_outcome())?;
-
         let block_height = block_and_block_outcome.block.info.height;
         let created_at = DateTime::<Utc>::from_naive_utc_and_offset(
             block_and_block_outcome

--- a/indexer/clickhouse/src/indexer/trades.rs
+++ b/indexer/clickhouse/src/indexer/trades.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         context::Context,
         entities::{candle_query::MAX_ITEMS, trade::Trade},
-        error::{IndexerError, Result},
+        error::Result,
         indexer::Indexer,
     },
     chrono::{DateTime, Utc},
@@ -19,14 +19,10 @@ pub mod cache;
 impl Indexer {
     pub(crate) async fn store_trades(
         dex_addr: &Addr,
-        ctx: &grug_app::IndexerContext,
+        block_and_block_outcome: &BlockAndBlockOutcomeWithHttpDetails,
         context: &Context,
     ) -> Result<()> {
         let clickhouse_client = context.clickhouse_client().clone();
-
-        let block_and_block_outcome = ctx
-            .get::<BlockAndBlockOutcomeWithHttpDetails>()
-            .ok_or(IndexerError::missing_block_or_block_outcome())?;
 
         // Clearing price is denominated as the units of quote asset per 1 unit
         // of the base asset.

--- a/indexer/hooked/Cargo.toml
+++ b/indexer/hooked/Cargo.toml
@@ -19,28 +19,12 @@ metrics = ["dep:metrics"]
 tracing = ["dep:tracing"]
 
 [dependencies]
-anyhow        = { workspace = true }
-async-graphql = { workspace = true, optional = true }
-async-stream  = { workspace = true }
-async-trait   = { workspace = true }
-borsh         = { workspace = true }
-futures       = { workspace = true }
-grug-app      = { workspace = true }
-grug-types    = { workspace = true, features = ["chrono", "sea-orm"] }
-http          = { workspace = true }
-metrics       = { workspace = true, optional = true }
-sea-orm       = { workspace = true }
-serde         = { workspace = true }
-serde_json    = { workspace = true }
-sqlx          = { workspace = true }
-strum         = { workspace = true }
-strum_macros  = { workspace = true }
-tempfile      = { workspace = true }
-thiserror     = { workspace = true }
-tokio         = { workspace = true }
-tokio-stream  = { workspace = true }
-tracing       = { workspace = true, optional = true }
-uuid          = { workspace = true }
-
-[dev-dependencies]
-test-case = { workspace = true }
+async-trait        = { workspace = true }
+grug-app           = { workspace = true }
+grug-types         = { workspace = true }
+indexer-cache      = { workspace = true }
+indexer-clickhouse = { workspace = true }
+indexer-sql        = { workspace = true }
+metrics            = { workspace = true, optional = true }
+tokio              = { workspace = true }
+tracing            = { workspace = true, optional = true }

--- a/indexer/hooked/src/lib.rs
+++ b/indexer/hooked/src/lib.rs
@@ -1,6 +1,5 @@
 use {
     async_trait::async_trait,
-    futures::executor::block_on,
     grug_app::{APP_CONFIG, CONFIG, Indexer, IndexerResult, LAST_FINALIZED_BLOCK},
     grug_types::{Config, Json},
     std::{
@@ -11,45 +10,51 @@ use {
         },
         time::Duration,
     },
-    tokio::{
-        sync::{Mutex, RwLock},
-        time::sleep,
-    },
+    tokio::{sync::Mutex, time::sleep},
 };
 
 // Re-export for convenience
 pub use grug_app::IndexerError;
 
-/// A composable indexer that can own multiple indexers and coordinate between them
+/// Composite indexer that owns the three production indexer components and
+/// orchestrates their per-block work as a single `grug_app::Indexer`.
+///
+/// The "Hooked" name is historical — earlier revisions of this crate held a
+/// dynamic `Arc<RwLock<Vec<Box<dyn Indexer>>>>` and broadcasted each trait
+/// method to its entries, plumbing data between them through an opaque
+/// `http::Extensions`-based `IndexerContext`. The current shape is three
+/// concrete fields with the data flow expressed by typed method arguments,
+/// but the crate and struct name are kept so callers, deploy scripts, and
+/// imports do not need to churn.
+///
+/// `post_indexing` is still spawned as a separate tokio task per block so
+/// SQL and Clickhouse writes do not block consensus; `wait_for_finish` drains
+/// the per-block task map before letting the binary exit.
 #[derive(Clone)]
 pub struct HookedIndexer {
-    /// List of registered indexers
-    indexers: Arc<RwLock<Vec<Box<dyn Indexer + Send + Sync>>>>,
-    /// Whether the indexer is currently running
+    pub file: indexer_cache::Cache,
+    pub sql: indexer_sql::Indexer,
+    pub clickhouse: indexer_clickhouse::Indexer,
+    /// Set to true between `start` and `shutdown`.
     is_running: Arc<AtomicBool>,
+    /// One join handle per in-flight `post_indexing` block. Inserted when the
+    /// task is spawned; removed by the task itself when it completes.
     post_indexing_tasks: Arc<Mutex<HashMap<u64, tokio::task::JoinHandle<()>>>>,
 }
 
 impl HookedIndexer {
-    pub fn new() -> Self {
+    pub fn new(
+        file: indexer_cache::Cache,
+        sql: indexer_sql::Indexer,
+        clickhouse: indexer_clickhouse::Indexer,
+    ) -> Self {
         Self {
-            indexers: Arc::new(RwLock::new(Vec::new())),
+            file,
+            sql,
+            clickhouse,
             is_running: Arc::new(AtomicBool::new(false)),
             post_indexing_tasks: Arc::new(Mutex::new(HashMap::new())),
         }
-    }
-
-    /// Add an indexer to the composition
-    pub async fn add_indexer<I>(&mut self, indexer: I) -> Result<&mut Self, grug_app::IndexerError>
-    where
-        I: Indexer + Send + Sync + 'static,
-    {
-        if self.is_running.load(Ordering::Relaxed) {
-            return Err(grug_app::IndexerError::already_running());
-        }
-
-        self.indexers.write().await.push(Box::new(indexer));
-        Ok(self)
     }
 
     /// Check if the indexer is running
@@ -57,154 +62,106 @@ impl HookedIndexer {
         self.is_running.load(Ordering::Relaxed)
     }
 
-    // Synchronous version for tests and sync contexts
-    pub fn indexer_count_sync(&self) -> usize {
-        // For sync access, use futures::executor::block_on
-        block_on(async { self.indexer_count().await })
-    }
-
-    /// Get the number of registered indexers
-    pub async fn indexer_count(&self) -> usize {
-        self.indexers.read().await.len()
-    }
-
-    /// This will reindex all indexers from their last indexed block height
+    /// Replay any blocks that the SQL or Clickhouse stores missed since their
+    /// last indexed height, up to `LAST_FINALIZED_BLOCK`. `index_block` is
+    /// intentionally skipped — the cached on-disk file is already there, so
+    /// `pre_indexing` reloads the payload and `post_indexing` flushes it to
+    /// the SQL and Clickhouse stores.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn reindex(&self, storage: &dyn grug_types::Storage) -> IndexerResult<()> {
-        match LAST_FINALIZED_BLOCK.load(storage) {
+        let block = match LAST_FINALIZED_BLOCK.load(storage) {
             Err(_err) => {
                 // This happens when the chain starts at genesis
                 #[cfg(feature = "tracing")]
                 tracing::warn!(error = %_err, "No `LAST_FINALIZED_BLOCK` found");
+                return Ok(());
             },
-            Ok(block) => {
-                #[cfg(feature = "tracing")]
-                tracing::warn!(
-                    block_height = block.height,
-                    "Start called, found LAST_FINALIZED_BLOCK"
-                );
+            Ok(block) => block,
+        };
 
-                let mut indexers = self.indexers.write().await;
+        #[cfg(feature = "tracing")]
+        tracing::warn!(
+            block_height = block.height,
+            "Start called, found LAST_FINALIZED_BLOCK"
+        );
 
-                let cfg = CONFIG.load(storage).map_err(|e| {
-                    grug_app::IndexerError::storage(format!("Failed to load CONFIG: {e}"))
-                })?;
+        let cfg = CONFIG
+            .load(storage)
+            .map_err(|e| IndexerError::storage(format!("Failed to load CONFIG: {e}")))?;
 
-                let app_cfg = APP_CONFIG.load(storage).map_err(|e| {
-                    grug_app::IndexerError::storage(format!("Failed to load APP_CONFIG: {e}"))
-                })?;
+        let app_cfg = APP_CONFIG
+            .load(storage)
+            .map_err(|e| IndexerError::storage(format!("Failed to load APP_CONFIG: {e}")))?;
 
-                // 1. We get the lowest last indexed block height among all indexers,
-                let mut min_heights = Vec::new();
-                for indexer in indexers.iter_mut() {
-                    min_heights.push(indexer.last_indexed_block_height().await.ok().flatten());
-                }
+        // Lowest last-indexed height across components decides where we resume.
+        // Cache has no DB-backed counter; only SQL/Clickhouse contribute. (See
+        // the inherent `last_indexed_block_height` impls.)
+        let sql_last = self.sql.last_indexed_block_height().await.ok().flatten();
+        let clickhouse_last = self
+            .clickhouse
+            .last_indexed_block_height()
+            .await
+            .ok()
+            .flatten();
+        let min_height = [sql_last, clickhouse_last]
+            .into_iter()
+            .flatten()
+            .min()
+            .unwrap_or_default();
 
-                let min_height = min_heights
-                    .iter()
-                    .flatten()
-                    .min()
-                    .cloned()
-                    .unwrap_or_default();
+        if min_height >= block.height {
+            #[cfg(feature = "tracing")]
+            tracing::info!(
+                block_height = block.height,
+                "No reindexing needed, all indexers are up to date",
+            );
+            return Ok(());
+        }
 
-                if min_height >= block.height {
-                    #[cfg(feature = "tracing")]
-                    tracing::info!(
-                        block_height = block.height,
-                        "No reindexing needed, all indexers are up to date",
-                    );
-                    return Ok(());
-                }
+        for block_height in (min_height + 1)..=block.height {
+            // Cache loads the cached file into its in-memory map.
+            self.file.pre_indexing(block_height).await?;
 
-                let mut errors = Vec::new();
+            // Skip `index_block`: we don't have the live block data here and
+            // it's only used to *write* the disk cache, which already exists.
 
-                // 2. We run all indexers to reindex until the last finalized block, like it would
-                // have happened during normal operation but calling a different method.
-                for block_height in (min_height + 1)..=block.height {
-                    let mut ctx = grug_app::IndexerContext::new();
-                    for indexer in &mut indexers.iter_mut() {
-                        if let Err(err) = indexer.pre_indexing(block_height, &mut ctx).await {
-                            #[cfg(feature = "tracing")]
-                            tracing::error!("Error in start calling reindex: {:?}", err);
-                            errors.push(err.to_string());
-                        }
-                    }
-
-                    // NOTE: I skip `index_block` here because we don't have the actual block data and
-                    // it's only used to store data on disk, which we already have.
-                    // In the future this can be an issue if an indexer relies on `index_block`
-
-                    // I recreate a context like classic indexing code path
-                    let mut ctx = grug_app::IndexerContext::new();
-                    for indexer in &mut indexers.iter_mut() {
-                        if let Err(err) = indexer
-                            .post_indexing(block_height, cfg.clone(), app_cfg.clone(), &mut ctx)
-                            .await
-                        {
-                            #[cfg(feature = "tracing")]
-                            tracing::error!("Error in start calling reindex: {:?}", err);
-                            errors.push(err.to_string());
-                        }
-                    }
-
-                    if !errors.is_empty() {
-                        return Err(grug_app::IndexerError::multiple(errors));
-                    }
-                }
-            },
+            // Cache drains its in-memory map for this block and hands the
+            // payload to the SQL + Clickhouse consumers.
+            let payload = self.file.post_indexing(block_height).await?;
+            self.sql
+                .post_indexing(block_height, cfg.clone(), app_cfg.clone(), &payload)
+                .await?;
+            self.clickhouse
+                .post_indexing(block_height, cfg.clone(), app_cfg.clone(), &payload)
+                .await?;
         }
 
         Ok(())
-    }
-}
-
-impl Default for HookedIndexer {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
 #[async_trait]
 impl Indexer for HookedIndexer {
-    /// Start all indexers
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     async fn start(&mut self, storage: &dyn grug_types::Storage) -> IndexerResult<()> {
         if self.is_running.load(Ordering::Relaxed) {
-            return Err(grug_app::IndexerError::already_running());
+            return Err(IndexerError::already_running());
         }
 
-        #[cfg(feature = "tracing")]
-        {
-            let count = self.indexer_count().await;
-            tracing::debug!("Starting HookedIndexer with {} indexers", count);
-        }
-
-        let mut errors = Vec::new();
-
-        // Call start on all indexers, running required migrations
-        // With tokio::sync::RwLock, we can hold the lock across await points
-        let mut guard = self.indexers.write().await;
-        for indexer in guard.iter_mut() {
-            if let Err(err) = indexer.start(storage).await {
-                #[cfg(feature = "tracing")]
-                tracing::error!("Error in start: {:?}", err);
-                errors.push(err.to_string());
-            }
-        }
-        drop(guard);
+        self.file.start(storage).await?;
+        self.sql.start(storage).await?;
+        self.clickhouse.start(storage).await?;
 
         self.reindex(storage).await?;
 
         self.is_running.store(true, Ordering::Relaxed);
 
-        if !errors.is_empty() {
-            return Err(grug_app::IndexerError::multiple(errors));
-        }
-
         Ok(())
     }
 
-    /// Shutdown all indexers in reverse order
+    /// Shut down in reverse-construction order so any tail work (e.g.
+    /// Clickhouse candle flushes in `wait_for_finish`) drains before the
+    /// upstream stores close.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     async fn shutdown(&mut self) -> IndexerResult<()> {
         if !self.is_running.load(Ordering::Relaxed) {
@@ -213,147 +170,131 @@ impl Indexer for HookedIndexer {
 
         self.wait_for_finish().await?;
 
-        // Call shutdown on all indexers in reverse order
         let mut errors = Vec::new();
-        let mut guard = self.indexers.write().await;
-        for indexer in guard.iter_mut().rev() {
-            if let Err(err) = indexer.shutdown().await {
-                #[cfg(feature = "tracing")]
-                tracing::error!(err = %err, indexer_name = indexer.name(), "Error in shutdown");
 
-                errors.push(err.to_string());
-            }
+        if let Err(err) = self.clickhouse.shutdown().await {
+            #[cfg(feature = "tracing")]
+            tracing::error!(err = %err, indexer = "clickhouse", "Error in shutdown");
+            errors.push(err.to_string());
         }
-        drop(guard);
+        if let Err(err) = self.sql.shutdown().await {
+            #[cfg(feature = "tracing")]
+            tracing::error!(err = %err, indexer = "sql", "Error in shutdown");
+            errors.push(err.to_string());
+        }
+        if let Err(err) = self.file.shutdown().await {
+            #[cfg(feature = "tracing")]
+            tracing::error!(err = %err, indexer = "file", "Error in shutdown");
+            errors.push(err.to_string());
+        }
 
         self.is_running.store(false, Ordering::Relaxed);
 
         if !errors.is_empty() {
-            return Err(grug_app::IndexerError::multiple(errors));
+            return Err(IndexerError::multiple(errors));
         }
 
         Ok(())
     }
 
-    /// Run pre_indexing for each block height
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn pre_indexing(
-        &self,
-        block_height: u64,
-        ctx: &mut grug_app::IndexerContext,
-    ) -> IndexerResult<()> {
+    async fn pre_indexing(&self, block_height: u64) -> IndexerResult<()> {
         if !self.is_running.load(Ordering::Relaxed) {
-            return Err(grug_app::IndexerError::not_running());
+            return Err(IndexerError::not_running());
         }
 
-        let mut errors = Vec::new();
-
-        let guard = self.indexers.read().await;
-        for indexer in guard.iter() {
-            if let Err(err) = indexer.pre_indexing(block_height, ctx).await {
-                #[cfg(feature = "tracing")]
-                tracing::error!("Error in pre_indexing: {:?}", err);
-
-                errors.push(err.to_string());
-            }
-        }
-        drop(guard);
-
-        if !errors.is_empty() {
-            return Err(grug_app::IndexerError::multiple(errors));
-        }
+        // Only Cache has work here: it reloads the on-disk file (if any) into
+        // its in-memory map so `post_indexing` can drain it later. SQL and
+        // Clickhouse do nothing in this phase.
+        self.file.pre_indexing(block_height).await?;
 
         Ok(())
     }
 
-    /// Index a block by calling all registered indexers
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     async fn index_block(
         &self,
         block: &grug_types::Block,
         block_outcome: &grug_types::BlockOutcome,
-        ctx: &mut grug_app::IndexerContext,
     ) -> IndexerResult<()> {
         if !self.is_running.load(Ordering::Relaxed) {
-            return Err(grug_app::IndexerError::not_running());
+            return Err(IndexerError::not_running());
         }
 
-        let mut errors = Vec::new();
-        let guard = self.indexers.read().await;
-        for indexer in guard.iter() {
-            if let Err(err) = indexer.index_block(block, block_outcome, ctx).await {
-                #[cfg(feature = "tracing")]
-                tracing::error!("Error in index_block: {:?}", err);
-                errors.push(err.to_string());
-            }
-        }
-        drop(guard);
-
-        if !errors.is_empty() {
-            return Err(grug_app::IndexerError::multiple(errors));
-        }
+        // Only Cache has work here: it writes the block to disk (or reloads
+        // it if it was already there) and stashes the payload in its
+        // in-memory map for `post_indexing`.
+        self.file.index_block(block, block_outcome).await?;
 
         Ok(())
     }
 
-    /// Run post_indexing in a separate task for each block height
+    /// Spawn one tokio task per block. The task drains Cache's in-memory map
+    /// (producing the typed payload), then hands the payload to SQL and
+    /// Clickhouse in sequence. SQL must run before Clickhouse so the single
+    /// pubsub publish at the end of `SQL.post_indexing` fires before
+    /// Clickhouse's own publish (preserves the post-phase-2 ordering).
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     async fn post_indexing(
         &self,
         block_height: u64,
         cfg: Config,
         app_cfg: Json,
-        ctx: &mut grug_app::IndexerContext,
     ) -> IndexerResult<()> {
         if !self.is_running.load(Ordering::Relaxed) {
-            return Err(grug_app::IndexerError::not_running());
+            return Err(IndexerError::not_running());
         }
 
+        let file = self.file.clone();
+        let sql = self.sql.clone();
+        let clickhouse = self.clickhouse.clone();
         let post_indexing_tasks = self.post_indexing_tasks.clone();
-        let indexers = self.indexers.clone();
-
-        // Clone the `IndexerContext` to avoid borrowing issues.
-        // I do this clone because:
-        // 1. `IndexerContext` isn't used in the main task after `post_indexing` is called
-        // 2. `post_indexing` is called in a separate task
-        let mut ctx = ctx.clone();
 
         let handle = tokio::spawn(async move {
-            let mut errors = Vec::new();
-
-            let indexers_guard = indexers.read().await;
-
-            for indexer in indexers_guard.iter() {
-                if let Err(err) = indexer
-                    .post_indexing(block_height, cfg.clone(), app_cfg.clone(), &mut ctx)
-                    .await
-                {
+            let payload = match file.post_indexing(block_height).await {
+                Ok(payload) => payload,
+                Err(_err) => {
                     #[cfg(feature = "tracing")]
                     tracing::error!(
-                        indexer = indexer.name(),
-                        err = %err,
+                        err = %_err,
                         block_height,
-                        "Error post_indexing"
+                        "Cache post_indexing failed; skipping SQL + Clickhouse writes"
                     );
 
-                    errors.push(err.to_string());
-                }
-            }
+                    // Cleanup is still required so `wait_for_finish` terminates.
+                    post_indexing_tasks.lock().await.remove(&block_height);
+                    return;
+                },
+            };
 
-            drop(indexers_guard);
-
-            // Remove this task from the map when it completes
-            let mut tasks_guard = post_indexing_tasks.lock().await;
-            tasks_guard.remove(&block_height);
-            drop(tasks_guard);
-
-            if !errors.is_empty() {
+            if let Err(_err) = sql
+                .post_indexing(block_height, cfg.clone(), app_cfg.clone(), &payload)
+                .await
+            {
                 #[cfg(feature = "tracing")]
-                tracing::error!("Errors in post_indexing: {:?}", errors);
+                tracing::error!(
+                    err = %_err,
+                    block_height,
+                    "SQL post_indexing failed"
+                );
             }
+
+            if let Err(_err) = clickhouse
+                .post_indexing(block_height, cfg, app_cfg, &payload)
+                .await
+            {
+                #[cfg(feature = "tracing")]
+                tracing::error!(
+                    err = %_err,
+                    block_height,
+                    "Clickhouse post_indexing failed"
+                );
+            }
+
+            // Remove our handle so `wait_for_finish` can terminate.
+            post_indexing_tasks.lock().await.remove(&block_height);
         });
 
-        // Store the task handle with its block height
         self.post_indexing_tasks
             .lock()
             .await
@@ -362,13 +303,15 @@ impl Indexer for HookedIndexer {
         Ok(())
     }
 
-    /// Wait for all indexers and post_indexing tasks to finish
+    /// Wait for in-flight `post_indexing` tasks to finish, then forward to the
+    /// three components' own `wait_for_finish` hooks. Same shape as the old
+    /// dyn-dispatch version: poll the task map every 100ms.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     async fn wait_for_finish(&self) -> IndexerResult<()> {
         #[cfg(feature = "tracing")]
         tracing::debug!("Waiting for indexer to finish");
 
-        // 1. We have our own internal tasks that are running post_indexing
+        // 1. Drain in-flight per-block `post_indexing` tasks.
         loop {
             let tasks_guard = self.post_indexing_tasks.lock().await;
 
@@ -376,7 +319,6 @@ impl Indexer for HookedIndexer {
                 break;
             }
 
-            // Collect block heights for logging
             #[cfg(feature = "tracing")]
             let block_heights: Vec<u64> = tasks_guard.keys().copied().collect();
             #[cfg(feature = "tracing")]
@@ -390,10 +332,8 @@ impl Indexer for HookedIndexer {
                 "Waiting for post_indexing tasks to finish"
             );
 
-            // Wait a bit and check which tasks have completed
             sleep(Duration::from_millis(100)).await;
 
-            // Remove completed tasks
             let mut tasks_guard = self.post_indexing_tasks.lock().await;
             tasks_guard.retain(|&block_height, handle| {
                 let finished = handle.is_finished();
@@ -402,298 +342,31 @@ impl Indexer for HookedIndexer {
                     tracing::debug!(block_height, "Post_indexing task completed");
                 }
                 #[cfg(not(feature = "tracing"))]
-                let _ = block_height; // Suppress unused variable warning when tracing is disabled
+                let _ = block_height;
                 !finished
             });
         }
 
-        #[cfg(feature = "tracing")]
-        tracing::debug!("Waiting for indexers to finish");
-
-        // 2. We have the indexers that are potentially running their own way
-        let guard = self.indexers.read().await;
-        for indexer in guard.iter() {
-            indexer.wait_for_finish().await?;
-        }
-        drop(guard);
-
-        #[cfg(feature = "tracing")]
-        tracing::debug!("Waited for indexers to finish");
+        // 2. Drain each component's own background work.
+        self.file.wait_for_finish().await?;
+        self.sql.wait_for_finish().await?;
+        self.clickhouse.wait_for_finish().await?;
 
         Ok(())
+    }
+
+    async fn last_indexed_block_height(&self) -> IndexerResult<Option<u64>> {
+        let sql = self.sql.last_indexed_block_height().await?;
+        let clickhouse = self.clickhouse.last_indexed_block_height().await?;
+        Ok([sql, clickhouse].into_iter().flatten().min())
     }
 }
 
 impl Drop for HookedIndexer {
     fn drop(&mut self) {
-        // Since shutdown is now async, we can't call it from Drop
-        // Just mark as not running - the actual cleanup will happen when the async context completes
+        // `shutdown` is async; we can't call it from `Drop`. Flip the flag so
+        // any concurrent operations bail; the actual cleanup runs through the
+        // explicit `shutdown` call in the binary's signal handler.
         self.is_running.store(false, Ordering::Relaxed);
-    }
-}
-
-// ----------------------------------- tests -----------------------------------
-
-#[cfg(test)]
-mod tests {
-    use {super::*, grug_types::MockStorage};
-
-    #[derive(Default)]
-    struct TestIndexer {
-        calls: Arc<std::sync::Mutex<Vec<String>>>,
-    }
-
-    impl TestIndexer {
-        fn record_call(&self, method: &str) {
-            self.calls.lock().unwrap().push(method.to_string());
-        }
-    }
-
-    #[async_trait]
-    impl Indexer for TestIndexer {
-        async fn start(&mut self, _storage: &dyn grug_types::Storage) -> IndexerResult<()> {
-            self.record_call("start");
-            Ok(())
-        }
-
-        async fn shutdown(&mut self) -> IndexerResult<()> {
-            self.record_call("shutdown");
-            Ok(())
-        }
-
-        async fn pre_indexing(
-            &self,
-            _block_height: u64,
-            _ctx: &mut grug_app::IndexerContext,
-        ) -> IndexerResult<()> {
-            self.record_call("pre_indexing");
-            Ok(())
-        }
-
-        async fn index_block(
-            &self,
-            _block: &grug_types::Block,
-            _block_outcome: &grug_types::BlockOutcome,
-            _ctx: &mut grug_app::IndexerContext,
-        ) -> IndexerResult<()> {
-            self.record_call("index_block");
-            Ok(())
-        }
-
-        async fn post_indexing(
-            &self,
-            _block_height: u64,
-            _cfg: Config,
-            _app_cfg: Json,
-            _ctx: &mut grug_app::IndexerContext,
-        ) -> IndexerResult<()> {
-            self.record_call("post_indexing");
-            Ok(())
-        }
-
-        async fn wait_for_finish(&self) -> IndexerResult<()> {
-            self.record_call("wait_for_finish");
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn test_hooked_indexer_creation() {
-        let indexer = HookedIndexer::new();
-        assert_eq!(indexer.indexer_count_sync(), 0);
-        assert!(!indexer.is_running());
-    }
-
-    #[tokio::test]
-    async fn test_add_indexers() {
-        let mut hooked_indexer = HookedIndexer::new();
-
-        hooked_indexer
-            .add_indexer(TestIndexer::default())
-            .await
-            .unwrap()
-            .add_indexer(TestIndexer::default())
-            .await
-            .unwrap();
-
-        assert_eq!(hooked_indexer.indexer_count().await, 2);
-    }
-
-    #[tokio::test]
-    async fn test_start_and_shutdown() {
-        let mut hooked_indexer = HookedIndexer::new();
-        hooked_indexer
-            .add_indexer(TestIndexer::default())
-            .await
-            .unwrap();
-
-        let storage = MockStorage::new();
-
-        // Test start
-        assert!(!hooked_indexer.is_running());
-        hooked_indexer.start(&storage).await.unwrap();
-        assert!(hooked_indexer.is_running());
-
-        // Test shutdown
-        hooked_indexer.shutdown().await.unwrap();
-        assert!(!hooked_indexer.is_running());
-    }
-
-    #[tokio::test]
-    async fn test_double_start_fails() {
-        let mut hooked_indexer = HookedIndexer::new();
-        hooked_indexer
-            .add_indexer(TestIndexer::default())
-            .await
-            .unwrap();
-
-        let storage = MockStorage::new();
-
-        hooked_indexer.start(&storage).await.unwrap();
-
-        // Second start should fail
-        assert!(hooked_indexer.start(&storage).await.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_operations_when_not_running() {
-        let mut hooked_indexer = HookedIndexer::new();
-        hooked_indexer
-            .add_indexer(TestIndexer::default())
-            .await
-            .unwrap();
-
-        let mut ctx = grug_app::IndexerContext::new();
-
-        // Operations should fail when not running
-        assert!(hooked_indexer.pre_indexing(1, &mut ctx).await.is_err());
-
-        let block = grug_types::Block {
-            info: grug_types::BlockInfo {
-                height: 1,
-                timestamp: grug_types::Timestamp::from_seconds(1),
-                hash: [0u8; 32].into(),
-            },
-            txs: vec![],
-        };
-
-        let outcome = grug_types::BlockOutcome {
-            height: 1,
-            app_hash: grug_types::Hash256::ZERO,
-            cron_outcomes: vec![],
-            tx_outcomes: vec![],
-        };
-
-        assert!(
-            hooked_indexer
-                .index_block(&block, &outcome, &mut ctx)
-                .await
-                .is_err()
-        );
-    }
-
-    /// Example indexer that stores data in the context for later indexers to use
-    #[derive(Default)]
-    struct DataProducerIndexer {
-        id: String,
-    }
-
-    impl DataProducerIndexer {
-        fn new(id: &str) -> Self {
-            Self { id: id.to_string() }
-        }
-    }
-
-    #[async_trait]
-    impl Indexer for DataProducerIndexer {
-        async fn pre_indexing(
-            &self,
-            block_height: u64,
-            ctx: &mut grug_app::IndexerContext,
-        ) -> IndexerResult<()> {
-            // Store some data that other indexers can use
-            ctx.insert(format!("data_from_{}_at_height_{}", self.id, block_height));
-            Ok(())
-        }
-    }
-
-    /// Example indexer that consumes data from the context
-    #[derive(Default)]
-    struct DataConsumerIndexer {
-        consumed_data: Arc<std::sync::Mutex<Vec<String>>>,
-    }
-
-    impl DataConsumerIndexer {
-        fn new() -> Self {
-            Self {
-                consumed_data: Arc::new(std::sync::Mutex::new(Vec::new())),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl Indexer for DataConsumerIndexer {
-        async fn index_block(
-            &self,
-            _block: &grug_types::Block,
-            _block_outcome: &grug_types::BlockOutcome,
-            ctx: &mut grug_app::IndexerContext,
-        ) -> IndexerResult<()> {
-            // Try to consume data stored by other indexers
-            if let Some(data) = ctx.get::<String>() {
-                self.consumed_data.lock().unwrap().push(data.clone());
-            }
-            Ok(())
-        }
-    }
-
-    #[tokio::test]
-    async fn test_context_data_passing() {
-        let mut hooked_indexer = HookedIndexer::new();
-
-        // Add a producer indexer that stores data
-        let producer = DataProducerIndexer::new("producer1");
-        hooked_indexer.add_indexer(producer).await.unwrap();
-
-        // Add a consumer indexer that reads data
-        let consumer = DataConsumerIndexer::new();
-        let consumer_data = consumer.consumed_data.clone();
-        hooked_indexer.add_indexer(consumer).await.unwrap();
-
-        let storage = MockStorage::new();
-        hooked_indexer.start(&storage).await.unwrap();
-
-        let block = grug_types::Block {
-            info: grug_types::BlockInfo {
-                height: 42,
-                timestamp: grug_types::Timestamp::from_seconds(123456789),
-                hash: grug_types::Hash256::ZERO,
-            },
-            txs: vec![],
-        };
-        let outcome = grug_types::BlockOutcome {
-            height: 42,
-            app_hash: grug_types::Hash256::ZERO,
-            cron_outcomes: vec![],
-            tx_outcomes: vec![],
-        };
-
-        let mut ctx = grug_app::IndexerContext::new();
-
-        // Run the indexing pipeline
-        hooked_indexer.pre_indexing(42, &mut ctx).await.unwrap();
-        hooked_indexer
-            .index_block(&block, &outcome, &mut ctx)
-            .await
-            .unwrap();
-
-        // Verify that data was passed from producer to consumer
-        {
-            let consumed_data = consumer_data.lock().unwrap();
-            assert_eq!(consumed_data.len(), 1);
-            assert_eq!(consumed_data[0], "data_from_producer1_at_height_42");
-        }
-
-        hooked_indexer.shutdown().await.unwrap();
     }
 }

--- a/indexer/sql/src/indexer.rs
+++ b/indexer/sql/src/indexer.rs
@@ -12,8 +12,6 @@ use {
         entity, error,
         pubsub::{MemoryPubSub, PostgresPubSub, PubSubType},
     },
-    async_trait::async_trait,
-    grug_app::Indexer as IndexerTrait,
     grug_types::{
         BlockAndBlockOutcomeWithHttpDetails, Config, Defined, Json, MaybeDefined, Storage,
         Undefined,
@@ -301,6 +299,7 @@ static INDEXER_COUNTER: AtomicU64 = AtomicU64::new(1);
 ///
 /// Decided to do different and prepare the data in memory in `blocks` to inject all data in a single Tokio
 /// spawned task
+#[derive(Clone)]
 pub struct Indexer {
     pub context: Context,
     // NOTE: this could be Arc<AtomicBool> because if this Indexer is cloned all instances should
@@ -465,9 +464,8 @@ impl Indexer {
     }
 }
 
-#[async_trait]
-impl IndexerTrait for Indexer {
-    async fn last_indexed_block_height(&self) -> grug_app::IndexerResult<Option<u64>> {
+impl Indexer {
+    pub async fn last_indexed_block_height(&self) -> grug_app::IndexerResult<Option<u64>> {
         let last_indexed_block_height =
             entity::blocks::Entity::find_last_block_height(&self.context.db)
                 .await
@@ -477,7 +475,7 @@ impl IndexerTrait for Indexer {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn start(&mut self, _storage: &dyn Storage) -> grug_app::IndexerResult<()> {
+    pub async fn start(&mut self, _storage: &dyn Storage) -> grug_app::IndexerResult<()> {
         #[cfg(feature = "metrics")]
         crate::metrics::init_indexer_metrics();
 
@@ -492,7 +490,7 @@ impl IndexerTrait for Indexer {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn shutdown(&mut self) -> grug_app::IndexerResult<()> {
+    pub async fn shutdown(&mut self) -> grug_app::IndexerResult<()> {
         // Avoid running this twice when called manually and from `Drop`
         if !self.indexing {
             return Ok(());
@@ -503,13 +501,20 @@ impl IndexerTrait for Indexer {
         Ok(())
     }
 
+    /// No-op kept for symmetry with the other indexers' `wait_for_finish`.
+    /// The SQL writer commits inline at the end of `post_indexing`, so there
+    /// is no background work to drain here.
+    pub async fn wait_for_finish(&self) -> grug_app::IndexerResult<()> {
+        Ok(())
+    }
+
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    async fn post_indexing(
+    pub async fn post_indexing(
         &self,
         block_height: u64,
         _cfg: Config,
         app_cfg: Json,
-        ctx: &mut grug_app::IndexerContext,
+        block: &BlockAndBlockOutcomeWithHttpDetails,
     ) -> grug_app::IndexerResult<()> {
         if !self.indexing {
             return Err(grug_app::IndexerError::not_running());
@@ -517,12 +522,6 @@ impl IndexerTrait for Indexer {
 
         #[cfg(feature = "tracing")]
         tracing::debug!(block_height, "`post_indexing` called");
-
-        let block = ctx.get::<BlockAndBlockOutcomeWithHttpDetails>().ok_or(
-            grug_app::IndexerError::hook(
-                "BlockAndBlockOutcomeWithHttpDetails not found".to_string(),
-            ),
-        )?;
 
         #[cfg(feature = "tracing")]
         let id = self.id;

--- a/indexer/testing/Cargo.toml
+++ b/indexer/testing/Cargo.toml
@@ -25,7 +25,7 @@ grug-testing          = { workspace = true }
 grug-types            = { workspace = true }
 grug-vm-rust          = { workspace = true }
 indexer-cache         = { workspace = true, features = ["http-request-details", "tracing"] }
-indexer-clickhouse    = { workspace = true }
+indexer-clickhouse    = { workspace = true, features = ["testing"] }
 indexer-graphql-types = { workspace = true }
 indexer-hooked        = { workspace = true, features = ["tracing"] }
 indexer-httpd         = { workspace = true, features = ["tracing"] }

--- a/indexer/testing/src/setup.rs
+++ b/indexer/testing/src/setup.rs
@@ -13,9 +13,16 @@ pub async fn create_hooked_indexer() -> (HookedIndexer, indexer_sql::Context, in
     let cache_indexer = indexer_cache::Cache::new_with_tempdir();
     let indexer_cache_context = cache_indexer.context.clone();
 
-    let mut hooked_indexer = HookedIndexer::new();
-    hooked_indexer.add_indexer(cache_indexer).await.unwrap();
-    hooked_indexer.add_indexer(sql_indexer).await.unwrap();
+    let clickhouse_context = indexer_clickhouse::context::Context::new(
+        "http://localhost:8123".to_string(),
+        "default".to_string(),
+        "default".to_string(),
+        "default".to_string(),
+    )
+    .with_mock();
+    let clickhouse_indexer = indexer_clickhouse::indexer::Indexer::new(clickhouse_context);
+
+    let hooked_indexer = HookedIndexer::new(cache_indexer, sql_indexer, clickhouse_indexer);
 
     (hooked_indexer, sql_indexer_context, indexer_cache_context)
 }

--- a/indexer/testing/tests/indexing/hooked/block.rs
+++ b/indexer/testing/tests/indexing/hooked/block.rs
@@ -1,6 +1,7 @@
 use {
     crate::sql::block::replier,
     assertor::*,
+    dango_types::config::AppConfig,
     grug_app::{Db, Indexer},
     grug_testing::TestBuilder,
     grug_types::{
@@ -91,6 +92,8 @@ async fn parse_previous_block_after_restart() {
     let (indexer, indexer_context, _) = create_hooked_indexer().await;
 
     let (mut suite, mut accounts) = TestBuilder::new_with_indexer(indexer)
+        .set_app_config(&AppConfig::default())
+        .unwrap()
         .add_account("owner", Coins::new())
         .add_account("sender", Coins::one(denom.clone(), 30_000).unwrap())
         .set_owner("owner")

--- a/indexer/testing/tests/indexing/sql/block.rs
+++ b/indexer/testing/tests/indexing/sql/block.rs
@@ -1,5 +1,6 @@
 use {
     assertor::*,
+    dango_types::config::AppConfig,
     grug_app::{Db, Indexer},
     grug_testing::TestBuilder,
     grug_types::{
@@ -90,6 +91,8 @@ async fn parse_previous_block_after_restart() {
     let (indexer, sql_indexer_context, ..) = create_hooked_indexer().await;
 
     let (mut suite, mut accounts) = TestBuilder::new_with_indexer(indexer)
+        .set_app_config(&AppConfig::default())
+        .unwrap()
         .add_account("owner", Coins::new())
         .add_account("sender", Coins::one(denom.clone(), 30_000).unwrap())
         .set_owner("owner")


### PR DESCRIPTION
Replace the dynamic `Arc<RwLock<Vec<Box<dyn Indexer>>>>` combinator with a concrete three-field `HookedIndexer { file, sql, clickhouse }` and remove the opaque `http::Extensions`-based `IndexerContext` data channel between indexers in favor of typed method arguments.