### PR TITLE
chore(deploy): expose ClickHouse HTTP port 8123 on Tailscale/Wireguard

### DIFF
--- a/deploy/roles/clickhouse/templates/docker-compose.yml
+++ b/deploy/roles/clickhouse/templates/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       environment: "production"
     ports:
       - "127.0.0.1:9000:9000"
+      - "${TAILSCALE_IP}:8123:8123"
+      - "${WIREGUARD_IP}:8123:8123"
       - "${TAILSCALE_IP}:9126:9126"
       - "${WIREGUARD_IP}:9126:9126"
     volumes:


### PR DESCRIPTION
## Summary

- Adds host port bindings for ClickHouse's HTTP query port (`8123`) on both Tailscale and Wireguard IPs in `roles/clickhouse/templates/docker-compose.yml`.
- Previously only the Prometheus metrics endpoint (`9126`) was exposed externally — query ports were restricted to `127.0.0.1`, blocking BI tools (Metabase, Grafana ClickHouse plugin) from reaching ClickHouse from another host.
- Authentication is already enforced in `users.xml` (`<password>` required, no anonymous user), so exposing on the private tailnet is safe.

Applies to all hosts deployed via the standalone `clickhouse.yml` playbook — devnet (ovh1, ovh2), testnet (hetzner2, hetzner4), mainnet (hetzner1), and any other host in the `[clickhouse]` inventory group. Preview / previewnet uses a different embedded compose in `roles/full-app/templates/docker-compose.yml` and is **not** affected by this change.

## Validation

### Completed

- [x] `just lint` — no new warnings introduced on the modified file
- [x] Verified ClickHouse already listens on `8123` inside the container (`http_port` in `roles/clickhouse/templates/config.xml`; live `wget http://localhost:8123/ping` returns `Ok.`)
- [x] Verified `users.xml` enforces `<password>` auth (no anonymous access)

### Remaining

- [ ] Apply to one devnet host first (`ovh1`) and verify connectivity
- [ ] Roll out to remaining devnet host (`ovh2`)
- [ ] Roll out to testnet (`hetzner2`, `hetzner4`)
- [ ] Roll out to mainnet (`hetzner1`)

## Manual QA

Per-host rollout (run from `deploy/`):

```bash
# 1. Deploy
uv run ansible-playbook clickhouse.yml --limit <tailscale-ip>

# 2. TCP reachability from tailnet
nc -zv <tailscale-ip> 8123

# 3. HTTP /ping (no auth)
curl -s http://<tailscale-ip>:8123/ping
# expected: Ok.

# 4. Authenticated query
curl -s "http://default:$CLICKHOUSE_PASSWORD@<tailscale-ip>:8123/?query=SELECT+version()"
# expected: a version string

# 5. Indexer smoke check — no clickhouse errors
ssh deploy@<host> "docker logs --tail 50 <indexer-container> 2>&1 | grep -i 'clickhouse\\|error'"
```

Recreation of the ClickHouse container causes ~10s of downtime per host. The dango indexer reconnects automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)