### PR TITLE
fix(ui): clamp PointsProgressBar window to a fixed step count

### DIFF
--- a/ui/portal/web/src/components/points/rewards/PointsProgressBar.tsx
+++ b/ui/portal/web/src/components/points/rewards/PointsProgressBar.tsx
@@ -89,6 +89,10 @@ const useProgressBarState = (currentVolume: number): ProgressBarState => {
   return useMemo(() => {
     const safeVolume = Math.max(currentVolume, 0);
     const steps = calculateSteps(safeVolume);
+    // Crashes (because `steps` would be empty) when `currentVolume` is NaN
+    // or Infinity — which would happen if the API returned volume as "NaN",
+    // "Infinity", or a non-numeric string. In practice this can't happen —
+    // the Rust server-side enforces volume as a numeric string.
     const firstThreshold = steps[0].threshold;
     const lastThreshold = steps[steps.length - 1].threshold;
     const span = lastThreshold - firstThreshold;

--- a/ui/portal/web/src/components/points/rewards/PointsProgressBar.tsx
+++ b/ui/portal/web/src/components/points/rewards/PointsProgressBar.tsx
@@ -22,6 +22,7 @@ type ProgressBarState = {
 
 const MILESTONE_STEP = 25_000;
 const LOOKAHEAD_STEPS = 24; // milestones rendered ahead of the user (>20 as requested)
+const LOOKBEHIND_STEPS = 1; // milestones rendered behind, so the just-passed milestone stays visible
 
 const TIER_LABELS: Record<TierKey, () => string> = {
   bronze: () => m["points.rewards.boxes.tiers.bronze"](),
@@ -60,10 +61,14 @@ const formatThresholdLabel = (value: number): string => {
 
 const calculateSteps = (currentVolume: number): Step[] => {
   const currentMs = Math.floor(Math.max(currentVolume, 0) / MILESTONE_STEP);
+  const startMs = Math.max(0, currentMs - LOOKBEHIND_STEPS);
   const endMs = currentMs + LOOKAHEAD_STEPS;
 
-  const steps: Step[] = [{ kind: "start", threshold: 0, tierKey: "bronze" }];
-  for (let n = 1; n <= endMs; n++) {
+  const steps: Step[] = [];
+  if (startMs === 0) {
+    steps.push({ kind: "start", threshold: 0, tierKey: "bronze" });
+  }
+  for (let n = Math.max(1, startMs); n <= endMs; n++) {
     const threshold = n * MILESTONE_STEP;
     steps.push({
       kind: "milestone",
@@ -84,9 +89,11 @@ const useProgressBarState = (currentVolume: number): ProgressBarState => {
   return useMemo(() => {
     const safeVolume = Math.max(currentVolume, 0);
     const steps = calculateSteps(safeVolume);
+    const firstThreshold = steps[0].threshold;
     const lastThreshold = steps[steps.length - 1].threshold;
+    const span = lastThreshold - firstThreshold;
     const progress =
-      lastThreshold > 0 ? Math.min(Math.max((safeVolume / lastThreshold) * 100, 0), 100) : 0;
+      span > 0 ? Math.min(Math.max(((safeVolume - firstThreshold) / span) * 100, 0), 100) : 0;
     const { tier: nextTier, target } = getNextMilestone(safeVolume);
     const remaining = Math.max(target - safeVolume, 0);
 

--- a/ui/portal/web/src/pages/(app)/_app.points.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.points.tsx
@@ -15,7 +15,7 @@ function RouteComponent() {
   const navigate = Route.useNavigate();
 
   const handleTabChange = (newTab: "profile" | "rewards" | "leaderboard") => {
-    navigate({ search: { tab: newTab }, replace: true });
+    navigate({ search: { tab: newTab }, replace: true, resetScroll: false });
   };
 
   return (

--- a/ui/portal/web/src/pages/(app)/_app.referral.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.referral.tsx
@@ -15,7 +15,7 @@ function RouteComponent() {
   const navigate = Route.useNavigate();
 
   const handleTabChange = (newTab: "affiliate" | "trader") => {
-    navigate({ search: { tab: newTab }, replace: true });
+    navigate({ search: { tab: newTab }, replace: true, resetScroll: false });
   };
 
   return (


### PR DESCRIPTION
The step array grew linearly with lifetime volume, producing tens of
thousands of absolutely-positioned DOM nodes for high-volume accounts
and dominating campaign-page render time.

Cap the visible window to LOOKBEHIND_STEPS + LOOKAHEAD_STEPS
milestones around the user's current position, and base the fill
percentage on the visible span instead of from $0.
