### PR TITLE
chore(hyperlane): route relayer/validator via local dango node

### DIFF
--- a/deploy/roles/hyperlane/files/config.json
+++ b/deploy/roles/hyperlane/files/config.json
@@ -2,7 +2,7 @@
   "chains": {
     "dango": {
       "chain_id": "dango-1",
-      "httpd_urls": ["https://api-mainnet.dango.zone"],
+      "httpd_urls": ["http://dango:8080", "https://api-mainnet.dango.zone"],
       "mailbox": "0x974e57564ed3ed7d8f99d0c359fd03f3d78259c7",
       "interchainGasPaymaster": "0x0000000000000000000000000000000000000000",
       "validatorAnnounce": "0x75f38c6fcfc2fb8333e5c3ef89d13b7036abe3ff",
@@ -17,7 +17,7 @@
     },
     "dangotestnet": {
       "chain_id": "dango-testnet-1",
-      "httpd_urls": ["https://api-testnet.dango.zone"],
+      "httpd_urls": ["http://dango:8080", "https://api-testnet.dango.zone"],
       "mailbox": "0x974e57564ed3ed7d8f99d0c359fd03f3d78259c7",
       "interchainGasPaymaster": "0x0000000000000000000000000000000000000000",
       "validatorAnnounce": "0x75f38c6fcfc2fb8333e5c3ef89d13b7036abe3ff",

--- a/deploy/roles/hyperlane/files/docker-compose-relayer.yml
+++ b/deploy/roles/hyperlane/files/docker-compose-relayer.yml
@@ -16,3 +16,10 @@ services:
       - "${HYPERLANE_METRICS_HOST_PORT}:9090"
     command: ["./relayer"]
     restart: unless-stopped
+    networks:
+      - default
+      - traefik
+
+networks:
+  traefik:
+    external: true

--- a/deploy/roles/hyperlane/files/docker-compose-validator.yml
+++ b/deploy/roles/hyperlane/files/docker-compose-validator.yml
@@ -16,3 +16,10 @@ services:
       - "${HYPERLANE_METRICS_HOST_PORT}:9090"
     command: ["./validator"]
     restart: unless-stopped
+    networks:
+      - default
+      - traefik
+
+networks:
+  traefik:
+    external: true


### PR DESCRIPTION
## Summary

Punta relayer e validator Hyperlane al nodo Dango locale (`http://dango:8080`) invece dell'API pubblica, così il traffico resta dentro la rete docker dell'host e non passa per l'API pubblico.

- `config.json` (mainnet + testnet): aggiunge `http://dango:8080` come URL primario per la chain `dango`/`dangotestnet`, mantenendo `https://api-{network}.dango.zone` come fallback.
- `docker-compose-validator.yml` / `docker-compose-relayer.yml`: attacca i container al network `traefik` (external) per risolvere il nome `dango` (il container Dango sta in quella rete).

Recupera il commit `5301b49b8` dal branch dormiente `chore/hyperlane-local-dango-routing`.

## Validation

### Completed

- [x] Diff equivalente al commit originale (`5301b49b8`), cherry-pick clean su `main`
- [x] `yamllint` non introduce nuovi errori sui file modificati (i preesistenti su linea 3 e document-start erano già presenti prima)

### Remaining

- [ ] Verificare che gli host hyperlane abbiano sia il container `dango` raggiungibile sul network `traefik`, sia che `dango:8080` sia l'endpoint httpd corretto
- [ ] Deploy + check log che il validator usi davvero l'URL interno (non il fallback)

## Manual QA

1. `just deploy-hyperlane mainnet validator <host> <index>` su un host (es. hetzner6, validator 2)
2. `ssh <host> 'docker logs mainnet-validator-<index> 2>&1 | grep -i httpd'` — l'URL usato deve essere `http://dango:8080`
3. Controllare metriche Hyperlane su Prometheus: nessuna anomalia di reindexing