### PR TITLE
refactor(oracle): collapse `PriceSource` and `Price<P>` into plain structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,9 +4006,12 @@ version = "0.0.0"
 dependencies = [
  "dango-bank",
  "dango-gateway",
+ "dango-oracle",
+ "dango-order-book",
  "dango-types",
  "grug",
  "grug-app",
+ "pyth-types",
  "tracing",
 ]
 

--- a/book/overview/3-dango-contracts.md
+++ b/book/overview/3-dango-contracts.md
@@ -155,15 +155,14 @@ Price feed aggregation for derivatives trading.
 | ---------------------- | --------------- | -------------------- |
 | `PRICE_SOURCES`        | `Denom`         | `PriceSource`        |
 | `PYTH_TRUSTED_SIGNERS` | `[u8]` (pubkey) | `Timestamp` (expiry) |
-| `PYTH_PRICES`          | `PythId`        | `PrecisionlessPrice` |
+| `PYTH_PRICES`          | `PythId`        | `Price`              |
 
 ### Price structure
 
 ```rust
-pub struct PrecisionlessPrice {
-    pub humanized_price: Udec128,  // e.g., 50000.0 for $50k BTC
-    pub timestamp: Timestamp,       // Feed age
-    pub precision: u8,              // Decimal places
+pub struct Price {
+    pub humanized_price: UsdPrice, // e.g., 50000.0 for $50k BTC
+    pub timestamp: Timestamp,      // Feed age
 }
 ```
 

--- a/dango/oracle/src/execute.rs
+++ b/dango/oracle/src/execute.rs
@@ -3,10 +3,7 @@ use {
     anyhow::{bail, ensure},
     dango_types::{
         DangoQuerier,
-        oracle::{
-            ExecuteMsg, InstantiateMsg, PrecisionlessPrice, PriceSource, ReplyMsg,
-            VaultRefreshFailed,
-        },
+        oracle::{ExecuteMsg, InstantiateMsg, Price, PriceSource, ReplyMsg, VaultRefreshFailed},
         perps,
     },
     grug::{
@@ -153,7 +150,7 @@ fn feed_prices(ctx: MutableCtx, price_update: PriceUpdate) -> anyhow::Result<Res
         // Store the prices from each feed.
         for feed in payload.feeds {
             let id = feed.feed_id.0;
-            let price = PrecisionlessPrice::try_from((feed, timestamp))?;
+            let price = Price::try_from((feed, timestamp))?;
 
             PYTH_PRICES.may_update(ctx.storage, id, |current| -> anyhow::Result<_> {
                 match current {
@@ -302,7 +299,7 @@ mod tests {
         let timestamp = Timestamp::from_micros(payload.timestamp_us.as_micros().into());
 
         for feed in payload.feeds {
-            let price = PrecisionlessPrice::try_from((feed, timestamp)).unwrap();
+            let price = Price::try_from((feed, timestamp)).unwrap();
             let _price_f64: f64 = price.humanized_price.to_string().parse().unwrap();
         }
     }

--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -2,17 +2,14 @@ use {
     crate::{PRICE_SOURCES, PYTH_PRICES},
     anyhow::{anyhow, ensure},
     dango_order_book::UsdPrice,
-    dango_types::oracle::{PrecisionedPrice, PrecisionlessPrice, PriceSource},
-    grug::{
-        Addr, Cache, Dec128_6, Denom, Inner, QuerierWrapper, StdResult, Storage, StorageQuerier,
-        Timestamp, Unsigned,
-    },
+    dango_types::oracle::{Price, PriceSource},
+    grug::{Addr, Cache, Denom, QuerierWrapper, StdResult, Storage, StorageQuerier, Timestamp},
     pyth_types::PythId,
     std::collections::HashMap,
 };
 
 pub struct OracleQuerier<'a> {
-    cache: Cache<'a, Denom, PrecisionedPrice, anyhow::Error, PriceSource>,
+    cache: Cache<'a, Denom, Price, anyhow::Error, PriceSource>,
     no_older_than: Option<Timestamp>,
 }
 
@@ -32,7 +29,7 @@ impl<'a> OracleQuerier<'a> {
 
     /// Create a new `OracleQuerier` that returns predefined prices in a hash map.
     /// For using in tests.
-    pub fn new_mock(prices: HashMap<Denom, PrecisionedPrice>) -> Self {
+    pub fn new_mock(prices: HashMap<Denom, Price>) -> Self {
         Self {
             cache: Cache::new(move |denom, _| {
                 prices.get(denom).cloned().ok_or_else(|| {
@@ -55,7 +52,7 @@ impl<'a> OracleQuerier<'a> {
         &mut self,
         denom: &Denom,
         price_source: Option<PriceSource>,
-    ) -> anyhow::Result<PrecisionedPrice> {
+    ) -> anyhow::Result<Price> {
         self.cache
             .get_or_fetch(denom, price_source)
             .and_then(|price| {
@@ -75,25 +72,11 @@ impl<'a> OracleQuerier<'a> {
             .cloned()
     }
 
-    /// Similar to `self.query_price` but converts the price to the format
-    /// expected by the perps contract.
-    // Oracle contract stores prices in Udec128_18. We need to convert it to Dec128_6.
-    // TODO: we should store prices in oracle contract as Dec128_6 as well.
+    /// Similar to `self.query_price` but returns just the humanized price,
+    /// matching the type used by the perps contract.
     pub fn query_price_for_perps(&mut self, denom: &Denom) -> anyhow::Result<UsdPrice> {
-        self.query_price(denom, None).and_then(|price| {
-            let price = price.humanized_price.checked_into_signed()?;
-            let inner = Dec128_6::checked_from_atomics(price.into_inner(), 18)?;
-            Ok(UsdPrice::new(inner))
-        })
-    }
-
-    /// Query the price for a given denom, optionally specifying the price source.
-    pub fn query_price_ignore_staleness(
-        &mut self,
-        denom: &Denom,
-        price_source: Option<PriceSource>,
-    ) -> anyhow::Result<PrecisionedPrice> {
-        self.cache.get_or_fetch(denom, price_source).cloned()
+        self.query_price(denom, None)
+            .map(|price| price.humanized_price)
     }
 }
 
@@ -116,12 +99,11 @@ impl<'a> OracleQuerierNoCache<'a> {
         &self,
         denom: &Denom,
         price_source: Option<PriceSource>,
-    ) -> anyhow::Result<PrecisionedPrice> {
+    ) -> anyhow::Result<Price> {
         // Query the denom's price source, if not provided.
         let price_source = price_source.map_or_else(|| self.ctx.get_price_source(denom), Ok)?;
 
-        let price = self.ctx.get_price(price_source.id)?;
-        Ok(price.with_precision(price_source.precision))
+        Ok(self.ctx.get_price(price_source.id)?)
     }
 }
 
@@ -137,7 +119,7 @@ enum OracleContext<'a> {
 
 #[rustfmt::skip]
 impl OracleContext<'_> {
-    fn get_price(&self, pyth_id: PythId) -> StdResult<PrecisionlessPrice> {
+    fn get_price(&self, pyth_id: PythId) -> StdResult<Price> {
         match self {
             OracleContext::Local { storage } => {
                 PYTH_PRICES.load(*storage, pyth_id)
@@ -167,36 +149,33 @@ mod tests {
     use {
         super::*,
         dango_types::constants::{eth, usdc},
-        grug::{ResultExt, Timestamp, Udec128, hash_map},
+        grug::{ResultExt, Timestamp, hash_map},
         test_case::test_case,
     };
 
     #[test_case(
         hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(2000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_int(2_000),
                 Timestamp::from_seconds(1730802926),
-                6,
             ),
         };
         "mock with one price"
     )]
     #[test_case(
         hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(2000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_int(2_000),
                 Timestamp::from_seconds(1730802926),
-                6,
             ),
-            usdc::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(1000),
+            usdc::DENOM.clone() => Price::new(
+                UsdPrice::new_int(1),
                 Timestamp::from_seconds(1730802926),
-                6,
             ),
         };
         "mock with two prices"
     )]
-    fn mock(prices: HashMap<Denom, PrecisionedPrice>) {
+    fn mock(prices: HashMap<Denom, Price>) {
         let mut oracle_querier = OracleQuerier::new_mock(prices.clone());
 
         for (denom, expected_price) in prices {
@@ -239,10 +218,9 @@ mod tests {
         no_older_than: Option<Timestamp>,
     ) -> bool {
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(2000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_int(2_000),
                 publish_time,
-                6,
             ),
         });
 

--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -120,21 +120,8 @@ impl<'a> OracleQuerierNoCache<'a> {
         // Query the denom's price source, if not provided.
         let price_source = price_source.map_or_else(|| self.ctx.get_price_source(denom), Ok)?;
 
-        // Compute the price based on the price source.
-        match price_source {
-            PriceSource::Fixed {
-                humanized_price,
-                precision,
-                timestamp,
-            } => {
-                let price = PrecisionlessPrice::new(humanized_price, timestamp);
-                Ok(price.with_precision(precision))
-            },
-            PriceSource::Pyth { id, precision, .. } => {
-                let price = self.ctx.get_price(id)?;
-                Ok(price.with_precision(precision))
-            },
-        }
+        let price = self.ctx.get_price(price_source.id)?;
+        Ok(price.with_precision(price_source.precision))
     }
 }
 

--- a/dango/oracle/src/query.rs
+++ b/dango/oracle/src/query.rs
@@ -1,6 +1,6 @@
 use {
     crate::{OracleQuerierNoCache, PRICE_SOURCES, PYTH_TRUSTED_SIGNERS},
-    dango_types::oracle::{PrecisionedPrice, PriceSource, QueryMsg},
+    dango_types::oracle::{Price, PriceSource, QueryMsg},
     grug::{
         Binary, Bound, DEFAULT_PAGE_LIMIT, Denom, ImmutableCtx, Json, JsonSerExt, Order, StdResult,
         Timestamp,
@@ -52,7 +52,7 @@ fn query_trusted_signers(
         .collect()
 }
 
-fn query_price(ctx: ImmutableCtx, denom: Denom) -> anyhow::Result<PrecisionedPrice> {
+fn query_price(ctx: ImmutableCtx, denom: Denom) -> anyhow::Result<Price> {
     let oracle_querier = OracleQuerierNoCache::new_local(ctx.storage);
     oracle_querier.query_price(&denom, None)
 }
@@ -61,7 +61,7 @@ fn query_prices(
     ctx: ImmutableCtx,
     start_after: Option<Denom>,
     limit: Option<u32>,
-) -> anyhow::Result<BTreeMap<Denom, PrecisionedPrice>> {
+) -> anyhow::Result<BTreeMap<Denom, Price>> {
     let oracle_querier = OracleQuerierNoCache::new_local(ctx.storage);
 
     let start = start_after.as_ref().map(Bound::Exclusive);

--- a/dango/oracle/src/state.rs
+++ b/dango/oracle/src/state.rs
@@ -1,5 +1,5 @@
 use {
-    dango_types::oracle::{PrecisionlessPrice, PriceSource},
+    dango_types::oracle::{Price, PriceSource},
     grug::{Denom, Map, Serde, Timestamp},
     pyth_types::PythId,
 };
@@ -8,4 +8,4 @@ pub const PRICE_SOURCES: Map<&Denom, PriceSource, Serde> = Map::new("price_sourc
 
 pub const PYTH_TRUSTED_SIGNERS: Map<&[u8], Timestamp> = Map::new("pyth_trusted_signer");
 
-pub const PYTH_PRICES: Map<PythId, PrecisionlessPrice> = Map::new("pyth_price");
+pub const PYTH_PRICES: Map<PythId, Price> = Map::new("pyth_price");

--- a/dango/perps/src/core/available_to_trade.rs
+++ b/dango/perps/src/core/available_to_trade.rs
@@ -160,10 +160,10 @@ mod tests {
         dango_order_book::{FundingPerUnit, UsdPrice},
         dango_types::{
             constants::{btc, eth},
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{PairParam, PairState, Position},
         },
-        grug::{Timestamp, Udec128, btree_map, hash_map},
+        grug::{Timestamp, btree_map, hash_map},
         test_case::test_case,
     };
 
@@ -249,15 +249,13 @@ mod tests {
         // must match the `CURRENT_PRICE` and `OTHER_PRICE` consts above
         // so unrealized pnl stays zero at entry.
         let oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new(2_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_int(2_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
-            btc::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new(50_000),
+            btc::DENOM.clone() => Price::new(
+                UsdPrice::new_int(50_000),
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 

--- a/dango/perps/src/core/closure.rs
+++ b/dango/perps/src/core/closure.rs
@@ -220,10 +220,10 @@ mod tests {
         dango_order_book::{Dimensionless, FundingPerUnit, Quantity, UsdPrice, UsdValue},
         dango_types::{
             constants::eth,
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{PairParam, PairState, Position},
         },
-        grug::{Timestamp, Udec128, btree_map, hash_map},
+        grug::{Timestamp, btree_map, hash_map},
         std::collections::HashMap,
     };
 
@@ -301,10 +301,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(250_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -349,10 +348,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -397,10 +395,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(150_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(150_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -453,10 +450,9 @@ mod tests {
                 },
             );
             let oracle_querier = OracleQuerier::new_mock(hash_map! {
-                eth::DENOM.clone() => PrecisionedPrice::new(
-                    Udec128::new_percent(200_000),
+                eth::DENOM.clone() => Price::new(
+                    UsdPrice::new_percent(200_000),
                     Timestamp::from_seconds(0),
-                    18,
                 ),
             });
             (user_state, perp_querier, oracle_querier)

--- a/dango/perps/src/core/liq_price.rs
+++ b/dango/perps/src/core/liq_price.rs
@@ -103,22 +103,18 @@ mod tests {
         dango_order_book::{Dimensionless, FundingPerUnit, Quantity, UsdPrice, UsdValue},
         dango_types::{
             constants::{btc, eth},
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{PairParam, PairState, Position},
         },
-        grug::{Timestamp, Udec128, btree_map, hash_map},
+        grug::{Timestamp, btree_map, hash_map},
         std::collections::HashMap,
     };
 
     /// Helper: build an oracle price entry for the mock querier.
     ///
     /// `price` is the integer dollar price (e.g. 2000 for $2,000).
-    fn oracle_entry(price: u128) -> PrecisionedPrice {
-        PrecisionedPrice::new(
-            Udec128::new_percent(price * 100),
-            Timestamp::from_seconds(0),
-            18,
-        )
+    fn oracle_entry(price: u128) -> Price {
+        Price::new(UsdPrice::new_int(price as i128), Timestamp::from_seconds(0))
     }
 
     fn pair_param_with_mmr(mmr_permille: i128) -> PairParam {

--- a/dango/perps/src/core/margin.rs
+++ b/dango/perps/src/core/margin.rs
@@ -286,10 +286,10 @@ mod tests {
         dango_order_book::{Dimensionless, FundingPerUnit, Quantity, UsdPrice, UsdValue},
         dango_types::{
             constants::{btc, eth},
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{PairParam, PairState, Param, Position, RateSchedule},
         },
-        grug::{Timestamp, Udec128, btree_map, hash_map},
+        grug::{Timestamp, btree_map, hash_map},
         std::collections::HashMap,
         test_case::test_case,
     };
@@ -402,10 +402,9 @@ mod tests {
             }
         });
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(250_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -441,10 +440,9 @@ mod tests {
             },
         });
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(250_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -493,15 +491,13 @@ mod tests {
             },
         });
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(250_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
-            btc::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(4_800_000),
+            btc::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(4_800_000),
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -536,10 +532,9 @@ mod tests {
             },
         });
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(150_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(150_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -590,10 +585,9 @@ mod tests {
             HashMap::new(),
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -641,15 +635,13 @@ mod tests {
             HashMap::new(),
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
-            btc::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000),
+            btc::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -676,10 +668,9 @@ mod tests {
             HashMap::new(),
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -722,10 +713,9 @@ mod tests {
             HashMap::new(),
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -774,15 +764,13 @@ mod tests {
             HashMap::new(),
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
-            btc::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000),
+            btc::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -813,10 +801,9 @@ mod tests {
             HashMap::new(),
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -872,15 +859,13 @@ mod tests {
             HashMap::new(),
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(200_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
-            btc::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000),
+            btc::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -978,10 +963,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(250_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -1024,10 +1008,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(250_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -1072,10 +1055,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(150_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(150_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -1120,10 +1102,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(250_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         });
 
@@ -1170,10 +1151,9 @@ mod tests {
             },
         );
         let mut oracle_querier = OracleQuerier::new_mock(hash_map! {
-            pair_id.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            pair_id.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 

--- a/dango/perps/src/cron/process_funding.rs
+++ b/dango/perps/src/cron/process_funding.rs
@@ -140,10 +140,10 @@ mod tests {
         super::*,
         dango_order_book::{Dimensionless, FundingPerUnit, FundingRate, UsdPrice},
         dango_types::{
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{PairParam, PairState, Param, Position, State, UserState},
         },
-        grug::{Duration, MockStorage, Udec128, hash_map},
+        grug::{Duration, MockStorage, hash_map},
         std::collections::{BTreeMap, BTreeSet},
     };
 
@@ -236,10 +236,9 @@ mod tests {
         );
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            pair_id.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            pair_id.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -279,10 +278,9 @@ mod tests {
         set_vault_position(&mut storage, &pair_id, 50);
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            pair_id.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            pair_id.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -321,10 +319,9 @@ mod tests {
         set_vault_position(&mut storage, &pair_id, -50);
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            pair_id.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            pair_id.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -357,10 +354,9 @@ mod tests {
 
         // No vault state stored → position defaults to zero → premium = 0.
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            pair_id.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000),
+            pair_id.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -402,10 +398,9 @@ mod tests {
         );
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            pair_id.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            pair_id.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -479,15 +474,13 @@ mod tests {
             .unwrap();
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            btc.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            btc.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
-            eth.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(300_000), // $3,000
+            eth.clone() => Price::new(
+                UsdPrice::new_percent(300_000), // $3,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 
@@ -535,10 +528,9 @@ mod tests {
         set_vault_position(&mut storage, &pair_id, -50);
 
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            pair_id.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000),
+            pair_id.clone() => Price::new(
+                UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 

--- a/dango/perps/src/cron/vault_snapshot.rs
+++ b/dango/perps/src/cron/vault_snapshot.rs
@@ -67,10 +67,10 @@ mod tests {
         crate::state::PAIR_STATES,
         dango_order_book::{FundingPerUnit, PairId, Quantity, UsdPrice},
         dango_types::{
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{PairState, Position, State, UserState},
         },
-        grug::{MockStorage, Order, Udec128, Uint128, hash_map},
+        grug::{MockStorage, Order, Uint128, hash_map},
         std::collections::BTreeMap,
     };
 
@@ -117,10 +117,9 @@ mod tests {
 
     fn mock_oracle_for_btc() -> OracleQuerier<'static> {
         OracleQuerier::new_mock(hash_map! {
-            btc_pair_id() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            btc_pair_id() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         })
     }

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -1071,15 +1071,14 @@ mod tests {
     }
 
     fn mock_oracle_querier(pairs: Vec<(PairId, i128)>) -> OracleQuerier<'static> {
-        use {dango_types::oracle::PrecisionedPrice, grug::Udec128};
+        use dango_types::oracle::Price;
         let mut map = std::collections::HashMap::new();
         for (pair_id, price) in pairs {
             map.insert(
                 pair_id,
-                PrecisionedPrice::new(
-                    Udec128::new_percent(price as u128 * 100),
+                Price::new(
+                    UsdPrice::new_percent((price as u128 * 100) as i128),
                     Timestamp::from_seconds(0),
-                    8,
                 ),
             );
         }

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -1646,13 +1646,10 @@ mod tests {
         crate::USER_STATES,
         dango_order_book::{Dimensionless, FundingPerUnit},
         dango_types::{
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{Position, RateSchedule},
         },
-        grug::{
-            Coins, EventName, JsonDeExt, MockContext, ResultExt, Timestamp, Udec128, Uint64,
-            hash_map,
-        },
+        grug::{Coins, EventName, JsonDeExt, MockContext, ResultExt, Timestamp, Uint64, hash_map},
     };
 
     const CONTRACT: Addr = Addr::mock(0);
@@ -1665,10 +1662,9 @@ mod tests {
 
     fn test_oracle_querier() -> OracleQuerier<'static> {
         OracleQuerier::new_mock(hash_map! {
-            pair_id() => PrecisionedPrice::new(
-                Udec128::new_percent(5_000_000), // $50,000
+            pair_id() => Price::new(
+                UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         })
     }
@@ -6523,10 +6519,9 @@ mod tests {
 
         // Oracle at $48k (matches the fill price).
         let mut oracle = OracleQuerier::new_mock(hash_map! {
-            pair_id() => PrecisionedPrice::new(
-                Udec128::new_percent(4_800_000), // $48,000
+            pair_id() => Price::new(
+                UsdPrice::new_percent(4_800_000), // $48,000
                 Timestamp::from_seconds(0),
-                8,
             ),
         });
 

--- a/dango/perps/src/vault/add_liquidity.rs
+++ b/dango/perps/src/vault/add_liquidity.rs
@@ -195,10 +195,10 @@ mod tests {
         dango_order_book::{Dimensionless, FundingPerUnit, Quantity, UsdPrice},
         dango_types::{
             constants::eth,
-            oracle::PrecisionedPrice,
+            oracle::Price,
             perps::{PairParam, PairState, Position, UserState},
         },
-        grug::{MockStorage, NumberConst, Timestamp, Udec128, Uint128, btree_map, hash_map},
+        grug::{MockStorage, NumberConst, Timestamp, Uint128, btree_map, hash_map},
     };
 
     fn default_param() -> Param {
@@ -676,10 +676,9 @@ mod tests {
         // initial margin used = 1 * $1950 * 10% = $195
         // available margin = $200 - $195 = $5
         let oracle_prices = hash_map! {
-            eth::DENOM.clone() => PrecisionedPrice::new(
-                Udec128::new_percent(195_000),
+            eth::DENOM.clone() => Price::new(
+                UsdPrice::new_percent(195_000),
                 Timestamp::from_seconds(0),
-                18,
             ),
         };
 

--- a/dango/proposal-preparer/src/pyth_handler.rs
+++ b/dango/proposal-preparer/src/pyth_handler.rs
@@ -403,11 +403,7 @@ fn pyth_ids_lazer(
             limit: Some(u32::MAX),
         })?
         .into_values()
-        .map(|price_source| PythLazerSubscriptionDetails {
-            id: price_source.id,
-            channel: price_source.channel,
-        })
-        .collect::<Vec<_>>();
+        .collect();
 
     Ok(new_ids)
 }

--- a/dango/proposal-preparer/src/pyth_handler.rs
+++ b/dango/proposal-preparer/src/pyth_handler.rs
@@ -1,7 +1,7 @@
 use {
     dango_types::{
         config::AppConfig,
-        oracle::{ExecuteMsg, PriceSource, QueryPriceSourcesRequest},
+        oracle::{ExecuteMsg, QueryPriceSourcesRequest},
     },
     grug::{
         Addr, Coins, Json, JsonSerExt, Lengthy, Message, NonEmpty, QuerierExt, QuerierWrapper,
@@ -403,12 +403,9 @@ fn pyth_ids_lazer(
             limit: Some(u32::MAX),
         })?
         .into_values()
-        .filter_map(|price_source| {
-            if let PriceSource::Pyth { id, channel, .. } = price_source {
-                Some(PythLazerSubscriptionDetails { id, channel })
-            } else {
-                None
-            }
+        .map(|price_source| PythLazerSubscriptionDetails {
+            id: price_source.id,
+            channel: price_source.channel,
         })
         .collect::<Vec<_>>();
 

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -15,6 +15,7 @@ anyhow                   = { workspace = true }
 async-trait              = { workspace = true }
 clickhouse               = { workspace = true, features = ["test-util"] }
 dango-genesis            = { workspace = true }
+dango-oracle             = { workspace = true, features = ["library"] }
 dango-order-book         = { workspace = true }
 dango-proposal-preparer  = { workspace = true }
 dango-types              = { workspace = true, features = ["async-graphql"] }
@@ -55,7 +56,6 @@ dango-auth                  = { workspace = true }
 dango-bank                  = { workspace = true, features = ["library"] }
 dango-gateway               = { workspace = true, features = ["library"] }
 dango-mock-httpd            = { workspace = true }
-dango-oracle                = { workspace = true, features = ["library"] }
 dango-taxman                = { workspace = true, features = ["library"] }
 eth-utils                   = { workspace = true }
 graphql_client              = { workspace = true }

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -1,17 +1,55 @@
 use {
     crate::{TestAccounts, TestSuiteWithIndexer},
     dango_genesis::Contracts,
+    dango_oracle::PYTH_PRICES,
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_types::{
         constants::usdc,
-        oracle::{self, PriceSource},
+        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
         perps,
     },
-    grug::{Coins, Denom, NumberConst, ResultExt, Timestamp, Udec128, Uint128, btree_map},
+    grug::{
+        Addr, BorshSerExt, Coins, Denom, NumberConst, ResultExt, Storage, Timestamp, Udec128,
+        Uint128, btree_map, concat,
+    },
+    grug_app::CONTRACT_NAMESPACE,
+    pyth_types::{Channel, PythId},
+    std::collections::BTreeMap,
 };
 
 pub fn pair_id() -> Denom {
     "perp/ethusd".parse().unwrap()
+}
+
+/// Specification for a single oracle price entry used in tests.
+///
+/// `pyth_id` is the synthetic Pyth Lazer feed ID under which the price is
+/// stored. Tests can use any `u32`; the value only has to be unique across
+/// entries within the same test environment.
+pub struct OracleTestEntry {
+    pub pyth_id: PythId,
+    pub precision: Precision,
+    pub humanized_price: Udec128,
+    pub timestamp: Timestamp,
+}
+
+/// Write a `PrecisionlessPrice` directly into the oracle contract's
+/// `PYTH_PRICES` storage map.
+///
+/// This bypasses `ExecuteMsg::FeedPrices`, which would otherwise require a
+/// valid Pyth Lazer ECDSA signature — impractical to satisfy in tests, since
+/// the trusted signer's private key is not available to us.
+pub fn write_pyth_price_raw(
+    storage: &mut dyn Storage,
+    oracle: Addr,
+    pyth_id: PythId,
+    price: &PrecisionlessPrice,
+) {
+    let map_key = PYTH_PRICES.path(pyth_id).storage_key().to_vec();
+    let contract_prefix = concat(CONTRACT_NAMESPACE, oracle.as_ref());
+    let full_key = concat(&contract_prefix, &map_key);
+    let value_bytes = price.to_borsh_vec().unwrap();
+    storage.write(&full_key, &value_bytes);
 }
 
 /// Common setup: register oracle prices + deposit margin for user1 and user2.
@@ -22,26 +60,48 @@ pub async fn setup_perps_env(
     eth_price: u128,
     margin_per_user: u128,
 ) {
+    let entries = btree_map! {
+        usdc::DENOM.clone() => OracleTestEntry {
+            pyth_id: 1,
+            precision: usdc::DECIMAL as Precision,
+            humanized_price: Udec128::ONE,
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        pair_id() => OracleTestEntry {
+            pyth_id: 2,
+            precision: 0,
+            humanized_price: Udec128::new(eth_price),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+    };
+
+    let price_sources: BTreeMap<Denom, PriceSource> = entries
+        .iter()
+        .map(|(denom, e)| {
+            (denom.clone(), PriceSource {
+                id: e.pyth_id,
+                channel: Channel::RealTime,
+                precision: e.precision,
+            })
+        })
+        .collect();
+
     suite
         .execute(
             &mut accounts.owner,
             contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
-                usdc::DENOM.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::ONE,
-                    precision: usdc::DECIMAL as u8,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                pair_id() => PriceSource::Fixed {
-                    humanized_price: Udec128::new(eth_price),
-                    precision: 0,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-            }),
+            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
             Coins::new(),
         )
         .await
         .should_succeed();
+
+    suite.app.db.with_state_storage_mut(|storage| {
+        for entry in entries.values() {
+            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
+        }
+    });
 
     for account in [&mut accounts.user1, &mut accounts.user2] {
         let amount = Uint128::new(margin_per_user * 1_000_000);

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -5,12 +5,11 @@ use {
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_types::{
         constants::usdc,
-        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
+        oracle::{self, Price, PriceSource},
         perps,
     },
     grug::{
-        Addr, BorshSerExt, Coins, Denom, NumberConst, ResultExt, Storage, Timestamp, Udec128,
-        Uint128, btree_map, concat,
+        Addr, BorshSerExt, Coins, Denom, ResultExt, Storage, Timestamp, Uint128, btree_map, concat,
     },
     grug_app::CONTRACT_NAMESPACE,
     pyth_types::{Channel, PythId},
@@ -28,13 +27,12 @@ pub fn pair_id() -> Denom {
 /// entries within the same test environment.
 pub struct OracleTestEntry {
     pub pyth_id: PythId,
-    pub precision: Precision,
-    pub humanized_price: Udec128,
+    pub humanized_price: UsdPrice,
     pub timestamp: Timestamp,
 }
 
-/// Write a `PrecisionlessPrice` directly into the oracle contract's
-/// `PYTH_PRICES` storage map.
+/// Write a `Price` directly into the oracle contract's `PYTH_PRICES` storage
+/// map.
 ///
 /// This bypasses `ExecuteMsg::FeedPrices`, which would otherwise require a
 /// valid Pyth Lazer ECDSA signature — impractical to satisfy in tests, since
@@ -43,7 +41,7 @@ pub fn write_pyth_price_raw(
     storage: &mut dyn Storage,
     oracle: Addr,
     pyth_id: PythId,
-    price: &PrecisionlessPrice,
+    price: &Price,
 ) {
     let map_key = PYTH_PRICES.path(pyth_id).storage_key().to_vec();
     let contract_prefix = concat(CONTRACT_NAMESPACE, oracle.as_ref());
@@ -63,14 +61,12 @@ pub async fn setup_perps_env(
     let entries = btree_map! {
         usdc::DENOM.clone() => OracleTestEntry {
             pyth_id: 1,
-            precision: usdc::DECIMAL as Precision,
-            humanized_price: Udec128::ONE,
+            humanized_price: UsdPrice::new_int(1),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
         pair_id() => OracleTestEntry {
             pyth_id: 2,
-            precision: 0,
-            humanized_price: Udec128::new(eth_price),
+            humanized_price: UsdPrice::new_int(eth_price as i128),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
     };
@@ -81,7 +77,6 @@ pub async fn setup_perps_env(
             (denom.clone(), PriceSource {
                 id: e.pyth_id,
                 channel: Channel::RealTime,
-                precision: e.precision,
             })
         })
         .collect();
@@ -98,7 +93,7 @@ pub async fn setup_perps_env(
 
     suite.app.db.with_state_storage_mut(|storage| {
         for entry in entries.values() {
-            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            let price = Price::new(entry.humanized_price, entry.timestamp);
             write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
         }
     });

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -9,9 +9,12 @@ use {
         perps,
     },
     grug::{
-        Addr, BorshSerExt, Coins, Denom, ResultExt, Storage, Timestamp, Uint128, btree_map, concat,
+        Addr, BorshSerExt, Coins, Denom, ResultExt, Signer, Storage, TestSuite, Timestamp, Uint128,
+        btree_map, concat,
     },
-    grug_app::CONTRACT_NAMESPACE,
+    grug_app::{AppError, CONTRACT_NAMESPACE, Indexer, ProposalPreparer},
+    grug_db_memory::MemDb,
+    grug_vm_rust::RustVm,
     pyth_types::{Channel, PythId},
     std::collections::BTreeMap,
 };
@@ -50,27 +53,24 @@ pub fn write_pyth_price_raw(
     storage.write(&full_key, &value_bytes);
 }
 
-/// Common setup: register oracle prices + deposit margin for user1 and user2.
-pub async fn setup_perps_env(
-    suite: &mut TestSuiteWithIndexer,
-    accounts: &mut TestAccounts,
-    contracts: &Contracts,
-    eth_price: u128,
-    margin_per_user: u128,
-) {
-    let entries = btree_map! {
-        usdc::DENOM.clone() => OracleTestEntry {
-            pyth_id: 1,
-            humanized_price: UsdPrice::new_int(1),
-            timestamp: Timestamp::from_nanos(u128::MAX),
-        },
-        pair_id() => OracleTestEntry {
-            pyth_id: 2,
-            humanized_price: UsdPrice::new_int(eth_price as i128),
-            timestamp: Timestamp::from_nanos(u128::MAX),
-        },
-    };
-
+/// Register a set of Pyth price sources and seed their humanized prices
+/// directly into `PYTH_PRICES`.
+///
+/// Each entry registers a `PriceSource { id, channel: RealTime }` via
+/// `oracle::ExecuteMsg::RegisterPriceSources` so the on-chain `PRICE_SOURCES`
+/// map sees them, then writes the corresponding `Price` to `PYTH_PRICES`
+/// storage via [`write_pyth_price_raw`] — bypassing the Pyth Lazer signature
+/// verification path that tests can't satisfy.
+pub async fn seed_oracle_prices<PP, ID>(
+    suite: &mut TestSuite<MemDb, RustVm, PP, ID>,
+    owner: &mut (dyn Signer + Send + Sync),
+    oracle: Addr,
+    entries: BTreeMap<Denom, OracleTestEntry>,
+) where
+    PP: ProposalPreparer,
+    ID: Indexer,
+    AppError: From<<PP as ProposalPreparer>::Error>,
+{
     let price_sources: BTreeMap<Denom, PriceSource> = entries
         .iter()
         .map(|(denom, e)| {
@@ -83,8 +83,8 @@ pub async fn setup_perps_env(
 
     suite
         .execute(
-            &mut accounts.owner,
-            contracts.oracle,
+            owner,
+            oracle,
             &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
             Coins::new(),
         )
@@ -94,9 +94,32 @@ pub async fn setup_perps_env(
     suite.app.db.with_state_storage_mut(|storage| {
         for entry in entries.values() {
             let price = Price::new(entry.humanized_price, entry.timestamp);
-            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
+            write_pyth_price_raw(storage, oracle, entry.pyth_id, &price);
         }
     });
+}
+
+/// Common setup: register oracle prices + deposit margin for user1 and user2.
+pub async fn setup_perps_env(
+    suite: &mut TestSuiteWithIndexer,
+    accounts: &mut TestAccounts,
+    contracts: &Contracts,
+    eth_price: u128,
+    margin_per_user: u128,
+) {
+    seed_oracle_prices(suite, &mut accounts.owner, contracts.oracle, btree_map! {
+        usdc::DENOM.clone() => OracleTestEntry {
+            pyth_id: 1,
+            humanized_price: UsdPrice::new_int(1),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        pair_id() => OracleTestEntry {
+            pyth_id: 2,
+            humanized_price: UsdPrice::new_int(eth_price as i128),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+    })
+    .await;
 
     for account in [&mut accounts.user1, &mut accounts.user2] {
         let amount = Uint128::new(margin_per_user * 1_000_000);

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -11,12 +11,12 @@ use {
     },
     dango_types::{
         constants::usdc,
-        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
+        oracle::{self, Price, PriceSource},
         perps::{self, PairParam, RateSchedule},
     },
     grug::{
-        BlockInfo, Coins, Denom, Duration, Hash256, NumberConst, ResultExt, Timestamp, Udec128,
-        Udec128_6, btree_map,
+        BlockInfo, Coins, Denom, Duration, Hash256, NumberConst, ResultExt, Timestamp, Udec128_6,
+        btree_map,
     },
     grug_app::Indexer,
     indexer_clickhouse::{
@@ -596,20 +596,17 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
     let entries = btree_map! {
         usdc::DENOM.clone() => OracleTestEntry {
             pyth_id: 1,
-            precision: usdc::DECIMAL as Precision,
-            humanized_price: Udec128::ONE,
+            humanized_price: UsdPrice::new_int(1),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
         eth_pair.clone() => OracleTestEntry {
             pyth_id: 2,
-            precision: 0,
-            humanized_price: Udec128::new(2_000),
+            humanized_price: UsdPrice::new_int(2_000),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
         btc_pair.clone() => OracleTestEntry {
             pyth_id: 3,
-            precision: 0,
-            humanized_price: Udec128::new(60_000),
+            humanized_price: UsdPrice::new_int(60_000),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
     };
@@ -620,7 +617,6 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
             (denom.clone(), PriceSource {
                 id: e.pyth_id,
                 channel: Channel::RealTime,
-                precision: e.precision,
             })
         })
         .collect();
@@ -637,7 +633,7 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
 
     suite.app.db.with_state_storage_mut(|storage| {
         for entry in entries.values() {
-            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            let price = Price::new(entry.humanized_price, entry.timestamp);
             write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
         }
     });

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -4,12 +4,14 @@ use {
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_testing::{
         Preset, TestAccounts, TestOption, TestSuiteWithIndexer,
-        perps::{create_perps_fill, pair_id, setup_perps_env},
+        perps::{
+            OracleTestEntry, create_perps_fill, pair_id, setup_perps_env, write_pyth_price_raw,
+        },
         setup_test_with_indexer, setup_test_with_indexer_and_custom_genesis,
     },
     dango_types::{
         constants::usdc,
-        oracle::{self, PriceSource},
+        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
         perps::{self, PairParam, RateSchedule},
     },
     grug::{
@@ -26,6 +28,7 @@ use {
         },
         indexer::perps_candles::cache::{PerpsCandleCache, PerpsCandleCacheKey},
     },
+    pyth_types::Channel,
     std::collections::HashMap,
 };
 
@@ -590,31 +593,54 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
     let btc_pair: Denom = "perp/btcusd".parse().unwrap();
 
     // Register oracle prices for both pairs.
+    let entries = btree_map! {
+        usdc::DENOM.clone() => OracleTestEntry {
+            pyth_id: 1,
+            precision: usdc::DECIMAL as Precision,
+            humanized_price: Udec128::ONE,
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        eth_pair.clone() => OracleTestEntry {
+            pyth_id: 2,
+            precision: 0,
+            humanized_price: Udec128::new(2_000),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        btc_pair.clone() => OracleTestEntry {
+            pyth_id: 3,
+            precision: 0,
+            humanized_price: Udec128::new(60_000),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+    };
+
+    let price_sources: std::collections::BTreeMap<_, PriceSource> = entries
+        .iter()
+        .map(|(denom, e)| {
+            (denom.clone(), PriceSource {
+                id: e.pyth_id,
+                channel: Channel::RealTime,
+                precision: e.precision,
+            })
+        })
+        .collect();
+
     suite
         .execute(
             &mut accounts.owner,
             contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
-                usdc::DENOM.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::ONE,
-                    precision: usdc::DECIMAL as u8,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                eth_pair.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::new(2_000),
-                    precision: 0,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                btc_pair.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::new(60_000),
-                    precision: 0,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-            }),
+            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
             Coins::new(),
         )
         .await
         .should_succeed();
+
+    suite.app.db.with_state_storage_mut(|storage| {
+        for entry in entries.values() {
+            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
+        }
+    });
 
     // Register the BTC pair via MaintainerMsg::Configure (ETH pair already
     // exists from genesis; re-specifying it keeps it unchanged).

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -4,14 +4,11 @@ use {
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_testing::{
         Preset, TestAccounts, TestOption, TestSuiteWithIndexer,
-        perps::{
-            OracleTestEntry, create_perps_fill, pair_id, setup_perps_env, write_pyth_price_raw,
-        },
+        perps::{OracleTestEntry, create_perps_fill, pair_id, seed_oracle_prices, setup_perps_env},
         setup_test_with_indexer, setup_test_with_indexer_and_custom_genesis,
     },
     dango_types::{
         constants::usdc,
-        oracle::{self, Price, PriceSource},
         perps::{self, PairParam, RateSchedule},
     },
     grug::{
@@ -28,7 +25,6 @@ use {
         },
         indexer::perps_candles::cache::{PerpsCandleCache, PerpsCandleCacheKey},
     },
-    pyth_types::Channel,
     std::collections::HashMap,
 };
 
@@ -593,50 +589,29 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
     let btc_pair: Denom = "perp/btcusd".parse().unwrap();
 
     // Register oracle prices for both pairs.
-    let entries = btree_map! {
-        usdc::DENOM.clone() => OracleTestEntry {
-            pyth_id: 1,
-            humanized_price: UsdPrice::new_int(1),
-            timestamp: Timestamp::from_nanos(u128::MAX),
+    seed_oracle_prices(
+        &mut suite,
+        &mut accounts.owner,
+        contracts.oracle,
+        btree_map! {
+            usdc::DENOM.clone() => OracleTestEntry {
+                pyth_id: 1,
+                humanized_price: UsdPrice::new_int(1),
+                timestamp: Timestamp::from_nanos(u128::MAX),
+            },
+            eth_pair.clone() => OracleTestEntry {
+                pyth_id: 2,
+                humanized_price: UsdPrice::new_int(2_000),
+                timestamp: Timestamp::from_nanos(u128::MAX),
+            },
+            btc_pair.clone() => OracleTestEntry {
+                pyth_id: 3,
+                humanized_price: UsdPrice::new_int(60_000),
+                timestamp: Timestamp::from_nanos(u128::MAX),
+            },
         },
-        eth_pair.clone() => OracleTestEntry {
-            pyth_id: 2,
-            humanized_price: UsdPrice::new_int(2_000),
-            timestamp: Timestamp::from_nanos(u128::MAX),
-        },
-        btc_pair.clone() => OracleTestEntry {
-            pyth_id: 3,
-            humanized_price: UsdPrice::new_int(60_000),
-            timestamp: Timestamp::from_nanos(u128::MAX),
-        },
-    };
-
-    let price_sources: std::collections::BTreeMap<_, PriceSource> = entries
-        .iter()
-        .map(|(denom, e)| {
-            (denom.clone(), PriceSource {
-                id: e.pyth_id,
-                channel: Channel::RealTime,
-            })
-        })
-        .collect();
-
-    suite
-        .execute(
-            &mut accounts.owner,
-            contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
-            Coins::new(),
-        )
-        .await
-        .should_succeed();
-
-    suite.app.db.with_state_storage_mut(|storage| {
-        for entry in entries.values() {
-            let price = Price::new(entry.humanized_price, entry.timestamp);
-            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
-        }
-    });
+    )
+    .await;
 
     // Register the BTC pair via MaintainerMsg::Configure (ETH pair already
     // exists from genesis; re-specifying it keeps it unchanged).

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -45,8 +45,8 @@ async fn pyth_lazer() {
             &mut accounts.owner,
             oracle,
             &ExecuteMsg::RegisterPriceSources(btree_map! {
-                btc::DENOM.clone() => PriceSource::Pyth { id: 1, precision: 8, channel:Channel::RealTime },
-                eth::DENOM.clone() => PriceSource::Pyth { id: 2, precision: 18 , channel:Channel::RealTime },
+                btc::DENOM.clone() => PriceSource { id: 1, precision: 8, channel: Channel::RealTime },
+                eth::DENOM.clone() => PriceSource { id: 2, precision: 18, channel: Channel::RealTime },
             }),
             Coins::default(),
         )

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -1,11 +1,12 @@
 use {
+    dango_order_book::UsdPrice,
     dango_testing::{TestAccounts, TestSuite, setup_test_naive},
     dango_types::{
         constants::{btc, eth},
         oracle::{ExecuteMsg, PriceSource, QueryPriceRequest, QueryTrustedSignersRequest},
     },
     grug::{
-        Addr, Binary, ByteArray, Coins, NonEmpty, QuerierExt, ResultExt, Timestamp, Udec128,
+        Addr, Binary, ByteArray, Coins, Dec128_6, NonEmpty, QuerierExt, ResultExt, Timestamp,
         btree_map,
     },
     grug_app::NaiveProposalPreparer,
@@ -45,8 +46,8 @@ async fn pyth_lazer() {
             &mut accounts.owner,
             oracle,
             &ExecuteMsg::RegisterPriceSources(btree_map! {
-                btc::DENOM.clone() => PriceSource { id: 1, precision: 8, channel: Channel::RealTime },
-                eth::DENOM.clone() => PriceSource { id: 2, precision: 18, channel: Channel::RealTime },
+                btc::DENOM.clone() => PriceSource { id: 1, channel: Channel::RealTime },
+                eth::DENOM.clone() => PriceSource { id: 2, channel: Channel::RealTime },
             }),
             Coins::default(),
         )
@@ -157,7 +158,7 @@ async fn pyth_lazer() {
 
     assert_eq!(
         price.humanized_price,
-        Udec128::from_str("112985.05901374").unwrap()
+        UsdPrice::new(Dec128_6::from_str("112985.059013").unwrap())
     );
     assert_eq!(price.timestamp, Timestamp::from_micros(1758539671000000));
 
@@ -170,7 +171,7 @@ async fn pyth_lazer() {
 
     assert_eq!(
         price.humanized_price,
-        Udec128::from_str("4185.88044686").unwrap()
+        UsdPrice::new(Dec128_6::from_str("4185.880446").unwrap())
     );
     assert_eq!(price.timestamp, Timestamp::from_micros(1758539671000000));
 }

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -6,12 +6,11 @@ use {
     },
     dango_testing::{
         TestOption,
-        perps::{OracleTestEntry, pair_id, write_pyth_price_raw},
+        perps::{OracleTestEntry, pair_id, seed_oracle_prices},
         setup_test_naive,
     },
     dango_types::{
         constants::usdc,
-        oracle::{self, Price, PriceSource},
         perps::{
             self, CancelOrderRequest, Param, SubmitOrCancelOrderRequest, SubmitOrderRequest,
             UserReferralData,
@@ -21,7 +20,6 @@ use {
         Addressable, CheckedContractEvent, Coins, Denom, JsonDeExt, NonEmpty, QuerierExt,
         ResultExt, SearchEvent, Timestamp, Uint64, Uint128, btree_map,
     },
-    pyth_types::Channel,
     std::collections::BTreeMap,
 };
 
@@ -656,50 +654,29 @@ async fn batch_across_two_pairs() {
     let btc_pair: Denom = "perp/btcusd".parse().unwrap();
 
     // Register oracle prices for both pairs (plus USDC for settlement).
-    let entries = btree_map! {
-        usdc::DENOM.clone() => OracleTestEntry {
-            pyth_id: 1,
-            humanized_price: UsdPrice::new_int(1),
-            timestamp: Timestamp::from_nanos(u128::MAX),
+    seed_oracle_prices(
+        &mut suite,
+        &mut accounts.owner,
+        contracts.oracle,
+        btree_map! {
+            usdc::DENOM.clone() => OracleTestEntry {
+                pyth_id: 1,
+                humanized_price: UsdPrice::new_int(1),
+                timestamp: Timestamp::from_nanos(u128::MAX),
+            },
+            eth_pair.clone() => OracleTestEntry {
+                pyth_id: 2,
+                humanized_price: UsdPrice::new_int(2_000),
+                timestamp: Timestamp::from_nanos(u128::MAX),
+            },
+            btc_pair.clone() => OracleTestEntry {
+                pyth_id: 3,
+                humanized_price: UsdPrice::new_int(60_000),
+                timestamp: Timestamp::from_nanos(u128::MAX),
+            },
         },
-        eth_pair.clone() => OracleTestEntry {
-            pyth_id: 2,
-            humanized_price: UsdPrice::new_int(2_000),
-            timestamp: Timestamp::from_nanos(u128::MAX),
-        },
-        btc_pair.clone() => OracleTestEntry {
-            pyth_id: 3,
-            humanized_price: UsdPrice::new_int(60_000),
-            timestamp: Timestamp::from_nanos(u128::MAX),
-        },
-    };
-
-    let price_sources: BTreeMap<_, PriceSource> = entries
-        .iter()
-        .map(|(denom, e)| {
-            (denom.clone(), PriceSource {
-                id: e.pyth_id,
-                channel: Channel::RealTime,
-            })
-        })
-        .collect();
-
-    suite
-        .execute(
-            &mut accounts.owner,
-            contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
-            Coins::new(),
-        )
-        .await
-        .should_succeed();
-
-    suite.app.db.with_state_storage_mut(|storage| {
-        for entry in entries.values() {
-            let price = Price::new(entry.humanized_price, entry.timestamp);
-            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
-        }
-    });
+    )
+    .await;
 
     // Add the BTC pair (the ETH pair is already configured at genesis;
     // re-specifying it keeps it unchanged).

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -4,10 +4,14 @@ use {
         Dimensionless, OrderId, OrderKind, OrderRemoved, Quantity, QueryOrdersByUserResponseItem,
         ReasonForOrderRemoval, TimeInForce, UsdPrice,
     },
-    dango_testing::{TestOption, perps::pair_id, setup_test_naive},
+    dango_testing::{
+        TestOption,
+        perps::{OracleTestEntry, pair_id, write_pyth_price_raw},
+        setup_test_naive,
+    },
     dango_types::{
         constants::usdc,
-        oracle::{self, PriceSource},
+        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
         perps::{
             self, CancelOrderRequest, Param, SubmitOrCancelOrderRequest, SubmitOrderRequest,
             UserReferralData,
@@ -17,6 +21,7 @@ use {
         Addressable, CheckedContractEvent, Coins, Denom, JsonDeExt, NonEmpty, NumberConst,
         QuerierExt, ResultExt, SearchEvent, Timestamp, Udec128, Uint64, Uint128, btree_map,
     },
+    pyth_types::Channel,
     std::collections::BTreeMap,
 };
 
@@ -651,31 +656,54 @@ async fn batch_across_two_pairs() {
     let btc_pair: Denom = "perp/btcusd".parse().unwrap();
 
     // Register oracle prices for both pairs (plus USDC for settlement).
+    let entries = btree_map! {
+        usdc::DENOM.clone() => OracleTestEntry {
+            pyth_id: 1,
+            precision: usdc::DECIMAL as Precision,
+            humanized_price: Udec128::ONE,
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        eth_pair.clone() => OracleTestEntry {
+            pyth_id: 2,
+            precision: 0,
+            humanized_price: Udec128::new(2_000),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        btc_pair.clone() => OracleTestEntry {
+            pyth_id: 3,
+            precision: 0,
+            humanized_price: Udec128::new(60_000),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+    };
+
+    let price_sources: BTreeMap<_, PriceSource> = entries
+        .iter()
+        .map(|(denom, e)| {
+            (denom.clone(), PriceSource {
+                id: e.pyth_id,
+                channel: Channel::RealTime,
+                precision: e.precision,
+            })
+        })
+        .collect();
+
     suite
         .execute(
             &mut accounts.owner,
             contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
-                usdc::DENOM.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::ONE,
-                    precision: usdc::DECIMAL as u8,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                eth_pair.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::new(2_000),
-                    precision: 0,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                btc_pair.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::new(60_000),
-                    precision: 0,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-            }),
+            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
             Coins::new(),
         )
         .await
         .should_succeed();
+
+    suite.app.db.with_state_storage_mut(|storage| {
+        for entry in entries.values() {
+            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
+        }
+    });
 
     // Add the BTC pair (the ETH pair is already configured at genesis;
     // re-specifying it keeps it unchanged).

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -11,15 +11,15 @@ use {
     },
     dango_types::{
         constants::usdc,
-        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
+        oracle::{self, Price, PriceSource},
         perps::{
             self, CancelOrderRequest, Param, SubmitOrCancelOrderRequest, SubmitOrderRequest,
             UserReferralData,
         },
     },
     grug::{
-        Addressable, CheckedContractEvent, Coins, Denom, JsonDeExt, NonEmpty, NumberConst,
-        QuerierExt, ResultExt, SearchEvent, Timestamp, Udec128, Uint64, Uint128, btree_map,
+        Addressable, CheckedContractEvent, Coins, Denom, JsonDeExt, NonEmpty, QuerierExt,
+        ResultExt, SearchEvent, Timestamp, Uint64, Uint128, btree_map,
     },
     pyth_types::Channel,
     std::collections::BTreeMap,
@@ -659,20 +659,17 @@ async fn batch_across_two_pairs() {
     let entries = btree_map! {
         usdc::DENOM.clone() => OracleTestEntry {
             pyth_id: 1,
-            precision: usdc::DECIMAL as Precision,
-            humanized_price: Udec128::ONE,
+            humanized_price: UsdPrice::new_int(1),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
         eth_pair.clone() => OracleTestEntry {
             pyth_id: 2,
-            precision: 0,
-            humanized_price: Udec128::new(2_000),
+            humanized_price: UsdPrice::new_int(2_000),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
         btc_pair.clone() => OracleTestEntry {
             pyth_id: 3,
-            precision: 0,
-            humanized_price: Udec128::new(60_000),
+            humanized_price: UsdPrice::new_int(60_000),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
     };
@@ -683,7 +680,6 @@ async fn batch_across_two_pairs() {
             (denom.clone(), PriceSource {
                 id: e.pyth_id,
                 channel: Channel::RealTime,
-                precision: e.precision,
             })
         })
         .collect();
@@ -700,7 +696,7 @@ async fn batch_across_two_pairs() {
 
     suite.app.db.with_state_storage_mut(|storage| {
         for entry in entries.values() {
-            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            let price = Price::new(entry.humanized_price, entry.timestamp);
             write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
         }
     });

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -4,10 +4,10 @@ use {
     dango_testing::perps::{OracleTestEntry, pair_id, write_pyth_price_raw},
     dango_types::{
         constants::usdc,
-        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
+        oracle::{self, Price, PriceSource},
         perps::{PairParam, Param, RateSchedule},
     },
-    grug::{Coins, Duration, NumberConst, ResultExt, Timestamp, Udec128, btree_map},
+    grug::{Coins, Duration, ResultExt, Timestamp, btree_map},
     pyth_types::Channel,
     std::collections::BTreeMap,
 };
@@ -67,14 +67,12 @@ pub async fn register_oracle_prices(
     let entries = btree_map! {
         usdc::DENOM.clone() => OracleTestEntry {
             pyth_id: 1,
-            precision: usdc::DECIMAL as Precision,
-            humanized_price: Udec128::ONE,
+            humanized_price: UsdPrice::new_int(1),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
         pair_id() => OracleTestEntry {
             pyth_id: 2,
-            precision: 0,
-            humanized_price: Udec128::new(eth_price),
+            humanized_price: UsdPrice::new_int(eth_price as i128),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
     };
@@ -85,7 +83,6 @@ pub async fn register_oracle_prices(
             (denom.clone(), PriceSource {
                 id: e.pyth_id,
                 channel: Channel::RealTime,
-                precision: e.precision,
             })
         })
         .collect();
@@ -102,7 +99,7 @@ pub async fn register_oracle_prices(
 
     suite.app.db.with_state_storage_mut(|storage| {
         for entry in entries.values() {
-            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            let price = Price::new(entry.humanized_price, entry.timestamp);
             write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
         }
     });

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -1,15 +1,12 @@
 use {
     dango_genesis::Contracts,
     dango_order_book::{Dimensionless, Quantity, UsdPrice},
-    dango_testing::perps::{OracleTestEntry, pair_id, write_pyth_price_raw},
+    dango_testing::perps::{OracleTestEntry, pair_id, seed_oracle_prices},
     dango_types::{
         constants::usdc,
-        oracle::{self, Price, PriceSource},
         perps::{PairParam, Param, RateSchedule},
     },
-    grug::{Coins, Duration, ResultExt, Timestamp, btree_map},
-    pyth_types::Channel,
-    std::collections::BTreeMap,
+    grug::{Duration, Timestamp, btree_map},
 };
 
 mod adl_bug_reproduction;
@@ -54,17 +51,13 @@ pub fn default_pair_param() -> PairParam {
 }
 
 /// Register fixed oracle prices for the perps pair and settlement currency.
-///
-/// Registers Pyth price sources via ExecuteMsg, then writes the prices
-/// directly into `PYTH_PRICES` storage to bypass the Pyth Lazer signature
-/// verification path.
 pub async fn register_oracle_prices(
     suite: &mut dango_testing::TestSuite<grug_app::NaiveProposalPreparer>,
     accounts: &mut dango_testing::TestAccounts,
     contracts: &Contracts,
     eth_price: u128,
 ) {
-    let entries = btree_map! {
+    seed_oracle_prices(suite, &mut accounts.owner, contracts.oracle, btree_map! {
         usdc::DENOM.clone() => OracleTestEntry {
             pyth_id: 1,
             humanized_price: UsdPrice::new_int(1),
@@ -75,32 +68,6 @@ pub async fn register_oracle_prices(
             humanized_price: UsdPrice::new_int(eth_price as i128),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
-    };
-
-    let price_sources: BTreeMap<_, PriceSource> = entries
-        .iter()
-        .map(|(denom, e)| {
-            (denom.clone(), PriceSource {
-                id: e.pyth_id,
-                channel: Channel::RealTime,
-            })
-        })
-        .collect();
-
-    suite
-        .execute(
-            &mut accounts.owner,
-            contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
-            Coins::new(),
-        )
-        .await
-        .should_succeed();
-
-    suite.app.db.with_state_storage_mut(|storage| {
-        for entry in entries.values() {
-            let price = Price::new(entry.humanized_price, entry.timestamp);
-            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
-        }
-    });
+    })
+    .await;
 }

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -1,13 +1,15 @@
 use {
     dango_genesis::Contracts,
     dango_order_book::{Dimensionless, Quantity, UsdPrice},
-    dango_testing::perps::pair_id,
+    dango_testing::perps::{OracleTestEntry, pair_id, write_pyth_price_raw},
     dango_types::{
         constants::usdc,
-        oracle::{self, PriceSource},
+        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
         perps::{PairParam, Param, RateSchedule},
     },
     grug::{Coins, Duration, NumberConst, ResultExt, Timestamp, Udec128, btree_map},
+    pyth_types::Channel,
+    std::collections::BTreeMap,
 };
 
 mod adl_bug_reproduction;
@@ -52,30 +54,56 @@ pub fn default_pair_param() -> PairParam {
 }
 
 /// Register fixed oracle prices for the perps pair and settlement currency.
+///
+/// Registers Pyth price sources via ExecuteMsg, then writes the prices
+/// directly into `PYTH_PRICES` storage to bypass the Pyth Lazer signature
+/// verification path.
 pub async fn register_oracle_prices(
     suite: &mut dango_testing::TestSuite<grug_app::NaiveProposalPreparer>,
     accounts: &mut dango_testing::TestAccounts,
     contracts: &Contracts,
     eth_price: u128,
 ) {
+    let entries = btree_map! {
+        usdc::DENOM.clone() => OracleTestEntry {
+            pyth_id: 1,
+            precision: usdc::DECIMAL as Precision,
+            humanized_price: Udec128::ONE,
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        pair_id() => OracleTestEntry {
+            pyth_id: 2,
+            precision: 0,
+            humanized_price: Udec128::new(eth_price),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+    };
+
+    let price_sources: BTreeMap<_, PriceSource> = entries
+        .iter()
+        .map(|(denom, e)| {
+            (denom.clone(), PriceSource {
+                id: e.pyth_id,
+                channel: Channel::RealTime,
+                precision: e.precision,
+            })
+        })
+        .collect();
+
     suite
         .execute(
             &mut accounts.owner,
             contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
-                usdc::DENOM.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::ONE,
-                    precision: usdc::DECIMAL as u8,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                pair_id() => PriceSource::Fixed {
-                    humanized_price: Udec128::new(eth_price),
-                    precision: 0,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-            }),
+            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
             Coins::new(),
         )
         .await
         .should_succeed();
+
+    suite.app.db.with_state_storage_mut(|storage| {
+        for entry in entries.values() {
+            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
+        }
+    });
 }

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -9,7 +9,7 @@ use {
     dango_types::{
         account_factory::{self, RegisterUserData},
         constants::usdc,
-        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
+        oracle::{self, Price, PriceSource},
         perps::{
             self, CommissionRate, FeeDistributed, FeeShareRatio, QueryParamRequest, RateSchedule,
             Referee, ReferrerSettings, ReferrerStatsOrderBy, ReferrerStatsOrderIndex,
@@ -17,9 +17,9 @@ use {
         },
     },
     grug::{
-        Addr, Addressable, CheckedContractEvent, Coins, HashExt, JsonDeExt, NumberConst, Op,
+        Addr, Addressable, CheckedContractEvent, Coins, HashExt, JsonDeExt, Op,
         Order as IterationOrder, QuerierExt, ResultExt, SearchEvent, Signer, Timestamp, TxOutcome,
-        Udec128, Uint128, btree_map,
+        Uint128, btree_map,
     },
     grug_app::NaiveProposalPreparer,
     pyth_types::Channel,
@@ -2714,14 +2714,12 @@ async fn register_oracle_prices(
     let entries = btree_map! {
         usdc::DENOM.clone() => OracleTestEntry {
             pyth_id: 1,
-            precision: usdc::DECIMAL as Precision,
-            humanized_price: Udec128::ONE,
+            humanized_price: UsdPrice::new_int(1),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
         dango_testing::perps::pair_id() => OracleTestEntry {
             pyth_id: 2,
-            precision: 0,
-            humanized_price: Udec128::new(eth_price),
+            humanized_price: UsdPrice::new_int(eth_price as i128),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
     };
@@ -2732,7 +2730,6 @@ async fn register_oracle_prices(
             (denom.clone(), PriceSource {
                 id: e.pyth_id,
                 channel: Channel::RealTime,
-                precision: e.precision,
             })
         })
         .collect();
@@ -2749,7 +2746,7 @@ async fn register_oracle_prices(
 
     suite.app.db.with_state_storage_mut(|storage| {
         for entry in entries.values() {
-            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            let price = Price::new(entry.humanized_price, entry.timestamp);
             write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
         }
     });

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -1,11 +1,15 @@
 use {
     crate::{default_pair_param, default_param},
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice, UsdValue},
-    dango_testing::{Factory, Preset, TestAccount, TestOption, perps::pair_id, setup_test_naive},
+    dango_testing::{
+        Factory, Preset, TestAccount, TestOption,
+        perps::{OracleTestEntry, pair_id, write_pyth_price_raw},
+        setup_test_naive,
+    },
     dango_types::{
         account_factory::{self, RegisterUserData},
         constants::usdc,
-        oracle::{self, PriceSource},
+        oracle::{self, Precision, PrecisionlessPrice, PriceSource},
         perps::{
             self, CommissionRate, FeeDistributed, FeeShareRatio, QueryParamRequest, RateSchedule,
             Referee, ReferrerSettings, ReferrerStatsOrderBy, ReferrerStatsOrderIndex,
@@ -18,6 +22,8 @@ use {
         Udec128, Uint128, btree_map,
     },
     grug_app::NaiveProposalPreparer,
+    pyth_types::Channel,
+    std::collections::BTreeMap,
 };
 
 // ---------------------------------------------------------------------------
@@ -2705,26 +2711,48 @@ async fn register_oracle_prices(
     contracts: &dango_genesis::Contracts,
     eth_price: u128,
 ) {
+    let entries = btree_map! {
+        usdc::DENOM.clone() => OracleTestEntry {
+            pyth_id: 1,
+            precision: usdc::DECIMAL as Precision,
+            humanized_price: Udec128::ONE,
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+        dango_testing::perps::pair_id() => OracleTestEntry {
+            pyth_id: 2,
+            precision: 0,
+            humanized_price: Udec128::new(eth_price),
+            timestamp: Timestamp::from_nanos(u128::MAX),
+        },
+    };
+
+    let price_sources: BTreeMap<_, PriceSource> = entries
+        .iter()
+        .map(|(denom, e)| {
+            (denom.clone(), PriceSource {
+                id: e.pyth_id,
+                channel: Channel::RealTime,
+                precision: e.precision,
+            })
+        })
+        .collect();
+
     suite
         .execute(
             &mut accounts.owner,
             contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
-                usdc::DENOM.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::ONE,
-                    precision: usdc::DECIMAL as u8,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                dango_testing::perps::pair_id() => PriceSource::Fixed {
-                    humanized_price: Udec128::new(eth_price),
-                    precision: 0,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-            }),
+            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
             Coins::new(),
         )
         .await
         .should_succeed();
+
+    suite.app.db.with_state_storage_mut(|storage| {
+        for entry in entries.values() {
+            let price = PrecisionlessPrice::new(entry.humanized_price, entry.timestamp);
+            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
+        }
+    });
 }
 
 async fn deposit_margin(

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -3,13 +3,12 @@ use {
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice, UsdValue},
     dango_testing::{
         Factory, Preset, TestAccount, TestOption,
-        perps::{OracleTestEntry, pair_id, write_pyth_price_raw},
+        perps::{OracleTestEntry, pair_id, seed_oracle_prices},
         setup_test_naive,
     },
     dango_types::{
         account_factory::{self, RegisterUserData},
         constants::usdc,
-        oracle::{self, Price, PriceSource},
         perps::{
             self, CommissionRate, FeeDistributed, FeeShareRatio, QueryParamRequest, RateSchedule,
             Referee, ReferrerSettings, ReferrerStatsOrderBy, ReferrerStatsOrderIndex,
@@ -22,8 +21,6 @@ use {
         Uint128, btree_map,
     },
     grug_app::NaiveProposalPreparer,
-    pyth_types::Channel,
-    std::collections::BTreeMap,
 };
 
 // ---------------------------------------------------------------------------
@@ -2711,7 +2708,7 @@ async fn register_oracle_prices(
     contracts: &dango_genesis::Contracts,
     eth_price: u128,
 ) {
-    let entries = btree_map! {
+    seed_oracle_prices(suite, &mut accounts.owner, contracts.oracle, btree_map! {
         usdc::DENOM.clone() => OracleTestEntry {
             pyth_id: 1,
             humanized_price: UsdPrice::new_int(1),
@@ -2722,34 +2719,8 @@ async fn register_oracle_prices(
             humanized_price: UsdPrice::new_int(eth_price as i128),
             timestamp: Timestamp::from_nanos(u128::MAX),
         },
-    };
-
-    let price_sources: BTreeMap<_, PriceSource> = entries
-        .iter()
-        .map(|(denom, e)| {
-            (denom.clone(), PriceSource {
-                id: e.pyth_id,
-                channel: Channel::RealTime,
-            })
-        })
-        .collect();
-
-    suite
-        .execute(
-            &mut accounts.owner,
-            contracts.oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
-            Coins::new(),
-        )
-        .await
-        .should_succeed();
-
-    suite.app.db.with_state_storage_mut(|storage| {
-        for entry in entries.values() {
-            let price = Price::new(entry.humanized_price, entry.timestamp);
-            write_pyth_price_raw(storage, contracts.oracle, entry.pyth_id, &price);
-        }
-    });
+    })
+    .await;
 }
 
 async fn deposit_margin(

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -12,7 +12,7 @@ use {
     },
     grug::{
         Addressable, Binary, ByteArray, Coins, Duration, NonEmpty, NumberConst, QuerierExt,
-        ResultExt, Timestamp, Udec128, Uint128, btree_map, concat,
+        ResultExt, Timestamp, Uint128, btree_map, concat,
     },
     grug_app::CONTRACT_NAMESPACE,
     pyth_types::{Channel, LeEcdsaMessage},
@@ -413,12 +413,10 @@ async fn oracle_triggers_on_oracle_update() {
                 usdc::DENOM.clone() => PriceSource {
                     id: 1,
                     channel: Channel::RealTime,
-                    precision: usdc::DECIMAL as u8,
                 },
                 pair.clone() => PriceSource {
                     id: 2,
                     channel: Channel::RealTime,
-                    precision: 18,
                 },
             }),
             Coins::new(),
@@ -429,10 +427,8 @@ async fn oracle_triggers_on_oracle_update() {
     // Seed USDC's PYTH_PRICES entry directly. The perp pair's price is fed via
     // signed Pyth Lazer messages later in the test.
     suite.app.db.with_state_storage_mut(|storage| {
-        let price = dango_types::oracle::PrecisionlessPrice::new(
-            Udec128::ONE,
-            Timestamp::from_nanos(u128::MAX),
-        );
+        let price =
+            dango_types::oracle::Price::new(UsdPrice::new_int(1), Timestamp::from_nanos(u128::MAX));
         dango_testing::perps::write_pyth_price_raw(storage, contracts.oracle, 1, &price);
     });
 
@@ -537,7 +533,7 @@ async fn oracle_triggers_on_oracle_update() {
         .unwrap();
 
     assert!(
-        price1.humanized_price > Udec128::ZERO,
+        price1.humanized_price > UsdPrice::ZERO,
         "oracle price should be set after feeding"
     );
 

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -410,21 +410,31 @@ async fn oracle_triggers_on_oracle_update() {
             &mut accounts.owner,
             contracts.oracle,
             &oracle::ExecuteMsg::RegisterPriceSources(btree_map! {
-                usdc::DENOM.clone() => PriceSource::Fixed {
-                    humanized_price: Udec128::ONE,
-                    precision: usdc::DECIMAL as u8,
-                    timestamp: Timestamp::from_nanos(u128::MAX),
-                },
-                pair.clone() => PriceSource::Pyth {
-                    id: 2,
-                    precision: 18,
+                usdc::DENOM.clone() => PriceSource {
+                    id: 1,
                     channel: Channel::RealTime,
+                    precision: usdc::DECIMAL as u8,
+                },
+                pair.clone() => PriceSource {
+                    id: 2,
+                    channel: Channel::RealTime,
+                    precision: 18,
                 },
             }),
             Coins::new(),
         )
         .await
         .should_succeed();
+
+    // Seed USDC's PYTH_PRICES entry directly. The perp pair's price is fed via
+    // signed Pyth Lazer messages later in the test.
+    suite.app.db.with_state_storage_mut(|storage| {
+        let price = dango_types::oracle::PrecisionlessPrice::new(
+            Udec128::ONE,
+            Timestamp::from_nanos(u128::MAX),
+        );
+        dango_testing::perps::write_pyth_price_raw(storage, contracts.oracle, 1, &price);
+    });
 
     // -------------------------------------------------------------------------
     // Setup: Deposit USDC and add vault liquidity (follows vault_lp_lifecycle).

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -4,10 +4,14 @@ use {
         Dimensionless, OrderId, OrderKind, Quantity, QueryOrdersByUserResponseItem, UsdPrice,
         UsdValue,
     },
-    dango_testing::{TestOption, perps::pair_id, setup_test_naive},
+    dango_testing::{
+        TestOption,
+        perps::{pair_id, write_pyth_price_raw},
+        setup_test_naive,
+    },
     dango_types::{
         constants::usdc,
-        oracle::{self, PriceSource, QueryPriceRequest},
+        oracle::{self, Price, PriceSource, QueryPriceRequest},
         perps::{self, PairParam, Param},
     },
     grug::{
@@ -427,9 +431,8 @@ async fn oracle_triggers_on_oracle_update() {
     // Seed USDC's PYTH_PRICES entry directly. The perp pair's price is fed via
     // signed Pyth Lazer messages later in the test.
     suite.app.db.with_state_storage_mut(|storage| {
-        let price =
-            dango_types::oracle::Price::new(UsdPrice::new_int(1), Timestamp::from_nanos(u128::MAX));
-        dango_testing::perps::write_pyth_price_raw(storage, contracts.oracle, 1, &price);
+        let price = Price::new(UsdPrice::new_int(1), Timestamp::from_nanos(u128::MAX));
+        write_pyth_price_raw(storage, contracts.oracle, 1, &price);
     });
 
     // -------------------------------------------------------------------------

--- a/dango/testing/tests/proposal_preparer.rs
+++ b/dango/testing/tests/proposal_preparer.rs
@@ -44,11 +44,9 @@ async fn proposal_pyth() {
             })
             .should_succeed()
             .into_values()
-            .filter_map(|price_source| match price_source {
-                PriceSource::Pyth { id, channel, .. } => {
-                    Some(PythLazerSubscriptionDetails { id, channel })
-                },
-                _ => None,
+            .map(|price_source| PythLazerSubscriptionDetails {
+                id: price_source.id,
+                channel: price_source.channel,
             })
             .collect::<Vec<_>>();
 
@@ -68,7 +66,7 @@ async fn proposal_pyth() {
     let oracle = contracts.oracle;
 
     let price_source = btree_map!(
-        btc::DENOM.clone() => PriceSource::Pyth { id: BTC_USD_ID.id, channel: BTC_USD_ID.channel, precision: 8 }
+        btc::DENOM.clone() => PriceSource { id: BTC_USD_ID.id, channel: BTC_USD_ID.channel, precision: 8 }
     );
 
     let pubkey = Binary::from_str(LAZER_TRUSTED_SIGNER).unwrap();
@@ -148,18 +146,15 @@ async fn proposal_pyth() {
             .should_succeed()
             .values()
             .map(|price_source| {
-                if let PriceSource::Pyth { id, .. } = price_source {
-                    assert_ne!(id, &NOT_USED_ID_LAZER.id);
-                }
+                assert_ne!(price_source.id, NOT_USED_ID_LAZER.id);
             });
 
         // Push NOT_USED_ID to the oracle.
-        let msg =
-            ExecuteMsg::RegisterPriceSources(btree_map!( test_denom.clone() => PriceSource::Pyth {
-                id: NOT_USED_ID_LAZER.id,
-                precision: 6,
-                channel: NOT_USED_ID_LAZER.channel,
-            }));
+        let msg = ExecuteMsg::RegisterPriceSources(btree_map!( test_denom.clone() => PriceSource {
+            id: NOT_USED_ID_LAZER.id,
+            precision: 6,
+            channel: NOT_USED_ID_LAZER.channel,
+        }));
 
         suite
             .execute(&mut accounts.owner, contracts.oracle, &msg, Coins::new())

--- a/dango/testing/tests/proposal_preparer.rs
+++ b/dango/testing/tests/proposal_preparer.rs
@@ -66,7 +66,7 @@ async fn proposal_pyth() {
     let oracle = contracts.oracle;
 
     let price_source = btree_map!(
-        btc::DENOM.clone() => PriceSource { id: BTC_USD_ID.id, channel: BTC_USD_ID.channel, precision: 8 }
+        btc::DENOM.clone() => PriceSource { id: BTC_USD_ID.id, channel: BTC_USD_ID.channel }
     );
 
     let pubkey = Binary::from_str(LAZER_TRUSTED_SIGNER).unwrap();
@@ -152,7 +152,6 @@ async fn proposal_pyth() {
         // Push NOT_USED_ID to the oracle.
         let msg = ExecuteMsg::RegisterPriceSources(btree_map!( test_denom.clone() => PriceSource {
             id: NOT_USED_ID_LAZER.id,
-            precision: 6,
             channel: NOT_USED_ID_LAZER.channel,
         }));
 

--- a/dango/testing/tests/proposal_preparer.rs
+++ b/dango/testing/tests/proposal_preparer.rs
@@ -44,10 +44,6 @@ async fn proposal_pyth() {
             })
             .should_succeed()
             .into_values()
-            .map(|price_source| PythLazerSubscriptionDetails {
-                id: price_source.id,
-                channel: price_source.channel,
-            })
             .collect::<Vec<_>>();
 
         // Create cache for ids if not present.

--- a/dango/testing/tests/proposal_preparer.rs
+++ b/dango/testing/tests/proposal_preparer.rs
@@ -146,13 +146,16 @@ async fn proposal_pyth() {
             });
 
         // Push NOT_USED_ID to the oracle.
-        let msg = ExecuteMsg::RegisterPriceSources(btree_map!( test_denom.clone() => PriceSource {
-            id: NOT_USED_ID_LAZER.id,
-            channel: NOT_USED_ID_LAZER.channel,
-        }));
-
         suite
-            .execute(&mut accounts.owner, contracts.oracle, &msg, Coins::new())
+            .execute(
+                &mut accounts.owner,
+                contracts.oracle,
+                &ExecuteMsg::RegisterPriceSources(btree_map!( test_denom.clone() => PriceSource {
+                    id: NOT_USED_ID_LAZER.id,
+                    channel: NOT_USED_ID_LAZER.channel,
+                })),
+                Coins::new(),
+            )
             .await
             .should_succeed();
 

--- a/dango/testing/tests/pyth_handler.rs
+++ b/dango/testing/tests/pyth_handler.rs
@@ -40,7 +40,6 @@ async fn handler() {
     let price_source = btree_map!(
         btc::DENOM.clone() => PriceSource {
             id: 1,
-            precision: 8,
             channel: Channel::RealTime,
         },
     );

--- a/dango/testing/tests/pyth_handler.rs
+++ b/dango/testing/tests/pyth_handler.rs
@@ -38,7 +38,7 @@ async fn handler() {
         .address;
 
     let price_source = btree_map!(
-        btc::DENOM.clone() => PriceSource::Pyth {
+        btc::DENOM.clone() => PriceSource {
             id: 1,
             precision: 8,
             channel: Channel::RealTime,

--- a/dango/types/src/constants/pyth.rs
+++ b/dango/types/src/constants/pyth.rs
@@ -18,57 +18,46 @@ pub static PYTH_PRICE_SOURCES: LazyLock<BTreeMap<Denom, PriceSource>> = LazyLock
         atom::DENOM.clone() => PriceSource {
             id: ATOM_USD_ID.id,
             channel: ATOM_USD_ID.channel,
-            precision: 6,
         },
         bch::DENOM.clone() => PriceSource {
             id: BCH_USD_ID.id,
             channel: BCH_USD_ID.channel,
-            precision: 8,
         },
         bnb::DENOM.clone() => PriceSource {
             id: BNB_USD_ID.id,
             channel: BNB_USD_ID.channel,
-            precision: 18,
         },
         btc::DENOM.clone() => PriceSource {
             id: BTC_USD_ID.id,
             channel: BTC_USD_ID.channel,
-            precision: 8,
         },
         doge::DENOM.clone() => PriceSource {
             id: DOGE_USD_ID.id,
             channel: DOGE_USD_ID.channel,
-            precision: 8,
         },
         eth::DENOM.clone() => PriceSource {
             id: ETH_USD_ID.id,
             channel: ETH_USD_ID.channel,
-            precision: 18,
         },
         ltc::DENOM.clone() => PriceSource {
             id: LTC_USD_ID.id,
             channel: LTC_USD_ID.channel,
-            precision: 8,
         },
         sol::DENOM.clone() => PriceSource {
             id: SOL_USD_ID.id,
             channel: SOL_USD_ID.channel,
-            precision: 9,
         },
         usdc::DENOM.clone() => PriceSource {
             id: USDC_USD_ID.id,
             channel: USDC_USD_ID.channel,
-            precision: 6,
         },
         xrp::DENOM.clone() => PriceSource {
             id: XRP_USD_ID.id,
             channel: XRP_USD_ID.channel,
-            precision: 6,
         },
         perp_eth::DENOM.clone() => PriceSource {
             id: ETH_USD_ID.id,
             channel: ETH_USD_ID.channel,
-            precision: 18,
         },
     }
 });

--- a/dango/types/src/constants/pyth.rs
+++ b/dango/types/src/constants/pyth.rs
@@ -15,57 +15,57 @@ use {
 
 pub static PYTH_PRICE_SOURCES: LazyLock<BTreeMap<Denom, PriceSource>> = LazyLock::new(|| {
     btree_map! {
-        atom::DENOM.clone() => PriceSource::Pyth {
+        atom::DENOM.clone() => PriceSource {
             id: ATOM_USD_ID.id,
             channel: ATOM_USD_ID.channel,
             precision: 6,
         },
-        bch::DENOM.clone() => PriceSource::Pyth {
+        bch::DENOM.clone() => PriceSource {
             id: BCH_USD_ID.id,
             channel: BCH_USD_ID.channel,
             precision: 8,
         },
-        bnb::DENOM.clone() => PriceSource::Pyth {
+        bnb::DENOM.clone() => PriceSource {
             id: BNB_USD_ID.id,
             channel: BNB_USD_ID.channel,
             precision: 18,
         },
-        btc::DENOM.clone() => PriceSource::Pyth {
+        btc::DENOM.clone() => PriceSource {
             id: BTC_USD_ID.id,
             channel: BTC_USD_ID.channel,
             precision: 8,
         },
-        doge::DENOM.clone() => PriceSource::Pyth {
+        doge::DENOM.clone() => PriceSource {
             id: DOGE_USD_ID.id,
             channel: DOGE_USD_ID.channel,
             precision: 8,
         },
-        eth::DENOM.clone() => PriceSource::Pyth {
+        eth::DENOM.clone() => PriceSource {
             id: ETH_USD_ID.id,
             channel: ETH_USD_ID.channel,
             precision: 18,
         },
-        ltc::DENOM.clone() => PriceSource::Pyth {
+        ltc::DENOM.clone() => PriceSource {
             id: LTC_USD_ID.id,
             channel: LTC_USD_ID.channel,
             precision: 8,
         },
-        sol::DENOM.clone() => PriceSource::Pyth {
+        sol::DENOM.clone() => PriceSource {
             id: SOL_USD_ID.id,
             channel: SOL_USD_ID.channel,
             precision: 9,
         },
-        usdc::DENOM.clone() => PriceSource::Pyth {
+        usdc::DENOM.clone() => PriceSource {
             id: USDC_USD_ID.id,
             channel: USDC_USD_ID.channel,
             precision: 6,
         },
-        xrp::DENOM.clone() => PriceSource::Pyth {
+        xrp::DENOM.clone() => PriceSource {
             id: XRP_USD_ID.id,
             channel: XRP_USD_ID.channel,
             precision: 6,
         },
-        perp_eth::DENOM.clone() => PriceSource::Pyth {
+        perp_eth::DENOM.clone() => PriceSource {
             id: ETH_USD_ID.id,
             channel: ETH_USD_ID.channel,
             precision: 18,

--- a/dango/types/src/oracle/msg.rs
+++ b/dango/types/src/oracle/msg.rs
@@ -1,5 +1,5 @@
 use {
-    crate::oracle::{PrecisionedPrice, PriceSource},
+    crate::oracle::{Price, PriceSource},
     grug::{Binary, Denom, Timestamp},
     pyth_types::PriceUpdate,
     std::collections::BTreeMap,
@@ -41,10 +41,10 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     /// Query the price of the given denom.
-    #[returns(PrecisionedPrice)]
+    #[returns(Price)]
     Price { denom: Denom },
     /// Enumerate the prices of all supported denoms.
-    #[returns(BTreeMap<Denom, PrecisionedPrice>)]
+    #[returns(BTreeMap<Denom, Price>)]
     Prices {
         start_after: Option<Denom>,
         limit: Option<u32>,

--- a/dango/types/src/oracle/price.rs
+++ b/dango/types/src/oracle/price.rs
@@ -1,159 +1,28 @@
 use {
-    bnum::types::U256,
-    grug::{
-        Dec, Defined, Exponentiate, FixedPoint, MathResult, MaybeDefined, MultiplyFraction,
-        NextNumber, Number, NumberConst, PrevNumber, Timestamp, Udec128, Uint128, Uint256,
-        Undefined,
-    },
+    dango_order_book::UsdPrice,
+    grug::{Dec128_6, Timestamp},
     pyth_types::{PayloadFeedData, PayloadPropertyValue},
-    std::cmp::Ordering,
 };
 
-pub type Precision = u8;
-
-pub type PrecisionlessPrice = Price<Undefined<Precision>>;
-
-pub type PrecisionedPrice = Price<Defined<Precision>>;
-
 #[grug::derive(Serde, Borsh)]
-pub struct Price<P>
-where
-    P: MaybeDefined<Precision>,
-{
+pub struct Price {
     /// The price of the token in its humanized form. I.e. the price of 1 ATOM,
     /// rather than 1 uatom.
-    pub humanized_price: Udec128,
+    pub humanized_price: UsdPrice,
     /// The UNIX timestamp of the price (seconds since UNIX epoch).
     pub timestamp: Timestamp,
-    /// The number of decimal places of the token that is used to convert
-    /// the price from its smallest unit to a humanized form. E.g. 1 ATOM
-    /// is 10^6 uatom, so the precision is 6.
-    precision: P,
 }
 
-impl PrecisionlessPrice {
-    /// Creates a new PrecisionlessPrice with the given humanized price.
-    pub fn new(humanized_price: Udec128, timestamp: Timestamp) -> Self {
+impl Price {
+    pub fn new(humanized_price: UsdPrice, timestamp: Timestamp) -> Self {
         Self {
             humanized_price,
             timestamp,
-            precision: Undefined::new(),
-        }
-    }
-
-    pub fn with_precision(self, precision: Precision) -> PrecisionedPrice {
-        Price {
-            humanized_price: self.humanized_price,
-            timestamp: self.timestamp,
-            precision: Defined::new(precision),
         }
     }
 }
 
-impl PrecisionedPrice {
-    pub fn new(humanized_price: Udec128, timestamp: Timestamp, precision: Precision) -> Self {
-        Self {
-            humanized_price,
-            timestamp,
-            precision: Defined::new(precision),
-        }
-    }
-
-    /// Returns the number of decimal places of the token that is used to
-    /// convert the price from its smallest unit to a humanized form. E.g.
-    /// 1 ATOM is 10^6 uatom, so the precision is 6.
-    pub fn precision(&self) -> Precision {
-        self.precision.into_inner()
-    }
-
-    /// Returns the value of a given unit amount. E.g. if this Price represents
-    /// the price in USD of one ATOM, then this function will return the value
-    /// in USD of the given number of uatom.
-    ///
-    /// e.g.
-    /// Humanized price: 3000
-    /// precision: 18
-    /// unit amount: 1*10^18
-    /// value: 3000 * 1*10^18 / 10^18 = 3000
-    pub fn value_of_unit_amount<const S: u32>(
-        &self,
-        unit_amount: Uint128,
-    ) -> MathResult<Dec<u128, S>>
-    where
-        Dec<u128, S>: FixedPoint<u128> + NumberConst,
-    {
-        self.humanized_price
-            .convert_precision()?
-            .checked_mul(Dec::<u128, S>::checked_from_ratio(
-                unit_amount,
-                10u128.pow(self.precision.into_inner() as u32),
-            )?)
-    }
-
-    /// Similar to `Self::value_of_unit_amount`, but returns the value as a
-    /// 256-bit, 24-decimal number. This is for use in the DEX contract, where
-    /// extreme price or amount multiplied together can overflow the limit of
-    /// 128-bit numbers.
-    pub fn value_of_unit_amount_256<const S: u32>(
-        &self,
-        unit_amount: Uint128,
-    ) -> MathResult<Dec<U256, S>> {
-        self.humanized_price
-            .into_next()
-            .convert_precision()?
-            .checked_mul(Dec::<U256, S>::checked_from_ratio(
-                unit_amount.into_next(),
-                Uint256::new_from_u128(10u128.pow(self.precision.into_inner() as u32)),
-            )?)
-    }
-
-    pub fn value_of_dec_amount<const S1: u32, const S2: u32>(
-        &self,
-        dec_amount: Dec<u128, S1>,
-    ) -> MathResult<Dec<u128, S2>> {
-        let mut num = dec_amount.0.checked_full_mul(self.humanized_price.0)?;
-
-        match S1.cmp(&S2) {
-            Ordering::Less => {
-                let diff = Uint256::TEN.checked_pow(S2 - S1)?;
-                num.checked_mul_assign(diff)?;
-            },
-            Ordering::Greater => {
-                let diff = Uint256::TEN.checked_pow(S1 - S2)?;
-                num.checked_div_assign(diff)?;
-            },
-            Ordering::Equal => {},
-        }
-
-        Dec::raw(
-            num.checked_div(Dec::<_, 18>::PRECISION)?
-                .checked_div(Uint256::TEN.checked_pow(self.precision.into_inner() as u32)?)?,
-        )
-        .checked_into_prev()
-    }
-
-    /// Returns the unit amount of a given value. E.g. if this Price represents
-    /// the price in USD of one ATOM, then this function will return the amount
-    /// in uatom of the given USD value.
-    ///
-    /// e.g.
-    /// Humanized price: 3000
-    /// precision: 18
-    /// value: 1000
-    /// unit amount: 1000 / 3000 * 10^18 = 1000*10^18 / 3000 = 3.33*10^17
-    pub fn unit_amount_from_value(&self, value: Udec128) -> MathResult<Uint128> {
-        Uint128::new(10u128.pow(self.precision.into_inner() as u32))
-            .checked_mul_dec(value.checked_div(self.humanized_price)?)
-    }
-
-    /// Returns the unit amount of a given value, rounded up.
-    pub fn unit_amount_from_value_ceil(&self, value: Udec128) -> MathResult<Uint128> {
-        Uint128::new(10u128.pow(self.precision.into_inner() as u32))
-            .checked_mul_dec_ceil(value.checked_div(self.humanized_price)?)
-    }
-}
-
-impl TryFrom<(PayloadFeedData, Timestamp)> for PrecisionlessPrice {
+impl TryFrom<(PayloadFeedData, Timestamp)> for Price {
     type Error = anyhow::Error;
 
     fn try_from((feed_data, timestamp): (PayloadFeedData, Timestamp)) -> Result<Self, Self::Error> {
@@ -176,76 +45,19 @@ impl TryFrom<(PayloadFeedData, Timestamp)> for PrecisionlessPrice {
         let price = price.ok_or_else(|| anyhow::anyhow!("price not found"))?;
         let exponent = exponent.ok_or_else(|| anyhow::anyhow!("exponent not found"))?;
 
-        let price = Udec128::checked_from_atomics::<u128>(
-            price.mantissa_i64().try_into()?,
+        // Pyth Lazer prices come as `mantissa * 10^exponent`. The exponent is
+        // negative for sub-integer precision (e.g. `-8` means the mantissa is
+        // scaled by `10^8`). `Dec128_6::checked_from_atomics` interprets its
+        // second argument as the number of decimal places to shift, so we pass
+        // `-exponent` to recover the humanized value.
+        let humanized_price = Dec128_6::checked_from_atomics::<i128>(
+            price.mantissa_i64().into(),
             (-exponent).try_into()?,
         )?;
 
         Ok(Price {
-            humanized_price: price,
+            humanized_price: UsdPrice::new(humanized_price),
             timestamp,
-            precision: Undefined::new(),
         })
-    }
-}
-
-// ----------------------------------- tests -----------------------------------
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        grug::{IsZero, Udec128_24},
-    };
-
-    #[test]
-    fn value_of_unit_amount_does_not_overflow_with_large_precision() {
-        // $100M per ETH
-        let price = PrecisionedPrice {
-            humanized_price: Udec128::new(100_000_000u128),
-            timestamp: Timestamp::from_seconds(0),
-            precision: Defined::new(18),
-        };
-
-        // Value of 100M ETH at $100M = $100000T
-        let value = price
-            .value_of_unit_amount(Uint128::new(100_000_000u128 * 10u128.pow(18)))
-            .unwrap();
-        assert_eq!(value, Udec128::new(10_000_000_000_000_000u128));
-    }
-
-    #[test]
-    fn unit_amount_from_value_does_not_overflow_with_large_precision() {
-        // $100M per ETH
-        let price = PrecisionedPrice {
-            humanized_price: Udec128::new(100_000_000u128),
-            timestamp: Timestamp::from_seconds(0),
-            precision: Defined::new(18),
-        };
-
-        // Value of 100M ETH at $100M = $100000T
-        let unit_amount = price
-            .unit_amount_from_value(Udec128::new(10_000_000_000_000_000u128))
-            .unwrap();
-        assert_eq!(unit_amount, Uint128::new(100_000_000u128 * 10u128.pow(18)));
-    }
-
-    #[test]
-    fn value_of_unit_amount_works_with_large_precision_and_small_price() {
-        // 0.000001 USD per token
-        let price = PrecisionedPrice {
-            humanized_price: Udec128::checked_from_ratio(1, 1_000_000).unwrap(),
-            timestamp: Timestamp::from_seconds(0),
-            precision: Defined::new(18),
-        };
-
-        // Value of 1 unit of token at 0.000001 USD = 0.000001 / 10^18 USD
-        let value: Udec128_24 = price.value_of_unit_amount(Uint128::new(1)).unwrap();
-        println!("value: {value}");
-        assert!(value.is_non_zero());
-        assert_eq!(
-            value,
-            Udec128_24::checked_from_ratio(1, 1_000_000 * 10u128.pow(18)).unwrap()
-        );
     }
 }

--- a/dango/types/src/oracle/price_source.rs
+++ b/dango/types/src/oracle/price_source.rs
@@ -1,7 +1,4 @@
-use {
-    crate::oracle::Precision,
-    pyth_types::{Channel, PythId},
-};
+use pyth_types::{Channel, PythId};
 
 #[grug::derive(Serde)]
 pub struct PriceSource {
@@ -9,8 +6,4 @@ pub struct PriceSource {
     pub id: PythId,
     /// The channel of the Pyth Lazer price feed.
     pub channel: Channel,
-    /// The number of decimal places of the token that is used to convert
-    /// the price from its smallest unit to a humanized form. E.g. 1 ATOM
-    /// is 10^6 uatom, so the precision is 6.
-    pub precision: Precision,
 }

--- a/dango/types/src/oracle/price_source.rs
+++ b/dango/types/src/oracle/price_source.rs
@@ -1,31 +1,16 @@
 use {
     crate::oracle::Precision,
-    grug::{Timestamp, Udec128},
     pyth_types::{Channel, PythId},
 };
 
 #[grug::derive(Serde)]
-pub enum PriceSource {
-    /// A price source that uses a fixed price. For testing purposes only.
-    Fixed {
-        /// The price of the token.
-        humanized_price: Udec128,
-        /// The number of decimal places of the token that is used to convert
-        /// the price from its smallest unit to a humanized form. E.g. 1 ATOM
-        /// is 10^6 uatom, so the precision is 6.
-        precision: Precision,
-        /// The timestamp of the price.
-        timestamp: Timestamp,
-    },
-    /// A price source that uses price feeds from Pyth Lazer.
-    Pyth {
-        /// The Pyth Lazer ID of the price feed.
-        id: PythId,
-        /// The number of decimal places of the token that is used to convert
-        /// the price from its smallest unit to a humanized form. E.g. 1 ATOM
-        /// is 10^6 uatom, so the precision is 6.
-        precision: Precision,
-        /// The channel of the Pyth Lazer price feed.
-        channel: Channel,
-    },
+pub struct PriceSource {
+    /// The Pyth Lazer ID of the price feed.
+    pub id: PythId,
+    /// The channel of the Pyth Lazer price feed.
+    pub channel: Channel,
+    /// The number of decimal places of the token that is used to convert
+    /// the price from its smallest unit to a humanized form. E.g. 1 ATOM
+    /// is 10^6 uatom, so the precision is 6.
+    pub precision: Precision,
 }

--- a/dango/types/src/oracle/price_source.rs
+++ b/dango/types/src/oracle/price_source.rs
@@ -1,9 +1,3 @@
-use pyth_types::{Channel, PythId};
-
-#[grug::derive(Serde)]
-pub struct PriceSource {
-    /// The Pyth Lazer ID of the price feed.
-    pub id: PythId,
-    /// The channel of the Pyth Lazer price feed.
-    pub channel: Channel,
-}
+/// The oracle's price source record. Identical in shape to a Pyth Lazer
+/// subscription, so we alias the upstream type directly.
+pub type PriceSource = pyth_types::PythLazerSubscriptionDetails;

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -9,9 +9,12 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 
 [dependencies]
-dango-bank    = { workspace = true, features = ["library"] }
-dango-gateway = { workspace = true, features = ["library"] }
-dango-types   = { workspace = true }
-grug          = { workspace = true }
-grug-app      = { workspace = true }
-tracing       = { workspace = true }
+dango-bank       = { workspace = true, features = ["library"] }
+dango-gateway    = { workspace = true, features = ["library"] }
+dango-oracle     = { workspace = true, features = ["library"] }
+dango-order-book = { workspace = true }
+dango-types      = { workspace = true }
+grug             = { workspace = true }
+grug-app         = { workspace = true }
+pyth-types       = { workspace = true }
+tracing          = { workspace = true }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,5 +1,6 @@
 mod app_config;
 mod gateway;
+mod oracle;
 mod perps;
 mod taxman;
 
@@ -11,5 +12,6 @@ use {
 pub fn do_upgrade<VM>(mut storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
     app_config::do_app_config_upgrade(&mut *storage)?;
     gateway::do_gateway_upgrades(storage.clone())?;
-    taxman::do_taxman_upgrades(storage.clone())
+    oracle::do_oracle_upgrades(storage.clone())?;
+    taxman::do_taxman_upgrades(storage)
 }

--- a/dango/upgrade/src/oracle.rs
+++ b/dango/upgrade/src/oracle.rs
@@ -1,0 +1,355 @@
+use {
+    dango_order_book::UsdPrice,
+    grug::{Addr, Dec128_6, Denom, Inner, Order, StdError, StdResult, Storage, Unsigned, addr},
+    grug_app::{AppResult, CONTRACT_NAMESPACE, StorageProvider},
+    pyth_types::PythId,
+};
+
+/// Address of the Oracle contract. Same on mainnet and testnet (per the public
+/// API documentation and the live `app_config.oracle` field).
+const ORACLE: Addr = addr!("cedc5f73cbb963a48471b849c3650e6e34cd3b6d");
+
+/// Snapshot of the pre-refactor oracle storage shapes.
+///
+/// `PriceSource` was an enum with `Fixed` (test-only) and `Pyth` variants;
+/// `PrecisionlessPrice` carried a `Udec128` humanized price and a phantom
+/// `Undefined<Precision>` ZST. The new code collapses both into plain structs
+/// holding only the fields we actually use, so the migration projects each
+/// legacy entry into the new shape and re-saves it under the same storage
+/// key.
+mod legacy_oracle {
+    use {
+        grug::{Denom, Map, Serde, Timestamp, Udec128},
+        pyth_types::{Channel, PythId},
+    };
+
+    #[grug::derive(Serde)]
+    pub enum PriceSource {
+        Fixed {
+            humanized_price: Udec128,
+            precision: u8,
+            timestamp: Timestamp,
+        },
+        Pyth {
+            id: PythId,
+            precision: u8,
+            channel: Channel,
+        },
+    }
+
+    /// Borsh layout: `Udec128 (16 bytes) + Timestamp (8 bytes)`. The
+    /// pre-refactor `Price<Undefined<Precision>>` ended the struct with a
+    /// `Undefined<u8>` ZST that Borsh encodes as 0 bytes, so the on-disk
+    /// representation matches this two-field shape verbatim.
+    #[grug::derive(Borsh)]
+    pub struct PrecisionlessPrice {
+        pub humanized_price: Udec128,
+        pub timestamp: Timestamp,
+    }
+
+    /// Same storage key (`"price_source"`) as `dango_oracle::PRICE_SOURCES`,
+    /// so loading through this handle reads the live on-disk JSON bytes
+    /// under the legacy enum shape.
+    pub const PRICE_SOURCES: Map<&Denom, PriceSource, Serde> = Map::new("price_source");
+
+    /// Same storage key (`"pyth_price"`) as `dango_oracle::PYTH_PRICES`.
+    pub const PYTH_PRICES: Map<PythId, PrecisionlessPrice> = Map::new("pyth_price");
+}
+
+pub fn do_oracle_upgrades(storage: Box<dyn Storage>) -> AppResult<()> {
+    let mut oracle_storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &ORACLE]);
+
+    do_price_sources_migration(&mut oracle_storage)?;
+    do_pyth_prices_migration(&mut oracle_storage)
+}
+
+/// Re-project every `PRICE_SOURCES` entry from the legacy enum shape
+/// (`{"pyth": {...}}` JSON tag) to the new struct shape (no tag).
+///
+/// `Fixed` variants are not expected in production but are skipped
+/// defensively if encountered.
+fn do_price_sources_migration(storage: &mut dyn Storage) -> AppResult<()> {
+    let legacy_entries: Vec<(Denom, legacy_oracle::PriceSource)> = legacy_oracle::PRICE_SOURCES
+        .range(storage, None, None, Order::Ascending)
+        .collect::<StdResult<_>>()?;
+
+    // Save the new shape under the same key. Each call to
+    // `dango_oracle::PRICE_SOURCES.save` overwrites the legacy JSON bytes.
+    for (denom, legacy) in legacy_entries {
+        match legacy {
+            legacy_oracle::PriceSource::Pyth {
+                id,
+                channel,
+                precision: _,
+            } => {
+                let new_source = dango_types::oracle::PriceSource { id, channel };
+
+                dango_oracle::PRICE_SOURCES.save(storage, &denom, &new_source)?;
+
+                tracing::info!(%denom, %id, "Migrated price source");
+            },
+            legacy_oracle::PriceSource::Fixed { .. } => {
+                legacy_oracle::PRICE_SOURCES.remove(storage, &denom);
+
+                tracing::warn!(
+                    %denom,
+                    "Encountered legacy `Fixed` price source during migration; dropped it"
+                );
+            },
+        }
+    }
+
+    Ok(())
+}
+
+/// Re-encode every `PYTH_PRICES` entry from the legacy Borsh layout
+/// (`Udec128`-backed humanized price, 18 decimal places) to the new layout
+/// (`Dec128_6`-backed `UsdPrice`, 6 decimal places).
+///
+/// The raw u128 of `Udec128` equals `humanized × 10^18`; the raw i128 of
+/// `Dec128_6` equals `humanized × 10^6`. The conversion divides the raw
+/// value by `10^12`, which `Dec128_6::checked_from_atomics(_, 18)` does
+/// internally — and which truncates digits beyond 6 decimal places, exactly
+/// matching the conversion that `query_price_for_perps` used to perform at
+/// every query.
+fn do_pyth_prices_migration(storage: &mut dyn Storage) -> AppResult<()> {
+    let legacy_entries: Vec<(PythId, legacy_oracle::PrecisionlessPrice)> =
+        legacy_oracle::PYTH_PRICES
+            .range(storage, None, None, Order::Ascending)
+            .collect::<StdResult<_>>()?;
+
+    for (id, legacy) in legacy_entries {
+        // `Udec128 (Dec<u128, 18>)` → `Dec<i128, 18>` → `Dec128_6` (raw / 10^12).
+        let signed = legacy
+            .humanized_price
+            .checked_into_signed()
+            .map_err(StdError::from)?;
+        let new_inner =
+            Dec128_6::checked_from_atomics(signed.into_inner(), 18).map_err(StdError::from)?;
+        let new_price = dango_types::oracle::Price {
+            humanized_price: UsdPrice::new(new_inner),
+            timestamp: legacy.timestamp,
+        };
+
+        dango_oracle::PYTH_PRICES.save(storage, id, &new_price)?;
+
+        tracing::info!(
+            %id,
+            humanized_price = %new_price.humanized_price,
+            timestamp = new_price.timestamp.to_rfc3339_string(),
+            "Migrated Pyth price"
+        );
+    }
+
+    Ok(())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        dango_types::constants::{atom, btc, eth, usdc},
+        grug::{MockStorage, Timestamp, Udec128, btree_map},
+        pyth_types::constants::{ATOM_USD_ID, BTC_USD_ID, ETH_USD_ID, USDC_USD_ID},
+        std::str::FromStr,
+    };
+
+    /// A representative pre-refactor `PRICE_SOURCES` map that mirrors what is
+    /// actually live on mainnet today (Pyth-only, with `precision` set per
+    /// the values in `dango/types/src/constants/pyth.rs`).
+    fn seed_legacy_price_sources(storage: &mut dyn Storage) {
+        let entries = btree_map! {
+            atom::DENOM.clone() => legacy_oracle::PriceSource::Pyth {
+                id: ATOM_USD_ID.id,
+                channel: ATOM_USD_ID.channel,
+                precision: 6,
+            },
+            btc::DENOM.clone() => legacy_oracle::PriceSource::Pyth {
+                id: BTC_USD_ID.id,
+                channel: BTC_USD_ID.channel,
+                precision: 8,
+            },
+            eth::DENOM.clone() => legacy_oracle::PriceSource::Pyth {
+                id: ETH_USD_ID.id,
+                channel: ETH_USD_ID.channel,
+                precision: 18,
+            },
+            usdc::DENOM.clone() => legacy_oracle::PriceSource::Pyth {
+                id: USDC_USD_ID.id,
+                channel: USDC_USD_ID.channel,
+                precision: 6,
+            },
+        };
+        for (denom, source) in entries {
+            legacy_oracle::PRICE_SOURCES
+                .save(storage, &denom, &source)
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn price_sources_migration_projects_pyth_entries_and_drops_precision() {
+        let mut storage = MockStorage::new();
+        seed_legacy_price_sources(&mut storage);
+
+        do_price_sources_migration(&mut storage).unwrap();
+
+        // Each entry should now decode under the new struct shape with the
+        // `id` and `channel` preserved; `precision` is gone.
+        let migrated_btc = dango_oracle::PRICE_SOURCES
+            .load(&storage, &btc::DENOM)
+            .unwrap();
+        assert_eq!(migrated_btc.id, BTC_USD_ID.id);
+        assert_eq!(migrated_btc.channel, BTC_USD_ID.channel);
+
+        let migrated_eth = dango_oracle::PRICE_SOURCES
+            .load(&storage, &eth::DENOM)
+            .unwrap();
+        assert_eq!(migrated_eth.id, ETH_USD_ID.id);
+        assert_eq!(migrated_eth.channel, ETH_USD_ID.channel);
+
+        // Every seeded denom must survive the migration.
+        let count = dango_oracle::PRICE_SOURCES
+            .range(&storage, None, None, Order::Ascending)
+            .count();
+        assert_eq!(count, 4);
+    }
+
+    #[test]
+    fn price_sources_migration_drops_legacy_fixed_entries() {
+        let mut storage = MockStorage::new();
+
+        legacy_oracle::PRICE_SOURCES
+            .save(
+                &mut storage,
+                &btc::DENOM,
+                &legacy_oracle::PriceSource::Pyth {
+                    id: BTC_USD_ID.id,
+                    channel: BTC_USD_ID.channel,
+                    precision: 8,
+                },
+            )
+            .unwrap();
+        legacy_oracle::PRICE_SOURCES
+            .save(
+                &mut storage,
+                &eth::DENOM,
+                &legacy_oracle::PriceSource::Fixed {
+                    humanized_price: Udec128::new(2_000),
+                    precision: 18,
+                    timestamp: Timestamp::from_seconds(0),
+                },
+            )
+            .unwrap();
+
+        do_price_sources_migration(&mut storage).unwrap();
+
+        // BTC survives as the new struct.
+        assert!(
+            dango_oracle::PRICE_SOURCES
+                .may_load(&storage, &btc::DENOM)
+                .unwrap()
+                .is_some(),
+        );
+        // ETH (the Fixed entry) is dropped entirely.
+        assert!(
+            dango_oracle::PRICE_SOURCES
+                .may_load(&storage, &eth::DENOM)
+                .unwrap()
+                .is_none(),
+        );
+    }
+
+    #[test]
+    fn pyth_prices_migration_rescales_humanized_price() {
+        let mut storage = MockStorage::new();
+
+        // Seed three legacy entries with prices that span integer and
+        // sub-cent humanized values so the truncation behavior is exercised.
+        legacy_oracle::PYTH_PRICES
+            .save(
+                &mut storage,
+                BTC_USD_ID.id,
+                &legacy_oracle::PrecisionlessPrice {
+                    // $50_000.00
+                    humanized_price: Udec128::new(50_000),
+                    timestamp: Timestamp::from_seconds(1_700_000_000),
+                },
+            )
+            .unwrap();
+        legacy_oracle::PYTH_PRICES
+            .save(
+                &mut storage,
+                ETH_USD_ID.id,
+                &legacy_oracle::PrecisionlessPrice {
+                    // $2_000.50
+                    humanized_price: Udec128::from_str("2000.50").unwrap(),
+                    timestamp: Timestamp::from_seconds(1_700_000_001),
+                },
+            )
+            .unwrap();
+        legacy_oracle::PYTH_PRICES
+            .save(
+                &mut storage,
+                USDC_USD_ID.id,
+                &legacy_oracle::PrecisionlessPrice {
+                    // $1.000000000123456789 — has 12 digits past the 6-decimal
+                    // cutoff; should truncate cleanly to "1.000000".
+                    humanized_price: Udec128::from_str("1.000000000123456789").unwrap(),
+                    timestamp: Timestamp::from_seconds(1_700_000_002),
+                },
+            )
+            .unwrap();
+
+        do_pyth_prices_migration(&mut storage).unwrap();
+
+        let btc = dango_oracle::PYTH_PRICES
+            .load(&storage, BTC_USD_ID.id)
+            .unwrap();
+        assert_eq!(
+            btc.humanized_price,
+            UsdPrice::new(Dec128_6::from_str("50000").unwrap()),
+        );
+        assert_eq!(btc.timestamp, Timestamp::from_seconds(1_700_000_000));
+
+        let eth = dango_oracle::PYTH_PRICES
+            .load(&storage, ETH_USD_ID.id)
+            .unwrap();
+        assert_eq!(
+            eth.humanized_price,
+            UsdPrice::new(Dec128_6::from_str("2000.5").unwrap()),
+        );
+
+        let usdc = dango_oracle::PYTH_PRICES
+            .load(&storage, USDC_USD_ID.id)
+            .unwrap();
+        assert_eq!(
+            usdc.humanized_price,
+            UsdPrice::new(Dec128_6::from_str("1.000000").unwrap()),
+        );
+    }
+
+    #[test]
+    fn empty_substore_is_noop() {
+        let mut storage = MockStorage::new();
+
+        do_price_sources_migration(&mut storage).unwrap();
+        do_pyth_prices_migration(&mut storage).unwrap();
+
+        // Both maps stay empty.
+        assert_eq!(
+            dango_oracle::PRICE_SOURCES
+                .range(&storage, None, None, Order::Ascending)
+                .count(),
+            0,
+        );
+        assert_eq!(
+            dango_oracle::PYTH_PRICES
+                .range(&storage, None, None, Order::Ascending)
+                .count(),
+            0,
+        );
+    }
+}

--- a/deploy/roles/full-app/templates/config/cometbft/genesis.json
+++ b/deploy/roles/full-app/templates/config/cometbft/genesis.json
@@ -664,88 +664,52 @@
           "msg": {
             "price_sources": {
               "bridge/atom": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 44,
-                  "precision": 6
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 44
               },
               "bridge/bch": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 24,
-                  "precision": 8
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 24
               },
               "bridge/bnb": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 15,
-                  "precision": 18
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 15
               },
               "bridge/btc": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 1,
-                  "precision": 8
-                }
+                "channel": "real_time",
+                "id": 1
               },
               "bridge/doge": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 13,
-                  "precision": 8
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 13
               },
               "bridge/eth": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 2,
-                  "precision": 18
-                }
+                "channel": "real_time",
+                "id": 2
               },
               "bridge/ltc": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 26,
-                  "precision": 8
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 26
               },
               "bridge/sol": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 6,
-                  "precision": 9
-                }
+                "channel": "real_time",
+                "id": 6
               },
               "bridge/usdc": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 7,
-                  "precision": 6
-                }
+                "channel": "real_time",
+                "id": 7
               },
               "bridge/xrp": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 14,
-                  "precision": 6
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 14
               },
               "perp/btcusd": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 1,
-                  "precision": 8
-                }
+                "channel": "real_time",
+                "id": 1
               },
               "perp/ethusd": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 2,
-                  "precision": 18
-                }
+                "channel": "real_time",
+                "id": 2
               }
             },
             "trusted_signers": {

--- a/localdango/configs/cometbft/config/genesis.json
+++ b/localdango/configs/cometbft/config/genesis.json
@@ -664,81 +664,48 @@
           "msg": {
             "price_sources": {
               "bridge/atom": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 44,
-                  "precision": 6
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 44
               },
               "bridge/bch": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 24,
-                  "precision": 8
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 24
               },
               "bridge/bnb": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 15,
-                  "precision": 18
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 15
               },
               "bridge/btc": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 1,
-                  "precision": 8
-                }
+                "channel": "real_time",
+                "id": 1
               },
               "bridge/doge": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 13,
-                  "precision": 8
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 13
               },
               "bridge/eth": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 2,
-                  "precision": 18
-                }
+                "channel": "real_time",
+                "id": 2
               },
               "bridge/ltc": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 26,
-                  "precision": 8
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 26
               },
               "bridge/sol": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 6,
-                  "precision": 9
-                }
+                "channel": "real_time",
+                "id": 6
               },
               "bridge/usdc": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 7,
-                  "precision": 6
-                }
+                "channel": "real_time",
+                "id": 7
               },
               "bridge/xrp": {
-                "pyth": {
-                  "channel": "fixed_rate@200ms",
-                  "id": 14,
-                  "precision": 6
-                }
+                "channel": "fixed_rate@200ms",
+                "id": 14
               },
               "perp/ethusd": {
-                "pyth": {
-                  "channel": "real_time",
-                  "id": 2,
-                  "precision": 18
-                }
+                "channel": "real_time",
+                "id": 2
               }
             },
             "trusted_signers": {

--- a/sdk/typescript/types/src/oracle.ts
+++ b/sdk/typescript/types/src/oracle.ts
@@ -1,18 +1,8 @@
 export type Price = {
-  /* The price of the token in its humanized form. I.e. the price of 1 ATOM,
-    rather than 1 uatom.
-  */
-  humanizedPrice: string;
-  /* The exponential moving average of the price of the token in its
-    humanized form.
-  */
-  humanizedEma: string;
-  /* The UNIX timestamp of the price (seconds since UNIX epoch).
+  /** The price of the token in its humanized form. E.g. the price of 1 ATOM,
+   * rather than 1 uatom.
    */
-  precision: number;
-  /* The number of decimal places of the token that is used to convert
-    the price from its smallest unit to a humanized form. E.g. 1 ATOM
-    is 10^6 uatom, so the precision is 6.
-  */
+  humanizedPrice: string;
+  /** The UNIX timestamp of the price (seconds since UNIX epoch). */
   timestamp: number;
 };


### PR DESCRIPTION
The oracle was originally designed to aggregate multiple data sources via an
  extensible `PriceSource` enum and a precision-tracking `Price<P>` generic. In
  practice the only data source is Pyth, the `Fixed` variant existed solely as a
  test-only escape hatch around Pyth signature verification, and the
  `Precision` machinery (`Defined`/`Undefined`, `with_precision`, five math
  methods) gated behavior that no production code ever exercised — the lone
  real consumer (`query_price_for_perps`) read `humanized_price` and ignored
  the per-denom precision entirely.

  This PR collapses both type families:

  - `PriceSource` becomes a plain struct `{ id, channel }`. `Fixed` is gone;
    tests that previously needed it now seed `PYTH_PRICES` directly via a small
    `write_pyth_price_raw` helper that uses the existing
    `with_state_storage_mut` pattern.
  - `Price<P>` is replaced by a single concrete struct
    `{ humanized_price: UsdPrice, timestamp: Timestamp }`. On-chain storage
    switches from `Udec128`-backed prices (18 decimals) to `UsdPrice`-backed
    prices (6 decimals), which is the format every consumer already wanted —
    `query_price_for_perps` is now a near-identity rather than a per-query
    rescale.

  State and JSON shape changes are migrated by `dango/upgrade/src/oracle.rs`,
  which projects every legacy `PRICE_SOURCES` entry into the new struct shape
  and rescales every legacy `PYTH_PRICES` entry's raw u128 from
  `humanized × 10^18` (`Udec128`) to `humanized × 10^6` (`Dec128_6`). The JSON
  field name `humanized_price` is preserved so no UI consumer needs updating.