### PR TITLE
feat(oracle): add `market_session` field to `Price`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,7 @@ dependencies = [
  "dango-types",
  "grug",
  "metrics",
+ "pyth-types",
  "test-case",
  "tracing",
 ]

--- a/dango/oracle/src/execute.rs
+++ b/dango/oracle/src/execute.rs
@@ -234,7 +234,7 @@ mod tests {
     use {
         super::*,
         grug::{Binary, ByteArray, Duration, MockApi, MockStorage, ResultExt},
-        pyth_types::{LeEcdsaMessage, constants::LAZER_TRUSTED_SIGNER},
+        pyth_types::{LeEcdsaMessage, MarketSession, constants::LAZER_TRUSTED_SIGNER},
         std::str::FromStr,
     };
 
@@ -301,6 +301,11 @@ mod tests {
         for feed in payload.feeds {
             let price = Price::try_from((feed, timestamp)).unwrap();
             let _price_f64: f64 = price.humanized_price.to_string().parse().unwrap();
+
+            // This payload was captured before we requested `MarketSession`
+            // in the subscription, so the property is absent and `try_from`
+            // falls back to `Other`.
+            assert_eq!(price.market_session, MarketSession::Other);
         }
     }
 }

--- a/dango/oracle/src/oracle_querier.rs
+++ b/dango/oracle/src/oracle_querier.rs
@@ -150,6 +150,7 @@ mod tests {
         super::*,
         dango_types::constants::{eth, usdc},
         grug::{ResultExt, Timestamp, hash_map},
+        pyth_types::MarketSession,
         test_case::test_case,
     };
 
@@ -158,6 +159,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_int(2_000),
                 Timestamp::from_seconds(1730802926),
+                MarketSession::Regular,
             ),
         };
         "mock with one price"
@@ -167,10 +169,12 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_int(2_000),
                 Timestamp::from_seconds(1730802926),
+                MarketSession::Regular,
             ),
             usdc::DENOM.clone() => Price::new(
                 UsdPrice::new_int(1),
                 Timestamp::from_seconds(1730802926),
+                MarketSession::Regular,
             ),
         };
         "mock with two prices"
@@ -221,6 +225,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_int(2_000),
                 publish_time,
+                MarketSession::Regular,
             ),
         });
 

--- a/dango/perps/Cargo.toml
+++ b/dango/perps/Cargo.toml
@@ -27,4 +27,5 @@ metrics               = { workspace = true, optional = true }
 tracing               = { workspace = true, optional = true }
 
 [dev-dependencies]
-test-case = { workspace = true }
+pyth-types = { workspace = true }
+test-case  = { workspace = true }

--- a/dango/perps/src/core/available_to_trade.rs
+++ b/dango/perps/src/core/available_to_trade.rs
@@ -164,6 +164,7 @@ mod tests {
             perps::{PairParam, PairState, Position},
         },
         grug::{Timestamp, btree_map, hash_map},
+        pyth_types::MarketSession,
         test_case::test_case,
     };
 
@@ -252,10 +253,12 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_int(2_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
             btc::DENOM.clone() => Price::new(
                 UsdPrice::new_int(50_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 

--- a/dango/perps/src/core/closure.rs
+++ b/dango/perps/src/core/closure.rs
@@ -224,6 +224,7 @@ mod tests {
             perps::{PairParam, PairState, Position},
         },
         grug::{Timestamp, btree_map, hash_map},
+        pyth_types::MarketSession,
         std::collections::HashMap,
     };
 
@@ -304,6 +305,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -351,6 +353,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -398,6 +401,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(150_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -453,6 +457,7 @@ mod tests {
                 eth::DENOM.clone() => Price::new(
                     UsdPrice::new_percent(200_000),
                     Timestamp::from_seconds(0),
+                    MarketSession::Regular,
                 ),
             });
             (user_state, perp_querier, oracle_querier)

--- a/dango/perps/src/core/liq_price.rs
+++ b/dango/perps/src/core/liq_price.rs
@@ -107,6 +107,7 @@ mod tests {
             perps::{PairParam, PairState, Position},
         },
         grug::{Timestamp, btree_map, hash_map},
+        pyth_types::MarketSession,
         std::collections::HashMap,
     };
 
@@ -114,7 +115,11 @@ mod tests {
     ///
     /// `price` is the integer dollar price (e.g. 2000 for $2,000).
     fn oracle_entry(price: u128) -> Price {
-        Price::new(UsdPrice::new_int(price as i128), Timestamp::from_seconds(0))
+        Price::new(
+            UsdPrice::new_int(price as i128),
+            Timestamp::from_seconds(0),
+            MarketSession::Regular,
+        )
     }
 
     fn pair_param_with_mmr(mmr_permille: i128) -> PairParam {

--- a/dango/perps/src/core/margin.rs
+++ b/dango/perps/src/core/margin.rs
@@ -290,6 +290,7 @@ mod tests {
             perps::{PairParam, PairState, Param, Position, RateSchedule},
         },
         grug::{Timestamp, btree_map, hash_map},
+        pyth_types::MarketSession,
         std::collections::HashMap,
         test_case::test_case,
     };
@@ -405,6 +406,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -443,6 +445,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -494,10 +497,12 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
             btc::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(4_800_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -535,6 +540,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(150_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -588,6 +594,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -638,10 +645,12 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
             btc::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -671,6 +680,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -716,6 +726,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -767,10 +778,12 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
             btc::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -804,6 +817,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -862,10 +876,12 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(200_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
             btc::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -966,6 +982,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -1011,6 +1028,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -1058,6 +1076,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(150_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -1105,6 +1124,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(250_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -1154,6 +1174,7 @@ mod tests {
             pair_id.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 

--- a/dango/perps/src/cron/process_funding.rs
+++ b/dango/perps/src/cron/process_funding.rs
@@ -144,6 +144,7 @@ mod tests {
             perps::{PairParam, PairState, Param, Position, State, UserState},
         },
         grug::{Duration, MockStorage, hash_map},
+        pyth_types::MarketSession,
         std::collections::{BTreeMap, BTreeSet},
     };
 
@@ -239,6 +240,7 @@ mod tests {
             pair_id.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -281,6 +283,7 @@ mod tests {
             pair_id.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -322,6 +325,7 @@ mod tests {
             pair_id.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -357,6 +361,7 @@ mod tests {
             pair_id.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -401,6 +406,7 @@ mod tests {
             pair_id.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -477,10 +483,12 @@ mod tests {
             btc.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
             eth.clone() => Price::new(
                 UsdPrice::new_percent(300_000), // $3,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 
@@ -531,6 +539,7 @@ mod tests {
             pair_id.clone() => Price::new(
                 UsdPrice::new_percent(5_000_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 

--- a/dango/perps/src/cron/vault_snapshot.rs
+++ b/dango/perps/src/cron/vault_snapshot.rs
@@ -71,6 +71,7 @@ mod tests {
             perps::{PairState, Position, State, UserState},
         },
         grug::{MockStorage, Order, Uint128, hash_map},
+        pyth_types::MarketSession,
         std::collections::BTreeMap,
     };
 
@@ -120,6 +121,7 @@ mod tests {
             btc_pair_id() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         })
     }

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -928,10 +928,14 @@ mod tests {
         },
         dango_order_book::{
             ChildOrder, Dimensionless, FundingPerUnit, LimitOrder, OrderKey, Quantity, UsdPrice,
-            UsdValue,
+            UsdValue, may_invert_price,
         },
-        dango_types::perps::{PairParam, PairState, Param, Position, State, UserState},
+        dango_types::{
+            oracle::Price,
+            perps::{PairParam, PairState, Param, Position, State, UserState},
+        },
         grug::{Addr, Coins, MockContext, Storage, Timestamp, Uint64},
+        pyth_types::MarketSession,
         std::collections::BTreeMap,
     };
 
@@ -1030,7 +1034,6 @@ mod tests {
         size: i128,
         price: i128,
     ) {
-        use dango_order_book::may_invert_price;
         let stored_price = may_invert_price(UsdPrice::new_int(price), true);
         let key: OrderKey = (pair_id.clone(), stored_price, Uint64::new(order_id));
         let order = LimitOrder {
@@ -1071,7 +1074,6 @@ mod tests {
     }
 
     fn mock_oracle_querier(pairs: Vec<(PairId, i128)>) -> OracleQuerier<'static> {
-        use {dango_types::oracle::Price, pyth_types::MarketSession};
         let mut map = std::collections::HashMap::new();
         for (pair_id, price) in pairs {
             map.insert(
@@ -2232,7 +2234,6 @@ mod tests {
             .unwrap();
 
         {
-            use dango_order_book::may_invert_price;
             let stored_price = may_invert_price(UsdPrice::new_int(47_500), true);
             let key: OrderKey = (pair_btc(), stored_price, Uint64::new(1));
             let order = LimitOrder {

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -1071,7 +1071,7 @@ mod tests {
     }
 
     fn mock_oracle_querier(pairs: Vec<(PairId, i128)>) -> OracleQuerier<'static> {
-        use dango_types::oracle::Price;
+        use {dango_types::oracle::Price, pyth_types::MarketSession};
         let mut map = std::collections::HashMap::new();
         for (pair_id, price) in pairs {
             map.insert(
@@ -1079,6 +1079,7 @@ mod tests {
                 Price::new(
                     UsdPrice::new_percent((price as u128 * 100) as i128),
                     Timestamp::from_seconds(0),
+                    MarketSession::Regular,
                 ),
             );
         }

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -1650,6 +1650,7 @@ mod tests {
             perps::{Position, RateSchedule},
         },
         grug::{Coins, EventName, JsonDeExt, MockContext, ResultExt, Timestamp, Uint64, hash_map},
+        pyth_types::MarketSession,
     };
 
     const CONTRACT: Addr = Addr::mock(0);
@@ -1665,6 +1666,7 @@ mod tests {
             pair_id() => Price::new(
                 UsdPrice::new_percent(5_000_000), // $50,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         })
     }
@@ -6522,6 +6524,7 @@ mod tests {
             pair_id() => Price::new(
                 UsdPrice::new_percent(4_800_000), // $48,000
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         });
 

--- a/dango/perps/src/vault/add_liquidity.rs
+++ b/dango/perps/src/vault/add_liquidity.rs
@@ -199,6 +199,7 @@ mod tests {
             perps::{PairParam, PairState, Position, UserState},
         },
         grug::{MockStorage, NumberConst, Timestamp, Uint128, btree_map, hash_map},
+        pyth_types::MarketSession,
     };
 
     fn default_param() -> Param {
@@ -679,6 +680,7 @@ mod tests {
             eth::DENOM.clone() => Price::new(
                 UsdPrice::new_percent(195_000),
                 Timestamp::from_seconds(0),
+                MarketSession::Regular,
             ),
         };
 

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -15,7 +15,7 @@ use {
     grug_app::{AppError, CONTRACT_NAMESPACE, Indexer, ProposalPreparer},
     grug_db_memory::MemDb,
     grug_vm_rust::RustVm,
-    pyth_types::{Channel, PythId},
+    pyth_types::{Channel, MarketSession, PythId},
     std::collections::BTreeMap,
 };
 
@@ -93,7 +93,11 @@ pub async fn seed_oracle_prices<PP, ID>(
 
     suite.app.db.with_state_storage_mut(|storage| {
         for entry in entries.values() {
-            let price = Price::new(entry.humanized_price, entry.timestamp);
+            let price = Price::new(
+                entry.humanized_price,
+                entry.timestamp,
+                MarketSession::Regular,
+            );
             write_pyth_price_raw(storage, oracle, entry.pyth_id, &price);
         }
     });

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -10,7 +10,7 @@ use {
         btree_map,
     },
     grug_app::NaiveProposalPreparer,
-    pyth_types::{Channel, LeEcdsaMessage, constants::LAZER_TRUSTED_SIGNER},
+    pyth_types::{Channel, LeEcdsaMessage, MarketSession, constants::LAZER_TRUSTED_SIGNER},
     std::str::FromStr,
 };
 
@@ -161,6 +161,9 @@ async fn pyth_lazer() {
         UsdPrice::new(Dec128_6::from_str("112985.059013").unwrap())
     );
     assert_eq!(price.timestamp, Timestamp::from_micros(1758539671000000));
+    // The captured payload predates our subscription to `MarketSession`,
+    // so the property is absent and the parser falls back to `Other`.
+    assert_eq!(price.market_session, MarketSession::Other);
 
     // Query the ETH price
     let price = suite
@@ -174,4 +177,5 @@ async fn pyth_lazer() {
         UsdPrice::new(Dec128_6::from_str("4185.880446").unwrap())
     );
     assert_eq!(price.timestamp, Timestamp::from_micros(1758539671000000));
+    assert_eq!(price.market_session, MarketSession::Other);
 }

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -19,7 +19,7 @@ use {
         ResultExt, Timestamp, Uint128, btree_map, concat,
     },
     grug_app::CONTRACT_NAMESPACE,
-    pyth_types::{Channel, LeEcdsaMessage},
+    pyth_types::{Channel, LeEcdsaMessage, MarketSession},
     std::{collections::BTreeMap, str::FromStr},
 };
 
@@ -431,7 +431,11 @@ async fn oracle_triggers_on_oracle_update() {
     // Seed USDC's PYTH_PRICES entry directly. The perp pair's price is fed via
     // signed Pyth Lazer messages later in the test.
     suite.app.db.with_state_storage_mut(|storage| {
-        let price = Price::new(UsdPrice::new_int(1), Timestamp::from_nanos(u128::MAX));
+        let price = Price::new(
+            UsdPrice::new_int(1),
+            Timestamp::from_nanos(u128::MAX),
+            MarketSession::Regular,
+        );
         write_pyth_price_raw(storage, contracts.oracle, 1, &price);
     });
 

--- a/dango/types/src/oracle/price.rs
+++ b/dango/types/src/oracle/price.rs
@@ -1,7 +1,7 @@
 use {
     dango_order_book::UsdPrice,
     grug::{Dec128_6, Timestamp},
-    pyth_types::{PayloadFeedData, PayloadPropertyValue},
+    pyth_types::{MarketSession, PayloadFeedData, PayloadPropertyValue},
 };
 
 #[grug::derive(Serde, Borsh)]
@@ -9,15 +9,28 @@ pub struct Price {
     /// The price of the token in its humanized form. I.e. the price of 1 ATOM,
     /// rather than 1 uatom.
     pub humanized_price: UsdPrice,
+
     /// The UNIX timestamp of the price (seconds since UNIX epoch).
     pub timestamp: Timestamp,
+
+    /// The market session at which the price was observed. For 24/7 markets
+    /// (e.g. crypto) this is always `Regular`. For markets with scheduled
+    /// sessions (e.g. equities) this captures whether the feed was in regular
+    /// trading hours or some other state (pre/post-market, overnight, closed).
+    /// Falls back to `Other` when the feed payload omits the property.
+    pub market_session: MarketSession,
 }
 
 impl Price {
-    pub fn new(humanized_price: UsdPrice, timestamp: Timestamp) -> Self {
+    pub fn new(
+        humanized_price: UsdPrice,
+        timestamp: Timestamp,
+        market_session: MarketSession,
+    ) -> Self {
         Self {
             humanized_price,
             timestamp,
+            market_session,
         }
     }
 }
@@ -26,24 +39,46 @@ impl TryFrom<(PayloadFeedData, Timestamp)> for Price {
     type Error = anyhow::Error;
 
     fn try_from((feed_data, timestamp): (PayloadFeedData, Timestamp)) -> Result<Self, Self::Error> {
-        let price = feed_data.properties.iter().find_map(|property| {
-            if let PayloadPropertyValue::Price(Some(price)) = property {
-                Some(price)
-            } else {
-                None
-            }
-        });
+        let price = feed_data
+            .properties
+            .iter()
+            .find_map(|property| {
+                if let PayloadPropertyValue::Price(Some(price)) = property {
+                    Some(price)
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| anyhow::anyhow!("price not found"))?;
 
-        let exponent = feed_data.properties.iter().find_map(|property| {
-            if let PayloadPropertyValue::Exponent(exponent) = property {
-                Some(exponent)
-            } else {
-                None
-            }
-        });
+        let exponent = feed_data
+            .properties
+            .iter()
+            .find_map(|property| {
+                if let PayloadPropertyValue::Exponent(exponent) = property {
+                    Some(exponent)
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| anyhow::anyhow!("exponent not found"))?;
 
-        let price = price.ok_or_else(|| anyhow::anyhow!("price not found"))?;
-        let exponent = exponent.ok_or_else(|| anyhow::anyhow!("exponent not found"))?;
+        // The `MarketSession` property is requested as part of the Pyth Lazer
+        // subscription, so it should always be present in well-formed payloads.
+        // We tolerate its absence by falling back to `Other` rather than
+        // erroring, since a missing session classification is less critical
+        // than a missing price or exponent.
+        let market_session = feed_data
+            .properties
+            .iter()
+            .find_map(|property| {
+                if let PayloadPropertyValue::MarketSession(value) = property {
+                    Some(MarketSession::from(*value))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(MarketSession::Other);
 
         // Pyth Lazer prices come as `mantissa * 10^exponent`. The exponent is
         // negative for sub-integer precision (e.g. `-8` means the mantissa is
@@ -58,6 +93,7 @@ impl TryFrom<(PayloadFeedData, Timestamp)> for Price {
         Ok(Price {
             humanized_price: UsdPrice::new(humanized_price),
             timestamp,
+            market_session,
         })
     }
 }

--- a/dango/upgrade/src/oracle.rs
+++ b/dango/upgrade/src/oracle.rs
@@ -2,7 +2,7 @@ use {
     dango_order_book::UsdPrice,
     grug::{Addr, Dec128_6, Denom, Inner, Order, StdError, StdResult, Storage, Unsigned, addr},
     grug_app::{AppResult, CONTRACT_NAMESPACE, StorageProvider},
-    pyth_types::PythId,
+    pyth_types::{MarketSession, PythId},
 };
 
 /// Address of the Oracle contract. Same on mainnet and testnet (per the public
@@ -112,6 +112,11 @@ fn do_price_sources_migration(storage: &mut dyn Storage) -> AppResult<()> {
 /// internally — and which truncates digits beyond 6 decimal places, exactly
 /// matching the conversion that `query_price_for_perps` used to perform at
 /// every query.
+///
+/// The new layout also carries a `market_session` field. We backfill it with
+/// `Regular` for every existing entry: at the time of this migration, all
+/// price sources point to crypto feeds, which trade 24/7 and are always in
+/// the regular session.
 fn do_pyth_prices_migration(storage: &mut dyn Storage) -> AppResult<()> {
     let legacy_entries: Vec<(PythId, legacy_oracle::PrecisionlessPrice)> =
         legacy_oracle::PYTH_PRICES
@@ -129,6 +134,7 @@ fn do_pyth_prices_migration(storage: &mut dyn Storage) -> AppResult<()> {
         let new_price = dango_types::oracle::Price {
             humanized_price: UsdPrice::new(new_inner),
             timestamp: legacy.timestamp,
+            market_session: MarketSession::Regular,
         };
 
         dango_oracle::PYTH_PRICES.save(storage, id, &new_price)?;
@@ -313,6 +319,7 @@ mod tests {
             UsdPrice::new(Dec128_6::from_str("50000").unwrap()),
         );
         assert_eq!(btc.timestamp, Timestamp::from_seconds(1_700_000_000));
+        assert_eq!(btc.market_session, MarketSession::Regular);
 
         let eth = dango_oracle::PYTH_PRICES
             .load(&storage, ETH_USD_ID.id)
@@ -321,6 +328,7 @@ mod tests {
             eth.humanized_price,
             UsdPrice::new(Dec128_6::from_str("2000.5").unwrap()),
         );
+        assert_eq!(eth.market_session, MarketSession::Regular);
 
         let usdc = dango_oracle::PYTH_PRICES
             .load(&storage, USDC_USD_ID.id)
@@ -329,6 +337,7 @@ mod tests {
             usdc.humanized_price,
             UsdPrice::new(Dec128_6::from_str("1.000000").unwrap()),
         );
+        assert_eq!(usdc.market_session, MarketSession::Regular);
     }
 
     #[test]

--- a/pyth/client/src/client.rs
+++ b/pyth/client/src/client.rs
@@ -78,7 +78,11 @@ impl PythClient {
         SubscriptionParams::new(SubscriptionParamsRepr {
             price_feed_ids: Some(price_feed_ids),
             symbols: None,
-            properties: vec![PriceFeedProperty::Price, PriceFeedProperty::Exponent],
+            properties: vec![
+                PriceFeedProperty::Price,
+                PriceFeedProperty::Exponent,
+                PriceFeedProperty::MarketSession,
+            ],
             formats: vec![Format::LeEcdsa],
             delivery_format: DeliveryFormat::Binary,
             json_binary_encoding: JsonBinaryEncoding::Base64,

--- a/pyth/types/src/lazer.rs
+++ b/pyth/types/src/lazer.rs
@@ -1,6 +1,9 @@
 use {
     grug::{Binary, ByteArray, Inner, NonEmpty},
-    pyth_lazer_protocol::{api::Channel, message::LeEcdsaMessage as LazerLeEcdsaMessage},
+    pyth_lazer_protocol::{
+        api::{Channel, MarketSession as LazerMarketSession},
+        message::LeEcdsaMessage as LazerLeEcdsaMessage,
+    },
 };
 
 pub type PythId = u32;
@@ -37,6 +40,31 @@ impl From<LazerLeEcdsaMessage> for LeEcdsaMessage {
             payload: message.payload.into(),
             signature: message.signature.into(),
             recovery_id: message.recovery_id,
+        }
+    }
+}
+
+/// A coarse classification of a Pyth Lazer feed's market session.
+///
+/// Upstream's `pyth_lazer_protocol::api::MarketSession` has 5 variants
+/// (`Regular`, `PreMarket`, `PostMarket`, `OverNight`, `Closed`). Dango
+/// only needs to know whether trading is currently in the regular session;
+/// every non-regular state collapses into a single `Other` variant.
+#[grug::derive(Serde, Borsh)]
+#[derive(Copy)]
+pub enum MarketSession {
+    Regular,
+    Other,
+}
+
+impl From<LazerMarketSession> for MarketSession {
+    fn from(upstream: LazerMarketSession) -> Self {
+        match upstream {
+            LazerMarketSession::Regular => MarketSession::Regular,
+            LazerMarketSession::PreMarket
+            | LazerMarketSession::PostMarket
+            | LazerMarketSession::OverNight
+            | LazerMarketSession::Closed => MarketSession::Other,
         }
     }
 }

--- a/sdk/typescript/types/src/oracle.ts
+++ b/sdk/typescript/types/src/oracle.ts
@@ -5,4 +5,10 @@ export type Price = {
   humanizedPrice: string;
   /** The UNIX timestamp of the price (seconds since UNIX epoch). */
   timestamp: number;
+  /** The market session at which the price was observed. For 24/7 markets
+   * (e.g. crypto) this is always `"regular"`. `"other"` covers any
+   * non-regular state (pre/post-market, overnight, closed) as well as
+   * payloads that omit the property.
+   */
+  marketSession: "regular" | "other";
 };


### PR DESCRIPTION
Surface Pyth Lazer's `MarketSession` property by adding a `market_session` field to `dango_types::oracle::Price`. Pyth's 5-variant enum (`Regular`, `PreMarket`, `PostMarket`, `OverNight`, `Closed`) is collapsed into a 2-variant local mirror in `pyth-types` — `Regular` and `Other` — since dango only needs to know whether trading is in the regular session.

The Pyth Lazer subscription now requests `PriceFeedProperty::MarketSession` so the property arrives in every payload; `TryFrom<(PayloadFeedData, _)>` extracts it and falls back to `Other` when absent.

The upgrade migration backfills every existing `PYTH_PRICES` entry with `MarketSession::Regular`: at the time of this migration all price sources point to crypto feeds, which trade 24/7 and are always regular.