### PR TITLE
fix(sdk): make ws resubscribe idempotent

### DIFF
--- a/sdk/typescript/dango/src/transports/graphql.ts
+++ b/sdk/typescript/dango/src/transports/graphql.ts
@@ -96,10 +96,17 @@ export function createTransport(
 
     wsRef.current = createWsClient(lazy);
 
+    let reconnecting = false;
     const attemptReconnect = () => {
-      if (!wsClientStatus.isConnected) {
-        wsRef.current?.dispose();
-        wsRef.current = createWsClient(false);
+      if (reconnecting) return;
+      reconnecting = true;
+      try {
+        if (!wsClientStatus.isConnected) {
+          wsRef.current?.dispose();
+          wsRef.current = createWsClient(false);
+        }
+      } finally {
+        reconnecting = false;
       }
     };
 

--- a/sdk/typescript/dango/src/transports/graphql.ts
+++ b/sdk/typescript/dango/src/transports/graphql.ts
@@ -58,7 +58,7 @@ export function createTransport(
     maxDelay: wsMaxDelay = 30_000,
   } = config.wsRetry ?? {};
 
-  const wsClientStatus = { isConnected: false };
+  const wsClientStatus = { isConnected: false, isConnecting: false };
   const wsStatusEmitter = new EventEmitter();
   const wsRef: { current: ReturnType<typeof createClient> | null } = { current: null };
   let wsInitialized = false;
@@ -81,14 +81,29 @@ export function createTransport(
           typeof retryCount === "number" ? retryCount < wsMaxRetries : true,
       });
 
+      if (!isLazy) {
+        wsClientStatus.isConnected = false;
+        wsClientStatus.isConnecting = true;
+      }
+
       ws.on("connected", () => {
+        if (wsRef.current !== ws) return;
         wsClientStatus.isConnected = true;
+        wsClientStatus.isConnecting = false;
         wsStatusEmitter.emit("connected");
       });
 
       ws.on("closed", () => {
+        if (wsRef.current !== ws) return;
         wsClientStatus.isConnected = false;
+        wsClientStatus.isConnecting = false;
         wsStatusEmitter.emit("closed");
+      });
+
+      ws.on("connecting", () => {
+        if (wsRef.current !== ws) return;
+        wsClientStatus.isConnected = false;
+        wsClientStatus.isConnecting = true;
       });
 
       return ws;
@@ -96,18 +111,11 @@ export function createTransport(
 
     wsRef.current = createWsClient(lazy);
 
-    let reconnecting = false;
     const attemptReconnect = () => {
-      if (reconnecting) return;
-      reconnecting = true;
-      try {
-        if (!wsClientStatus.isConnected) {
-          wsRef.current?.dispose();
-          wsRef.current = createWsClient(false);
-        }
-      } finally {
-        reconnecting = false;
-      }
+      if (wsClientStatus.isConnected || wsClientStatus.isConnecting) return;
+      const previousWs = wsRef.current;
+      wsRef.current = createWsClient(false);
+      void previousWs?.dispose();
     };
 
     if (typeof document !== "undefined") {

--- a/sdk/typescript/utils/src/createSubscription.spec.ts
+++ b/sdk/typescript/utils/src/createSubscription.spec.ts
@@ -1,0 +1,54 @@
+import type { EventEmitter } from "eventemitter3";
+import { describe, expect, it, vi } from "vitest";
+
+import { createSubscription } from "./createSubscription.js";
+
+const createEmitter = () => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  return {
+    on(event: string, listener: (...args: unknown[]) => void) {
+      const eventListeners = listeners.get(event) ?? new Set();
+      eventListeners.add(listener);
+      listeners.set(event, eventListeners);
+      return this;
+    },
+    off(event: string, listener: (...args: unknown[]) => void) {
+      listeners.get(event)?.delete(listener);
+      return this;
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const listener of listeners.get(event) ?? []) listener(...args);
+      return true;
+    },
+  } as unknown as EventEmitter;
+};
+
+describe("createSubscription", () => {
+  it("cleans up the previous ws subscription before resubscribing", () => {
+    const emitter = createEmitter();
+    const firstUnsubscribe = vi.fn();
+    const secondUnsubscribe = vi.fn();
+    const wsSubscribe = vi.fn().mockReturnValueOnce(firstUnsubscribe).mockReturnValueOnce(secondUnsubscribe);
+
+    const unsubscribe = createSubscription(
+      {
+        wsSubscribe,
+        httpInterval: 1_000,
+        emitter,
+        getStatus: () => ({ isConnected: true }),
+      },
+      vi.fn(),
+    );
+
+    emitter.emit("connected");
+
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(secondUnsubscribe).not.toHaveBeenCalled();
+    expect(wsSubscribe).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+
+    expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sdk/typescript/utils/src/createSubscription.ts
+++ b/sdk/typescript/utils/src/createSubscription.ts
@@ -127,6 +127,7 @@ export function createSubscription<TData>(
     clearFallbackTimer();
     currentMode = "ws";
     emitter.emit("transport-mode", currentMode);
+    stopWs();
     wsUnsub = wsSubscribe(listener);
   };
 


### PR DESCRIPTION
## Summary
Closes a WS-handle leak in `createSubscription.startWs` by calling `stopWs()` before re-subscribing, and wraps `attemptReconnect` in single-flight guards so back-to-back `visibilitychange`+`online` triggers don't double-recreate the WS client.

Partial relief for `PORTAL-WEBSITE-5NY` (per-connection subscription limit, 4883 users / 294k events). Permanent fix is the upcoming subscription multiplexer refactor; this PR delivers the cheap idempotency fix that closes the leak path.

## Validation
### Completed
- [x] SDK lint
- [x] SDK build
- [ ] (unit tests if present)

### Remaining
- [ ] Sentry event-rate decrease for `5NY` in 24h post-deploy
- [ ] Confirm no regression in WS reconnect behavior (flaky network simulation)

## Manual QA
- Open portal `/trade/ETH-USD` with devtools open.
- Toggle the network offline/online a few times in rapid succession.
- Confirm the WS reconnects without subscription-count growth in the indexer logs.