### PR TITLE
fix(ui): disable browser auto-translation to prevent dom races

### DIFF
--- a/ui/portal/web/public/index.html
+++ b/ui/portal/web/public/index.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
 
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <meta name="google" content="notranslate" />
   <link rel="icon" href="/favicon.svg" />
   <link rel="shortcut icon" href="/favicon.svg" />
   <link rel="icon" sizes="32x32" href="/favicon.svg" />


### PR DESCRIPTION
## Summary
Adds `<meta name="google" content="notranslate">` and `translate="no"` on `<html>` to prevent Chrome auto-translate from injecting `<font>` wrappers that race with React's reconciler.

Fixes `PORTAL-WEBSITE-6VC` (122 users, 202 events, still active) and `6VF`. Sentry breadcrumbs confirmed translated `<font>` tags and Russian alt text.

## Validation
### Completed
- [x] `pnpm lint`
- [x] `pnpm build` — HTML template emitted correctly

### Remaining
- [ ] Sentry resolution check after deploy — `6VC` event rate should drop to zero

## Manual QA
- Open portal with Chrome auto-translate enabled (Russian/Spanish/etc).
- Verify page loads in English and translation prompt does not auto-fire.
- Confirm no `removeChild` exceptions in console while navigating /points.