### PR TITLE
fix(ui): guard tradingview resetcache against unmounted widget

### DIFF
--- a/ui/portal/web/src/components/dex/components/TradingView.tsx
+++ b/ui/portal/web/src/components/dex/components/TradingView.tsx
@@ -34,6 +34,7 @@ export const TradingView: React.FC<TradingViewProps> = ({ coins }) => {
   const storageKey = `tv_v4.${pairSymbol}_perps`;
 
   const widgetRef = useRef<TV.IChartingLibraryWidget | null>(null);
+  const readyRef = useRef(false);
 
   useEffect(() => {
     try {
@@ -139,14 +140,19 @@ export const TradingView: React.FC<TradingViewProps> = ({ coins }) => {
       });
 
     const invalidateCandles = () => {
-      widget.resetCache();
-      widget.chart().resetData();
+      if (!widgetRef.current || !readyRef.current) return;
+      try {
+        widgetRef.current.resetCache();
+        widgetRef.current.chart().resetData();
+      } catch {
+        // Iframe not yet same-origin or widget torn down — next getBars will refetch.
+      }
     };
-
-    publicClient.subscribe?.emitter?.addListener("connected", invalidateCandles);
 
     widget.onChartReady(() => {
       widgetRef.current = widget;
+      readyRef.current = true;
+      publicClient.subscribe?.emitter?.on("connected", invalidateCandles);
       const chart = widget.chart();
       const allStudies = chart.getAllStudies();
 
@@ -169,8 +175,9 @@ export const TradingView: React.FC<TradingViewProps> = ({ coins }) => {
       });
     });
     return () => {
-      publicClient.subscribe?.emitter?.removeListener("connected", invalidateCandles);
-      widgetRef.current?.remove();
+      readyRef.current = false;
+      publicClient.subscribe?.emitter?.off("connected", invalidateCandles);
+      widget.remove();
       widgetRef.current = null;
     };
   }, [theme]);


### PR DESCRIPTION
## Summary
Stabilizes the TradingView `invalidateCandles` listener via refs + try/catch, and registers it only after `onChartReady` so we don't touch a half-initialized widget or its cross-origin iframe.

Fixes `PORTAL-WEBSITE-6V7` (241 users, 429 events) and `PORTAL-WEBSITE-6VS` (7 users, cross-origin SecurityError) — both originate from the same code site but surface as different exceptions depending on which lifecycle phase the WS `connected` event lands in.

## Validation
### Completed
- [x] `pnpm lint`
- [x] TypeScript compile / build

### Remaining
- [ ] Manual QA on `/trade/ETH-USD` with flaky network
- [ ] Sentry event-rate drop confirmation post-deploy

## Manual QA
- Open `/trade/ETH-USD`, wait for chart to load.
- Toggle network offline → online → offline (triggering WS reconnects).
- Confirm chart refreshes on reconnect; no console errors; Sentry shows no `6V7`/`6VS` events from this session.
- Switch theme (forces widget re-instantiation) and confirm no errors.