### PR TITLE
fix(ui): guard evmdeposit when bridge config router is missing

### DIFF
--- a/ui/portal/web/src/components/bridge/Bridge.tsx
+++ b/ui/portal/web/src/components/bridge/Bridge.tsx
@@ -85,9 +85,12 @@ const BridgeContainer: React.FC<PropsWithChildren<BridgeProps>> = ({
 
 const BridgeDeposit: React.FC = () => {
   const { state } = useBridge();
-  const { action, network } = state;
+  const { action, network, coin, config } = state;
 
   if (action !== "deposit") return null;
+
+  const isEvmNetwork = !!network && !["bitcoin", "solana"].includes(network);
+  const showUnsupportedFallback = isEvmNetwork && !!coin && !config?.router;
 
   return (
     <>
@@ -95,7 +98,11 @@ const BridgeDeposit: React.FC = () => {
 
       {network === "bitcoin" && <BitcoinDeposit />}
 
-      {network && !["bitcoin", "solana"].includes(network) && <EvmDeposit />}
+      {isEvmNetwork && config?.router && <EvmDeposit />}
+
+      {showUnsupportedFallback && (
+        <WarningContainer description="This network does not support this asset." />
+      )}
 
       <WarningContainer description={m["bridge.rateLimitWarning"]()} />
     </>

--- a/ui/store/src/hooks/useBridgeEvmDeposit.ts
+++ b/ui/store/src/hooks/useBridgeEvmDeposit.ts
@@ -18,6 +18,10 @@ import type { useBridgeState } from "./useBridgeState.js";
 
 const MAX_SAFE = 2n ** 256n - 1n;
 
+export class BridgeConfigError extends Error {
+  override name = "BridgeConfigError";
+}
+
 export type UseBridgeEvmDepositParameters = {
   connector?: Connector;
   coin: AnyCoin;
@@ -27,7 +31,7 @@ export type UseBridgeEvmDepositParameters = {
 
 export function useBridgeEvmDeposit(parameters: UseBridgeEvmDepositParameters) {
   const { connector, coin, amount, config } = parameters;
-  if (!config || !config.router) throw new Error("Unexpected missing router config");
+  if (!config || !config.router) throw new BridgeConfigError("Unexpected missing router config");
 
   const { bridger, router, chain } = config;
 


### PR DESCRIPTION
## Summary
Adds a `state.config?.router` runtime guard to the `EvmDeposit` mount condition in `Bridge.tsx`, and converts the inner throw in `useBridgeEvmDeposit` to a typed `BridgeConfigError` so missing router config no longer crashes the bridge route.

Fixes `PORTAL-WEBSITE-6V6` (173 users, 233 events). Root cause was a type cast (`NonNullablePropertiesBy<...>`) with no runtime backing when a network/coin combination has no warp_route.

## Validation
### Completed
- [x] `pnpm lint`
- [x] TypeScript compile

### Remaining
- [ ] Manual QA - pick a coin/network combo with no warp route and confirm friendly fallback (not crash)

## Manual QA
- Open `/bridge`, select a network for which the current asset has no warp route.
- Confirm a friendly "This network does not support this asset" message renders instead of a blank bridge route.
- Confirm `Unexpected missing router config` does not surface to Sentry from this session.