### PR TITLE
fix(ui): defensive guards for undefined inputs

### DIFF
--- a/ui/applets/kit/src/components/Cell.tsx
+++ b/ui/applets/kit/src/components/Cell.tsx
@@ -48,9 +48,9 @@ type CellAssetProps = Prettify<
 const Asset: React.FC<CellAssetProps> = ({ asset, noImage, denom }) => {
   const { coins } = useConfig();
 
-  const coin = asset || coins.getCoinInfo(denom as string);
+  const coin = asset ?? (denom ? coins.getCoinInfo(denom as string) : null);
 
-  if (!coin) return <div className="flex h-full items-center diatype-sm-medium ">-</div>;
+  if (!coin) return <div className="flex h-full items-center diatype-sm-medium">-</div>;
 
   return (
     <div className="flex h-full gap-2 diatype-sm-medium justify-start items-center my-auto">

--- a/ui/applets/kit/src/components/FormattedNumber.tsx
+++ b/ui/applets/kit/src/components/FormattedNumber.tsx
@@ -26,8 +26,17 @@ export const FormattedNumber: React.FC<FormattedNumberProps> = ({
   const { settings } = useApp();
   const { formatNumberOptions } = settings;
 
-  const parts = formatDisplayNumber(number, { ...formatNumberOptions, ...formatOptions });
   const Component = as;
+
+  if (
+    number === null ||
+    number === undefined ||
+    (typeof number === "number" && !Number.isFinite(number))
+  ) {
+    return <Component className={twMerge(className)}>-</Component>;
+  }
+
+  const parts = formatDisplayNumber(number, { ...formatNumberOptions, ...formatOptions });
 
   return (
     <Component className={twMerge(className)}>

--- a/ui/applets/kit/src/components/FormattedNumber.tsx
+++ b/ui/applets/kit/src/components/FormattedNumber.tsx
@@ -2,7 +2,7 @@ import { useApp } from "@left-curve/foundation";
 import { useId } from "react";
 import { twMerge } from "@left-curve/foundation";
 
-import { formatDisplayNumber } from "@left-curve/utils";
+import { Decimal, formatDisplayNumber } from "@left-curve/utils";
 
 import type React from "react";
 import type { FormatNumberOptions } from "@left-curve/utils";
@@ -28,11 +28,7 @@ export const FormattedNumber: React.FC<FormattedNumberProps> = ({
 
   const Component = as;
 
-  if (
-    number === null ||
-    number === undefined ||
-    (typeof number === "number" && !Number.isFinite(number))
-  ) {
+  if (number === null || number === undefined || Decimal.isNaN(number)) {
     return <Component className={twMerge(className)}>-</Component>;
   }
 

--- a/ui/portal/web/src/components/dex/components/TradeMenu.tsx
+++ b/ui/portal/web/src/components/dex/components/TradeMenu.tsx
@@ -47,6 +47,7 @@ import {
   useApp,
   type useInputs,
   useMediaQuery,
+  usePortalTarget,
 } from "@left-curve/applets-kit";
 import { Sheet } from "react-modal-sheet";
 
@@ -846,6 +847,9 @@ const Menu: React.FC<TradeMenuProps> = ({ controllers, className }) => {
 
 const MenuMobile: React.FC<TradeMenuProps> = (props) => {
   const { isTradeBarVisible, setTradeBarVisibility } = useApp();
+  const portalTarget = usePortalTarget("#root");
+
+  if (!portalTarget) return null;
 
   return (
     <Sheet isOpen={isTradeBarVisible} onClose={() => setTradeBarVisibility(false)} rootId="root">

--- a/ui/portal/web/src/components/dex/helpers/tradePairSymbols.test.ts
+++ b/ui/portal/web/src/components/dex/helpers/tradePairSymbols.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDefaultTradePairSymbols,
+  getPerpsPairIdFromSymbols,
+  getTradeQuoteDenom,
+  normalizeTradePairSymbols,
+  parseTradePairSymbols,
+} from "./tradePairSymbols";
+
+describe("trade pair symbols", () => {
+  it("uses the environment-specific default pair", () => {
+    expect(getDefaultTradePairSymbols("Devnet")).toBe("ETH-USD");
+    expect(getDefaultTradePairSymbols("Mainnet")).toBe("BTC-USD");
+  });
+
+  it("normalizes single-symbol URLs to USD pairs", () => {
+    expect(normalizeTradePairSymbols("ETH")).toBe("ETH-USD");
+    expect(normalizeTradePairSymbols("btc")).toBe("BTC-USD");
+  });
+
+  it("normalizes explicit pairs and rejects malformed pairs", () => {
+    expect(normalizeTradePairSymbols("eth-usd")).toBe("ETH-USD");
+    expect(normalizeTradePairSymbols("-USD")).toBeNull();
+    expect(normalizeTradePairSymbols("ETH-USD-EXTRA")).toBeNull();
+  });
+
+  it("derives perps pair ids from normalized symbols", () => {
+    expect(getPerpsPairIdFromSymbols("ETH")).toBe("perp/ethusd");
+    expect(getPerpsPairIdFromSymbols("BTC-USDC")).toBe("perp/btcusdc");
+    expect(getPerpsPairIdFromSymbols("BTC-USD-EXTRA")).toBeNull();
+  });
+
+  it("parses normalized symbols for UI denom lookup", () => {
+    expect(parseTradePairSymbols("eth")).toEqual({ baseSymbol: "ETH", quoteSymbol: "USD" });
+  });
+
+  it("uses the synthetic USD quote denom for perps", () => {
+    expect(getTradeQuoteDenom("USD", {})).toBe("usd");
+    expect(getTradeQuoteDenom("USDC", { USDC: { denom: "bridge/usdc" } })).toBe("bridge/usdc");
+  });
+});

--- a/ui/portal/web/src/components/dex/helpers/tradePairSymbols.test.ts
+++ b/ui/portal/web/src/components/dex/helpers/tradePairSymbols.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getDefaultTradePairSymbols,
-  getPerpsPairIdFromSymbols,
+  getPerpsPairId,
   getTradeQuoteDenom,
   normalizeTradePairSymbols,
   parseTradePairSymbols,
@@ -14,25 +14,26 @@ describe("trade pair symbols", () => {
     expect(getDefaultTradePairSymbols("Mainnet")).toBe("BTC-USD");
   });
 
-  it("normalizes single-symbol URLs to USD pairs", () => {
-    expect(normalizeTradePairSymbols("ETH")).toBe("ETH-USD");
-    expect(normalizeTradePairSymbols("btc")).toBe("BTC-USD");
+  it("parses single-symbol URLs into USD pairs", () => {
+    expect(parseTradePairSymbols("ETH")).toEqual({ baseSymbol: "ETH", quoteSymbol: "USD" });
+    expect(parseTradePairSymbols("btc")).toEqual({ baseSymbol: "BTC", quoteSymbol: "USD" });
   });
 
-  it("normalizes explicit pairs and rejects malformed pairs", () => {
+  it("parses explicit pairs and rejects malformed input", () => {
+    expect(parseTradePairSymbols("eth-usd")).toEqual({ baseSymbol: "ETH", quoteSymbol: "USD" });
+    expect(parseTradePairSymbols("-USD")).toBeNull();
+    expect(parseTradePairSymbols("ETH-USD-EXTRA")).toBeNull();
+  });
+
+  it("normalizes parsed symbols back into a canonical string", () => {
+    expect(normalizeTradePairSymbols("ETH")).toBe("ETH-USD");
     expect(normalizeTradePairSymbols("eth-usd")).toBe("ETH-USD");
     expect(normalizeTradePairSymbols("-USD")).toBeNull();
-    expect(normalizeTradePairSymbols("ETH-USD-EXTRA")).toBeNull();
   });
 
-  it("derives perps pair ids from normalized symbols", () => {
-    expect(getPerpsPairIdFromSymbols("ETH")).toBe("perp/ethusd");
-    expect(getPerpsPairIdFromSymbols("BTC-USDC")).toBe("perp/btcusdc");
-    expect(getPerpsPairIdFromSymbols("BTC-USD-EXTRA")).toBeNull();
-  });
-
-  it("parses normalized symbols for UI denom lookup", () => {
-    expect(parseTradePairSymbols("eth")).toEqual({ baseSymbol: "ETH", quoteSymbol: "USD" });
+  it("derives perps pair ids from parsed symbols", () => {
+    expect(getPerpsPairId({ baseSymbol: "ETH", quoteSymbol: "USD" })).toBe("perp/ethusd");
+    expect(getPerpsPairId({ baseSymbol: "BTC", quoteSymbol: "USDC" })).toBe("perp/btcusdc");
   });
 
   it("uses the synthetic USD quote denom for perps", () => {

--- a/ui/portal/web/src/components/dex/helpers/tradePairSymbols.ts
+++ b/ui/portal/web/src/components/dex/helpers/tradePairSymbols.ts
@@ -2,7 +2,7 @@ const DEFAULT_QUOTE_SYMBOL = "USD";
 const DEFAULT_DEVNET_PAIR_SYMBOLS = `ETH-${DEFAULT_QUOTE_SYMBOL}`;
 const DEFAULT_PAIR_SYMBOLS = `BTC-${DEFAULT_QUOTE_SYMBOL}`;
 
-type TradePairSymbols = {
+export type TradePairSymbols = {
   baseSymbol: string;
   quoteSymbol: string;
 };
@@ -11,29 +11,24 @@ export function getDefaultTradePairSymbols(chainName: string): string {
   return chainName === "Devnet" ? DEFAULT_DEVNET_PAIR_SYMBOLS : DEFAULT_PAIR_SYMBOLS;
 }
 
-export function normalizeTradePairSymbols(pairSymbols: string): string | null {
-  const [rawBaseSymbol, rawQuoteSymbol, ...extraSymbols] = pairSymbols.split("-");
-  const baseSymbol = rawBaseSymbol?.trim().toUpperCase();
-  const quoteSymbol = rawQuoteSymbol?.trim().toUpperCase() || DEFAULT_QUOTE_SYMBOL;
-
-  if (!baseSymbol || extraSymbols.length > 0) return null;
-
-  return `${baseSymbol}-${quoteSymbol}`;
-}
-
 export function parseTradePairSymbols(pairSymbols: string): TradePairSymbols | null {
-  const normalizedPairSymbols = normalizeTradePairSymbols(pairSymbols);
-  if (!normalizedPairSymbols) return null;
+  const [rawBase, rawQuote, ...extra] = pairSymbols.split("-");
+  if (extra.length > 0) return null;
 
-  const [baseSymbol = "", quoteSymbol = DEFAULT_QUOTE_SYMBOL] = normalizedPairSymbols.split("-");
+  const baseSymbol = rawBase?.trim().toUpperCase();
+  if (!baseSymbol) return null;
+
+  const quoteSymbol = rawQuote?.trim().toUpperCase() || DEFAULT_QUOTE_SYMBOL;
   return { baseSymbol, quoteSymbol };
 }
 
-export function getPerpsPairIdFromSymbols(pairSymbols: string): string | null {
-  const symbols = parseTradePairSymbols(pairSymbols);
-  if (!symbols) return null;
+export function normalizeTradePairSymbols(pairSymbols: string): string | null {
+  const parsed = parseTradePairSymbols(pairSymbols);
+  return parsed && `${parsed.baseSymbol}-${parsed.quoteSymbol}`;
+}
 
-  return `perp/${symbols.baseSymbol.toLowerCase()}${symbols.quoteSymbol.toLowerCase()}`;
+export function getPerpsPairId({ baseSymbol, quoteSymbol }: TradePairSymbols): string {
+  return `perp/${baseSymbol.toLowerCase()}${quoteSymbol.toLowerCase()}`;
 }
 
 export function getTradeQuoteDenom(

--- a/ui/portal/web/src/components/dex/helpers/tradePairSymbols.ts
+++ b/ui/portal/web/src/components/dex/helpers/tradePairSymbols.ts
@@ -1,0 +1,44 @@
+const DEFAULT_QUOTE_SYMBOL = "USD";
+const DEFAULT_DEVNET_PAIR_SYMBOLS = `ETH-${DEFAULT_QUOTE_SYMBOL}`;
+const DEFAULT_PAIR_SYMBOLS = `BTC-${DEFAULT_QUOTE_SYMBOL}`;
+
+type TradePairSymbols = {
+  baseSymbol: string;
+  quoteSymbol: string;
+};
+
+export function getDefaultTradePairSymbols(chainName: string): string {
+  return chainName === "Devnet" ? DEFAULT_DEVNET_PAIR_SYMBOLS : DEFAULT_PAIR_SYMBOLS;
+}
+
+export function normalizeTradePairSymbols(pairSymbols: string): string | null {
+  const [rawBaseSymbol, rawQuoteSymbol, ...extraSymbols] = pairSymbols.split("-");
+  const baseSymbol = rawBaseSymbol?.trim().toUpperCase();
+  const quoteSymbol = rawQuoteSymbol?.trim().toUpperCase() || DEFAULT_QUOTE_SYMBOL;
+
+  if (!baseSymbol || extraSymbols.length > 0) return null;
+
+  return `${baseSymbol}-${quoteSymbol}`;
+}
+
+export function parseTradePairSymbols(pairSymbols: string): TradePairSymbols | null {
+  const normalizedPairSymbols = normalizeTradePairSymbols(pairSymbols);
+  if (!normalizedPairSymbols) return null;
+
+  const [baseSymbol = "", quoteSymbol = DEFAULT_QUOTE_SYMBOL] = normalizedPairSymbols.split("-");
+  return { baseSymbol, quoteSymbol };
+}
+
+export function getPerpsPairIdFromSymbols(pairSymbols: string): string | null {
+  const symbols = parseTradePairSymbols(pairSymbols);
+  if (!symbols) return null;
+
+  return `perp/${symbols.baseSymbol.toLowerCase()}${symbols.quoteSymbol.toLowerCase()}`;
+}
+
+export function getTradeQuoteDenom(
+  quoteSymbol: string,
+  bySymbol: Record<string, { denom: string }>,
+) {
+  return quoteSymbol === DEFAULT_QUOTE_SYMBOL ? "usd" : bySymbol[quoteSymbol]?.denom;
+}

--- a/ui/portal/web/src/components/foundation/ErrorPage.tsx
+++ b/ui/portal/web/src/components/foundation/ErrorPage.tsx
@@ -2,7 +2,7 @@ import { Spinner, isChunkLoadError, reloadOnChunkError } from "@left-curve/apple
 import { captureException } from "@sentry/react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import { NotFound } from "./NotFound";
 
@@ -15,8 +15,7 @@ type ErrorPageProps = {
 
 export const ErrorPage: React.FC<ErrorPageProps> = ({ error, reset }) => {
   const navigate = useNavigate();
-  const isChunkError = error instanceof Error && isChunkLoadError(error);
-  const handledChunkError = useRef(false);
+  const isChunkError = isChunkLoadError(error);
 
   const { data: isChainRunning, isFetched } = useQuery({
     queryKey: ["error_page_chain_status"],
@@ -40,11 +39,8 @@ export const ErrorPage: React.FC<ErrorPageProps> = ({ error, reset }) => {
   }, [error, isChunkError, isFetched, isChainRunning, navigate]);
 
   useEffect(() => {
-    if (!isChunkError || handledChunkError.current) return;
-    handledChunkError.current = true;
-    if (!reloadOnChunkError()) {
-      reset();
-    }
+    if (!isChunkError) return;
+    if (!reloadOnChunkError()) reset();
   }, [isChunkError, reset]);
 
   if (isChunkError || !isFetched || !isChainRunning) {

--- a/ui/portal/web/src/components/foundation/ErrorPage.tsx
+++ b/ui/portal/web/src/components/foundation/ErrorPage.tsx
@@ -2,7 +2,7 @@ import { Spinner, isChunkLoadError, reloadOnChunkError } from "@left-curve/apple
 import { captureException } from "@sentry/react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { NotFound } from "./NotFound";
 
@@ -16,6 +16,7 @@ type ErrorPageProps = {
 export const ErrorPage: React.FC<ErrorPageProps> = ({ error, reset }) => {
   const navigate = useNavigate();
   const isChunkError = error instanceof Error && isChunkLoadError(error);
+  const handledChunkError = useRef(false);
 
   const { data: isChainRunning, isFetched } = useQuery({
     queryKey: ["error_page_chain_status"],
@@ -36,18 +37,17 @@ export const ErrorPage: React.FC<ErrorPageProps> = ({ error, reset }) => {
     if (isChunkError || !isFetched) return;
     if (isChainRunning) captureException(error);
     else navigate({ to: "/maintenance" });
-  }, [isChunkError, isFetched, isChainRunning]);
+  }, [error, isChunkError, isFetched, isChainRunning, navigate]);
 
-  if (isChunkError) {
-    if (!reloadOnChunkError()) reset();
-    return (
-      <div className="flex-1 w-full flex justify-center items-center h-screen">
-        <Spinner size="lg" color="pink" />
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (!isChunkError || handledChunkError.current) return;
+    handledChunkError.current = true;
+    if (!reloadOnChunkError()) {
+      reset();
+    }
+  }, [isChunkError, reset]);
 
-  if (!isFetched || !isChainRunning) {
+  if (isChunkError || !isFetched || !isChainRunning) {
     return (
       <div className="flex-1 w-full flex justify-center items-center h-screen">
         <Spinner size="lg" color="pink" />

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
@@ -5,6 +5,10 @@ import { useNavigate } from "@tanstack/react-router";
 import { useHeaderHeight } from "@left-curve/applets-kit";
 
 import { ProTrade } from "~/components/dex/components/ProTrade";
+import {
+  getTradeQuoteDenom,
+  parseTradePairSymbols,
+} from "~/components/dex/helpers/tradePairSymbols";
 
 export const Route = createLazyFileRoute("/(app)/_app/trade/$pairSymbols")({
   component: ProTradeApplet,
@@ -43,11 +47,11 @@ function ProTradeApplet() {
     });
   };
 
-  const [baseSymbol, quoteSymbol] = pairSymbols.split("-");
+  const symbols = parseTradePairSymbols(pairSymbols);
 
   const pairId = {
-    baseDenom: coins.bySymbol[baseSymbol]?.denom,
-    quoteDenom: coins.bySymbol[quoteSymbol]?.denom,
+    baseDenom: symbols ? (coins.bySymbol[symbols.baseSymbol]?.denom ?? "") : "",
+    quoteDenom: symbols ? (getTradeQuoteDenom(symbols.quoteSymbol, coins.bySymbol) ?? "") : "",
   };
 
   return (

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.lazy.tsx
@@ -47,11 +47,11 @@ function ProTradeApplet() {
     });
   };
 
-  const symbols = parseTradePairSymbols(pairSymbols);
+  const { baseSymbol = "", quoteSymbol = "" } = parseTradePairSymbols(pairSymbols) ?? {};
 
   const pairId = {
-    baseDenom: symbols ? (coins.bySymbol[symbols.baseSymbol]?.denom ?? "") : "",
-    quoteDenom: symbols ? (getTradeQuoteDenom(symbols.quoteSymbol, coins.bySymbol) ?? "") : "",
+    baseDenom: coins.bySymbol[baseSymbol]?.denom ?? "",
+    quoteDenom: getTradeQuoteDenom(quoteSymbol, coins.bySymbol) ?? "",
   };
 
   return (

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
@@ -12,6 +12,13 @@ export const Route = createFileRoute("/(app)/_app/trade/$pairSymbols")({
     const { pairSymbols } = params;
     const [baseSymbol, quoteSymbol] = pairSymbols.split("-");
 
+    if (!baseSymbol || !quoteSymbol) {
+      throw redirect({
+        to: "/trade/$pairSymbols",
+        params: { pairSymbols: "ETH-USD" },
+      });
+    }
+
     const pairId = `perp/${baseSymbol.toLowerCase()}${quoteSymbol.toLowerCase()}`;
     const pair = await client.getPerpsPairParam({ pairId }).catch(() => null);
     if (!pair)

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
@@ -2,29 +2,49 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { z } from "zod";
 import { m } from "@left-curve/foundation/paraglide/messages.js";
+import {
+  getDefaultTradePairSymbols,
+  getPerpsPairIdFromSymbols,
+  normalizeTradePairSymbols,
+} from "~/components/dex/helpers/tradePairSymbols";
 
 export const Route = createFileRoute("/(app)/_app/trade/$pairSymbols")({
   head: () => ({
     meta: [{ title: `Dango | ${m["applets.trade.title"]()}` }],
   }),
   beforeLoad: async ({ context, params }) => {
-    const { client } = context;
+    const { client, config } = context;
     const { pairSymbols } = params;
-    const [baseSymbol, quoteSymbol] = pairSymbols.split("-");
+    const defaultPairSymbols = getDefaultTradePairSymbols(config.chain.name);
+    const normalizedPairSymbols = normalizeTradePairSymbols(pairSymbols);
 
-    if (!baseSymbol || !quoteSymbol) {
+    if (!normalizedPairSymbols) {
       throw redirect({
         to: "/trade/$pairSymbols",
-        params: { pairSymbols: "ETH-USD" },
+        params: { pairSymbols: defaultPairSymbols },
       });
     }
 
-    const pairId = `perp/${baseSymbol.toLowerCase()}${quoteSymbol.toLowerCase()}`;
+    if (normalizedPairSymbols !== pairSymbols) {
+      throw redirect({
+        to: "/trade/$pairSymbols",
+        params: { pairSymbols: normalizedPairSymbols },
+      });
+    }
+
+    const pairId = getPerpsPairIdFromSymbols(normalizedPairSymbols);
+    if (!pairId) {
+      throw redirect({
+        to: "/trade/$pairSymbols",
+        params: { pairSymbols: defaultPairSymbols },
+      });
+    }
+
     const pair = await client.getPerpsPairParam({ pairId }).catch(() => null);
     if (!pair)
       throw redirect({
         to: "/trade/$pairSymbols",
-        params: { pairSymbols: "ETH-USD" },
+        params: { pairSymbols: defaultPairSymbols },
       });
   },
   validateSearch: z.object({

--- a/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$pairSymbols.tsx
@@ -4,48 +4,33 @@ import { z } from "zod";
 import { m } from "@left-curve/foundation/paraglide/messages.js";
 import {
   getDefaultTradePairSymbols,
-  getPerpsPairIdFromSymbols,
-  normalizeTradePairSymbols,
+  getPerpsPairId,
+  parseTradePairSymbols,
 } from "~/components/dex/helpers/tradePairSymbols";
 
 export const Route = createFileRoute("/(app)/_app/trade/$pairSymbols")({
   head: () => ({
-    meta: [{ title: `Dango | ${m["applets.trade.title"]()}` }],
+    meta: [{ title: `Dango | ${m["applets.trade.title"]()}` }],
   }),
   beforeLoad: async ({ context, params }) => {
     const { client, config } = context;
     const { pairSymbols } = params;
     const defaultPairSymbols = getDefaultTradePairSymbols(config.chain.name);
-    const normalizedPairSymbols = normalizeTradePairSymbols(pairSymbols);
+    const fallback = {
+      to: "/trade/$pairSymbols",
+      params: { pairSymbols: defaultPairSymbols },
+    } as const;
 
-    if (!normalizedPairSymbols) {
-      throw redirect({
-        to: "/trade/$pairSymbols",
-        params: { pairSymbols: defaultPairSymbols },
-      });
-    }
+    const parsed = parseTradePairSymbols(pairSymbols);
+    if (!parsed) throw redirect(fallback);
 
+    const normalizedPairSymbols = `${parsed.baseSymbol}-${parsed.quoteSymbol}`;
     if (normalizedPairSymbols !== pairSymbols) {
-      throw redirect({
-        to: "/trade/$pairSymbols",
-        params: { pairSymbols: normalizedPairSymbols },
-      });
+      throw redirect({ ...fallback, params: { pairSymbols: normalizedPairSymbols } });
     }
 
-    const pairId = getPerpsPairIdFromSymbols(normalizedPairSymbols);
-    if (!pairId) {
-      throw redirect({
-        to: "/trade/$pairSymbols",
-        params: { pairSymbols: defaultPairSymbols },
-      });
-    }
-
-    const pair = await client.getPerpsPairParam({ pairId }).catch(() => null);
-    if (!pair)
-      throw redirect({
-        to: "/trade/$pairSymbols",
-        params: { pairSymbols: defaultPairSymbols },
-      });
+    const pair = await client.getPerpsPairParam({ pairId: getPerpsPairId(parsed) }).catch(() => null);
+    if (!pair) throw redirect(fallback);
   },
   validateSearch: z.object({
     order_type: z.enum(["limit", "market"]).default("market"),

--- a/ui/portal/web/src/pages/(app)/_app.trade.index.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.index.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { getDefaultTradePairSymbols } from "~/components/dex/helpers/tradePairSymbols";
 
 export const Route = createFileRoute("/(app)/_app/trade/")({
   beforeLoad: async ({ context }) => {
     const { config } = context;
-    const isDevnet = config.chain.name === "Devnet";
 
     throw redirect({
       to: "/trade/$pairSymbols",
-      params: { pairSymbols: isDevnet ? "ETH-USD" : "BTC-USD" },
+      params: { pairSymbols: getDefaultTradePairSymbols(config.chain.name) },
     });
   },
 });

--- a/ui/portal/web/src/pages/(app)/_app.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.tsx
@@ -95,8 +95,7 @@ function LayoutApp() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const scrollTop =
-        window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
+      const scrollTop = window.scrollY || 0;
       setIsScrolled(scrollTop > headerThreshold);
     };
 

--- a/ui/store/src/stores/coinStore.ts
+++ b/ui/store/src/stores/coinStore.ts
@@ -21,7 +21,6 @@ export const CoinStore = create<CoinStore>((set, get) => ({
     set((s) => ({ ...s, byDenom: coins, bySymbol }));
   },
   getCoinInfo: (denom: Denom) => {
-    if (!denom) throw new Error("getCoinInfo called with undefined denom");
     const { byDenom } = get();
     const coin = byDenom[denom];
     if (coin) return coin;

--- a/ui/store/src/stores/coinStore.ts
+++ b/ui/store/src/stores/coinStore.ts
@@ -21,6 +21,7 @@ export const CoinStore = create<CoinStore>((set, get) => ({
     set((s) => ({ ...s, byDenom: coins, bySymbol }));
   },
   getCoinInfo: (denom: Denom) => {
+    if (!denom) throw new Error("getCoinInfo called with undefined denom");
     const { byDenom } = get();
     const coin = byDenom[denom];
     if (coin) return coin;


### PR DESCRIPTION
## Summary
Bundle of small surgical guards for several low-volume but recurring undefined/null Sentry issues:
- `FormattedNumber` short-circuits when `number` is null/undefined/NaN (`PORTAL-WEBSITE-6X6`).
- `_app.tsx` scroll handler reads `window.scrollY` only (no nullable `documentElement`/`body` chain) (`6X3`).
- Trade route `beforeLoad` guards single-symbol URLs (`6W8`).
- `ErrorPage.tsx` moves `reset()` out of render into `useEffect` to break setState-in-render loop (`6X0`, `6VR`).
- `getCoinInfo` null-guards `denom` (`6VE`).
- Mobile Sheet wrapper in `TradeMenu.tsx` uses existing `usePortalTarget("#root")` hook to skip render until target exists (`6X1`).

## Validation
### Completed
- [x] `pnpm lint` (one pre-existing warning in `sdk/typescript/dango/src/actions/app/queries/simulate.ts`, not introduced here)
- [x] TypeScript compile across `ui/portal/web`, `ui/applets/kit`, `ui/store`
- [x] `formatted-number.test.tsx` suite (30/30 pass)

### Remaining
- [ ] Sentry resolution check after deploy
- [ ] Manual QA — see below
- [ ] Sheet portal guard applied to `TradeMenu.tsx` only (the one in Sentry breadcrumbs). Follow-up: apply to `AccountMenu.tsx`, `RootModal.tsx`, `SearchToken.tsx`, `SettingSelect.tsx` if those start producing the same crashes. Reused the existing `usePortalTarget` hook in applets-kit — no new abstraction.

## Manual QA
- ` /points` page: confirm leaderboard renders with rows that have missing stats.
- `/trade/ETH`: confirm redirect to a valid pair (no crash).
- Trigger a chunk load error (force-evict service worker cache, refresh) — confirm ErrorPage doesn't loop.