### PR TITLE
fix(ui): stabilize ui state and effect deps

### DIFF
--- a/ui/applets/kit/src/components/TextLoop.tsx
+++ b/ui/applets/kit/src/components/TextLoop.tsx
@@ -9,11 +9,9 @@ export const TextLoop: React.FC<TextLoopProps> = ({ texts }) => {
   const [index, setIndex] = useState<number>(0);
 
   useEffect(() => {
-    setTimeout(() => {
-      const next = index + 1;
-      setIndex(next % texts.length);
-    }, 2 * 1000);
-  }, [index, setIndex, texts]);
+    const t = setTimeout(() => setIndex((i) => (i + 1) % texts.length), 2000);
+    return () => clearTimeout(t);
+  }, [texts.length]);
 
   return (
     <span className="overflow-hidden relative min-h-[1.56rem] w-[8rem]">

--- a/ui/portal/web/src/components/earn/VaultPerformanceChart.tsx
+++ b/ui/portal/web/src/components/earn/VaultPerformanceChart.tsx
@@ -204,7 +204,13 @@ export function VaultPerformanceChart({ period, onPeriodChange }: VaultPerforman
               cursor={{ stroke: "var(--color-ink-tertiary-500)", strokeDasharray: "4 4" }}
             />
             <ReferenceLine yAxisId="change" y={0} stroke="var(--color-outline-secondary-gray)" />
-            <Bar yAxisId="change" dataKey="dailyChange" radius={[2, 2, 0, 0]} barSize={30}>
+            <Bar
+              yAxisId="change"
+              dataKey="dailyChange"
+              radius={[2, 2, 0, 0]}
+              barSize={30}
+              isAnimationActive={false}
+            >
               {data.map((entry, index) => (
                 <Cell
                   key={`bar-${index}`}
@@ -235,6 +241,7 @@ export function VaultPerformanceChart({ period, onPeriodChange }: VaultPerforman
                 strokeWidth: 2,
                 stroke: "var(--color-surface-primary-rice)",
               }}
+              isAnimationActive={false}
             />
           </ComposedChart>
         </ResponsiveContainer>

--- a/ui/portal/web/src/components/points/PointsHeader.tsx
+++ b/ui/portal/web/src/components/points/PointsHeader.tsx
@@ -162,7 +162,8 @@ export const PointsHeader: React.FC = () => {
 
   const hasPredicted = isStarted && predicted.total > 0;
 
-  const countdown = useCountdown({ date: endDate ?? undefined });
+  const endTs = useMemo(() => (endDate ? +new Date(endDate) : undefined), [endDate]);
+  const countdown = useCountdown({ date: endTs });
   const hasRefetchedRef = useRef(false);
 
   useEffect(() => {
@@ -170,18 +171,25 @@ export const PointsHeader: React.FC = () => {
   }, [currentEpoch]);
 
   useEffect(() => {
-    if (!isStarted || !endDate) return;
+    if (!isStarted || !endTs) return;
 
-    const isZero =
-      countdown.days === "0" &&
-      countdown.hours === "0" &&
-      countdown.minutes === "0" &&
-      countdown.seconds === "0";
-    if (isZero && !hasRefetchedRef.current) {
-      hasRefetchedRef.current = true;
-      refetch();
+    const remaining = endTs - Date.now();
+    if (remaining <= 0) {
+      if (!hasRefetchedRef.current) {
+        hasRefetchedRef.current = true;
+        refetch();
+      }
+      return;
     }
-  }, [isStarted, endDate, countdown, refetch]);
+
+    const timer = setTimeout(() => {
+      if (!hasRefetchedRef.current) {
+        hasRefetchedRef.current = true;
+        refetch();
+      }
+    }, remaining);
+    return () => clearTimeout(timer);
+  }, [isStarted, endTs, refetch]);
 
   return (
     <div className="p-4 lg:p-8 lg:pb-[30px] flex flex-col gap-4 rounded-t-xl">

--- a/ui/portal/web/src/pages/(app)/_app.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.tsx
@@ -3,6 +3,8 @@ import { useAccount, useBalances, useConfig } from "@left-curve/store";
 import { captureException } from "@sentry/react";
 import { Outlet, createFileRoute, useRouter, useSearch } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { ChunkErrorFallback } from "~/components/foundation/ChunkErrorFallback";
 import { Footer } from "~/components/foundation/Footer";
 import { Header } from "~/components/foundation/Header";
 import { NotFound } from "~/components/foundation/NotFound";
@@ -126,7 +128,14 @@ function LayoutApp() {
       {!isLg ? <TestnetBanner /> : null}
       <Header isScrolled={effectiveIsScrolled} />
       <div className="flex flex-1 items-center justify-start w-full h-full relative flex-col z-30">
-        <Outlet />
+        <ErrorBoundary
+          FallbackComponent={ChunkErrorFallback}
+          resetKeys={[router.state.location.pathname]}
+          onReset={() => router.invalidate()}
+          onError={(error) => captureException(error)}
+        >
+          <Outlet />
+        </ErrorBoundary>
       </div>
       <Footer />
     </main>


### PR DESCRIPTION
## Summary

- Rebased the old Sentry-focused UI stability fixes onto current `main`.
- Keeps the targeted fixes that still map to current code: route-level Sentry capture with a resettable error boundary, points epoch boundary refetching, cleanup-safe text loop timers, and disabled animated vault chart rendering.
- Dropped obsolete/conflicted hunks from the old branch, including the shared `Table` auto-reset flags after review showed no current owner for that behavior.

## Validation

### Completed

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm -F @left-curve/portal-web test`
- [x] `pnpm build:portal-web`

### Remaining

- [ ] Full `pnpm lint` remains blocked by pre-existing Biome issues in touched portal files.

## Manual QA

None.