### PR TITLE
refactor: remove WasmVM boilerplate from core contracts

### DIFF
--- a/dango/account-factory/Cargo.toml
+++ b/dango/account-factory/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow      = { workspace = true }
 dango-auth  = { workspace = true }

--- a/dango/account-factory/src/execute.rs
+++ b/dango/account-factory/src/execute.rs
@@ -18,7 +18,6 @@ use {
     },
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> {
     // Save the code hashes associated with the Dango account contract.
     CODE_HASH.save(ctx.storage, &msg.account_code_hash)?;
@@ -57,7 +56,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> 
 // then send a transaction with the account factory as sender, that contains
 // exactly one message, to execute the factory itself with `Execute::RegisterUser`.
 // This transaction does not need to include any metadata or credential.
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
     let mut msgs = tx.msgs.iter();
 
@@ -107,7 +105,6 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
     Ok(Response::new().may_add_message(maybe_msg))
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::RegisterUser {

--- a/dango/account-factory/src/query.rs
+++ b/dango/account-factory/src/query.rs
@@ -10,7 +10,6 @@ use {
     std::collections::BTreeMap,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
     match msg {
         QueryMsg::CodeHash {} => {

--- a/dango/account/Cargo.toml
+++ b/dango/account/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow      = { workspace = true }
 dango-auth  = { workspace = true }

--- a/dango/account/src/execute.rs
+++ b/dango/account/src/execute.rs
@@ -3,21 +3,18 @@ use {
     grug::{AuthCtx, MutableCtx, Response, Tx},
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     dango_auth::create_account(ctx, msg.activate)?;
 
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
     dango_auth::authenticate_tx(ctx, tx, None)?;
 
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn receive(ctx: MutableCtx) -> anyhow::Result<Response> {
     dango_auth::receive_transfer(ctx)?;
 

--- a/dango/account/src/query.rs
+++ b/dango/account/src/query.rs
@@ -4,7 +4,6 @@ use {
     grug::{ImmutableCtx, Json, JsonSerExt, StdResult},
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
     match msg {
         QueryMsg::Status {} => {

--- a/dango/bank/Cargo.toml
+++ b/dango/bank/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow      = { workspace = true }
 dango-types = { workspace = true }

--- a/dango/bank/src/execute.rs
+++ b/dango/bank/src/execute.rs
@@ -11,7 +11,6 @@ use {
     std::collections::HashMap,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     let mut supplies = HashMap::<Denom, Uint128>::new();
 
@@ -45,7 +44,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
     Ok(Response::new()) // No need to emit events during genesis.
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     ensure!(ctx.funds.is_empty(), "don't send funds to bank contract");
 
@@ -254,7 +252,6 @@ fn recover_transfer(ctx: MutableCtx, sender: Addr, recipient: Addr) -> anyhow::R
 ///    an "**orphaned transfer**". The tokens will be temporarily held in the bank
 ///    contract. Either the sender or the recipient (once it exists) can claim
 ///    the tokens by calling the `recover_transfer` method.
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn bank_execute(ctx: SudoCtx, msg: BankMsg) -> anyhow::Result<Response> {
     let mut events = EventBuilder::with_capacity(msg.transfers.len() * 3);
 

--- a/dango/bank/src/query.rs
+++ b/dango/bank/src/query.rs
@@ -11,7 +11,6 @@ use {
     std::collections::BTreeMap,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
     match msg {
         QueryMsg::NamespaceOwner { namespace } => {
@@ -160,7 +159,6 @@ fn query_orphaned_transfers_by_recipient(
         .collect()
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn bank_query(ctx: ImmutableCtx, msg: BankQuery) -> StdResult<BankQueryResponse> {
     match msg {
         BankQuery::Balance(req) => {

--- a/dango/gateway/Cargo.toml
+++ b/dango/gateway/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow      = { workspace = true }
 dango-types = { workspace = true }

--- a/dango/gateway/src/execute.rs
+++ b/dango/gateway/src/execute.rs
@@ -17,7 +17,6 @@ use {
     std::collections::{BTreeMap, BTreeSet},
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     _set_routes(ctx.storage, msg.routes)?;
     rate_limit::init(ctx.storage, msg.rate_limits)?;
@@ -26,7 +25,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::SetRoutes(mapping) => set_routes(ctx, mapping),
@@ -352,7 +350,6 @@ fn transfer_remote(ctx: MutableCtx, remote: Remote, recipient: Addr32) -> anyhow
         }))
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn cron_execute(ctx: SudoCtx) -> StdResult<Response> {
     rate_limit::tick(ctx.storage, ctx.querier, ctx.block.timestamp)?;
 

--- a/dango/gateway/src/query.rs
+++ b/dango/gateway/src/query.rs
@@ -10,7 +10,6 @@ use {
     },
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
     match msg {
         QueryMsg::Route { bridge, remote } => {

--- a/dango/genesis/Cargo.toml
+++ b/dango/genesis/Cargo.toml
@@ -14,21 +14,21 @@ metrics = ["dango-oracle/metrics", "dango-perps/metrics"]
 
 [dependencies]
 anyhow                = { workspace = true }
-dango-account         = { workspace = true, features = ["library"] }
-dango-account-factory = { workspace = true, features = ["library"] }
-dango-bank            = { workspace = true, features = ["library"] }
-dango-gateway         = { workspace = true, features = ["library"] }
-dango-oracle          = { workspace = true, features = ["library"] }
+dango-account         = { workspace = true }
+dango-account-factory = { workspace = true }
+dango-bank            = { workspace = true }
+dango-gateway         = { workspace = true }
+dango-oracle          = { workspace = true }
 dango-order-book      = { workspace = true }
-dango-perps           = { workspace = true, features = ["library", "tracing"] }
-dango-taxman          = { workspace = true, features = ["library"] }
+dango-perps           = { workspace = true, features = ["tracing"] }
+dango-taxman          = { workspace = true }
 dango-types           = { workspace = true }
-dango-vesting         = { workspace = true, features = ["library"] }
-dango-warp            = { workspace = true, features = ["library"] }
+dango-vesting         = { workspace = true }
+dango-warp            = { workspace = true }
 grug                  = { workspace = true }
 grug-vm-rust          = { workspace = true }
-hyperlane-ism         = { workspace = true, features = ["library"] }
-hyperlane-mailbox     = { workspace = true, features = ["library"] }
+hyperlane-ism         = { workspace = true }
+hyperlane-mailbox     = { workspace = true }
 hyperlane-types       = { workspace = true }
-hyperlane-va          = { workspace = true, features = ["library"] }
+hyperlane-va          = { workspace = true }
 serde                 = { workspace = true }

--- a/dango/oracle/Cargo.toml
+++ b/dango/oracle/Cargo.toml
@@ -10,9 +10,6 @@ rust-version  = { workspace = true }
 version       = { workspace = true }
 
 [features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
 metrics = ["dep:metrics", "grug/metrics"]
 tracing = ["dep:tracing"]
 

--- a/dango/oracle/src/execute.rs
+++ b/dango/oracle/src/execute.rs
@@ -15,7 +15,6 @@ use {
     std::collections::BTreeMap,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     for (denom, price_source) in msg.price_sources {
         PRICE_SOURCES.save(ctx.storage, &denom, &price_source)?;
@@ -37,7 +36,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
 /// - This one message is an `Execute`.
 /// - The contract being executed must be the oracle itself.
 /// - the execute message must be `FeedPrices`.
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
     // Authenticate can only be called during finalize.
     ensure!(
@@ -65,7 +63,6 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::RegisterPriceSources(price_sources) => {
@@ -80,7 +77,6 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     }
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn reply(_ctx: SudoCtx, msg: ReplyMsg, res: SubMsgResult) -> StdResult<Response> {
     match msg {
         ReplyMsg::AfterOnOracleUpdate {} => {

--- a/dango/oracle/src/query.rs
+++ b/dango/oracle/src/query.rs
@@ -8,7 +8,6 @@ use {
     std::collections::BTreeMap,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
     match msg {
         QueryMsg::TrustedSigners { start_after, limit } => {

--- a/dango/perps/Cargo.toml
+++ b/dango/perps/Cargo.toml
@@ -10,16 +10,13 @@ rust-version  = { workspace = true }
 version       = { workspace = true }
 
 [features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
 metrics = ["dep:metrics", "grug/metrics"]
 tracing = ["dep:tracing"]
 
 [dependencies]
 anyhow                = { workspace = true }
-dango-account-factory = { workspace = true, features = ["library"] }
-dango-oracle          = { workspace = true, features = ["library"] }
+dango-account-factory = { workspace = true }
+dango-oracle          = { workspace = true }
 dango-order-book      = { workspace = true }
 dango-types           = { workspace = true }
 grug                  = { workspace = true }

--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -78,7 +78,6 @@ fn account_factory(querier: impl DangoQuerier) -> Addr {
     }
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     STATE.save(ctx.storage, &State {
         last_funding_time: ctx.block.timestamp,
@@ -91,7 +90,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
     maintain::configure(ctx, msg.param, msg.pair_params)
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
     #[cfg(feature = "metrics")]
     let start = std::time::Instant::now();
@@ -137,7 +135,6 @@ pub fn cron_execute(ctx: SudoCtx) -> anyhow::Result<Response> {
     Ok(Response::new().add_events(events)?)
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     // Only `Deposit` and `Donate` methods accept attached funds (settlement currency).
     // Every other endpoint must be called without funds — tokens sent here would
@@ -238,7 +235,6 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     }
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
     match msg {
         QueryMsg::Param {} => {

--- a/dango/taxman/Cargo.toml
+++ b/dango/taxman/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow      = { workspace = true }
 dango-types = { workspace = true }

--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -13,14 +13,12 @@ use {
     std::collections::BTreeMap,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> {
     CONFIG.save(ctx.storage, &msg.config)?;
 
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::Configure { new_cfg } => configure(ctx, new_cfg),
@@ -80,7 +78,6 @@ fn pay(ctx: MutableCtx, ty: FeeType, payments: BTreeMap<Addr, Coins>) -> anyhow:
 }
 
 // TODO: exempt the account factory from paying fee.
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn withhold_fee(ctx: AuthCtx, tx: Tx) -> StdResult<Response> {
     let fee_cfg = CONFIG.load(ctx.storage)?;
 
@@ -132,7 +129,6 @@ pub fn withhold_fee(ctx: AuthCtx, tx: Tx) -> StdResult<Response> {
     Ok(Response::new().may_add_message(withhold_msg))
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn finalize_fee(ctx: AuthCtx, tx: Tx, outcome: TxOutcome) -> StdResult<Response> {
     let (fee_cfg, withheld_amount) = WITHHELD_FEE.take(ctx.storage)?;
 

--- a/dango/taxman/src/query.rs
+++ b/dango/taxman/src/query.rs
@@ -4,7 +4,6 @@ use {
     grug::{ImmutableCtx, Json, JsonSerExt, StdResult},
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
     match msg {
         QueryMsg::Config {} => {

--- a/dango/testing/Cargo.toml
+++ b/dango/testing/Cargo.toml
@@ -15,7 +15,7 @@ anyhow                   = { workspace = true }
 async-trait              = { workspace = true }
 clickhouse               = { workspace = true, features = ["test-util"] }
 dango-genesis            = { workspace = true }
-dango-oracle             = { workspace = true, features = ["library"] }
+dango-oracle             = { workspace = true }
 dango-order-book         = { workspace = true }
 dango-proposal-preparer  = { workspace = true }
 dango-types              = { workspace = true, features = ["async-graphql"] }
@@ -51,12 +51,12 @@ assertor                    = { workspace = true }
 bip32                       = { workspace = true }
 chrono                      = { workspace = true }
 criterion                   = { workspace = true }
-dango-account-factory       = { workspace = true, features = ["library"] }
+dango-account-factory       = { workspace = true }
 dango-auth                  = { workspace = true }
-dango-bank                  = { workspace = true, features = ["library"] }
-dango-gateway               = { workspace = true, features = ["library"] }
+dango-bank                  = { workspace = true }
+dango-gateway               = { workspace = true }
 dango-mock-httpd            = { workspace = true }
-dango-taxman                = { workspace = true, features = ["library"] }
+dango-taxman                = { workspace = true }
 eth-utils                   = { workspace = true }
 graphql_client              = { workspace = true }
 hex                         = { workspace = true }

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -9,9 +9,9 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 
 [dependencies]
-dango-bank       = { workspace = true, features = ["library"] }
-dango-gateway    = { workspace = true, features = ["library"] }
-dango-oracle     = { workspace = true, features = ["library"] }
+dango-bank       = { workspace = true }
+dango-gateway    = { workspace = true }
+dango-oracle     = { workspace = true }
 dango-order-book = { workspace = true }
 dango-types      = { workspace = true }
 grug             = { workspace = true }

--- a/dango/vesting/Cargo.toml
+++ b/dango/vesting/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow      = { workspace = true }
 dango-types = { workspace = true }

--- a/dango/vesting/src/execute.rs
+++ b/dango/vesting/src/execute.rs
@@ -10,7 +10,6 @@ use {
     },
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     UNLOCKING_SCHEDULE.save(ctx.storage, &Schedule {
         // Unlocking start time is defined as the token generation time.
@@ -24,7 +23,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::Create { user, schedule } => create(ctx, user, schedule),

--- a/dango/vesting/src/query.rs
+++ b/dango/vesting/src/query.rs
@@ -5,7 +5,6 @@ use {
     std::collections::BTreeMap,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
     match msg {
         QueryMsg::Position { user } => {

--- a/dango/warp/Cargo.toml
+++ b/dango/warp/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow          = { workspace = true }
 dango-types     = { workspace = true }

--- a/dango/warp/src/execute.rs
+++ b/dango/warp/src/execute.rs
@@ -14,14 +14,12 @@ use {
     },
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> {
     MAILBOX.save(ctx.storage, &msg.mailbox)?;
 
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::Recipient(RecipientMsg::Handle {

--- a/dango/warp/src/query.rs
+++ b/dango/warp/src/query.rs
@@ -5,7 +5,6 @@ use {
     hyperlane_types::recipients::{RecipientQuery, RecipientQueryResponse},
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
     match msg {
         QueryMsg::Mailbox {} => {

--- a/hyperlane/isms/multisig/Cargo.toml
+++ b/hyperlane/isms/multisig/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow          = { workspace = true }
 grug            = { workspace = true }

--- a/hyperlane/isms/multisig/src/execute.rs
+++ b/hyperlane/isms/multisig/src/execute.rs
@@ -9,7 +9,6 @@ use {
     std::collections::BTreeSet,
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     for (domain, validator_set) in msg.validator_sets {
         ensure!(
@@ -30,7 +29,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::SetValidators {

--- a/hyperlane/isms/multisig/src/query.rs
+++ b/hyperlane/isms/multisig/src/query.rs
@@ -17,7 +17,6 @@ use {
     std::collections::{BTreeMap, BTreeSet},
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
     match msg {
         QueryMsg::ValidatorSet { domain } => {

--- a/hyperlane/mailbox/Cargo.toml
+++ b/hyperlane/mailbox/Cargo.toml
@@ -9,11 +9,6 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow          = { workspace = true }
 grug            = { workspace = true }

--- a/hyperlane/mailbox/src/execute.rs
+++ b/hyperlane/mailbox/src/execute.rs
@@ -13,7 +13,6 @@ use {
     },
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> {
     CONFIG.save(ctx.storage, &msg.config)?;
     MERKLE_TREE.save(ctx.storage, &IncrementalMerkleTree::default())?;
@@ -21,7 +20,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> 
     Ok(Response::new())
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::Dispatch {

--- a/hyperlane/mailbox/src/query.rs
+++ b/hyperlane/mailbox/src/query.rs
@@ -7,7 +7,6 @@ use {
     },
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
     match msg {
         QueryMsg::Config {} => {

--- a/hyperlane/va/Cargo.toml
+++ b/hyperlane/va/Cargo.toml
@@ -9,13 +9,8 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 version       = { workspace = true }
 
-[features]
-# If enabled, Wasm exports won't be created. This allows this contract to be
-# imported into other contracts as a library.
-library = []
-
 [dependencies]
 anyhow            = { workspace = true }
 grug              = { workspace = true }
-hyperlane-mailbox = { workspace = true, features = ["library"] }
+hyperlane-mailbox = { workspace = true }
 hyperlane-types   = { workspace = true }

--- a/hyperlane/va/src/execute.rs
+++ b/hyperlane/va/src/execute.rs
@@ -8,7 +8,6 @@ use {
     },
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
     MAILBOX.save(ctx.storage, &msg.mailbox)?;
     ANNOUNCE_FEE_PER_BYTE.save(ctx.storage, &msg.announce_fee_per_byte)?;
@@ -20,7 +19,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Respo
     })?)
 }
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::Announce {

--- a/hyperlane/va/src/query.rs
+++ b/hyperlane/va/src/query.rs
@@ -8,7 +8,6 @@ use {
     std::collections::{BTreeMap, BTreeSet},
 };
 
-#[cfg_attr(not(feature = "library"), grug::export)]
 pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> StdResult<Json> {
     match msg {
         QueryMsg::Mailbox {} => {

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -44,7 +44,7 @@ url                   = { workspace = true }
 [dev-dependencies]
 assertor              = { workspace = true }
 csv                   = { workspace = true }
-dango-account-factory = { workspace = true, features = ["library"] }
+dango-account-factory = { workspace = true }
 dango-genesis         = { workspace = true }
 dango-mock-httpd      = { workspace = true }
 dango-testing         = { workspace = true }


### PR DESCRIPTION
All core dango and hyperlane contracts run in the RustVM. Remove the now-dead WasmVM artifacts: `#[cfg_attr(not(feature = "library"), grug::export)]` macro invocations, the `library` Cargo feature, and all `features = ["library"]` references in dependent crates.