### PR TITLE
refactor(order-book): move `compute_impact_price` from perps to order-book

### DIFF
--- a/dango/order-book/src/impact_price.rs
+++ b/dango/order-book/src/impact_price.rs
@@ -1,0 +1,101 @@
+use {
+    crate::{Quantity, UsdPrice, UsdValue},
+    grug_types::StdResult,
+};
+
+/// Walk an ordered sequence of `(limit_price, size)` pairs and compute the
+/// volume-weighted average execution price for filling `impact_size` worth
+/// of notional value.
+///
+/// Each item is `(limit_price, absolute_order_size)`. The caller is responsible
+/// for iterating the correct side of the book (bids or asks) in price-priority
+/// order and mapping storage entries to `(real_price, absolute_size)`.
+///
+/// Returns: `Some(vwap)` if enough depth exists, `None` otherwise.
+pub fn compute_impact_price<I>(orders: I, impact_size: UsdValue) -> StdResult<Option<UsdPrice>>
+where
+    I: Iterator<Item = StdResult<(UsdPrice, Quantity)>>,
+{
+    let mut total_size = Quantity::ZERO;
+    let mut total_notional = UsdValue::ZERO;
+
+    for result in orders {
+        let (price, size) = result?;
+        let order_notional = size.checked_mul(price)?;
+        let remaining = impact_size.checked_sub(total_notional)?;
+
+        if order_notional >= remaining {
+            let partial_size = remaining.checked_div(price)?;
+
+            total_size.checked_add_assign(partial_size)?;
+            total_notional = impact_size;
+
+            break;
+        }
+
+        total_size.checked_add_assign(size)?;
+        total_notional.checked_add_assign(order_notional)?;
+    }
+
+    if total_notional < impact_size {
+        return Ok(None);
+    }
+
+    Ok(Some(total_notional.checked_div(total_size)?))
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::Quantity, grug_types::StdResult};
+
+    #[test]
+    fn impact_price_empty_book() {
+        let orders = std::iter::empty::<StdResult<(UsdPrice, Quantity)>>();
+        let result = compute_impact_price(orders, UsdValue::new_int(10_000)).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn impact_price_insufficient_depth() {
+        let orders = vec![Ok((UsdPrice::new_int(50_000), Quantity::new_int(1)))];
+        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(100_000)).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn impact_price_exact_fill_single_order() {
+        let orders = vec![Ok((UsdPrice::new_int(50_000), Quantity::new_int(2)))];
+        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(100_000)).unwrap();
+        assert_eq!(result, Some(UsdPrice::new_int(50_000)));
+    }
+
+    #[test]
+    fn impact_price_partial_fill_last_order() {
+        // Two orders: price=100, size=5 (notional=500) and price=110, size=10 (notional=1100)
+        // Impact notional = 1000 → fill all of first (500) then 500/110 ≈ 4.545454 of second
+        // total_size = 5 + 500/110 = 5 + 4.545454... = 9.545454...
+        // VWAP = 1000 / 9.545454... = 104.761904...
+        let orders = vec![
+            Ok((UsdPrice::new_int(100), Quantity::new_int(5))),
+            Ok((UsdPrice::new_int(110), Quantity::new_int(10))),
+        ];
+        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(1_000)).unwrap();
+        let vwap = result.unwrap();
+        assert!(vwap > UsdPrice::new_int(100));
+        assert!(vwap < UsdPrice::new_int(110));
+    }
+
+    #[test]
+    fn impact_price_multi_order_exact() {
+        // Two orders that exactly fill: price=100, size=5 (500) + price=200, size=5 (1000)
+        // total = 1500, need 1500, total_size=10 → VWAP = 1500/10 = 150
+        let orders = vec![
+            Ok((UsdPrice::new_int(100), Quantity::new_int(5))),
+            Ok((UsdPrice::new_int(200), Quantity::new_int(5))),
+        ];
+        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(1_500)).unwrap();
+        assert_eq!(result, Some(UsdPrice::new_int(150)));
+    }
+}

--- a/dango/order-book/src/lib.rs
+++ b/dango/order-book/src/lib.rs
@@ -6,6 +6,7 @@
 mod cancel;
 mod decompose;
 mod events;
+mod impact_price;
 mod liquidity_depth;
 mod matching_engine;
 mod min_size;
@@ -19,7 +20,7 @@ mod types;
 mod volume;
 
 pub use {
-    cancel::*, decompose::*, events::*, liquidity_depth::*, matching_engine::*, min_size::*,
-    price::*, price_band::*, slippage::*, state::*, target_price::*, typed_number::*, types::*,
-    volume::*,
+    cancel::*, decompose::*, events::*, impact_price::*, liquidity_depth::*, matching_engine::*,
+    min_size::*, price::*, price_band::*, slippage::*, state::*, target_price::*, typed_number::*,
+    types::*, volume::*,
 };

--- a/dango/perps/src/core/funding.rs
+++ b/dango/perps/src/core/funding.rs
@@ -1,52 +1,7 @@
 use {
-    dango_order_book::{
-        Days, Dimensionless, FundingPerUnit, FundingRate, Quantity, UsdPrice, UsdValue,
-    },
+    dango_order_book::{Days, Dimensionless, FundingPerUnit, FundingRate, UsdPrice},
     grug_math::MathResult,
-    grug_types::StdResult,
 };
-
-/// Walk an ordered sequence of `(limit_price, size)` pairs and compute the
-/// volume-weighted average execution price for filling `impact_size` worth
-/// of notional value.
-///
-/// Each item is `(limit_price, absolute_order_size)`. The caller is responsible
-/// for iterating the correct side of the book (bids or asks) in price-priority
-/// order and mapping storage entries to `(real_price, absolute_size)`.
-///
-/// Returns: `Some(vwap)` if enough depth exists, `None` otherwise.
-pub fn compute_impact_price(
-    orders: impl Iterator<Item = StdResult<(UsdPrice, Quantity)>>,
-    impact_size: UsdValue,
-) -> StdResult<Option<UsdPrice>> {
-    let mut total_size = Quantity::ZERO;
-    let mut total_notional = UsdValue::ZERO;
-
-    for result in orders {
-        let (price, size) = result?;
-        let order_notional = size.checked_mul(price)?;
-        let remaining = impact_size.checked_sub(total_notional)?;
-
-        if order_notional >= remaining {
-            // Partial fill of this order completes the impact notional.
-            let partial_size = remaining.checked_div(price)?;
-
-            total_size.checked_add_assign(partial_size)?;
-            total_notional = impact_size;
-
-            break;
-        }
-
-        total_size.checked_add_assign(size)?;
-        total_notional.checked_add_assign(order_notional)?;
-    }
-
-    if total_notional < impact_size {
-        return Ok(None);
-    }
-
-    Ok(Some(total_notional.checked_div(total_size)?))
-}
 
 /// Compute the premium from the midpoint of the two impact prices relative
 /// to the oracle price.
@@ -108,64 +63,10 @@ pub fn compute_funding_delta(
 mod tests {
     use {
         super::*,
-        dango_order_book::{Days, Dimensionless, FundingPerUnit, FundingRate, UsdPrice, UsdValue},
-        grug_types::{Duration, StdResult},
+        dango_order_book::{Days, Dimensionless, FundingPerUnit, FundingRate, UsdPrice},
+        grug_types::Duration,
         test_case::test_case,
     };
-
-    // ---- compute_impact_price tests ----
-
-    #[test]
-    fn impact_price_empty_book() {
-        let orders = std::iter::empty::<StdResult<(UsdPrice, Quantity)>>();
-        let result = compute_impact_price(orders, UsdValue::new_int(10_000)).unwrap();
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn impact_price_insufficient_depth() {
-        let orders = vec![Ok((UsdPrice::new_int(50_000), Quantity::new_int(1)))];
-        // Need 100_000 notional but only have 50_000
-        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(100_000)).unwrap();
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn impact_price_exact_fill_single_order() {
-        // Single order: price=50_000, size=2 → notional=100_000
-        let orders = vec![Ok((UsdPrice::new_int(50_000), Quantity::new_int(2)))];
-        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(100_000)).unwrap();
-        assert_eq!(result, Some(UsdPrice::new_int(50_000)));
-    }
-
-    #[test]
-    fn impact_price_partial_fill_last_order() {
-        // Two orders: price=100, size=5 (notional=500) and price=110, size=10 (notional=1100)
-        // Impact notional = 1000 → fill all of first (500) then 500/110 ≈ 4.545454 of second
-        // total_size = 5 + 500/110 = 5 + 4.545454... = 9.545454...
-        // VWAP = 1000 / 9.545454... = 104.761904...
-        let orders = vec![
-            Ok((UsdPrice::new_int(100), Quantity::new_int(5))),
-            Ok((UsdPrice::new_int(110), Quantity::new_int(10))),
-        ];
-        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(1_000)).unwrap();
-        let vwap = result.unwrap();
-        // VWAP should be between 100 and 110
-        assert!(vwap > UsdPrice::new_int(100));
-        assert!(vwap < UsdPrice::new_int(110));
-    }
-
-    #[test]
-    fn impact_price_multi_order_exact() {
-        // Two orders that exactly fill: price=100, size=5 (500) + price=200, size=5 (1000)
-        // total = 1500, need 1500, total_size=10 → VWAP = 1500/10 = 150
-        let orders = vec![
-            Ok((UsdPrice::new_int(100), Quantity::new_int(5))),
-            Ok((UsdPrice::new_int(200), Quantity::new_int(5))),
-        ];
-        let result = compute_impact_price(orders.into_iter(), UsdValue::new_int(1_500)).unwrap();
-        assert_eq!(result, Some(UsdPrice::new_int(150)));
-    }
 
     // ---- compute_premium tests ----
 

--- a/dango/perps/src/core/funding.rs
+++ b/dango/perps/src/core/funding.rs
@@ -17,7 +17,7 @@ use {
 /// attempt to compute a one-sided mid.
 ///
 /// Returns: premium as a `Dimensionless` value.
-pub fn compute_premium(
+pub fn compute_impact_premium(
     impact_bid: UsdPrice,
     impact_ask: UsdPrice,
     oracle_price: UsdPrice,
@@ -81,7 +81,7 @@ mod tests {
         let impact_ask = UsdPrice::new_int(ask);
         let oracle_price = UsdPrice::new_int(oracle);
 
-        let premium = compute_premium(impact_bid, impact_ask, oracle_price).unwrap();
+        let premium = compute_impact_premium(impact_bid, impact_ask, oracle_price).unwrap();
         assert_eq!(premium, Dimensionless::new_raw(expected_raw));
     }
 

--- a/dango/perps/src/cron/process_funding.rs
+++ b/dango/perps/src/cron/process_funding.rs
@@ -85,7 +85,7 @@ fn process_funding_for_pair(
     //
     // let premium = match (impact_bid, impact_ask) {
     //     (Some(impact_bid), Some(impact_ask)) => {
-    //         compute_premium(impact_bid, impact_ask, oracle_price)?
+    //         compute_impact_premium(impact_bid, impact_ask, oracle_price)?
     //     },
     //     _ => Dimensionless::ZERO,
     // };

--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ test:
 # Run all perp-related tests specifically
 test-perps:
   RUST_BACKTRACE=1 cargo test --all-features --tests -p dango-types perps::tests -- --nocapture
+  RUST_BACKTRACE=1 cargo test --all-features --tests -p dango-order-book -- --nocapture
   RUST_BACKTRACE=1 cargo test --all-features --tests -p dango-perps -- --nocapture
   RUST_BACKTRACE=1 cargo test --all-features -p dango-testing --test perps -- --nocapture
 


### PR DESCRIPTION
Impact price (VWAP for a hypothetical fill of a given notional size) is a
generic order-book concept, not specific to perpetual futures. Move the
function and its unit tests to `dango-order-book` so spot, options, and
prediction-market books can reuse it.

The function was dead code in the perps crate — the funding rate mechanism
now uses the vault-skew-based premium model exclusively.
