### PR TITLE
fix(deploy): include perp-liquidator in restart-services

### DIFF
--- a/deploy/restart-services.yml
+++ b/deploy/restart-services.yml
@@ -6,6 +6,7 @@
     services:
       - dango
       - cometbft
+      - perp-liquidator
     cometbft_rpc_port: 26657
   vars_files:
     - roles/full-app/vars/main.yml


### PR DESCRIPTION
`just restart-mainnet` / `restart-testnet` / `restart-devnet` only recreated `dango` and `cometbft`, leaving the `perp-liquidator` container untouched. It already lives in the same compose project on every host the playbook targets, so adding it to the `services` list restarts it alongside the others.