### PR TITLE
feat(ui): add tab filter to pair selector

### DIFF
--- a/ui/applets/kit/src/components/Cell.tsx
+++ b/ui/applets/kit/src/components/Cell.tsx
@@ -27,8 +27,7 @@ import type React from "react";
 import type { PropsWithChildren } from "react";
 import { Button } from "./Button";
 import { PairAssets } from "./PairAssets";
-import { IconStar } from "./icons/IconStar";
-import { IconEmptyStar } from "./icons/IconEmptyStar";
+import { StarToggleButton } from "./StarToggleButton";
 
 const TokenImage = memo(({ src, alt }: { src?: string; alt: string }) => (
   <img src={src} alt={alt} className="w-5 h-5 flex-shrink-0" />
@@ -367,14 +366,12 @@ type CellPairNameWithFavProps = {
 
 const PairNameWithFav: React.FC<CellPairNameWithFavProps> = memo(({ pairId, type, className }) => {
   const { coins } = useConfig();
+  const { toggleFavPair, hasFavPair } = useFavPairs();
   const { baseDenom, quoteDenom } = pairId;
   const baseCoin = coins.byDenom[baseDenom];
   const quoteCoin = coins.byDenom[quoteDenom];
-  const { toggleFavPair, hasFavPair } = useFavPairs();
 
   const pairSymbols = `${baseCoin.symbol}-${quoteCoin.symbol}`;
-
-  const isFav = hasFavPair(pairSymbols);
 
   return (
     <div
@@ -383,22 +380,12 @@ const PairNameWithFav: React.FC<CellPairNameWithFavProps> = memo(({ pairId, type
         className,
       )}
     >
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          toggleFavPair(pairSymbols);
-        }}
-        className="focus:outline-none flex-shrink-0"
-      >
-        {isFav ? (
-          <IconStar className="w-4 h-4 text-fg-primary-700" />
-        ) : (
-          <IconEmptyStar className="w-4 h-4 text-fg-primary-700" />
-        )}
-      </button>
+      <StarToggleButton
+        isActive={hasFavPair(pairSymbols)}
+        onToggle={() => toggleFavPair(pairSymbols)}
+      />
       <TokenImage src={baseCoin.logoURI} alt={baseCoin.symbol} />
-      <p className="whitespace-nowrap">{`${baseCoin.symbol}-${quoteCoin.symbol}`}</p>
+      <p className="whitespace-nowrap">{pairSymbols}</p>
       {type ? <Badge text={type} color="blue" size="s" /> : null}
     </div>
   );

--- a/ui/applets/kit/src/components/StarToggleButton.tsx
+++ b/ui/applets/kit/src/components/StarToggleButton.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import { twMerge } from "@left-curve/foundation";
+import { m } from "@left-curve/foundation/paraglide/messages.js";
 
 import { IconStar } from "./icons/IconStar";
 import { IconEmptyStar } from "./icons/IconEmptyStar";
@@ -15,10 +16,11 @@ type StarToggleButtonProps = {
 export const StarToggleButton = memo<StarToggleButtonProps>(
   ({ isActive, onToggle, className, isDisabled, "aria-label": ariaLabel }) => {
     const Icon = isActive ? IconStar : IconEmptyStar;
+    const defaultLabel = isActive ? m["common.starToggle.remove"]() : m["common.starToggle.add"]();
     return (
       <button
         type="button"
-        aria-label={ariaLabel ?? (isActive ? "Remove from favorites" : "Add to favorites")}
+        aria-label={ariaLabel ?? defaultLabel}
         aria-pressed={isActive}
         disabled={isDisabled}
         onPointerDown={(e) => e.stopPropagation()}

--- a/ui/applets/kit/src/components/StarToggleButton.tsx
+++ b/ui/applets/kit/src/components/StarToggleButton.tsx
@@ -1,0 +1,35 @@
+import { memo } from "react";
+import { twMerge } from "@left-curve/foundation";
+
+import { IconStar } from "./icons/IconStar";
+import { IconEmptyStar } from "./icons/IconEmptyStar";
+
+type StarToggleButtonProps = {
+  isActive: boolean;
+  onToggle: () => void;
+  className?: string;
+  isDisabled?: boolean;
+  "aria-label"?: string;
+};
+
+export const StarToggleButton = memo<StarToggleButtonProps>(
+  ({ isActive, onToggle, className, isDisabled, "aria-label": ariaLabel }) => {
+    const Icon = isActive ? IconStar : IconEmptyStar;
+    return (
+      <button
+        type="button"
+        aria-label={ariaLabel ?? (isActive ? "Remove from favorites" : "Add to favorites")}
+        aria-pressed={isActive}
+        disabled={isDisabled}
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle();
+        }}
+        className="focus:outline-none flex-shrink-0 disabled:opacity-50"
+      >
+        <Icon className={twMerge("w-4 h-4 text-fg-primary-700", className)} />
+      </button>
+    );
+  },
+);

--- a/ui/applets/kit/src/components/Table.tsx
+++ b/ui/applets/kit/src/components/Table.tsx
@@ -46,6 +46,7 @@ interface TableProps<T> extends VariantProps<typeof tabsVariants> {
   onColumnFiltersChange?: (updater: Updater<ColumnFiltersState>) => void;
   onRowClick?: (row: Row<T>) => void;
   onRowPointerDown?: (row: Row<T>) => void;
+  getRowId?: (row: T, index: number, parent?: Row<T>) => string;
   classNames?: TableClassNames;
   isLoading?: boolean;
   skeletonType?: "row" | "cell";
@@ -63,6 +64,7 @@ export const Table = <T,>({
   onColumnFiltersChange,
   onRowClick,
   onRowPointerDown,
+  getRowId,
   isLoading = false,
   emptyComponent,
   initialSortState = { fixed: [], variable: [] },
@@ -103,6 +105,7 @@ export const Table = <T,>({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getRowId,
   });
 
   const styles = tabsVariants({

--- a/ui/applets/kit/src/components/index.ts
+++ b/ui/applets/kit/src/components/index.ts
@@ -6,6 +6,7 @@ export { Button, type ButtonProps } from "./Button";
 export { Link } from "./Link";
 export { Badge } from "./Badge";
 export { IconButton, type IconButtonProps } from "./IconButton";
+export { StarToggleButton } from "./StarToggleButton";
 export { Spinner } from "./Spinner";
 export { QRCode } from "./QRCode";
 export { Select, type SelectProps, type SelectRef } from "./Select";

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -87,7 +87,9 @@
     "welcomeToDango": "Welcome to Dango",
     "connectWithPasskey": "Connect with Passkey",
     "connectWallet": "Connect Wallet",
-    "createNewUser": "Create New User"
+    "createNewUser": "Create New User",
+    "starToggle.add": "Add to favorites",
+    "starToggle.remove": "Remove from favorites"
   },
   "footer": {
     "terms": "Terms of Use",

--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -1278,7 +1278,13 @@
         "name": "Name",
         "price": "Price",
         "24hChange": "24h Change",
-        "volume": "Volume"
+        "volume": "Volume",
+        "tabs": {
+          "all": "All",
+          "favorites": "Favorites",
+          "crypto": "Crypto"
+        },
+        "emptyFavorites": "You haven't added any favorites yet. Tap the star next to a pair to add it."
       },
       "perps": {
         "availableToTrade": "Available to Trade",

--- a/ui/portal/web/src/components/dex/components/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/components/SearchToken.tsx
@@ -1,7 +1,7 @@
-import { useAppConfig, useConfig, perpsMarginAsset } from "@left-curve/store";
+import { useAppConfig, useConfig, perpsMarginAsset, useFavPairs } from "@left-curve/store";
 import { useRef, useState } from "react";
 
-import { IconSearch, Input, Popover, useMediaQuery } from "@left-curve/applets-kit";
+import { IconSearch, Input, Popover, Tabs, useMediaQuery } from "@left-curve/applets-kit";
 import { Sheet } from "react-modal-sheet";
 import { SearchTokenTable } from "./SearchTokenTable";
 
@@ -80,25 +80,42 @@ function normalizeRows(
   return rows;
 }
 
+const SEARCH_TOKEN_TABS = ["All", "Favorites", "Crypto"] as const;
+type SearchTokenTab = (typeof SEARCH_TOKEN_TABS)[number];
+
 const SearchTokenMenu: React.FC<{
   pairId: PairId;
   onChangePairId: (row: SearchTokenRow) => void;
 }> = ({ onChangePairId }) => {
+  const [activeTab, setActiveTab] = useState<SearchTokenTab>("All");
   const [searchText, setSearchText] = useState<string>("");
   const { data: config } = useAppConfig();
   const { coins } = useConfig();
+  const { hasFavPair, favPairs } = useFavPairs();
 
   const allRows = normalizeRows(config, coins);
 
-  const filteredRows = allRows.filter((row) => {
-    if (!searchText) return true;
-    const upper = searchText.toUpperCase();
-    return (
-      row.baseCoin.symbol.toUpperCase().includes(upper) ||
-      row.quoteCoin.symbol.toUpperCase().includes(upper) ||
-      row.pairKey.toUpperCase().includes(upper)
-    );
-  });
+  const filteredRows = allRows
+    .filter((row) => {
+      switch (activeTab) {
+        case "All":
+        case "Crypto":
+          return true;
+        case "Favorites":
+          return hasFavPair(row.pairKey);
+      }
+    })
+    .filter((row) => {
+      if (!searchText) return true;
+      const upper = searchText.toUpperCase();
+      return (
+        row.baseCoin.symbol.toUpperCase().includes(upper) ||
+        row.quoteCoin.symbol.toUpperCase().includes(upper) ||
+        row.pairKey.toUpperCase().includes(upper)
+      );
+    });
+
+  const showFavoritesEmpty = activeTab === "Favorites" && favPairs.length === 0;
 
   return (
     <div className="flex flex-col gap-2">
@@ -116,7 +133,24 @@ const SearchTokenMenu: React.FC<{
           </div>
         }
       />
-      <SearchTokenTable data={filteredRows} onChangePairId={onChangePairId} />
+      <div className="relative overflow-x-auto scrollbar-none pt-1">
+        <Tabs
+          color="line-red"
+          layoutId="search-token-tabs"
+          selectedTab={activeTab}
+          keys={[...SEARCH_TOKEN_TABS]}
+          onTabChange={(tab) => setActiveTab(tab as SearchTokenTab)}
+          classNames={{ base: "z-10" }}
+        />
+        <span className="w-full absolute h-[2px] bg-outline-secondary-gray bottom-[0px] z-0" />
+      </div>
+      {showFavoritesEmpty ? (
+        <p className="diatype-sm-medium text-ink-tertiary-500 text-center py-8">
+          You haven't added any favorites yet. Tap the star next to a pair to add it.
+        </p>
+      ) : (
+        <SearchTokenTable data={filteredRows} onChangePairId={onChangePairId} />
+      )}
     </div>
   );
 };

--- a/ui/portal/web/src/components/dex/components/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/components/SearchToken.tsx
@@ -8,9 +8,14 @@ import { SearchTokenTable } from "./SearchTokenTable";
 import { m } from "@left-curve/foundation/paraglide/messages.js";
 
 import type { PopoverRef } from "@left-curve/applets-kit";
-import type { PairId, PerpsPairParam } from "@left-curve/types";
+import type { GetAppConfigData } from "@left-curve/store";
+import type { PairId } from "@left-curve/types";
 import type { AnyCoin } from "@left-curve/store/types";
 import type React from "react";
+
+function assertNever(x: never): never {
+  throw new Error(`Unexpected value: ${String(x)}`);
+}
 
 type SearchTokenHeaderProps = {
   pairId: PairId;
@@ -56,13 +61,13 @@ const PERPS_QUOTE_COIN: AnyCoin = {
 };
 
 function normalizeRows(
-  config: any,
+  config: GetAppConfigData | undefined,
   coins: { byDenom: Record<string, AnyCoin>; bySymbol: Record<string, AnyCoin> },
 ): SearchTokenRow[] {
   const rows: SearchTokenRow[] = [];
 
-  const perpsPairs: Record<string, PerpsPairParam> = (config as any)?.perpsPairs ?? {};
-  for (const [perpsPairId, _param] of Object.entries(perpsPairs)) {
+  const perpsPairs = config?.perpsPairs ?? {};
+  for (const [perpsPairId] of Object.entries(perpsPairs)) {
     const symbol = perpsPairId.replace("perp/", "").toUpperCase();
 
     const baseSym = symbol.replace(/USDC$|USD$/, "");
@@ -106,6 +111,8 @@ const SearchTokenMenu: React.FC<{
               return true;
             case "favorites":
               return hasFavPair(row.pairKey);
+            default:
+              return assertNever(activeTab);
           }
         })
         .filter((row) => {

--- a/ui/portal/web/src/components/dex/components/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/components/SearchToken.tsx
@@ -1,7 +1,7 @@
 import { useAppConfig, useConfig, perpsMarginAsset, useFavPairs } from "@left-curve/store";
 import { useRef, useState } from "react";
 
-import { IconSearch, Input, Popover, Tabs, useMediaQuery } from "@left-curve/applets-kit";
+import { IconSearch, Input, Popover, Tab, Tabs, useMediaQuery } from "@left-curve/applets-kit";
 import { Sheet } from "react-modal-sheet";
 import { SearchTokenTable } from "./SearchTokenTable";
 
@@ -80,14 +80,13 @@ function normalizeRows(
   return rows;
 }
 
-const SEARCH_TOKEN_TABS = ["All", "Favorites", "Crypto"] as const;
-type SearchTokenTab = (typeof SEARCH_TOKEN_TABS)[number];
+type SearchTokenTab = "all" | "favorites" | "crypto";
 
 const SearchTokenMenu: React.FC<{
   pairId: PairId;
   onChangePairId: (row: SearchTokenRow) => void;
 }> = ({ onChangePairId }) => {
-  const [activeTab, setActiveTab] = useState<SearchTokenTab>("All");
+  const [activeTab, setActiveTab] = useState<SearchTokenTab>("all");
   const [searchText, setSearchText] = useState<string>("");
   const { data: config } = useAppConfig();
   const { coins } = useConfig();
@@ -98,10 +97,10 @@ const SearchTokenMenu: React.FC<{
   const filteredRows = allRows
     .filter((row) => {
       switch (activeTab) {
-        case "All":
-        case "Crypto":
+        case "all":
+        case "crypto":
           return true;
-        case "Favorites":
+        case "favorites":
           return hasFavPair(row.pairKey);
       }
     })
@@ -115,7 +114,7 @@ const SearchTokenMenu: React.FC<{
       );
     });
 
-  const showFavoritesEmpty = activeTab === "Favorites" && favPairs.length === 0;
+  const showFavoritesEmpty = activeTab === "favorites" && favPairs.length === 0;
 
   return (
     <div className="flex flex-col gap-2">
@@ -138,15 +137,18 @@ const SearchTokenMenu: React.FC<{
           color="line-red"
           layoutId="search-token-tabs"
           selectedTab={activeTab}
-          keys={[...SEARCH_TOKEN_TABS]}
           onTabChange={(tab) => setActiveTab(tab as SearchTokenTab)}
           classNames={{ base: "z-10" }}
-        />
+        >
+          <Tab title="all">{m["dex.protrade.searchPairTable.tabs.all"]()}</Tab>
+          <Tab title="favorites">{m["dex.protrade.searchPairTable.tabs.favorites"]()}</Tab>
+          <Tab title="crypto">{m["dex.protrade.searchPairTable.tabs.crypto"]()}</Tab>
+        </Tabs>
         <span className="w-full absolute h-[2px] bg-outline-secondary-gray bottom-[0px] z-0" />
       </div>
       {showFavoritesEmpty ? (
         <p className="diatype-sm-medium text-ink-tertiary-500 text-center py-8">
-          You haven't added any favorites yet. Tap the star next to a pair to add it.
+          {m["dex.protrade.searchPairTable.emptyFavorites"]()}
         </p>
       ) : (
         <SearchTokenTable data={filteredRows} onChangePairId={onChangePairId} />

--- a/ui/portal/web/src/components/dex/components/SearchToken.tsx
+++ b/ui/portal/web/src/components/dex/components/SearchToken.tsx
@@ -1,5 +1,5 @@
 import { useAppConfig, useConfig, perpsMarginAsset, useFavPairs } from "@left-curve/store";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { IconSearch, Input, Popover, Tab, Tabs, useMediaQuery } from "@left-curve/applets-kit";
 import { Sheet } from "react-modal-sheet";
@@ -43,6 +43,16 @@ export type SearchTokenRow = {
   pairId: PairId;
   pairKey: string;
   perpsPairId: string;
+  isFavorite: boolean;
+};
+
+const PERPS_QUOTE_COIN: AnyCoin = {
+  symbol: perpsMarginAsset.symbol,
+  denom: "usd",
+  decimals: perpsMarginAsset.decimals,
+  name: perpsMarginAsset.name,
+  logoURI: perpsMarginAsset.logoURI,
+  type: "native",
 };
 
 function normalizeRows(
@@ -59,21 +69,13 @@ function normalizeRows(
     const base = coins.bySymbol[baseSym];
     if (!base) continue;
 
-    const syntheticQuote: AnyCoin = {
-      symbol: perpsMarginAsset.symbol,
-      denom: "usd",
-      decimals: perpsMarginAsset.decimals,
-      name: perpsMarginAsset.name,
-      logoURI: perpsMarginAsset.logoURI,
-      type: "native",
-    };
-
     rows.push({
       baseCoin: base,
-      quoteCoin: syntheticQuote,
+      quoteCoin: PERPS_QUOTE_COIN,
       pairId: { baseDenom: base.denom, quoteDenom: "usd" },
       pairKey: `${base.symbol}-USD`,
       perpsPairId,
+      isFavorite: false,
     });
   }
 
@@ -92,27 +94,32 @@ const SearchTokenMenu: React.FC<{
   const { coins } = useConfig();
   const { hasFavPair, favPairs } = useFavPairs();
 
-  const allRows = normalizeRows(config, coins);
+  const allRows = useMemo(() => normalizeRows(config, coins), [config, coins]);
 
-  const filteredRows = allRows
-    .filter((row) => {
-      switch (activeTab) {
-        case "all":
-        case "crypto":
-          return true;
-        case "favorites":
-          return hasFavPair(row.pairKey);
-      }
-    })
-    .filter((row) => {
-      if (!searchText) return true;
-      const upper = searchText.toUpperCase();
-      return (
-        row.baseCoin.symbol.toUpperCase().includes(upper) ||
-        row.quoteCoin.symbol.toUpperCase().includes(upper) ||
-        row.pairKey.toUpperCase().includes(upper)
-      );
-    });
+  const filteredRows = useMemo(
+    () =>
+      allRows
+        .filter((row) => {
+          switch (activeTab) {
+            case "all":
+            case "crypto":
+              return true;
+            case "favorites":
+              return hasFavPair(row.pairKey);
+          }
+        })
+        .filter((row) => {
+          if (!searchText) return true;
+          const upper = searchText.toUpperCase();
+          return (
+            row.baseCoin.symbol.toUpperCase().includes(upper) ||
+            row.quoteCoin.symbol.toUpperCase().includes(upper) ||
+            row.pairKey.toUpperCase().includes(upper)
+          );
+        })
+        .map((row) => ({ ...row, isFavorite: hasFavPair(row.pairKey) })),
+    [allRows, activeTab, searchText, hasFavPair],
+  );
 
   const showFavoritesEmpty = activeTab === "favorites" && favPairs.length === 0;
 

--- a/ui/portal/web/src/components/dex/components/SearchTokenTable.tsx
+++ b/ui/portal/web/src/components/dex/components/SearchTokenTable.tsx
@@ -1,15 +1,14 @@
-import { allPerpsPairStatsStore, useFavPairs, TradePairStore } from "@left-curve/store";
+import { allPerpsPairStatsStore, TradePairStore, useFavPairs } from "@left-curve/store";
 import {
   Badge,
   Cell,
   FormattedNumber,
-  IconEmptyStar,
-  IconStar,
   PairStatValue,
   SortHeader,
+  StarToggleButton,
   Table,
 } from "@left-curve/applets-kit";
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import { m } from "@left-curve/foundation/paraglide/messages.js";
 
 import type { TableHeaderContext, TableClassNames, TableColumn } from "@left-curve/applets-kit";
@@ -27,25 +26,10 @@ const PerpsPairNameWithFav: React.FC<{
   pairKey: string;
 }> = memo(({ baseCoin, quoteCoin, pairKey }) => {
   const { toggleFavPair, hasFavPair } = useFavPairs();
-  const isFav = hasFavPair(pairKey);
 
   return (
     <div className="flex h-full gap-2 diatype-sm-medium justify-start items-center my-auto min-w-fit pr-2">
-      <button
-        type="button"
-        onPointerDown={(e) => e.stopPropagation()}
-        onClick={(e) => {
-          e.stopPropagation();
-          toggleFavPair(pairKey);
-        }}
-        className="focus:outline-none flex-shrink-0"
-      >
-        {isFav ? (
-          <IconStar className="w-4 h-4 text-fg-primary-700" />
-        ) : (
-          <IconEmptyStar className="w-4 h-4 text-fg-primary-700" />
-        )}
-      </button>
+      <StarToggleButton isActive={hasFavPair(pairKey)} onToggle={() => toggleFavPair(pairKey)} />
       <TokenImage src={baseCoin.logoURI} alt={baseCoin.symbol} />
       <p className="whitespace-nowrap">{`${baseCoin.symbol}-${quoteCoin.symbol}`}</p>
       <Badge text="Perp" color="green" size="s" />
@@ -118,98 +102,103 @@ export const SearchTokenTable: React.FC<SearchTokenTableProps> = ({
   data: rows,
   onChangePairId,
 }) => {
-  const { favPairs } = useFavPairs();
-
-  const perpStatsByPairId = allPerpsPairStatsStore((s) => s.perpsPairStatsByPairId);
   const getPerpsPairId = TradePairStore((s) => s.getPerpsPairId);
 
-  const data = useMemo(() => [...rows], [rows, favPairs]);
+  const columns = useMemo<TableColumn<SearchTokenRow>>(
+    () => [
+      {
+        id: "isFavorite",
+        accessorFn: (row) => row.isFavorite,
+      },
+      {
+        id: "pairName",
+        header: (ctx: TableHeaderContext<SearchTokenRow>) => (
+          <SortHeader
+            label={m["dex.protrade.searchPairTable.name"]()}
+            sorted={ctx.column.getIsSorted()}
+            toggleSort={ctx.column.toggleSorting}
+          />
+        ),
+        cell: ({ row }) => (
+          <PerpsPairNameWithFav
+            baseCoin={row.original.baseCoin}
+            quoteCoin={row.original.quoteCoin}
+            pairKey={row.original.pairKey}
+          />
+        ),
+        filterFn: (row, _, value) => {
+          const v = String(value ?? "").toUpperCase();
+          return (
+            row.original.baseCoin.symbol.toUpperCase().includes(v) ||
+            row.original.quoteCoin.symbol.toUpperCase().includes(v)
+          );
+        },
+        accessorFn: (row) => row.pairKey,
+      },
+      {
+        id: "price",
+        header: (ctx: TableHeaderContext<SearchTokenRow>) => (
+          <SortHeader
+            label={m["dex.protrade.searchPairTable.price"]()}
+            sorted={ctx.column.getIsSorted()}
+            toggleSort={ctx.column.toggleSorting}
+          />
+        ),
+        cell: ({ row }) => <PriceCell row={row.original} />,
+        accessorFn: (row) => {
+          const stats =
+            allPerpsPairStatsStore.getState().perpsPairStatsByPairId[getPerpsPairId(row.pairId)];
+          return Number(stats?.currentPrice ?? 0);
+        },
+      },
+      {
+        id: "change24h",
+        header: (ctx: TableHeaderContext<SearchTokenRow>) => (
+          <SortHeader
+            label={m["dex.protrade.searchPairTable.24hChange"]()}
+            sorted={ctx.column.getIsSorted()}
+            toggleSort={ctx.column.toggleSorting}
+          />
+        ),
+        cell: ({ row }) => <ChangeCell row={row.original} />,
+        accessorFn: (row) => {
+          const stats =
+            allPerpsPairStatsStore.getState().perpsPairStatsByPairId[getPerpsPairId(row.pairId)];
+          const value = stats?.priceChange24H;
+          return value === null || value === undefined ? Number.NEGATIVE_INFINITY : Number(value);
+        },
+      },
+      {
+        id: "volume",
+        header: (ctx: TableHeaderContext<SearchTokenRow>) => (
+          <SortHeader
+            label={m["dex.protrade.searchPairTable.volume"]()}
+            sorted={ctx.column.getIsSorted()}
+            toggleSort={ctx.column.toggleSorting}
+            className="ml-auto w-full justify-end"
+          />
+        ),
+        cell: ({ row }) => <VolumeCell row={row.original} />,
+        accessorFn: (row) => {
+          const stats =
+            allPerpsPairStatsStore.getState().perpsPairStatsByPairId[getPerpsPairId(row.pairId)];
+          const value = stats?.volume24H;
+          return value === undefined ? Number.NEGATIVE_INFINITY : Number(value);
+        },
+      },
+    ],
+    [getPerpsPairId],
+  );
 
-  const getPairStats = (row: SearchTokenRow) => {
-    return perpStatsByPairId[getPerpsPairId(row.pairId)];
-  };
-
-  const columns: TableColumn<SearchTokenRow> = [
-    {
-      id: "isFavorite",
-      accessorFn: (row) => favPairs.includes(row.pairKey),
-    },
-    {
-      id: "pairName",
-      header: (ctx: TableHeaderContext<SearchTokenRow>) => (
-        <SortHeader
-          label={m["dex.protrade.searchPairTable.name"]()}
-          sorted={ctx.column.getIsSorted()}
-          toggleSort={ctx.column.toggleSorting}
-        />
-      ),
-      cell: ({ row }) => (
-        <PerpsPairNameWithFav
-          baseCoin={row.original.baseCoin}
-          quoteCoin={row.original.quoteCoin}
-          pairKey={row.original.pairKey}
-        />
-      ),
-      filterFn: (row, _, value) => {
-        const v = String(value ?? "").toUpperCase();
-        return (
-          row.original.baseCoin.symbol.toUpperCase().includes(v) ||
-          row.original.quoteCoin.symbol.toUpperCase().includes(v)
-        );
-      },
-      accessorFn: (row) => row.pairKey,
-    },
-    {
-      id: "price",
-      header: (ctx: TableHeaderContext<SearchTokenRow>) => (
-        <SortHeader
-          label={m["dex.protrade.searchPairTable.price"]()}
-          sorted={ctx.column.getIsSorted()}
-          toggleSort={ctx.column.toggleSorting}
-        />
-      ),
-      cell: ({ row }) => <PriceCell row={row.original} />,
-      accessorFn: (row) => Number(getPairStats(row)?.currentPrice ?? 0),
-    },
-    {
-      id: "change24h",
-      header: (ctx: TableHeaderContext<SearchTokenRow>) => (
-        <SortHeader
-          label={m["dex.protrade.searchPairTable.24hChange"]()}
-          sorted={ctx.column.getIsSorted()}
-          toggleSort={ctx.column.toggleSorting}
-        />
-      ),
-      cell: ({ row }) => <ChangeCell row={row.original} />,
-      accessorFn: (row) => {
-        const value = getPairStats(row)?.priceChange24H;
-        return value === null || value === undefined ? Number.NEGATIVE_INFINITY : Number(value);
-      },
-    },
-    {
-      id: "volume",
-      header: (ctx: TableHeaderContext<SearchTokenRow>) => (
-        <SortHeader
-          label={m["dex.protrade.searchPairTable.volume"]()}
-          sorted={ctx.column.getIsSorted()}
-          toggleSort={ctx.column.toggleSorting}
-          className="ml-auto w-full justify-end"
-        />
-      ),
-      cell: ({ row }) => <VolumeCell row={row.original} />,
-      accessorFn: (row) => {
-        const value = getPairStats(row)?.volume24H;
-        return value === undefined ? Number.NEGATIVE_INFINITY : Number(value);
-      },
-    },
-  ];
+  const getRowId = useCallback((row: SearchTokenRow) => row.pairKey, []);
 
   return (
     <Table
-      data={data}
+      data={rows}
       columns={columns}
       style="simple"
       classNames={classNames}
+      getRowId={getRowId}
       initialSortState={{
         fixed: [{ id: "isFavorite", desc: true }],
         variable: [{ id: "pairName", desc: false }],

--- a/ui/portal/web/src/components/dex/components/SearchTokenTable.tsx
+++ b/ui/portal/web/src/components/dex/components/SearchTokenTable.tsx
@@ -33,6 +33,7 @@ const PerpsPairNameWithFav: React.FC<{
     <div className="flex h-full gap-2 diatype-sm-medium justify-start items-center my-auto min-w-fit pr-2">
       <button
         type="button"
+        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
           toggleFavPair(pairKey);

--- a/ui/portal/web/src/components/foundation/SearchItem.tsx
+++ b/ui/portal/web/src/components/foundation/SearchItem.tsx
@@ -1,12 +1,12 @@
-import { AddressVisualizer, useMediaQuery } from "@left-curve/applets-kit";
+import { AddressVisualizer, StarToggleButton, useMediaQuery } from "@left-curve/applets-kit";
 import { useFavApplets } from "@left-curve/store";
 
-import { IconEmptyStar, IconStar, TruncateText } from "@left-curve/applets-kit";
+import { TruncateText } from "@left-curve/applets-kit";
 import { motion } from "framer-motion";
 
 import type { AccountDetails, Address, ContractInfo, User } from "@left-curve/types";
 import type { AnyCoin, AppletMetadata, WithPrice } from "@left-curve/store/types";
-import type { MouseEvent, PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 const childVariants = {
   hidden: { opacity: 0, y: -30 },
@@ -24,12 +24,6 @@ const AppletItem: React.FC<SearchAppletItemProps> = (applet) => {
   const { favApplets, addFavApplet, removeFavApplet } = useFavApplets();
   const isFav = favApplets.includes(id);
 
-  const onClickStar = (e: MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
-    if (isFav) removeFavApplet(applet);
-    else addFavApplet(applet);
-  };
-
   return (
     <motion.div
       className="w-full p-2 flex items-center justify-between hover:bg-surface-tertiary-rice rounded-xs group-data-[selected=true]:bg-surface-tertiary-rice cursor-pointer"
@@ -45,13 +39,11 @@ const AppletItem: React.FC<SearchAppletItemProps> = (applet) => {
           <p className="diatype-m-regular text-ink-tertiary-500">{description}</p>
         </div>
       </div>
-      <div onClick={onClickStar}>
-        {isFav ? (
-          <IconStar className="w-6 h-6 text-primitives-rice-light-500" />
-        ) : (
-          <IconEmptyStar className="w-6 h-6 text-primitives-rice-light-500" />
-        )}
-      </div>
+      <StarToggleButton
+        isActive={isFav}
+        onToggle={() => (isFav ? removeFavApplet(applet) : addFavApplet(applet))}
+        className="w-6 h-6 text-primitives-rice-light-500"
+      />
     </motion.div>
   );
 };


### PR DESCRIPTION
Reintroduces the tab selector in the trading pair search popover that was removed alongside the spot DEX. Tabs filter the table by all pairs, user favorites, or crypto (currently equivalent to all). Favorites shows an empty-state message when the user has none.