### PR TITLE
 perf(indexer): bound pair-stats ClickHouse scans

### DIFF
--- a/dango/indexer/clickhouse/src/indexer/pair_stats/cache.rs
+++ b/dango/indexer/clickhouse/src/indexer/pair_stats/cache.rs
@@ -102,7 +102,9 @@ impl PairStatsCache {
             .collect())
     }
 
-    /// Clearing price closest to (but not after) 24 h ago, per pair.
+    /// Clearing price closest to (but not after) 24 h ago, per pair, within a
+    /// 7-day lookback. Pairs with no row in that window fall through to
+    /// `fetch_earliest_prices`.
     async fn fetch_prices_24h_ago(
         client: &clickhouse::Client,
     ) -> Result<HashMap<(String, String), u128>> {
@@ -114,7 +116,8 @@ impl PairStatsCache {
                 SELECT base_denom, quote_denom,
                        argMax(clearing_price, created_at) AS price
                 FROM pair_prices
-                WHERE created_at <= toDateTime64(?, 6)
+                WHERE created_at >= now() - INTERVAL 7 DAY
+                  AND created_at <= toDateTime64(?, 6)
                 GROUP BY base_denom, quote_denom
                 "#,
             )

--- a/dango/indexer/clickhouse/src/indexer/pair_stats/cache.rs
+++ b/dango/indexer/clickhouse/src/indexer/pair_stats/cache.rs
@@ -76,7 +76,10 @@ impl PairStatsCache {
 
     // -- batch helpers --------------------------------------------------------
 
-    /// Latest clearing_price per pair (the one with the highest block_height).
+    /// Latest clearing_price per pair (the one with the highest block_height),
+    /// bounded to the last 7 days. Pairs dormant for >7 days drop out of
+    /// "current" — acceptable since the same pair would also report zero 24 h
+    /// volume.
     async fn fetch_current_prices(
         client: &clickhouse::Client,
     ) -> Result<HashMap<(String, String), u128>> {
@@ -86,6 +89,7 @@ impl PairStatsCache {
                 SELECT base_denom, quote_denom,
                        argMax(clearing_price, block_height) AS price
                 FROM pair_prices
+                WHERE created_at >= now() - INTERVAL 7 DAY
                 GROUP BY base_denom, quote_denom
                 "#,
             )
@@ -124,8 +128,8 @@ impl PairStatsCache {
             .collect())
     }
 
-    /// Earliest clearing_price per pair – used as fallback when no data exists
-    /// from 24 h ago.
+    /// Earliest clearing_price per pair within the last 24 h – used as
+    /// fallback when no data exists from 24 h ago.
     async fn fetch_earliest_prices(
         client: &clickhouse::Client,
     ) -> Result<HashMap<(String, String), u128>> {
@@ -135,6 +139,7 @@ impl PairStatsCache {
                 SELECT base_denom, quote_denom,
                        argMin(clearing_price, block_height) AS price
                 FROM pair_prices
+                WHERE created_at >= now() - INTERVAL 24 HOUR
                 GROUP BY base_denom, quote_denom
                 "#,
             )

--- a/dango/indexer/clickhouse/src/indexer/perps_pair_stats/cache.rs
+++ b/dango/indexer/clickhouse/src/indexer/perps_pair_stats/cache.rs
@@ -67,7 +67,10 @@ impl PerpsPairStatsCache {
 
     // -- batch helpers --------------------------------------------------------
 
-    /// Latest close price per pair (the one with the highest block_height).
+    /// Latest close price per pair (the one with the highest block_height),
+    /// bounded to the last 7 days. Pairs dormant for >7 days drop out of
+    /// "current" — acceptable since the same pair would also report zero 24 h
+    /// volume.
     async fn fetch_current_prices(client: &clickhouse::Client) -> Result<HashMap<String, u128>> {
         let rows: Vec<PerpsPriceRow> = client
             .query(
@@ -75,6 +78,7 @@ impl PerpsPairStatsCache {
                 SELECT pair_id,
                        argMax(close, block_height) AS price
                 FROM perps_pair_prices
+                WHERE created_at >= now() - INTERVAL 7 DAY
                 GROUP BY pair_id
                 "#,
             )
@@ -105,7 +109,8 @@ impl PerpsPairStatsCache {
         Ok(rows.into_iter().map(|r| (r.pair_id, r.price)).collect())
     }
 
-    /// Earliest close price per pair – fallback when no data from 24 h ago.
+    /// Earliest close price per pair within the last 24 h – fallback when no
+    /// data from 24 h ago.
     async fn fetch_earliest_prices(client: &clickhouse::Client) -> Result<HashMap<String, u128>> {
         let rows: Vec<PerpsPriceRow> = client
             .query(
@@ -113,6 +118,7 @@ impl PerpsPairStatsCache {
                 SELECT pair_id,
                        argMin(close, block_height) AS price
                 FROM perps_pair_prices
+                WHERE created_at >= now() - INTERVAL 24 HOUR
                 GROUP BY pair_id
                 "#,
             )

--- a/dango/indexer/clickhouse/src/indexer/perps_pair_stats/cache.rs
+++ b/dango/indexer/clickhouse/src/indexer/perps_pair_stats/cache.rs
@@ -88,7 +88,9 @@ impl PerpsPairStatsCache {
         Ok(rows.into_iter().map(|r| (r.pair_id, r.price)).collect())
     }
 
-    /// Close price closest to (but not after) 24 h ago, per pair.
+    /// Close price closest to (but not after) 24 h ago, per pair, within a
+    /// 7-day lookback. Pairs with no row in that window fall through to
+    /// `fetch_earliest_prices`.
     async fn fetch_prices_24h_ago(client: &clickhouse::Client) -> Result<HashMap<String, u128>> {
         let ts = chrono::Utc::now() - chrono::Duration::hours(24);
 
@@ -98,7 +100,8 @@ impl PerpsPairStatsCache {
                 SELECT pair_id,
                        argMax(close, created_at) AS price
                 FROM perps_pair_prices
-                WHERE created_at <= toDateTime64(?, 6)
+                WHERE created_at >= now() - INTERVAL 7 DAY
+                  AND created_at <= toDateTime64(?, 6)
                 GROUP BY pair_id
                 "#,
             )

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -12,7 +12,7 @@ use {
         gateway::{Domain, Remote},
         warp,
     },
-    grug::{Addr, BlockInfo, Coins, ContractWrapper, Duration, Message, Uint128},
+    grug::{Addr, BlockInfo, Coins, ContractWrapper, Duration, Message, Timestamp, Uint128},
     grug_app::{AppError, Db, Indexer, NaiveProposalPreparer, NullIndexer, SimpleCommitment, Vm},
     grug_db_disk::DiskDb,
     grug_db_memory::MemDb,
@@ -44,6 +44,24 @@ impl TestOption {
         Self {
             mocked_clickhouse: true,
             ..Self::default()
+        }
+    }
+
+    /// Anchor the genesis block (and therefore every derived block timestamp)
+    /// to wall-clock `now()`. Indexer tests that read ClickHouse columns
+    /// filtered by `created_at >= now() - INTERVAL …` need this so the synthetic
+    /// block timestamps fall inside the lookback window.
+    pub fn with_recent_genesis(self) -> Self {
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_secs();
+        Self {
+            genesis_block: BlockInfo {
+                timestamp: Timestamp::from_seconds(now_secs as u128),
+                ..self.genesis_block
+            },
+            ..self
         }
     }
 }

--- a/dango/testing/tests/httpd/pair_stats.rs
+++ b/dango/testing/tests/httpd/pair_stats.rs
@@ -22,7 +22,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_pair_stats() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     create_pair_prices(&mut suite, &mut accounts, &contracts).await?;
 
@@ -75,7 +75,7 @@ async fn query_pair_stats() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_pair_stats_nonexistent_pair() -> anyhow::Result<()> {
     let (suite, _, _, _, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -113,7 +113,7 @@ async fn query_pair_stats_nonexistent_pair() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_all_pair_stats() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     create_pair_prices(&mut suite, &mut accounts, &contracts).await?;
 
@@ -162,7 +162,7 @@ async fn query_all_pair_stats() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_pair_stats_partial_fields() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     create_pair_prices(&mut suite, &mut accounts, &contracts).await?;
 
@@ -204,7 +204,7 @@ async fn query_pair_stats_partial_fields() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_pair_stats_formats_small_prices_without_scientific_notation() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     // Required for DEX execution in tests.
     suite

--- a/dango/testing/tests/httpd/perps_pair_stats.rs
+++ b/dango/testing/tests/httpd/perps_pair_stats.rs
@@ -16,7 +16,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_pair_stats() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     let pair = pair_id();
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
@@ -73,7 +73,7 @@ async fn query_perps_pair_stats() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_pair_stats_nonexistent_pair() -> anyhow::Result<()> {
     let (suite, _, _, _, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -110,7 +110,7 @@ async fn query_perps_pair_stats_nonexistent_pair() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_all_perps_pair_stats() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     let pair = pair_id();
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);
@@ -161,7 +161,7 @@ async fn query_all_perps_pair_stats() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_pair_stats_partial_fields() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, dango_httpd_context, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     let pair = pair_id();
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000);


### PR DESCRIPTION
## Summary

  Cap the in-memory pair-stats cache's underlying ClickHouse scans to bounded time
  windows so they can prune partitions on `pair_prices` and `perps_pair_prices`:

  - `fetch_current_prices`: last 7 days
  - `fetch_prices_24h_ago`: 7-day lookback ending at the 24 h mark
  - `fetch_earliest_prices`: last 24 h (fallback)

  Pairs dormant for >7 days drop out of "current", which matches the existing behaviour
  of a pair reporting zero 24 h volume. The cache continues to refresh once per block in
  `post_indexing`.

  ## Validation

  ### Completed
  - [x] `cargo check -p dango-indexer-clickhouse`
  - [x] `cargo clippy -p dango-indexer-clickhouse --all-targets -- -D warnings`
  - [x] `just fmt`