### PR TITLE
fix(jemalloc): drop background_thread + harden admin endpoints

### DIFF
--- a/dango/cli/src/main.rs
+++ b/dango/cli/src/main.rs
@@ -29,8 +29,13 @@ use {
 /// (inflating RSS). jemalloc fixes all three. With the `profiling` feature
 /// enabled, heap snapshots can be dumped on demand from the `/debug/pprof/heap`
 /// endpoint on the metrics server — see `indexer-httpd::server`. To arm
-/// profiling without paying its cost at rest, set the env var
-/// `MALLOC_CONF=prof:true,prof_active:false`.
+/// profiling without active sampling, set the env var
+/// `MALLOC_CONF=prof:true,prof_active:false`. `prof:true` is not zero-cost:
+/// the profiling-aware allocator hot path adds ~1-3% CPU even when sampling
+/// is dormant. Do NOT add `background_thread:true` — under dango's allocation
+/// rate the dedicated decay threads generated a `madvise` syscall storm that
+/// loaded dockerd and starved cloudflared on the testnet host (incident
+/// 2026-05-25).
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -177,11 +177,16 @@ services:
       - INDEXER__CLICKHOUSE__DATABASE=${CLICKHOUSE_DATABASE}
       - INDEXER__CLICKHOUSE__URL=${CLICKHOUSE_URL}
       - RUST_BACKTRACE=1
-      # Arm jemalloc heap profiling without activating it: zero overhead at
-      # rest, can be turned on at incident time by POSTing to
-      # /debug/pprof/heap/activate on the metrics port (9191), then dumped
-      # via GET /debug/pprof/heap. See indexer-httpd::server for the endpoints.
-      - MALLOC_CONF=prof:true,prof_active:false,lg_prof_sample:19,background_thread:true
+      # Arm jemalloc heap profiling without activating it. The instrumentation
+      # itself has ~1-3% CPU overhead at the allocator hot path; sampling is
+      # dormant until POST /debug/pprof/heap/activate on the metrics port
+      # (9191). Dump via GET /debug/pprof/heap, deactivate via POST
+      # /debug/pprof/heap/deactivate. See indexer-httpd::server for the
+      # endpoints. Do NOT add background_thread:true here — on dango's
+      # allocation rate the background decay threads cause a syscall storm
+      # that loads dockerd and starves cloudflared (testnet incident
+      # 2026-05-25).
+      - MALLOC_CONF=prof:true,prof_active:false
     tty: true
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/up"]

--- a/indexer/httpd/src/server.rs
+++ b/indexer/httpd/src/server.rs
@@ -274,8 +274,6 @@ async fn dump_jemalloc_stats() -> HttpResponse {
         ptr,
     };
 
-    let mut buf = String::new();
-
     unsafe extern "C" fn write_cb(opaque: *mut c_void, msg: *const c_char) {
         if msg.is_null() || opaque.is_null() {
             return;
@@ -290,28 +288,41 @@ async fn dump_jemalloc_stats() -> HttpResponse {
         }
     }
 
-    // SAFETY: calling jemalloc's stats printer with our callback. The buffer
-    // outlives the call (we own it in this stack frame, and the function is
-    // synchronous despite the async wrapper).
-    unsafe {
-        malloc_stats_print(
-            Some(write_cb),
-            &mut buf as *mut _ as *mut c_void,
-            ptr::null(),
-        );
-    }
+    // `malloc_stats_print` walks every arena and emits a multi-MB report on
+    // a large heap; on a 30 GiB process this can stall the calling thread
+    // for hundreds of ms. Run it on the blocking pool so it doesn't tie up
+    // an actix worker (which is exactly when we'd want it: during an
+    // incident with a bloated heap).
+    let result = tokio::task::spawn_blocking(|| {
+        let mut buf = String::new();
+        // SAFETY: jemalloc invokes the callback synchronously from the
+        // calling thread for the duration of this call. `buf` lives on this
+        // stack frame until `malloc_stats_print` returns.
+        unsafe {
+            malloc_stats_print(
+                Some(write_cb),
+                &mut buf as *mut _ as *mut c_void,
+                ptr::null(),
+            );
+        }
+        buf
+    })
+    .await;
 
-    HttpResponse::Ok()
-        .content_type("text/plain; charset=utf-8")
-        .body(buf)
+    match result {
+        Ok(buf) => HttpResponse::Ok()
+            .content_type("text/plain; charset=utf-8")
+            .body(buf),
+        Err(err) => HttpResponse::InternalServerError()
+            .body(format!("dump_jemalloc_stats join failed: {err}")),
+    }
 }
 
 // ---- jemalloc statistics gauges ----
 
 /// Refresh the jemalloc gauges every `JEMALLOC_REFRESH_INTERVAL`.
 ///
-/// These six numbers are the cheapest way to understand the allocator's
-/// state in real time:
+/// Memory-state gauges (refreshed only after a successful `epoch.advance()`):
 /// - `allocated`: bytes requested by the application and currently live.
 /// - `active`:    bytes in active pages assigned to threads (≈ allocated + small overhead).
 /// - `resident`:  bytes mapped into RAM from jemalloc's POV (≈ container RSS).
@@ -322,6 +333,12 @@ async fn dump_jemalloc_stats() -> HttpResponse {
 ///   the virtual reservation.
 /// - `metadata`:  bytes consumed by jemalloc's own bookkeeping (arenas, chunks).
 ///   Should be small (tens of MiB) — sustained growth signals a structural problem.
+///
+/// Profiling-state gauge (refreshed every tick, independent of stats):
+/// - `profiling_active`: 1 if heap sampling is currently on, 0 otherwise.
+///   Pair with an alert (`> 0 for 15m`) to catch a forgotten activation —
+///   live sampling costs ~5-15% CPU on top of the ~1-3% baseline of armed-but-
+///   inactive profiling.
 ///
 /// The ratio `resident / allocated` is the best at-a-glance fragmentation
 /// signal: ~1.0 means the process is using what it has; >1.5 means the
@@ -365,6 +382,21 @@ async fn refresh_jemalloc_gauges_forever() {
 
     loop {
         interval.tick().await;
+
+        // Profiling-active state lives in `jemalloc_pprof::PROF_CTL`, not in
+        // the stats epoch — update it unconditionally so a forgotten
+        // activation is observable even if stats reads fail.
+        let profiling_active = match jemalloc_pprof::PROF_CTL.as_ref() {
+            Some(prof_ctl) => {
+                if prof_ctl.lock().await.activated() {
+                    1.0
+                } else {
+                    0.0
+                }
+            },
+            None => 0.0,
+        };
+        metrics::gauge!("jemalloc_profiling_active").set(profiling_active);
 
         // Stats are cached until the epoch is advanced.
         if let Err(_err) = epoch_mib.advance() {

--- a/indexer/httpd/src/server.rs
+++ b/indexer/httpd/src/server.rs
@@ -387,14 +387,8 @@ async fn refresh_jemalloc_gauges_forever() {
         // the stats epoch — update it unconditionally so a forgotten
         // activation is observable even if stats reads fail.
         let profiling_active = match jemalloc_pprof::PROF_CTL.as_ref() {
-            Some(prof_ctl) => {
-                if prof_ctl.lock().await.activated() {
-                    1.0
-                } else {
-                    0.0
-                }
-            },
-            None => 0.0,
+            Some(prof_ctl) if prof_ctl.lock().await.activated() => 1.0,
+            _ => 0.0,
         };
         metrics::gauge!("jemalloc_profiling_active").set(profiling_active);
 


### PR DESCRIPTION
## Summary

- Drop `background_thread:true` and `lg_prof_sample:19` from `MALLOC_CONF` after the testnet incident on 2026-05-25 — jemalloc's background decay threads added enough scheduling pressure to destabilize cloudflared's tunnel HA connections, breaking testnet uptime for ~8 hours
- Move `dump_jemalloc_stats` into `tokio::task::spawn_blocking` (multi-MB output on big heaps was blocking actix workers, exactly the wrong time during an incident)
- Add `jemalloc_profiling_active` gauge (0/1) so a forgotten heap profiling activation is alertable
- Doc comments updated to reflect the actual ~1-3% baseline cost of `prof:true,prof_active:false` (was misleadingly described as "zero overhead at rest")

## User-facing impact

~8 hours of Uptime Kuma alerts between the jemalloc deploy (~19:00 UTC) and the rollback (02:46 UTC). Services affected:

- `api-testnet.dango.zone/up` — LB round-robin, ~50% of requests timed out (24s) because they landed on hetzner2 via the Cloudflare edge POP that had broken state
- `api-testnet-hetzner2.dango.zone/up` — direct route, 0/15 successful probes from the monitoring container (which exits via the same CF POP)
- `www-testnet.dango.zone/` — same LB path

`api-testnet-hetzner4.dango.zone` stayed 15/15 throughout. Resolved automatically once the rollback restarted the dango container.

## Failure mechanism

Both hosts ran the same dango image (commit `ac630ed5d`); the only deployment difference was `MALLOC_CONF` on hetzner2 including `background_thread:true`. Under dango's allocation rate this added scheduling pressure from continuous `madvise` calls by jemalloc's background decay threads:

| Metric (8h window 05-25 18:49Z → 05-26 02:46Z) | hetzner2 (jemalloc) | hetzner4 (vanilla) |
|---|---|---|
| Host CPU avg (32-core normalized) | 13.6% | 5.7% |
| Kernel sys-mode CPU avg | 1.25% | 0.68% |
| dockerd CPU avg | 0.66 cores | 0.04 cores |
| dockerd CPU p95 | 5.0 cores | 0.07 cores |
| load1 avg / p95 | 5.27 / 11.45 | 2.33 / 2.51 |
| Memory used avg | 31.4% | 31.0% |
| Cloudflared tunnel re-registrations | 21 | 6 |

Absolute CPU was not high — both hosts had plenty of headroom. The 15× relative difference on dockerd represents real syscall churn from background-thread `madvise`. That was enough to delay cloudflared's UDP read loop past QUIC heartbeat timeouts occasionally, causing tunnel HA connections to reconnect ~3.5× more often than on hetzner4. A subset of those reconnects left the Cloudflare edge POP holding a tunnel HA connection that did not auto-heal, so traffic routed through that POP black-holed until the host was restarted.

Memory was identical between the two hosts — jemalloc didn't leak; the cost was purely scheduler/syscall.

## Why the new config is the right trade-off

`prof:true,prof_active:false` retains heap-profiling capability for incident debugging without the background-thread machinery. The ~1-3% baseline CPU overhead is worth being able to capture a pprof snapshot when a host's RSS climbs unexpectedly. `background_thread:true` added no diagnostic value and significant scheduling pressure.

## Validation

### Completed

- [x] Quantitative reproduction of the cascade via Prometheus over the 8h jemalloc window
- [x] Verified the metrics/debug endpoints are not publicly exposed (Traefik route bound to internal interfaces only)
- [x] `cargo check -p indexer-httpd --features metrics,tracing` — green
- [x] `cargo clippy -p indexer-httpd --features metrics,tracing -- -D warnings` — clean

### Remaining

- [ ] Devnet smoke test (ovh1/ovh2)
- [ ] Prometheus alert rule for `jemalloc_profiling_active > 0 for 15m`
- [ ] Backport `spawn_blocking` + `profiling_active` gauge to `main`'s `indexer-metrics` crate

## Manual QA

1. Build dango image from this branch.
2. Deploy to devnet, wait the 10s gauge refresh interval, verify `jemalloc_*` series populated in Prometheus.
3. `POST /debug/pprof/heap/activate` on a devnet node, verify `jemalloc_profiling_active` flips to `1` within 10s.
4. `POST /debug/pprof/heap/deactivate`, verify it returns to `0`.
5. `GET /debug/jemalloc/stats` while issuing concurrent requests to a normal endpoint on `:8080` — confirm the latter stays responsive (validates the `spawn_blocking` change).
6. Roll to testnet (hetzner2 first, then hetzner4), confirm `node_load1` and `dockerd` CPU stay flat for 30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)