### PR TITLE
refactor(perps): separate index price refresh from vault order refresh

### DIFF
--- a/dango/genesis/src/codes.rs
+++ b/dango/genesis/src/codes.rs
@@ -73,7 +73,6 @@ impl GenesisCodes for RustVm {
             .with_execute(Box::new(dango_oracle::execute))
             .with_authenticate(Box::new(dango_oracle::authenticate))
             .with_query(Box::new(dango_oracle::query))
-            .with_reply(Box::new(dango_oracle::reply))
             .build();
 
         let taxman = ContractBuilder::new(Box::new(dango_taxman::instantiate))
@@ -97,6 +96,7 @@ impl GenesisCodes for RustVm {
             .with_execute(Box::new(dango_perps::execute))
             .with_query(Box::new(dango_perps::query))
             .with_cron_execute(Box::new(dango_perps::cron_execute))
+            .with_authenticate(Box::new(dango_perps::authenticate))
             .build();
 
         #[cfg(feature = "metrics")]

--- a/dango/oracle/src/execute.rs
+++ b/dango/oracle/src/execute.rs
@@ -1,15 +1,10 @@
 use {
     crate::{PRICE_SOURCES, PYTH_PRICES, PYTH_TRUSTED_SIGNERS},
     anyhow::{bail, ensure},
-    dango_types::{
-        DangoQuerier,
-        oracle::{ExecuteMsg, InstantiateMsg, Price, PriceSource, ReplyMsg, VaultRefreshFailed},
-        perps,
-    },
+    dango_types::oracle::{ExecuteMsg, InstantiateMsg, Price, PriceSource},
     grug_types::{
-        Addr, Api, AuthCtx, AuthMode, Binary, Coins, Denom, Inner, JsonDeExt, Message, MsgExecute,
-        MutableCtx, QuerierExt, Response, StdResult, Storage, SubMessage, SubMsgResult, SudoCtx,
-        Timestamp, Tx,
+        Api, AuthCtx, AuthMode, Binary, Denom, Inner, JsonDeExt, Message, MsgExecute, MutableCtx,
+        QuerierExt, Response, Storage, Timestamp, Tx,
     },
     pyth_types::{LeEcdsaMessage, PayloadData, PriceUpdate},
     std::collections::BTreeMap,
@@ -74,21 +69,6 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
         } => register_trusted_signer(ctx, public_key, expires_at),
         ExecuteMsg::RemoveTrustedSigner { public_key } => remove_trusted_signer(ctx, public_key),
         ExecuteMsg::FeedPrices(price_update) => feed_prices(ctx, price_update),
-    }
-}
-
-pub fn reply(_ctx: SudoCtx, msg: ReplyMsg, res: SubMsgResult) -> StdResult<Response> {
-    match msg {
-        ReplyMsg::AfterOnOracleUpdate {} => {
-            let error = res.unwrap_err();
-
-            #[cfg(feature = "tracing")]
-            {
-                tracing::error!(error, "!!! PERPS VAULT REFRESH FAILED !!!");
-            }
-
-            Response::new().add_event(VaultRefreshFailed { error })
-        },
     }
 }
 
@@ -170,26 +150,7 @@ fn feed_prices(ctx: MutableCtx, price_update: PriceUpdate) -> anyhow::Result<Res
         }
     }
 
-    // Call the perps contract's `on_oracle_update` function.
-    // The perps market making vault refreshes its quotes based on the latest
-    // oracle prices.
-    // Use `reply_on_error` to ensure that even if the perps contract errors,
-    // the oracle update itself isn't reverted.
-    // Skip if perps address is zero (not yet instantiated).
-    let perps = ctx.querier.query_perps()?;
-
-    Ok(Response::new().may_add_submessage(if perps != Addr::ZERO {
-        Some(SubMessage::reply_on_error(
-            Message::execute(
-                perps,
-                &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
-                Coins::new(),
-            )?,
-            &ReplyMsg::AfterOnOracleUpdate {},
-        )?)
-    } else {
-        None
-    }))
+    Ok(Response::new())
 }
 
 fn verify_pyth_lazer_message(

--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -149,8 +149,8 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
                 user,
                 maker_taker_fee_rates,
             } => maintain::set_fee_rate_override(ctx, user, maker_taker_fee_rates),
-            MaintainerMsg::RefreshIndexPrices => maintain::refresh_index_prices(ctx),
-            MaintainerMsg::RefreshVaultOrders => maintain::refresh_vault_orders(ctx),
+            MaintainerMsg::RefreshIndexPrices {} => maintain::refresh_index_prices(ctx),
+            MaintainerMsg::RefreshVaultOrders {} => maintain::refresh_vault_orders(ctx),
         },
         ExecuteMsg::Trade(msg) => match msg {
             TraderMsg::Deposit { to } => trade::deposit(ctx, to),
@@ -394,7 +394,7 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
         );
 
         let Ok(ExecuteMsg::Maintain(
-            MaintainerMsg::RefreshIndexPrices | MaintainerMsg::RefreshVaultOrders,
+            MaintainerMsg::RefreshIndexPrices {} | MaintainerMsg::RefreshVaultOrders {},
         )) = msg.clone().deserialize_json()
         else {
             bail!("all execute messages must be RefreshIndexPrices or RefreshVaultOrders");
@@ -429,7 +429,7 @@ mod tests {
     fn refresh_index_prices_msg(contract: Addr) -> Message {
         Message::execute(
             contract,
-            &ExecuteMsg::Maintain(MaintainerMsg::RefreshIndexPrices),
+            &ExecuteMsg::Maintain(MaintainerMsg::RefreshIndexPrices {}),
             Coins::new(),
         )
         .unwrap()
@@ -438,7 +438,7 @@ mod tests {
     fn refresh_vault_orders_msg(contract: Addr) -> Message {
         Message::execute(
             contract,
-            &ExecuteMsg::Maintain(MaintainerMsg::RefreshVaultOrders),
+            &ExecuteMsg::Maintain(MaintainerMsg::RefreshVaultOrders {}),
             Coins::new(),
         )
         .unwrap()

--- a/dango/perps/src/lib.rs
+++ b/dango/perps/src/lib.rs
@@ -14,7 +14,7 @@ pub mod vault;
 
 use {
     crate::state::{FEE_RATE_OVERRIDES, PAIR_PARAMS, PAIR_STATES, PARAM, STATE, USER_STATES},
-    anyhow::ensure,
+    anyhow::{bail, ensure},
     dango_order_book::{FillId, NEXT_FILL_ID, NEXT_ORDER_ID, OrderId, UsdValue},
     dango_types::{
         DangoQuerier,
@@ -25,7 +25,8 @@ use {
     },
     grug_math::{NumberConst, Uint128},
     grug_types::{
-        Addr, Duration, EventBuilder, ImmutableCtx, Json, JsonSerExt, MutableCtx, Response, SudoCtx,
+        Addr, AuthCtx, AuthMode, Duration, EventBuilder, ImmutableCtx, Json, JsonDeExt, JsonSerExt,
+        Message, MsgExecute, MutableCtx, Response, SudoCtx, Tx,
     },
 };
 
@@ -148,6 +149,8 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
                 user,
                 maker_taker_fee_rates,
             } => maintain::set_fee_rate_override(ctx, user, maker_taker_fee_rates),
+            MaintainerMsg::RefreshIndexPrices => maintain::refresh_index_prices(ctx),
+            MaintainerMsg::RefreshVaultOrders => maintain::refresh_vault_orders(ctx),
         },
         ExecuteMsg::Trade(msg) => match msg {
             TraderMsg::Deposit { to } => trade::deposit(ctx, to),
@@ -201,7 +204,6 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
             VaultMsg::RemoveLiquidity { shares_to_burn } => {
                 vault::remove_liquidity(ctx, shares_to_burn)
             },
-            VaultMsg::Refresh {} => vault::refresh_orders(ctx),
         },
         ExecuteMsg::Referral(msg) => match msg {
             ReferralMsg::SetReferral { referrer, referee } => {
@@ -373,4 +375,176 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
         },
     }
     .map_err(Into::into)
+}
+
+pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
+    ensure!(
+        ctx.mode == AuthMode::Finalize,
+        "you don't have the right, O you don't have the right"
+    );
+
+    for msg in tx.msgs.iter() {
+        let Message::Execute(MsgExecute { contract, msg, .. }) = msg else {
+            bail!("all messages must be execute messages");
+        };
+
+        ensure!(
+            contract == ctx.contract,
+            "all messages must target the perps contract"
+        );
+
+        let Ok(ExecuteMsg::Maintain(
+            MaintainerMsg::RefreshIndexPrices | MaintainerMsg::RefreshVaultOrders,
+        )) = msg.clone().deserialize_json()
+        else {
+            bail!("all execute messages must be RefreshIndexPrices or RefreshVaultOrders");
+        };
+    }
+
+    Ok(Response::new())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        grug_types::{Coins, Json, MockContext, NonEmpty, ResultExt},
+        std::collections::BTreeMap,
+    };
+
+    const CONTRACT: Addr = Addr::mock(0);
+
+    fn make_tx(msgs: Vec<Message>) -> Tx {
+        Tx {
+            sender: CONTRACT,
+            gas_limit: 1_000_000,
+            msgs: NonEmpty::new_unchecked(msgs),
+            data: Json::null(),
+            credential: Json::null(),
+        }
+    }
+
+    fn refresh_index_prices_msg(contract: Addr) -> Message {
+        Message::execute(
+            contract,
+            &ExecuteMsg::Maintain(MaintainerMsg::RefreshIndexPrices),
+            Coins::new(),
+        )
+        .unwrap()
+    }
+
+    fn refresh_vault_orders_msg(contract: Addr) -> Message {
+        Message::execute(
+            contract,
+            &ExecuteMsg::Maintain(MaintainerMsg::RefreshVaultOrders),
+            Coins::new(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn authenticate_single_refresh_index_prices() {
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Finalize);
+
+        let tx = make_tx(vec![refresh_index_prices_msg(CONTRACT)]);
+        authenticate(ctx.as_auth(), tx).should_succeed();
+    }
+
+    #[test]
+    fn authenticate_single_refresh_vault_orders() {
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Finalize);
+
+        let tx = make_tx(vec![refresh_vault_orders_msg(CONTRACT)]);
+        authenticate(ctx.as_auth(), tx).should_succeed();
+    }
+
+    #[test]
+    fn authenticate_both_messages() {
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Finalize);
+
+        let tx = make_tx(vec![
+            refresh_index_prices_msg(CONTRACT),
+            refresh_vault_orders_msg(CONTRACT),
+        ]);
+        authenticate(ctx.as_auth(), tx).should_succeed();
+    }
+
+    #[test]
+    fn authenticate_rejects_check_mode() {
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Check);
+
+        let tx = make_tx(vec![refresh_index_prices_msg(CONTRACT)]);
+        authenticate(ctx.as_auth(), tx).should_fail_with_error("you don't have the right");
+    }
+
+    #[test]
+    fn authenticate_rejects_wrong_contract() {
+        let wrong_contract = Addr::mock(99);
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Finalize);
+
+        let tx = make_tx(vec![refresh_index_prices_msg(wrong_contract)]);
+        authenticate(ctx.as_auth(), tx)
+            .should_fail_with_error("all messages must target the perps contract");
+    }
+
+    #[test]
+    fn authenticate_rejects_non_execute_message() {
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Finalize);
+
+        let tx = make_tx(vec![Message::Transfer(BTreeMap::new())]);
+        authenticate(ctx.as_auth(), tx)
+            .should_fail_with_error("all messages must be execute messages");
+    }
+
+    #[test]
+    fn authenticate_rejects_invalid_execute() {
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Finalize);
+
+        let msg = Message::execute(
+            CONTRACT,
+            &ExecuteMsg::Maintain(MaintainerMsg::Donate {}),
+            Coins::new(),
+        )
+        .unwrap();
+
+        let tx = make_tx(vec![msg]);
+        authenticate(ctx.as_auth(), tx).should_fail_with_error(
+            "all execute messages must be RefreshIndexPrices or RefreshVaultOrders",
+        );
+    }
+
+    #[test]
+    fn authenticate_rejects_mixed_valid_invalid() {
+        let mut ctx = MockContext::new()
+            .with_contract(CONTRACT)
+            .with_mode(AuthMode::Finalize);
+
+        let invalid_msg = Message::execute(
+            CONTRACT,
+            &ExecuteMsg::Maintain(MaintainerMsg::Donate {}),
+            Coins::new(),
+        )
+        .unwrap();
+
+        let tx = make_tx(vec![refresh_index_prices_msg(CONTRACT), invalid_msg]);
+        authenticate(ctx.as_auth(), tx).should_fail_with_error(
+            "all execute messages must be RefreshIndexPrices or RefreshVaultOrders",
+        );
+    }
 }

--- a/dango/perps/src/maintain.rs
+++ b/dango/perps/src/maintain.rs
@@ -1,6 +1,11 @@
 mod configure;
 mod donate;
 mod liquidate;
+mod refresh_index_prices;
+mod refresh_vault_orders;
 mod set_fee_rate_override;
 
-pub use {configure::*, donate::*, liquidate::*, set_fee_rate_override::*};
+pub use {
+    configure::*, donate::*, liquidate::*, refresh_index_prices::*, refresh_vault_orders::*,
+    set_fee_rate_override::*,
+};

--- a/dango/perps/src/maintain/refresh_index_prices.rs
+++ b/dango/perps/src/maintain/refresh_index_prices.rs
@@ -1,0 +1,138 @@
+use {
+    crate::{index_price::process_index_price, oracle, state::LAST_INDEX_PRICE_UPDATE},
+    anyhow::ensure,
+    dango_oracle::OracleQuerier,
+    grug_types::{MutableCtx, QuerierExt, Response},
+};
+
+pub fn refresh_index_prices(ctx: MutableCtx) -> anyhow::Result<Response> {
+    ensure!(
+        ctx.sender == ctx.contract || ctx.sender == ctx.querier.query_owner()?,
+        "only the perps contract itself or the chain owner may refresh index prices"
+    );
+
+    ensure!(
+        {
+            let last_update = LAST_INDEX_PRICE_UPDATE.may_load(ctx.storage)?.unwrap_or(0);
+            ctx.block.height > last_update
+        },
+        "index prices already updated this block"
+    );
+
+    let oracle_addr = oracle(ctx.querier);
+    let mut oracle_querier = OracleQuerier::new_remote(oracle_addr, ctx.querier);
+
+    process_index_price(ctx.storage, ctx.block.timestamp, &mut oracle_querier)?;
+
+    LAST_INDEX_PRICE_UPDATE.save(ctx.storage, &ctx.block.height)?;
+
+    Ok(Response::new())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::state::PAIR_IDS,
+        dango_types::config::AppConfig,
+        grug_types::{
+            Addr, Coins, Config, Duration, MockContext, MockQuerier, Permission, Permissions,
+            ResultExt,
+        },
+        std::collections::BTreeMap,
+    };
+
+    const CONTRACT: Addr = Addr::mock(0);
+    const ORACLE: Addr = Addr::mock(1);
+    const OWNER: Addr = Addr::mock(2);
+
+    fn mock_config() -> Config {
+        Config {
+            owner: OWNER,
+            bank: Addr::mock(3),
+            taxman: Addr::mock(4),
+            cronjobs: BTreeMap::new(),
+            permissions: Permissions {
+                upload: Permission::Nobody,
+                instantiate: Permission::Nobody,
+            },
+            max_orphan_age: Duration::from_seconds(0),
+        }
+    }
+
+    fn mock_querier() -> MockQuerier {
+        MockQuerier::new()
+            .with_app_config(AppConfig {
+                addresses: dango_types::config::AppAddresses {
+                    oracle: ORACLE,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .unwrap()
+            .with_config(mock_config())
+    }
+
+    #[test]
+    fn rejects_unauthorized_sender() {
+        let mut ctx = MockContext::new()
+            .with_querier(mock_querier())
+            .with_contract(CONTRACT)
+            .with_sender(Addr::mock(99))
+            .with_funds(Coins::default())
+            .with_block_height(10);
+
+        refresh_index_prices(ctx.as_mutable()).should_fail_with_error(
+            "only the perps contract itself or the chain owner may refresh index prices",
+        );
+    }
+
+    #[test]
+    fn owner_can_trigger() {
+        let mut ctx = MockContext::new()
+            .with_querier(mock_querier())
+            .with_contract(CONTRACT)
+            .with_sender(OWNER)
+            .with_funds(Coins::default())
+            .with_block_height(10);
+
+        PAIR_IDS
+            .save(&mut ctx.storage, &Default::default())
+            .unwrap();
+
+        refresh_index_prices(ctx.as_mutable()).should_succeed();
+    }
+
+    #[test]
+    fn contract_can_trigger() {
+        let mut ctx = MockContext::new()
+            .with_querier(mock_querier())
+            .with_contract(CONTRACT)
+            .with_sender(CONTRACT)
+            .with_funds(Coins::default())
+            .with_block_height(10);
+
+        PAIR_IDS
+            .save(&mut ctx.storage, &Default::default())
+            .unwrap();
+
+        refresh_index_prices(ctx.as_mutable()).should_succeed();
+    }
+
+    #[test]
+    fn once_per_block() {
+        let mut ctx = MockContext::new()
+            .with_querier(mock_querier())
+            .with_contract(CONTRACT)
+            .with_sender(CONTRACT)
+            .with_funds(Coins::default())
+            .with_block_height(10);
+
+        LAST_INDEX_PRICE_UPDATE.save(&mut ctx.storage, &10).unwrap();
+
+        refresh_index_prices(ctx.as_mutable())
+            .should_fail_with_error("index prices already updated this block");
+    }
+}

--- a/dango/perps/src/maintain/refresh_vault_orders.rs
+++ b/dango/perps/src/maintain/refresh_vault_orders.rs
@@ -14,6 +14,17 @@ use {
     grug_types::{MutableCtx, Order as IterationOrder, QuerierExt, Response},
 };
 
+/// Entry point for vault market-making, triggered at the beginning of each
+/// block after the index price refresh.
+///
+/// 1. Cancels all existing vault orders.
+/// 2. Computes available margin for the vault.
+/// 3. For each trading pair, places fresh bid/ask limit orders based on the
+///    oracle price and the pair's market-making parameters.
+///
+/// Mutates: `USER_STATES[contract]`, `BIDS`, `ASKS`, `NEXT_ORDER_ID`.
+///
+/// Returns: empty `Response` (no token transfers).
 pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
     #[cfg(feature = "metrics")]
     let start = std::time::Instant::now();
@@ -46,7 +57,7 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
         ctx.storage,
         ctx.contract,
         &vault_state,
-        None,
+        None, // Vault order churn is not user-facing — no events emitted.
         ReasonForOrderRemoval::Canceled,
     )?;
 
@@ -54,12 +65,17 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
 
     // ------------- Step 2: Compute the vault's available margin --------------
 
+    // Compute available margin: equity minus margin consumed by existing
+    // positions. After cancellation reserved_margin is zero, so the formula
+    // simplifies to: max(0, equity - used_margin).
     let vault_margin_value = {
         let perp_querier = NoCachePerpQuerier::new_local(ctx.storage);
         compute_available_margin(&perp_querier, &vault_state)?
     };
 
+    // If vault_total_weight is zero, no pairs have weights configured — skip.
     if param.vault_total_weight.is_zero() || !vault_margin_value.is_positive() {
+        // Persist vault state (orders were cancelled).
         if vault_state.is_empty() {
             USER_STATES.remove(ctx.storage, ctx.contract)?;
         } else {
@@ -78,16 +94,19 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
     for pair_id in &pair_ids {
         let pair_param = PAIR_PARAMS.load(ctx.storage, pair_id)?;
 
+        // Skip pairs with zero weight.
         if pair_param.vault_liquidity_weight.is_zero() {
             continue;
         }
 
         let oracle_price = PAIR_STATES.load(ctx.storage, pair_id)?.index_price;
 
+        // Compute this pair's allocated margin.
         let pair_margin = vault_margin_value
             .checked_mul(pair_param.vault_liquidity_weight)?
             .checked_div(param.vault_total_weight)?;
 
+        // Read best bid (un-inverted) and best ask from the book.
         let best_bid = BIDS
             .prefix(pair_id.clone())
             .range(ctx.storage, None, None, IterationOrder::Ascending)
@@ -102,12 +121,14 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             .transpose()?
             .map(|((stored_price, _), _)| stored_price);
 
+        // Vault's current position for this pair (zero if none).
         let position_size = vault_state
             .positions
             .get(pair_id)
             .map(|p| p.size)
             .unwrap_or(Quantity::ZERO);
 
+        // Compute vault quotes with inventory skew.
         let (bid, ask) = compute_vault_quotes(
             oracle_price,
             &pair_param,
@@ -117,6 +138,7 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             position_size,
         )?;
 
+        // Place bid order.
         if let Some(bid_quote) = bid {
             let stored_price = may_invert_price(bid_quote.price, true);
             let order = LimitOrder {
@@ -149,6 +171,7 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             next_order_id.checked_add_assign(Uint64::ONE)?;
         }
 
+        // Place ask order.
         if let Some(ask_quote) = ask {
             let order = LimitOrder {
                 user: ctx.contract,

--- a/dango/perps/src/maintain/refresh_vault_orders.rs
+++ b/dango/perps/src/maintain/refresh_vault_orders.rs
@@ -1,14 +1,11 @@
 use {
     crate::{
         core::{compute_available_margin, compute_vault_quotes},
-        index_price::process_index_price,
-        oracle,
         querier::NoCachePerpQuerier,
         state::{LAST_VAULT_ORDERS_UPDATE, PAIR_IDS, PAIR_PARAMS, PAIR_STATES, PARAM, USER_STATES},
         trade::{CancelAllOrdersOutcome, compute_cancel_all_orders_outcome},
     },
     anyhow::ensure,
-    dango_oracle::OracleQuerier,
     dango_order_book::{
         ASKS, BIDS, LimitOrder, NEXT_ORDER_ID, Quantity, ReasonForOrderRemoval, UsdValue,
         increase_liquidity_depths, may_invert_price,
@@ -17,30 +14,13 @@ use {
     grug_types::{MutableCtx, Order as IterationOrder, QuerierExt, Response},
 };
 
-/// Entry point for vault market-making, triggered at the beginning of each
-/// block after the oracle update.
-///
-/// 1. Cancels all existing vault orders.
-/// 2. Computes available margin for the vault.
-/// 3. For each trading pair, places fresh bid/ask limit orders based on the
-///    oracle price and the pair's market-making parameters.
-///
-/// Mutates: `USER_STATES[contract]`, `BIDS`, `ASKS`, `NEXT_ORDER_ID`.
-///
-/// Returns: empty `Response` (no token transfers).
-pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
+pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
     #[cfg(feature = "metrics")]
     let start = std::time::Instant::now();
 
-    let oracle_addr = oracle(ctx.querier);
-
-    // Only the oracle contract (after feeding fresh prices) or the chain owner
-    // may trigger a vault refresh. Without this check any account could consume
-    // the once-per-block refresh token on stale prices, causing the oracle's
-    // legitimate refresh submessage to be rejected.
     ensure!(
-        ctx.sender == oracle_addr || ctx.sender == ctx.querier.query_owner()?,
-        "only the oracle contract or the chain owner may refresh vault orders"
+        ctx.sender == ctx.contract || ctx.sender == ctx.querier.query_owner()?,
+        "only the perps contract itself or the chain owner may refresh vault orders"
     );
 
     ensure!(
@@ -58,15 +38,6 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
         .may_load(ctx.storage, ctx.contract)?
         .unwrap_or_default();
 
-    // --------------------- Step 0. Refresh index prices ----------------------
-
-    // Update index prices from the oracle before reading them. The oracle
-    // just fed fresh prices in the same transaction that triggered this
-    // refresh, so process_index_price will pick them up immediately.
-    let mut oracle_querier = OracleQuerier::new_remote(oracle_addr, ctx.querier);
-
-    process_index_price(ctx.storage, ctx.block.timestamp, &mut oracle_querier)?;
-
     // --------------- Step 1: Cancel all existing vault orders ----------------
 
     let CancelAllOrdersOutcome {
@@ -75,7 +46,7 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
         ctx.storage,
         ctx.contract,
         &vault_state,
-        None, // Vault order churn is not user-facing — no events emitted.
+        None,
         ReasonForOrderRemoval::Canceled,
     )?;
 
@@ -83,17 +54,12 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
 
     // ------------- Step 2: Compute the vault's available margin --------------
 
-    // Compute available margin: equity minus margin consumed by existing
-    // positions. After cancellation reserved_margin is zero, so the formula
-    // simplifies to: max(0, equity - used_margin).
     let vault_margin_value = {
         let perp_querier = NoCachePerpQuerier::new_local(ctx.storage);
         compute_available_margin(&perp_querier, &vault_state)?
     };
 
-    // If vault_total_weight is zero, no pairs have weights configured — skip.
     if param.vault_total_weight.is_zero() || !vault_margin_value.is_positive() {
-        // Persist vault state (orders were cancelled).
         if vault_state.is_empty() {
             USER_STATES.remove(ctx.storage, ctx.contract)?;
         } else {
@@ -112,19 +78,16 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
     for pair_id in &pair_ids {
         let pair_param = PAIR_PARAMS.load(ctx.storage, pair_id)?;
 
-        // Skip pairs with zero weight.
         if pair_param.vault_liquidity_weight.is_zero() {
             continue;
         }
 
         let oracle_price = PAIR_STATES.load(ctx.storage, pair_id)?.index_price;
 
-        // Compute this pair's allocated margin.
         let pair_margin = vault_margin_value
             .checked_mul(pair_param.vault_liquidity_weight)?
             .checked_div(param.vault_total_weight)?;
 
-        // Read best bid (un-inverted) and best ask from the book.
         let best_bid = BIDS
             .prefix(pair_id.clone())
             .range(ctx.storage, None, None, IterationOrder::Ascending)
@@ -139,14 +102,12 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             .transpose()?
             .map(|((stored_price, _), _)| stored_price);
 
-        // Vault's current position for this pair (zero if none).
         let position_size = vault_state
             .positions
             .get(pair_id)
             .map(|p| p.size)
             .unwrap_or(Quantity::ZERO);
 
-        // Compute vault quotes with inventory skew.
         let (bid, ask) = compute_vault_quotes(
             oracle_price,
             &pair_param,
@@ -156,7 +117,6 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             position_size,
         )?;
 
-        // Place bid order.
         if let Some(bid_quote) = bid {
             let stored_price = may_invert_price(bid_quote.price, true);
             let order = LimitOrder {
@@ -189,7 +149,6 @@ pub fn refresh_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             next_order_id.checked_add_assign(Uint64::ONE)?;
         }
 
-        // Place ask order.
         if let Some(ask_quote) = ask {
             let order = LimitOrder {
                 user: ctx.contract,
@@ -284,8 +243,6 @@ mod tests {
         }
     }
 
-    /// Build a mock querier whose `AppConfig` returns `ORACLE` as the oracle
-    /// address and whose `Config` returns `OWNER` as the chain owner.
     fn mock_querier() -> MockQuerier {
         MockQuerier::new()
             .with_app_config(AppConfig {
@@ -300,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_orders_rejects_unauthorized_sender() {
+    fn rejects_unauthorized_sender() {
         let mut ctx = MockContext::new()
             .with_querier(mock_querier())
             .with_contract(CONTRACT)
@@ -308,13 +265,13 @@ mod tests {
             .with_funds(Coins::default())
             .with_block_height(10);
 
-        refresh_orders(ctx.as_mutable()).should_fail_with_error(
-            "only the oracle contract or the chain owner may refresh vault orders",
+        refresh_vault_orders(ctx.as_mutable()).should_fail_with_error(
+            "only the perps contract itself or the chain owner may refresh vault orders",
         );
     }
 
     #[test]
-    fn refresh_orders_owner_can_trigger() {
+    fn owner_can_trigger() {
         let mut ctx = MockContext::new()
             .with_querier(mock_querier())
             .with_contract(CONTRACT)
@@ -327,34 +284,40 @@ mod tests {
             .save(&mut ctx.storage, &Default::default())
             .unwrap();
 
-        refresh_orders(ctx.as_mutable()).should_succeed();
+        refresh_vault_orders(ctx.as_mutable()).should_succeed();
     }
 
     #[test]
-    fn refresh_orders_once_per_block() {
-        // Use the contract itself as sender (self-call path).
+    fn contract_can_trigger() {
         let mut ctx = MockContext::new()
             .with_querier(mock_querier())
             .with_contract(CONTRACT)
-            .with_sender(ORACLE) // note: refreshing order is permissioned to only the oracle contract.
+            .with_sender(CONTRACT)
             .with_funds(Coins::default())
             .with_block_height(10);
 
-        // Simulate a previous successful call at block 10.
+        PARAM.save(&mut ctx.storage, &Default::default()).unwrap();
+        PAIR_IDS
+            .save(&mut ctx.storage, &Default::default())
+            .unwrap();
+
+        refresh_vault_orders(ctx.as_mutable()).should_succeed();
+    }
+
+    #[test]
+    fn once_per_block() {
+        let mut ctx = MockContext::new()
+            .with_querier(mock_querier())
+            .with_contract(CONTRACT)
+            .with_sender(CONTRACT)
+            .with_funds(Coins::default())
+            .with_block_height(10);
+
         LAST_VAULT_ORDERS_UPDATE
             .save(&mut ctx.storage, &10)
             .unwrap();
 
-        // Second call at the same block height should fail.
-        let result = refresh_orders(ctx.as_mutable());
-
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("already updated this block"),
-            "expected 'already updated this block' error"
-        );
+        refresh_vault_orders(ctx.as_mutable())
+            .should_fail_with_error("vault orders already updated this block");
     }
 }

--- a/dango/perps/src/state.rs
+++ b/dango/perps/src/state.rs
@@ -16,6 +16,8 @@ use {
 
 // --------------------------------- constants ---------------------------------
 
+pub const LAST_INDEX_PRICE_UPDATE: Item<u64> = Item::new("last_index_price_update");
+
 pub const LAST_VAULT_ORDERS_UPDATE: Item<u64> = Item::new("last_vault_orders_update");
 
 pub const PARAM: Item<Param> = Item::new("param");

--- a/dango/perps/src/vault.rs
+++ b/dango/perps/src/vault.rs
@@ -1,5 +1,4 @@
 mod add_liquidity;
-mod refresh;
 mod remove_liquidity;
 
-pub use {add_liquidity::*, refresh::*, remove_liquidity::*};
+pub use {add_liquidity::*, remove_liquidity::*};

--- a/dango/proposal-preparer/src/maker_priority_handler.rs
+++ b/dango/proposal-preparer/src/maker_priority_handler.rs
@@ -205,7 +205,7 @@ mod tests {
             constants::btc,
             perps::{
                 CancelConditionalOrderRequest, CancelOrderRequest, ExecuteMsg, MaintainerMsg,
-                ReferralMsg, SubmitOrCancelOrderRequest, SubmitOrderRequest, TraderMsg, VaultMsg,
+                ReferralMsg, SubmitOrCancelOrderRequest, SubmitOrderRequest, TraderMsg,
             },
         },
         grug_math::Uint64,
@@ -498,7 +498,8 @@ mod tests {
     // A perps Execute message whose payload is not `Trade(...)` is never
     // priority — covers all sibling variants of `ExecuteMsg`.
     #[test_case(ExecuteMsg::Maintain(MaintainerMsg::Donate {})                             => PriorityClass::Other ; "case_non_trade_maintain")]
-    #[test_case(ExecuteMsg::Vault(VaultMsg::Refresh {})                                    => PriorityClass::Other ; "case_non_trade_vault")]
+    #[test_case(ExecuteMsg::Maintain(MaintainerMsg::RefreshIndexPrices {})                 => PriorityClass::Other ; "case_non_trade_refresh_index")]
+    #[test_case(ExecuteMsg::Maintain(MaintainerMsg::RefreshVaultOrders {})                 => PriorityClass::Other ; "case_non_trade_refresh_vault")]
     #[test_case(ExecuteMsg::Referral(ReferralMsg::SetReferral { referrer: 1, referee: 2 }) => PriorityClass::Other ; "case_non_trade_referral")]
     fn priority_tx_non_trade_execute_msg(execute_msg: ExecuteMsg) -> PriorityClass {
         let tx = tx_with_messages(vec![

--- a/dango/proposal-preparer/src/pyth_handler.rs
+++ b/dango/proposal-preparer/src/pyth_handler.rs
@@ -2,6 +2,7 @@ use {
     dango_types::{
         config::AppConfig,
         oracle::{ExecuteMsg, QueryPriceSourcesRequest},
+        perps,
     },
     grug_types::{
         Addr, Coins, Json, JsonSerExt, Lengthy, Message, NonEmpty, QuerierExt, QuerierWrapper,
@@ -210,20 +211,56 @@ where
             return Ok(txs);
         };
 
-        // Build the tx and insert it at the front of the block.
-        let tx = Tx {
-            sender: cfg.addresses.oracle,
-            gas_limit: GAS_LIMIT,
-            msgs: NonEmpty::new_unchecked(vec![Message::execute(
-                cfg.addresses.oracle,
-                &ExecuteMsg::FeedPrices(price_update),
-                Coins::new(),
-            )?]),
-            data: Json::null(),
-            credential: Json::null(),
-        };
+        // Build the oracle price-feed tx and insert it at the front of the block.
+        {
+            let oracle_tx = Tx {
+                sender: cfg.addresses.oracle,
+                gas_limit: GAS_LIMIT,
+                msgs: NonEmpty::new_unchecked(vec![Message::execute(
+                    cfg.addresses.oracle,
+                    &ExecuteMsg::FeedPrices(price_update),
+                    Coins::new(),
+                )?]),
+                data: Json::null(),
+                credential: Json::null(),
+            };
 
-        txs.insert(0, tx.to_json_vec()?.into());
+            txs.insert(0, oracle_tx.to_json_vec()?.into());
+        }
+
+        // Insert perps index-price refresh transaction.
+        {
+            let index_tx = Tx {
+                sender: cfg.addresses.perps,
+                gas_limit: GAS_LIMIT,
+                msgs: NonEmpty::new_unchecked(vec![Message::execute(
+                    cfg.addresses.perps,
+                    &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+                    Coins::new(),
+                )?]),
+                data: Json::null(),
+                credential: Json::null(),
+            };
+
+            txs.insert(1, index_tx.to_json_vec()?.into());
+        }
+
+        // Insert perps vault-order refresh transaction.
+        {
+            let vault_tx = Tx {
+                sender: cfg.addresses.perps,
+                gas_limit: GAS_LIMIT,
+                msgs: NonEmpty::new_unchecked(vec![Message::execute(
+                    cfg.addresses.perps,
+                    &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
+                    Coins::new(),
+                )?]),
+                data: Json::null(),
+                credential: Json::null(),
+            };
+
+            txs.insert(2, vault_tx.to_json_vec()?.into());
+        }
 
         #[cfg(feature = "metrics")]
         histogram!("proposal_preparer.prepare_proposal.duration",)

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{OracleExt, TestAccounts, TestSuiteWithIndexer},
+    crate::{OracleExt, TestAccounts, TestSuiteNaiveWithIndexer},
     dango_genesis::Contracts,
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_types::{constants::usdc, perps},
@@ -24,7 +24,7 @@ pub struct OracleTestEntry {
 
 /// Common setup: register oracle prices + deposit margin for user1 and user2.
 pub async fn setup_perps_env(
-    suite: &mut TestSuiteWithIndexer,
+    suite: &mut TestSuiteNaiveWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
     eth_price: u128,
@@ -60,7 +60,7 @@ pub async fn setup_perps_env(
 /// Place a limit ask (user2) then a market buy (user1) to produce an
 /// `OrderFilled` at the given price and size.
 pub async fn create_perps_fill(
-    suite: &mut TestSuiteWithIndexer,
+    suite: &mut TestSuiteNaiveWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
     pair_id: &Denom,

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -31,7 +31,7 @@ pub async fn setup_perps_env(
     margin_per_user: u128,
 ) {
     suite
-        .seed_oracle_prices(&mut accounts.owner, contracts.oracle, btree_map! {
+        .seed_oracle_prices(&mut accounts.owner, btree_map! {
             usdc::DENOM.clone() => OracleTestEntry {
                 pyth_id: 1,
                 humanized_price: UsdPrice::new_int(1),

--- a/dango/testing/src/pyth.rs
+++ b/dango/testing/src/pyth.rs
@@ -2,11 +2,16 @@ use {
     crate::{OracleTestEntry, TestSuite},
     byteorder::LE,
     dango_order_book::UsdPrice,
-    dango_types::oracle::{self, PriceSource},
+    dango_types::{
+        oracle::{self, PriceSource},
+        perps,
+    },
     grug_app::{AppError, Indexer, ProposalPreparer},
     grug_db_memory::MemDb,
     grug_math::Fraction,
-    grug_types::{Addr, Binary, ByteArray, Coins, Denom, NonEmpty, ResultExt, Signer, Timestamp},
+    grug_types::{
+        Binary, ByteArray, Coins, Denom, Message, NonEmpty, ResultExt, Signer, Timestamp,
+    },
     grug_vm_rust::RustVm,
     identity::Identity256,
     k256::ecdsa::SigningKey,
@@ -106,17 +111,28 @@ fn timestamp_to_micros(t: Timestamp) -> u64 {
 
 #[allow(async_fn_in_trait)]
 pub trait OracleExt {
+    /// Execute an arbitrary combination of oracle and perps maintenance actions.
+    async fn do_oracle_actions(
+        &mut self,
+        owner: &mut (dyn Signer + Send + Sync),
+        do_register_price_sources: Option<BTreeMap<Denom, OracleTestEntry>>,
+        do_feed_prices: Option<(&[(PythId, UsdPrice, MarketSession)], Timestamp)>,
+        do_refresh_index_prices: bool,
+        do_refresh_vault_orders: bool,
+    );
+
+    /// Register price sources, feed initial prices, and refresh index prices
+    /// and vault orders.
     async fn seed_oracle_prices(
         &mut self,
         owner: &mut (dyn Signer + Send + Sync),
-        oracle: Addr,
         entries: BTreeMap<Denom, OracleTestEntry>,
     );
 
+    /// Feed prices and refresh index prices and vault orders.
     async fn feed_oracle_prices(
         &mut self,
         owner: &mut (dyn Signer + Send + Sync),
-        oracle: Addr,
         feeds: &[(PythId, UsdPrice, MarketSession)],
         timestamp: Option<Timestamp>,
     );
@@ -128,57 +144,107 @@ where
     ID: Indexer,
     AppError: From<<PP as ProposalPreparer>::Error>,
 {
+    async fn do_oracle_actions(
+        &mut self,
+        owner: &mut (dyn Signer + Send + Sync),
+        do_register_price_sources: Option<BTreeMap<Denom, OracleTestEntry>>,
+        do_feed_prices: Option<(&[(PythId, UsdPrice, MarketSession)], Timestamp)>,
+        do_refresh_index_prices: bool,
+        do_refresh_vault_orders: bool,
+    ) {
+        if let Some(entries) = do_register_price_sources {
+            let price_sources: BTreeMap<Denom, PriceSource> = entries
+                .iter()
+                .map(|(denom, e)| {
+                    (denom.clone(), PriceSource {
+                        id: e.pyth_id,
+                        channel: Channel::RealTime,
+                    })
+                })
+                .collect();
+
+            self.execute(
+                owner,
+                self.contracts.oracle,
+                &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
+                Coins::new(),
+            )
+            .await
+            .should_succeed();
+        }
+
+        let mut msgs = Vec::new();
+
+        if let Some((feeds, timestamp)) = do_feed_prices {
+            let signer = MockPythSigner::new();
+            let message = signer.sign_prices(feeds, timestamp);
+
+            msgs.push(
+                Message::execute(
+                    self.contracts.oracle,
+                    &oracle::ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message])),
+                    Coins::new(),
+                )
+                .unwrap(),
+            );
+        }
+
+        if do_refresh_index_prices {
+            msgs.push(
+                Message::execute(
+                    self.contracts.perps,
+                    &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+                    Coins::new(),
+                )
+                .unwrap(),
+            );
+        }
+
+        if do_refresh_vault_orders {
+            msgs.push(
+                Message::execute(
+                    self.contracts.perps,
+                    &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
+                    Coins::new(),
+                )
+                .unwrap(),
+            );
+        }
+
+        if !msgs.is_empty() {
+            let msgs = NonEmpty::new_unchecked(msgs);
+            self.send_messages(owner, msgs).await.should_succeed();
+        }
+    }
+
     async fn seed_oracle_prices(
         &mut self,
         owner: &mut (dyn Signer + Send + Sync),
-        oracle: Addr,
         entries: BTreeMap<Denom, OracleTestEntry>,
     ) {
-        let price_sources: BTreeMap<Denom, PriceSource> = entries
-            .iter()
-            .map(|(denom, e)| {
-                (denom.clone(), PriceSource {
-                    id: e.pyth_id,
-                    channel: Channel::RealTime,
-                })
-            })
-            .collect();
-
-        self.execute(
-            owner,
-            oracle,
-            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
-            Coins::new(),
-        )
-        .await
-        .should_succeed();
-
         let feeds: Vec<_> = entries
             .values()
             .map(|e| (e.pyth_id, e.humanized_price, MarketSession::Regular))
             .collect();
 
-        self.feed_oracle_prices(owner, oracle, &feeds, None).await;
+        self.do_oracle_actions(
+            owner,
+            Some(entries),
+            Some((&feeds, Timestamp::MAX)),
+            true,
+            true,
+        )
+        .await;
     }
 
     async fn feed_oracle_prices(
         &mut self,
         owner: &mut (dyn Signer + Send + Sync),
-        oracle: Addr,
         feeds: &[(PythId, UsdPrice, MarketSession)],
         timestamp: Option<Timestamp>,
     ) {
-        let signer = MockPythSigner::new();
         let timestamp = timestamp.unwrap_or(Timestamp::MAX);
-        let message = signer.sign_prices(feeds, timestamp);
-
-        self.execute(
-            owner,
-            oracle,
-            &oracle::ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message])),
-            Coins::new(),
-        )
-        .await
-        .should_succeed();
+        self.do_oracle_actions(owner, None, Some((feeds, timestamp)), true, true)
+            .await;
     }
 }

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -46,7 +46,7 @@ impl TestOption {
     pub fn with_mocked_clickhouse(self) -> Self {
         Self {
             mocked_clickhouse: true,
-            ..Self::default()
+            ..self
         }
     }
 
@@ -59,6 +59,7 @@ impl TestOption {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock before unix epoch")
             .as_secs();
+
         Self {
             genesis_block: BlockInfo {
                 timestamp: Timestamp::from_seconds(now_secs as u128),
@@ -187,10 +188,7 @@ pub async fn setup_test_naive_with_indexer(
 ) {
     setup_test_with_indexer_pp_and_custom_genesis(
         NaiveProposalPreparer,
-        TestOption {
-            mocked_clickhouse: true,
-            ..test_opt
-        },
+        test_opt,
         GenesisOption::preset_test(),
     )
     .await
@@ -239,7 +237,7 @@ pub async fn setup_test_with_indexer_and_custom_genesis(
     .await
 }
 
-async fn setup_test_with_indexer_pp_and_custom_genesis<PP>(
+pub async fn setup_test_with_indexer_pp_and_custom_genesis<PP>(
     pp: PP,
     options: TestOption,
     genesis_opt: GenesisOption,

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -477,6 +477,7 @@ where
         pp,
         indexer,
         None, // TODO: support customizing upgrade handler in tests
+        contracts.clone(),
         test_opt.chain_id,
         test_opt.block_time,
         test_opt.default_gas_limit,

--- a/dango/testing/src/suite.rs
+++ b/dango/testing/src/suite.rs
@@ -3,6 +3,7 @@ use {
         BalanceTracker, InstantiateOutcome, MakeBlockOutcome, UploadAndInstantiateOutcome,
         UploadOutcome,
     },
+    dango_genesis::Contracts,
     error_backtrace::Backtraceable,
     grug_app::{
         App, AppError, AppResult, Db, Indexer, NaiveProposalPreparer, NullIndexer,
@@ -39,6 +40,7 @@ where
     ID: Indexer,
 {
     pub app: App<DB, VM, PP, ID>,
+    pub contracts: Contracts,
     /// The chain ID can be queries from the `app`, but we internally track it in
     /// the test suite, so we don't need to query it every time we need it.
     pub chain_id: String,
@@ -55,6 +57,7 @@ where
 impl TestSuite {
     /// Create a new test suite.
     pub fn new(
+        contracts: Contracts,
         chain_id: String,
         block_time: Duration,
         default_gas_limit: u64,
@@ -63,6 +66,7 @@ impl TestSuite {
     ) -> Self {
         Self::new_with_vm(
             RustVm::new(),
+            contracts,
             chain_id,
             block_time,
             default_gas_limit,
@@ -81,6 +85,7 @@ where
     /// given VM.
     pub fn new_with_vm(
         vm: VM,
+        contracts: Contracts,
         chain_id: String,
         block_time: Duration,
         default_gas_limit: u64,
@@ -93,6 +98,7 @@ where
             PythProposalPreparer::new_with_cache(),
             NullIndexer,
             None,
+            contracts,
             chain_id,
             block_time,
             default_gas_limit,
@@ -111,6 +117,7 @@ where
     /// preparer.
     pub fn new_with_pp(
         pp: PP,
+        contracts: Contracts,
         chain_id: String,
         block_time: Duration,
         default_gas_limit: u64,
@@ -123,6 +130,7 @@ where
             pp,
             NullIndexer,
             None,
+            contracts,
             chain_id,
             block_time,
             default_gas_limit,
@@ -147,6 +155,7 @@ where
         pp: PP,
         mut id: ID,
         upgrade_handler: Option<UpgradeHandler<VM>>,
+        contracts: Contracts,
         chain_id: String,
         block_time: Duration,
         default_gas_limit: u64,
@@ -188,12 +197,20 @@ where
                 panic!("fatal error while initializing chain: {err}");
             });
 
-        Self::new_with_app(app, chain_id, genesis_block, block_time, default_gas_limit)
+        Self::new_with_app(
+            app,
+            contracts,
+            chain_id,
+            genesis_block,
+            block_time,
+            default_gas_limit,
+        )
     }
 
     /// Create a new test suite with the given already initialized app instance.
     pub fn new_with_app(
         app: App<DB, VM, PP, ID>,
+        contracts: Contracts,
         chain_id: String,
         last_finalized_block: BlockInfo,
         block_time: Duration,
@@ -201,6 +218,7 @@ where
     ) -> Self {
         Self {
             app,
+            contracts,
             chain_id,
             block: last_finalized_block,
             block_time,

--- a/dango/testing/tests/graphql/block.rs
+++ b/dango/testing/tests/graphql/block.rs
@@ -14,8 +14,11 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_blocks() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -41,8 +44,11 @@ async fn graphql_returns_blocks() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_batched_blocks() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -72,8 +78,11 @@ async fn graphql_returns_batched_blocks() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_block() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -99,8 +108,11 @@ async fn graphql_returns_block() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_last_block() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -126,8 +138,11 @@ async fn graphql_returns_last_block() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_paginate_blocks() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 10).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        10,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -202,7 +217,11 @@ async fn graphql_paginate_blocks() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_subscribe_to_block() -> anyhow::Result<()> {
     let (mut suite, mut accounts, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+        setup_test_naive_with_indexer_and_create_blocks(
+            TestOption::default().with_mocked_clickhouse(),
+            1,
+        )
+        .await;
 
     // Use typed subscription from indexer-graphql-types
     let request_body = GraphQLCustomRequest::from_query_body(

--- a/dango/testing/tests/graphql/datetime.rs
+++ b/dango/testing/tests/graphql/datetime.rs
@@ -9,8 +9,11 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_iso_8601() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 

--- a/dango/testing/tests/graphql/event.rs
+++ b/dango/testing/tests/graphql/event.rs
@@ -18,8 +18,11 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_events() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -45,8 +48,11 @@ async fn graphql_returns_events() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_events_transaction_hashes() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -80,8 +86,11 @@ async fn graphql_returns_events_transaction_hashes() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_paginate_events() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 10).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        10,
+    )
+    .await;
 
     let events_total_count = indexer_sql::entity::events::Entity::find()
         .count(&httpd_context.db)
@@ -176,7 +185,11 @@ async fn graphql_paginate_events() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_subscribe_to_events() -> anyhow::Result<()> {
     let (mut suite, mut accounts, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+        setup_test_naive_with_indexer_and_create_blocks(
+            TestOption::default().with_mocked_clickhouse(),
+            1,
+        )
+        .await;
 
     // Use typed subscription from indexer-graphql-types
     let request_body = GraphQLCustomRequest::from_query_body(
@@ -256,8 +269,11 @@ async fn graphql_subscribe_to_events() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_nested_events() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 

--- a/dango/testing/tests/graphql/grug.rs
+++ b/dango/testing/tests/graphql/grug.rs
@@ -31,8 +31,11 @@ struct RequesterIpGraphqlResponse {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_query_app() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let body_request = Query::AppConfig(QueryAppConfigRequest {}).to_json_value()?;
 
@@ -71,7 +74,11 @@ async fn graphql_returns_query_app() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_subscribe_to_query_app() -> anyhow::Result<()> {
     let (mut suite, mut accounts, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+        setup_test_naive_with_indexer_and_create_blocks(
+            TestOption::default().with_mocked_clickhouse(),
+            1,
+        )
+        .await;
 
     let user2_addr = accounts.user2.address();
 
@@ -173,7 +180,7 @@ async fn graphql_subscribe_to_query_app() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_requester_ip() -> anyhow::Result<()> {
     let (_, _, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -213,7 +220,7 @@ async fn graphql_returns_requester_ip() -> anyhow::Result<()> {
 async fn graphql_prefers_cf_connecting_ip_when_forwarded_headers_are_proxy_hops()
 -> anyhow::Result<()> {
     let (_, _, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let local_set = tokio::task::LocalSet::new();
 

--- a/dango/testing/tests/graphql/message.rs
+++ b/dango/testing/tests/graphql/message.rs
@@ -14,8 +14,11 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_messages() -> anyhow::Result<()> {
-    let (_, accounts, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, accounts, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let sender_addr = accounts.user1.address().to_string();
 
@@ -47,8 +50,11 @@ async fn graphql_returns_messages() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_paginate_messages() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 10).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        10,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -123,7 +129,11 @@ async fn graphql_paginate_messages() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_subscribe_to_messages() -> anyhow::Result<()> {
     let (mut suite, mut accounts, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+        setup_test_naive_with_indexer_and_create_blocks(
+            TestOption::default().with_mocked_clickhouse(),
+            1,
+        )
+        .await;
 
     let owner_addr = accounts.user1.address().to_string();
 

--- a/dango/testing/tests/graphql/transaction.rs
+++ b/dango/testing/tests/graphql/transaction.rs
@@ -26,8 +26,11 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_last_block_transactions() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -57,8 +60,11 @@ async fn graphql_returns_last_block_transactions() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_returns_transactions() -> anyhow::Result<()> {
-    let (_, accounts, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, accounts, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let sender_addr = accounts.user1.address().to_string();
 
@@ -90,8 +96,11 @@ async fn graphql_returns_transactions() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_paginate_transactions() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 10).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        10,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -166,7 +175,11 @@ async fn graphql_paginate_transactions() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_subscribe_to_transactions() -> anyhow::Result<()> {
     let (mut suite, mut accounts, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+        setup_test_naive_with_indexer_and_create_blocks(
+            TestOption::default().with_mocked_clickhouse(),
+            1,
+        )
+        .await;
 
     // Use typed subscription from indexer-graphql-types
     let request_body = GraphQLCustomRequest::from_query_body(

--- a/dango/testing/tests/httpd/perps_candles.rs
+++ b/dango/testing/tests/httpd/perps_candles.rs
@@ -3,7 +3,7 @@ use {
     dango_testing::{
         GraphQLCustomRequest, TestOption, build_app_service, call_graphql_query_with_context,
         call_ws_graphql_stream, create_perps_fill, pair_id, parse_graphql_subscription_response,
-        setup_perps_env, setup_test_with_indexer,
+        setup_perps_env, setup_test_naive_with_indexer,
     },
     graphql_client::GraphQLQuery,
     grug_app::Indexer,
@@ -22,7 +22,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_candles() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
@@ -71,7 +71,7 @@ async fn query_perps_candles() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn graphql_subscribe_to_perps_candles() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 

--- a/dango/testing/tests/httpd/perps_events.rs
+++ b/dango/testing/tests/httpd/perps_events.rs
@@ -2,7 +2,7 @@ use {
     assertor::*,
     dango_testing::{
         TestOption, call_graphql_query_with_context, create_perps_fill, pair_id, setup_perps_env,
-        setup_test_with_indexer,
+        setup_test_naive_with_indexer,
     },
     graphql_client::GraphQLQuery,
     grug_app::Indexer,
@@ -15,7 +15,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_events_user_lifecycle() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     let pair = pair_id();
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;

--- a/dango/testing/tests/httpd/perps_pair_stats.rs
+++ b/dango/testing/tests/httpd/perps_pair_stats.rs
@@ -1,7 +1,7 @@
 use {
     dango_testing::{
         TestOption, call_graphql_query_with_context, create_perps_fill, pair_id, setup_perps_env,
-        setup_test_with_indexer,
+        setup_test_naive_with_indexer,
     },
     graphql_client::GraphQLQuery,
     grug_app::Indexer,
@@ -14,7 +14,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_pair_stats() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     let pair = pair_id();
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
@@ -72,7 +72,7 @@ async fn query_perps_pair_stats() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_pair_stats_nonexistent_pair() -> anyhow::Result<()> {
     let (suite, _, _, _, _, dango_httpd_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     suite.app.indexer.wait_for_finish().await?;
 
@@ -110,7 +110,7 @@ async fn query_perps_pair_stats_nonexistent_pair() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_all_perps_pair_stats() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     let pair = pair_id();
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
@@ -162,7 +162,7 @@ async fn query_all_perps_pair_stats() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_perps_pair_stats_partial_fields() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default().with_recent_genesis()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_recent_genesis()).await;
 
     let pair = pair_id();
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;

--- a/dango/testing/tests/indexer_infra/api.rs
+++ b/dango/testing/tests/indexer_infra/api.rs
@@ -23,8 +23,11 @@ struct RequesterIpResponse {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn up_returns_200() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -53,8 +56,11 @@ async fn up_returns_200() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn api_returns_block() -> anyhow::Result<()> {
-    let (_, _, httpd_context, _db_guard) =
-        setup_test_naive_with_indexer_and_create_blocks(TestOption::default(), 1).await;
+    let (_, _, httpd_context, _db_guard) = setup_test_naive_with_indexer_and_create_blocks(
+        TestOption::default().with_mocked_clickhouse(),
+        1,
+    )
+    .await;
 
     let local_set = tokio::task::LocalSet::new();
 
@@ -98,7 +104,7 @@ async fn api_returns_block() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn requester_ip_returns_forwarded_client_ip() -> anyhow::Result<()> {
     let (_, _, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let local_set = tokio::task::LocalSet::new();
 

--- a/dango/testing/tests/indexer_infra/hooked.rs
+++ b/dango/testing/tests/indexer_infra/hooked.rs
@@ -18,7 +18,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_block() {
     let (mut suite, mut accounts, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let to = accounts.owner.address();
 
@@ -79,7 +79,7 @@ async fn index_block() {
 #[tokio::test(flavor = "multi_thread")]
 async fn parse_previous_block_after_restart() {
     let (mut suite, mut accounts, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let to = accounts.owner.address();
 
@@ -175,7 +175,7 @@ async fn parse_previous_block_after_restart() {
 #[tokio::test(flavor = "multi_thread")]
 async fn no_sql_index_error_after_restart() {
     let (mut suite, mut accounts, _, _, _, httpd_context, cache_context, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let to = accounts.owner.address();
 
@@ -288,7 +288,7 @@ async fn no_sql_index_error_after_restart() {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_block_events() {
     let (mut suite, mut accounts, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let replier_code = ContractBuilder::new(Box::new(replier::instantiate))
         .with_execute(Box::new(replier::execute))

--- a/dango/testing/tests/indexer_infra/sql.rs
+++ b/dango/testing/tests/indexer_infra/sql.rs
@@ -17,7 +17,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_block() {
     let (mut suite, mut accounts, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let to = accounts.owner.address();
 
@@ -78,7 +78,7 @@ async fn index_block() {
 #[tokio::test(flavor = "multi_thread")]
 async fn parse_previous_block_after_restart() {
     let (mut suite, mut accounts, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let to = accounts.owner.address();
 
@@ -163,7 +163,7 @@ async fn parse_previous_block_after_restart() {
 #[tokio::test(flavor = "multi_thread")]
 async fn no_sql_index_error_after_restart() {
     let (mut suite, mut accounts, _, _, _, httpd_context, cache_context, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let to = accounts.owner.address();
 
@@ -404,7 +404,7 @@ pub mod replier {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_block_events() {
     let (mut suite, mut accounts, _, _, _, httpd_context, _, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     let replier_code = ContractBuilder::new(Box::new(replier::instantiate))
         .with_execute(Box::new(replier::execute))
@@ -491,7 +491,7 @@ async fn index_block_events() {
 #[tokio::test(flavor = "multi_thread")]
 async fn blocks_on_disk_compressed() {
     let (mut suite, mut accounts, _, _, _, _, cache_context, _, _db_guard) =
-        setup_test_naive_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
 
     // Just create a block.
     let replier_code = ContractBuilder::new(Box::new(replier::instantiate))

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -3,9 +3,9 @@ use {
     dango_genesis::Contracts,
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_testing::{
-        OracleExt, OracleTestEntry, Preset, TestAccounts, TestOption, TestSuiteWithIndexer,
-        create_perps_fill, pair_id, setup_perps_env, setup_test_with_indexer,
-        setup_test_with_indexer_and_custom_genesis,
+        OracleExt, OracleTestEntry, Preset, TestAccounts, TestOption, TestSuiteNaiveWithIndexer,
+        create_perps_fill, pair_id, setup_perps_env, setup_test_naive_with_indexer,
+        setup_test_with_indexer_pp_and_custom_genesis,
     },
     dango_types::{
         constants::usdc,
@@ -28,7 +28,7 @@ use {
 
 /// Place a resting limit ask for user2 (no immediate fill).
 async fn place_limit_ask(
-    suite: &mut TestSuiteWithIndexer,
+    suite: &mut TestSuiteNaiveWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
     price: u128,
@@ -58,7 +58,7 @@ async fn place_limit_ask(
 
 /// Submit a market buy for user1 (crosses resting asks).
 async fn market_buy(
-    suite: &mut TestSuiteWithIndexer,
+    suite: &mut TestSuiteNaiveWithIndexer,
     accounts: &mut TestAccounts,
     contracts: &Contracts,
     size: u128,
@@ -125,7 +125,7 @@ fn assert_candle_continuity(candles: &[PerpsCandle]) {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_basic() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
@@ -169,7 +169,7 @@ async fn index_perps_candles_basic() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_multiple_fills_same_block() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 
@@ -212,7 +212,7 @@ async fn index_perps_candles_multiple_fills_same_block() -> anyhow::Result<()> {
 async fn index_perps_candles_changing_prices() -> anyhow::Result<()> {
     // Default block time is 250ms, so all fills land in the same second/minute.
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
@@ -247,7 +247,8 @@ async fn index_perps_candles_changing_prices() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_across_minute_boundary() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer_and_custom_genesis(
+        setup_test_with_indexer_pp_and_custom_genesis(
+            grug_app::NaiveProposalPreparer,
             TestOption {
                 block_time: Duration::from_seconds(20),
                 genesis_block: BlockInfo {
@@ -308,7 +309,7 @@ async fn index_perps_candles_across_minute_boundary() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_many_fills_one_minute() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
@@ -353,7 +354,7 @@ async fn index_perps_candles_many_fills_one_minute() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_cache_consistency() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
@@ -390,7 +391,7 @@ async fn index_perps_candles_cache_consistency() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_one_second_interval() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 50_000).await;
 
@@ -443,7 +444,8 @@ async fn index_perps_candles_one_second_interval() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_full_timeline() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer_and_custom_genesis(
+        setup_test_with_indexer_pp_and_custom_genesis(
+            grug_app::NaiveProposalPreparer,
             TestOption {
                 block_time: Duration::from_seconds(10),
                 genesis_block: BlockInfo {
@@ -581,7 +583,7 @@ async fn index_perps_candles_full_timeline() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     let eth_pair = pair_id(); // perp/ethusd
     let btc_pair: Denom = "perp/btcusd".parse().unwrap();
@@ -723,7 +725,8 @@ async fn index_perps_candles_preload_rebuilds_current_bucket_from_clickhouse() -
     let genesis_secs = chrono::Utc::now().timestamp() as u128 - 3_600;
 
     let (mut suite, mut accounts, _, contracts, _, _, _, clickhouse_context, _db_guard) =
-        setup_test_with_indexer_and_custom_genesis(
+        setup_test_with_indexer_pp_and_custom_genesis(
+            grug_app::NaiveProposalPreparer,
             TestOption {
                 genesis_block: BlockInfo {
                     height: 0,

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -588,7 +588,7 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
 
     // Register oracle prices for both pairs.
     suite
-        .seed_oracle_prices(&mut accounts.owner, contracts.oracle, btree_map! {
+        .seed_oracle_prices(&mut accounts.owner, btree_map! {
             usdc::DENOM.clone() => OracleTestEntry {
                 pyth_id: 1,
                 humanized_price: UsdPrice::new_int(1),

--- a/dango/testing/tests/indexing/perps_events.rs
+++ b/dango/testing/tests/indexing/perps_events.rs
@@ -1,7 +1,7 @@
 use {
     assertor::*,
     dango_testing::{
-        TestOption, create_perps_fill, pair_id, setup_perps_env, setup_test_with_indexer,
+        TestOption, create_perps_fill, pair_id, setup_perps_env, setup_test_naive_with_indexer,
     },
     grug_app::Indexer,
     indexer_sql::entity,
@@ -11,7 +11,7 @@ use {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_perps_events() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, dango_context, _, _, _db_guard) =
-        setup_test_with_indexer(TestOption::default()).await;
+        setup_test_naive_with_indexer(TestOption::default()).await;
 
     setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
 

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -73,7 +73,7 @@ async fn adl_bug_absurd_book_price() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Oracle = $2,000.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -248,7 +248,7 @@ async fn adl_bug_absurd_book_price() {
     //   → close entire SHORT position
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_300).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_300).await;
 
     // -------------------------------------------------------------------------
     // Step 5: Liquidate user1.

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -55,7 +55,7 @@ fn limit_ask(price: i128, size: i128, cid: Option<u64>) -> SubmitOrderRequest {
 #[tokio::test]
 async fn batch_submit_then_cancel() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -105,7 +105,7 @@ async fn batch_submit_then_cancel() {
 #[tokio::test]
 async fn batch_atomic_replace() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -178,7 +178,7 @@ async fn batch_atomic_replace() {
 #[tokio::test]
 async fn batch_reuse_client_order_id() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let cid = 42u64;
 
@@ -242,7 +242,7 @@ async fn batch_reuse_client_order_id() {
 #[tokio::test]
 async fn batch_atomicity_on_submit_failure() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -307,7 +307,7 @@ async fn batch_atomicity_on_submit_failure() {
 #[tokio::test]
 async fn batch_atomicity_on_cancel_failure() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -378,7 +378,7 @@ async fn batch_atomicity_on_cancel_failure() {
 #[tokio::test]
 async fn batch_fill_reverts_on_later_failure() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // Both users deposit margin.
     for user in [&mut accounts.user1, &mut accounts.user2] {
@@ -512,7 +512,7 @@ async fn batch_fill_reverts_on_later_failure() {
 #[tokio::test]
 async fn batch_single_action() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -553,7 +553,7 @@ async fn batch_single_action() {
 #[tokio::test]
 async fn batch_size_cap_enforced() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // Lower the cap to 3.
     suite
@@ -652,7 +652,7 @@ async fn batch_across_two_pairs() {
 
     // Register oracle prices for both pairs (plus USDC for settlement).
     suite
-        .seed_oracle_prices(&mut accounts.owner, contracts.oracle, btree_map! {
+        .seed_oracle_prices(&mut accounts.owner, btree_map! {
             usdc::DENOM.clone() => OracleTestEntry {
                 pyth_id: 1,
                 humanized_price: UsdPrice::new_int(1),
@@ -761,7 +761,7 @@ async fn batch_across_two_pairs() {
 #[tokio::test]
 async fn batch_stp_fires_for_self_match() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -846,7 +846,7 @@ async fn batch_stp_fires_for_self_match() {
 #[tokio::test]
 async fn batch_cancel_fails_for_filled_order() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -962,7 +962,7 @@ async fn batch_cancel_fails_for_filled_order() {
 #[tokio::test]
 async fn batch_referral_commissions_rollback() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // user1 activates their referrer slot by setting a fee share
     // ratio; user2 then points to user1 as their referrer.

--- a/dango/testing/tests/perps/client_order_id.rs
+++ b/dango/testing/tests/perps/client_order_id.rs
@@ -21,7 +21,7 @@ use {
 async fn submit_cancel_resubmit_by_client_order_id() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
     let cid: ClientOrderId = Uint64::new(42);
@@ -132,7 +132,7 @@ async fn submit_cancel_resubmit_by_client_order_id() {
 async fn cancel_by_unknown_client_order_id_fails() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -23,7 +23,7 @@ use {
 async fn conditional_order_tp_triggers_on_price_rise() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -159,7 +159,7 @@ async fn conditional_order_tp_triggers_on_price_rise() {
         .should_succeed();
 
     // Step 7: Oracle updated to $2,500.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_500).await;
 
     // Step 8: Advance time so perps cron fires (interval = 1 min).
     suite.increase_time(Duration::from_minutes(2)).await;
@@ -199,7 +199,7 @@ async fn conditional_order_tp_triggers_on_price_rise() {
 async fn conditional_order_sl_triggers_on_price_drop() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -305,7 +305,7 @@ async fn conditional_order_sl_triggers_on_price_drop() {
         .should_succeed();
 
     // Step 4: Oracle drops to $1,800, advance time so perps cron fires.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_800).await;
     suite.increase_time(Duration::from_minutes(2)).await;
 
     // Step 5: Verify trader state — position closed, PnL = 5*($1,800-$2,000) = -$1,000.
@@ -350,7 +350,7 @@ async fn conditional_order_sl_triggers_on_price_drop() {
 async fn conditional_orders_follow_price_time_priority() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -559,7 +559,7 @@ async fn conditional_orders_follow_price_time_priority() {
     // Both $1,790 and $1,770 are above $1,764 → within tolerance.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_800).await;
     suite.increase_time(Duration::from_minutes(2)).await;
 
     // -------------------------------------------------------------------------
@@ -628,7 +628,7 @@ async fn conditional_orders_follow_price_time_priority() {
 async fn conditional_order_failure_does_not_block_others() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -857,7 +857,7 @@ async fn conditional_order_failure_does_not_block_others() {
     //      → succeeds.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_800).await;
     suite.increase_time(Duration::from_minutes(2)).await;
 
     // -------------------------------------------------------------------------
@@ -933,7 +933,7 @@ async fn conditional_order_failure_does_not_block_others() {
 async fn conditional_order_self_trade_failure_preserves_user_state() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1060,7 +1060,7 @@ async fn conditional_order_self_trade_failure_preserves_user_state() {
     // memory, `match_order` has no more liquidity, `ensure!` fails, and
     // `process_triggered_order` gracefully cancels the conditional order via
     // `SlippageExceeded`.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_960).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_960).await;
     suite.increase_time(Duration::from_minutes(2)).await;
 
     // --- Post-trigger assertions ---
@@ -1159,7 +1159,7 @@ async fn child_order_market_with_tp_triggers() {
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // Deposit for user1 (trader) and user2 (maker).
     for user in [&mut accounts.user1, &mut accounts.user2] {
@@ -1233,7 +1233,7 @@ async fn child_order_market_with_tp_triggers() {
     assert!(pos.conditional_order_below.is_none(), "no SL");
 
     // Oracle rises to $2,500 → trigger TP.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_500).await;
 
     // Maker places bid to fill the TP market sell.
     suite
@@ -1284,7 +1284,7 @@ async fn child_order_market_with_sl_triggers() {
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -1357,7 +1357,7 @@ async fn child_order_market_with_sl_triggers() {
     assert!(pos.conditional_order_above.is_none(), "no TP");
 
     // Oracle drops to $1,800 → trigger SL.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_800).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_800).await;
 
     // Maker places bid to fill SL.
     suite
@@ -1405,7 +1405,7 @@ async fn child_order_ignored_when_position_closed() {
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -1528,7 +1528,7 @@ async fn child_order_overwrites_existing() {
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     for user in [&mut accounts.user1, &mut accounts.user2] {
         suite
@@ -1653,7 +1653,7 @@ async fn conditional_order_overwrite_same_direction() {
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -1773,7 +1773,7 @@ async fn conditional_order_size_exceeds_position_allowed() {
         setup_test_naive(TestOption::default());
 
     let pair = pair_id();
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     suite
         .execute(
@@ -1876,7 +1876,7 @@ async fn conditional_order_size_exceeds_position_allowed() {
 async fn conditional_order_cancelled_when_slippage_cap_tightened() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -2023,7 +2023,7 @@ async fn conditional_order_cancelled_when_slippage_cap_tightened() {
         .should_succeed();
 
     // Oracle rises to the TP trigger.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_500).await;
 
     // Advance time so the perps cron fires.
     suite.increase_time(Duration::from_minutes(2)).await;
@@ -2057,7 +2057,7 @@ async fn conditional_order_cancelled_when_slippage_cap_tightened() {
 async fn conditional_order_trigger_fills_carry_fill_id() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -2163,7 +2163,7 @@ async fn conditional_order_trigger_fills_carry_fill_id() {
     // Move oracle above the TP trigger and advance time to fire cron.
     // `increase_time` discards the block outcome, so inline its body to
     // keep access to the cron-emitted events.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_500).await;
 
     let old_block_time = suite.block_time;
     suite.block_time = Duration::from_minutes(2);
@@ -2217,7 +2217,7 @@ async fn conditional_order_trigger_fills_carry_fill_id() {
 async fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -2344,7 +2344,7 @@ async fn two_conditional_triggers_in_one_cron_tick_have_consecutive_fill_ids() {
     }
 
     // Move the oracle so both TPs trigger, then fire cron.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_500).await;
 
     let old_block_time = suite.block_time;
     suite.block_time = Duration::from_minutes(2);

--- a/dango/testing/tests/perps/index_price.rs
+++ b/dango/testing/tests/perps/index_price.rs
@@ -32,7 +32,7 @@ async fn query_index_price(
 async fn e1_basic_snap() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let index = query_index_price(&suite, contracts.perps).await;
     assert_eq!(index, UsdPrice::new_int(2_000));
@@ -48,7 +48,7 @@ async fn e2_close_drift_reopen() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Step 1: Feed Regular@2000. After this block, index = 2000.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let index_before = query_index_price(&suite, contracts.perps).await;
     assert_eq!(index_before, UsdPrice::new_int(2_000));
@@ -124,7 +124,6 @@ async fn e2_close_drift_reopen() {
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(ETH_PYTH_ID, UsdPrice::new_int(2_000), MarketSession::Other)],
             None,
         )
@@ -149,7 +148,6 @@ async fn e2_close_drift_reopen() {
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(
                 ETH_PYTH_ID,
                 UsdPrice::new_int(2_005),
@@ -175,13 +173,12 @@ async fn e3_stale_regular_triggers_ewma() {
     suite.block_time = Duration::from_millis(100);
 
     // Seed oracle price sources first.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // Re-feed with an explicit (non-MAX) timestamp.
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(
                 ETH_PYTH_ID,
                 UsdPrice::new_int(2_000),
@@ -214,13 +211,12 @@ async fn e3_stale_regular_triggers_ewma() {
 async fn e5_empty_book_closed_market_no_movement() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // Switch to Other session (market closed).
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(ETH_PYTH_ID, UsdPrice::new_int(2_000), MarketSession::Other)],
             None,
         )
@@ -246,7 +242,7 @@ async fn e5_empty_book_closed_market_no_movement() {
 async fn e6_oracle_flapping() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // Deposit and place orders so EWMA has something to drift toward.
     suite
@@ -290,7 +286,6 @@ async fn e6_oracle_flapping() {
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(ETH_PYTH_ID, UsdPrice::new_int(2_000), MarketSession::Other)],
             None,
         )
@@ -309,7 +304,6 @@ async fn e6_oracle_flapping() {
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(
                 ETH_PYTH_ID,
                 UsdPrice::new_int(2_001),
@@ -326,7 +320,6 @@ async fn e6_oracle_flapping() {
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(ETH_PYTH_ID, UsdPrice::new_int(2_001), MarketSession::Other)],
             None,
         )
@@ -344,7 +337,6 @@ async fn e6_oracle_flapping() {
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(
                 ETH_PYTH_ID,
                 UsdPrice::new_int(1_999),

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -62,7 +62,7 @@ async fn liquidation_on_order_book() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -189,7 +189,7 @@ async fn liquidation_on_order_book() {
     // MM = 5 * $1,450 * 5% = $362.50; equity < MM -> liquidatable.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_450).await;
 
     // -------------------------------------------------------------------------
     // Step 5: Bidder (user3) deposits $10,000 USDC and places bid: 5 ETH @ $1,450.
@@ -354,7 +354,7 @@ async fn liquidation_on_order_book() {
 async fn liquidation_snaps_to_full_close_when_remainder_would_be_dust() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -478,7 +478,7 @@ async fn liquidation_snaps_to_full_close_when_remainder_would_be_dust() {
     // test: equity $240, MM $362.50, deficit $122.50).
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_450).await;
 
     // -------------------------------------------------------------------------
     // Bidder (user3) posts a 5 ETH bid @ $1,450 ($7,250 notional > $5,000 min).
@@ -606,7 +606,7 @@ async fn liquidation_with_adl() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -793,7 +793,7 @@ async fn liquidation_with_adl() {
     // PnL = 5 * ($1,450 - $2,000) = -$2,750; equity = $1,090 - $2,750 = -$1,660.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_450).await;
 
     // -------------------------------------------------------------------------
     // Step 9: Liquidate Trader A.
@@ -947,7 +947,7 @@ async fn liquidation_with_adl() {
 async fn liquidation_cancels_conditional_orders() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1088,7 +1088,7 @@ async fn liquidation_cancels_conditional_orders() {
     );
 
     // Step 4: Oracle drops to $1,450.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_450).await;
 
     // Step 5: Bidder (user3) deposits and places bid: 5 ETH @ $1,450.
     suite
@@ -1196,7 +1196,7 @@ async fn vault_liquidation_on_order_book() {
 
     let pair = pair_id();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // -------------------------------------------------------------------------
     // Step 1: LP (user1) deposits $5,000 USDC and adds all as vault liquidity.
@@ -1260,7 +1260,17 @@ async fn vault_liquidation_on_order_book() {
         .execute(
             &mut accounts.owner,
             contracts.perps,
-            &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
             Coins::new(),
         )
         .await
@@ -1336,7 +1346,7 @@ async fn vault_liquidation_on_order_book() {
     //   $250 < $1,000 → liquidatable
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_600).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_600).await;
 
     // Sanity: verify vault is liquidatable (equity < MM).
     let vault_ext: perps::UserStateExtended = suite
@@ -1538,7 +1548,7 @@ async fn vault_liquidation_on_order_book() {
 async fn liquidation_book_fills_have_fill_id_adl_does_not() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1662,7 +1672,7 @@ async fn liquidation_book_fills_have_fill_id_adl_does_not() {
     // Oracle drops to $1,450. Trader A is deeply underwater and forced
     // to close the full position; equity is negative so target_price for
     // book matching is the oracle ($1,450).
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_450).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_450).await;
 
     // Partial book liquidity for the liquidation: Maker places a bid for
     // 2 ETH @ $1,450. Trader A's liquidation will fill this, then ADL

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -1,5 +1,4 @@
 use {
-    dango_genesis::Contracts,
     dango_order_book::{Dimensionless, Quantity, UsdPrice},
     dango_testing::{OracleExt, OracleTestEntry, TestAccounts, TestSuiteNaive, pair_id},
     dango_types::{
@@ -55,11 +54,10 @@ pub fn default_pair_param() -> PairParam {
 pub async fn register_oracle_prices(
     suite: &mut TestSuiteNaive,
     accounts: &mut TestAccounts,
-    contracts: &Contracts,
     eth_price: u128,
 ) {
     suite
-        .seed_oracle_prices(&mut accounts.owner, contracts.oracle, btree_map! {
+        .seed_oracle_prices(&mut accounts.owner, btree_map! {
             usdc::DENOM.clone() => OracleTestEntry {
                 pyth_id: 1,
                 humanized_price: UsdPrice::new_int(1),

--- a/dango/testing/tests/perps/price_band.rs
+++ b/dango/testing/tests/perps/price_band.rs
@@ -26,7 +26,7 @@ macro_rules! setup_band_suite {
         let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
         let pair = pair_id();
 
-        register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+        register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
         suite
             .execute(
@@ -256,7 +256,7 @@ async fn banding_drift_maker_cancelled_at_match_time() {
     // Oracle moves to $2,500 → new allowed range [$2,250, $2,750].
     //   - user1's $2,199 ask: now below the lower bound ($2,199 < $2,250).
     //     OUT of band.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_500).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_500).await;
 
     // user3 deposits and (at T2, in the new band) places a PostOnly ask
     // at $2,400 — this one stays in-band.

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -472,7 +472,7 @@ async fn set_share_ratio_aggregates_volume_across_accounts() {
         .should_succeed();
 
     // Register oracle prices: ETH = $1,000.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_000).await;
 
     // Create a second account for user1 (same user_index, different address).
     let mut user1_account2 = accounts
@@ -538,7 +538,7 @@ async fn set_share_ratio_aggregates_volume_across_accounts() {
 async fn referral_active_flag() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000).await;
@@ -701,7 +701,7 @@ async fn commission_rate_override() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
 
@@ -795,7 +795,7 @@ async fn commission_rate_override() {
 async fn referrer_stats() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
@@ -945,7 +945,7 @@ async fn commission_rate_margins() {
         .query_wasm_smart(contracts.perps, QueryParamRequest {})
         .unwrap();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // Deposit margin for user8 (maker) and all referee/referrer users.
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
@@ -1310,7 +1310,7 @@ async fn referee_count() {
 async fn active_referral() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
@@ -1401,7 +1401,7 @@ async fn active_referral() {
 async fn negative_maker_fee_does_not_debit_referrers() {
     let (mut suite, mut accounts, _, contracts, ..) = setup_test_naive(TestOption::preset_test());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1609,7 +1609,7 @@ async fn fee_distributed_event_without_referrer() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
 
@@ -1691,7 +1691,7 @@ async fn fee_distributed_event_with_referrer() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000).await;
@@ -1820,7 +1820,7 @@ async fn fee_distributed_event_with_referrer_without_share_ratio() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user8, 100_000).await;
@@ -1935,7 +1935,7 @@ async fn cr_100_direct_referrer_taker() {
         .query_wasm_smart(contracts.perps, QueryParamRequest {})
         .unwrap();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
@@ -2023,7 +2023,7 @@ async fn cr_100_indirect_referrer_taker() {
         .query_wasm_smart(contracts.perps, QueryParamRequest {})
         .unwrap();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
@@ -2204,7 +2204,7 @@ async fn cr_100_direct_referrer_maker_positive_fee() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
@@ -2314,7 +2314,7 @@ async fn cr_100_indirect_referrer_maker_positive_fee() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
@@ -2453,7 +2453,7 @@ async fn cr_100_direct_referrer_maker_rebate() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user4, 100_000).await;
@@ -2551,7 +2551,7 @@ async fn cr_100_indirect_referrer_maker_rebate() {
         .await
         .should_succeed();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user1, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user2, 100_000).await;
     deposit_margin(&mut suite, contracts.perps, &mut accounts.user3, 100_000).await;
@@ -2700,11 +2700,10 @@ fn snapshot_margins(suite: &TestSuiteNaive, perps: Addr, addrs: &[Addr]) -> Vec<
 async fn register_oracle_prices(
     suite: &mut TestSuiteNaive,
     accounts: &mut dango_testing::TestAccounts,
-    contracts: &dango_genesis::Contracts,
     eth_price: u128,
 ) {
     suite
-        .seed_oracle_prices(&mut accounts.owner, contracts.oracle, btree_map! {
+        .seed_oracle_prices(&mut accounts.owner, btree_map! {
             usdc::DENOM.clone() => OracleTestEntry {
                 pyth_id: 1,
                 humanized_price: UsdPrice::new_int(1),

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -31,7 +31,7 @@ async fn trading_lifecycle() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -218,7 +218,7 @@ async fn limit_order_partial_fill_and_cancel() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -396,7 +396,7 @@ async fn limit_order_partial_fill_and_cancel() {
 async fn liquidity_depth_tracking() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -633,7 +633,7 @@ async fn liquidity_depth_tracking() {
 async fn protocol_fee_accumulates_across_fills() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -798,7 +798,7 @@ async fn protocol_fee_accumulates_across_fills() {
 async fn negative_maker_fee_rebate_lifecycle() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -971,7 +971,7 @@ async fn negative_maker_fee_rebate_lifecycle() {
 async fn ioc_limit_order_partial_fill() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1103,7 +1103,7 @@ async fn ioc_limit_order_partial_fill() {
 async fn ioc_limit_order_no_fill_rejected() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1154,7 +1154,7 @@ macro_rules! setup_slippage_cap_suite {
         let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
         let pair = pair_id();
 
-        register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+        register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
         suite
             .execute(
@@ -1317,7 +1317,7 @@ async fn slippage_cap_does_not_affect_limit_orders() {
 async fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1463,7 +1463,7 @@ async fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
 async fn sell_side_market_order_partial_fill() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -1586,7 +1586,7 @@ async fn sell_side_market_order_partial_fill() {
 async fn buy_side_market_order_partial_fill() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -409,10 +409,17 @@ async fn vault_lp_lifecycle() {
     );
 }
 
-/// Verify that feeding Pyth prices triggers `OnOracleUpdate` (placing vault
-/// orders), and that when `OnOracleUpdate` fails the oracle price update is
-/// **not** reverted while the perps state changes from the failed call are
-/// rolled back.
+/// Verify that an oracle price update succeeds even when the perps contract
+/// is in a broken state, and that vault orders remain unchanged.
+///
+/// Under the old architecture the oracle's `FeedPrices` called perps
+/// `VaultMsg::Refresh` via a submessage with `reply_on_error`, so a perps
+/// failure had to be explicitly caught to avoid reverting the oracle update.
+/// Under the new architecture oracle feeding and perps refreshing are
+/// separate transactions injected by the proposal preparer, so a perps
+/// failure cannot affect the oracle by construction. The property this test
+/// asserts is therefore guaranteed structurally, making the test technically
+/// irrelevant, but we keep it since there is no cost.
 #[tokio::test]
 async fn oracle_triggers_on_oracle_update() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -40,7 +40,7 @@ async fn vault_lp_lifecycle() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
     // Register oracle prices: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     let pair = pair_id();
 
@@ -138,7 +138,17 @@ async fn vault_lp_lifecycle() {
         .execute(
             &mut accounts.owner,
             contracts.perps,
-            &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
             Coins::new(),
         )
         .await
@@ -228,7 +238,7 @@ async fn vault_lp_lifecycle() {
     // Step 5: Oracle → $2,200. Vault's long has unrealized profit.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_200).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_200).await;
 
     // -------------------------------------------------------------------------
     // Step 6: OnOracleUpdate at $2,200 → vault refreshes orders.
@@ -240,7 +250,17 @@ async fn vault_lp_lifecycle() {
         .execute(
             &mut accounts.owner,
             contracts.perps,
-            &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
             Coins::new(),
         )
         .await
@@ -405,7 +425,7 @@ async fn oracle_triggers_on_oracle_update() {
     // -------------------------------------------------------------------------
 
     suite
-        .seed_oracle_prices(&mut accounts.owner, contracts.oracle, btree_map! {
+        .seed_oracle_prices(&mut accounts.owner, btree_map! {
             usdc::DENOM.clone() => OracleTestEntry {
                 pyth_id: 1,
                 humanized_price: UsdPrice::new_int(1),
@@ -493,7 +513,6 @@ async fn oracle_triggers_on_oracle_update() {
     suite
         .feed_oracle_prices(
             &mut accounts.owner,
-            contracts.oracle,
             &[(2, eth_price, MarketSession::Regular)],
             Some(Timestamp::MAX - Duration::from_seconds(1)),
         )
@@ -562,8 +581,8 @@ async fn oracle_triggers_on_oracle_update() {
     assert_eq!(vo1_asks[0].size, Quantity::new_int(-2));
 
     // -------------------------------------------------------------------------
-    // Step 2: Corrupt perps PARAM storage so OnOracleUpdate will fail on the
-    // next invocation (deserialization error).
+    // Step 2: Corrupt perps PARAM storage so RefreshVaultOrders will fail on
+    // the next invocation (deserialization error).
     // -------------------------------------------------------------------------
 
     suite.app.db.with_state_storage_mut(|storage| {
@@ -573,17 +592,18 @@ async fn oracle_triggers_on_oracle_update() {
     });
 
     // -------------------------------------------------------------------------
-    // Step 3: Feed price #2. The oracle update itself succeeds (reply_on_error
-    // catches the perps failure), but OnOracleUpdate rolls back its state
-    // changes, so vault orders remain unchanged.
+    // Step 3: Feed price #2 without perps refresh. The oracle update succeeds
+    // independently. Then verify the perps refresh fails (corrupted storage)
+    // but the oracle price is still updated.
     // -------------------------------------------------------------------------
 
     suite
-        .feed_oracle_prices(
+        .do_oracle_actions(
             &mut accounts.owner,
-            contracts.oracle,
-            &[(2, eth_price, MarketSession::Regular)],
             None,
+            Some((&[(2, eth_price, MarketSession::Regular)], Timestamp::MAX)),
+            false,
+            false,
         )
         .await;
 
@@ -596,11 +616,11 @@ async fn oracle_triggers_on_oracle_update() {
 
     assert!(
         price2.timestamp >= price1.timestamp,
-        "oracle price should be updated despite OnOracleUpdate failure"
+        "oracle price should be updated despite perps failure"
     );
 
-    // Vault orders should be unchanged — the failed OnOracleUpdate rolled back
-    // any state changes it attempted (cancel + re-place). Compare order IDs to
+    // Vault orders should be unchanged — we did not call refresh, and even if
+    // we tried, it would fail on the corrupted storage. Compare order IDs to
     // prove these are the exact same orders, not new ones at the same price.
     let vault_orders_2: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
         .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
@@ -613,7 +633,7 @@ async fn oracle_triggers_on_oracle_update() {
             .keys()
             .zip(vault_orders_2.keys())
             .all(|(a, b)| a == b),
-        "order IDs should be unchanged after failed OnOracleUpdate"
+        "order IDs should be unchanged after skipped refresh"
     );
 }
 
@@ -657,7 +677,7 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
     let pair = pair_id();
 
     // Register oracle: ETH = $2,000, USDC = $1.
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // -------------------------------------------------------------------------
     // Step 1: LP (user1) deposits $5,000 USDC and adds all of it as vault
@@ -737,7 +757,17 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
         .execute(
             &mut accounts.owner,
             contracts.perps,
-            &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
             Coins::new(),
         )
         .await
@@ -816,7 +846,7 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
     //   Vault is STILL HEALTHY ($1,500 >= $1,062.50) but has $0 available.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_700).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_700).await;
 
     // Sanity check: vault should be healthy at this point.
     let vault_ext: perps::UserStateExtended = suite
@@ -865,7 +895,17 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
         .execute(
             &mut accounts.owner,
             contracts.perps,
-            &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
             Coins::new(),
         )
         .await

--- a/dango/testing/tests/perps/vault_snapshots.rs
+++ b/dango/testing/tests/perps/vault_snapshots.rs
@@ -23,7 +23,7 @@ use {
 async fn vault_snapshots_accrue_daily() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // LP deposits collateral and adds liquidity. None of these short-interval
     // blocks trigger the perps cron (interval = 1 min, block time = 250ms),

--- a/dango/testing/tests/perps/vault_withdrawal_health.rs
+++ b/dango/testing/tests/perps/vault_withdrawal_health.rs
@@ -42,7 +42,7 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
     let pair = pair_id();
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 2_000).await;
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
     // -------------------------------------------------------------------------
     // Step 1: LP (user1) deposits $5,000 USDC and adds $5,000 as vault liquidity.
@@ -116,7 +116,17 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
         .execute(
             &mut accounts.owner,
             contracts.perps,
-            &perps::ExecuteMsg::Vault(perps::VaultMsg::Refresh {}),
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
             Coins::new(),
         )
         .await
@@ -202,7 +212,7 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
     // Vault is healthy: $5,000 > $1,900.
     // -------------------------------------------------------------------------
 
-    register_oracle_prices(&mut suite, &mut accounts, &contracts, 1_900).await;
+    register_oracle_prices(&mut suite, &mut accounts, 1_900).await;
 
     let vault_ext: perps::UserStateExtended = suite
         .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {

--- a/dango/types/src/oracle/msg.rs
+++ b/dango/types/src/oracle/msg.rs
@@ -27,11 +27,6 @@ pub enum ExecuteMsg {
     FeedPrices(PriceUpdate),
 }
 
-#[grug_types::derive(Serde)]
-pub enum ReplyMsg {
-    AfterOnOracleUpdate {},
-}
-
 #[grug_types::derive(Serde, QueryRequest)]
 pub enum QueryMsg {
     /// Query Pyth Lazer trusted signers and their expiration times.
@@ -58,12 +53,4 @@ pub enum QueryMsg {
         start_after: Option<Denom>,
         limit: Option<u32>,
     },
-}
-
-/// Emitted by the oracle's reply handler when the perps vault refresh
-/// submessage fails, providing on-chain observability for monitors.
-#[grug_types::event("vault_refresh_failed")]
-#[grug_types::derive(Serde)]
-pub struct VaultRefreshFailed {
-    pub error: String,
 }

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -830,10 +830,10 @@ pub enum MaintainerMsg {
     },
 
     /// Update index prices from the latest oracle data.
-    RefreshIndexPrices,
+    RefreshIndexPrices {},
 
     /// Refresh vault market-making orders based on the current index prices.
-    RefreshVaultOrders,
+    RefreshVaultOrders {},
 }
 
 #[grug_types::derive(Serde)]

--- a/dango/types/src/perps.rs
+++ b/dango/types/src/perps.rs
@@ -828,6 +828,12 @@ pub enum MaintainerMsg {
         /// First element is maker rate, second is taker rate.
         maker_taker_fee_rates: Op<(Dimensionless, Dimensionless)>,
     },
+
+    /// Update index prices from the latest oracle data.
+    RefreshIndexPrices,
+
+    /// Refresh vault market-making orders based on the current index prices.
+    RefreshVaultOrders,
 }
 
 #[grug_types::derive(Serde)]
@@ -894,13 +900,6 @@ pub enum VaultMsg {
 
     /// Request to withdraw liquidity from the counterparty vault.
     RemoveLiquidity { shares_to_burn: Uint128 },
-
-    /// Refresh vault market-making orders. Triggered at the beginning of each
-    /// block, right after the oracle update.
-    ///
-    /// The vault places new orders based on the oracle price, the state of the
-    /// order book at the time, and its policy for market making.
-    Refresh {},
 }
 
 #[grug_types::derive(Serde)]


### PR DESCRIPTION
Split VaultMsg::Refresh into two independent MaintainerMsg variants
(RefreshIndexPrices and RefreshVaultOrders) so that a vault order
failure no longer reverts index price updates, and consumers can call
each operation independently.

The perps contract now implements authenticate_tx (Finalize-mode only),
allowing the proposal preparer to inject separate signature-less
transactions for each refresh step. The oracle no longer calls into
perps via submessage.