### PR TITLE
feat(testing): add oracle helper methods to TestSuite and MockClient

### DIFF
--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{OracleExt, TestAccounts, TestSuiteNaiveWithIndexer},
+    crate::{TestAccounts, TestSuiteNaiveWithIndexer},
     dango_genesis::Contracts,
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_types::{constants::usdc, perps},

--- a/dango/testing/src/pyth.rs
+++ b/dango/testing/src/pyth.rs
@@ -10,8 +10,8 @@ use {
     grug_db_memory::MemDb,
     grug_math::Fraction,
     grug_types::{
-        Binary, BroadcastClient, ByteArray, Coins, Denom, Message, NonEmpty, ResultExt, Signer,
-        Timestamp,
+        Addr, Binary, BroadcastClient, ByteArray, Coins, Denom, Message, NonEmpty, ResultExt,
+        Signer, Timestamp,
     },
     grug_vm_rust::RustVm,
     identity::Identity256,
@@ -109,8 +109,8 @@ fn timestamp_to_micros(t: Timestamp) -> u64 {
 }
 
 fn build_oracle_messages(
-    oracle: grug_types::Addr,
-    perps: grug_types::Addr,
+    oracle: Addr,
+    perps: Addr,
     do_feed_prices: Option<(&[(PythId, UsdPrice, MarketSession)], Timestamp)>,
     do_refresh_index_prices: bool,
     do_refresh_vault_orders: bool,
@@ -208,8 +208,7 @@ where
             do_refresh_vault_orders,
         );
 
-        if !msgs.is_empty() {
-            let msgs = NonEmpty::new_unchecked(msgs);
+        if let Ok(msgs) = NonEmpty::new(msgs) {
             self.send_messages(owner, msgs).await.should_succeed();
         }
     }
@@ -243,9 +242,14 @@ where
         feeds: &[(PythId, UsdPrice, MarketSession)],
         timestamp: Option<Timestamp>,
     ) {
-        let timestamp = timestamp.unwrap_or(Timestamp::MAX);
-        self.do_oracle_actions(owner, None, Some((feeds, timestamp)), true, true)
-            .await;
+        self.do_oracle_actions(
+            owner,
+            None,
+            Some((feeds, timestamp.unwrap_or(Timestamp::MAX))),
+            true,
+            true,
+        )
+        .await;
     }
 }
 
@@ -276,19 +280,21 @@ where
         if let Some(entries) = &do_register_price_sources {
             let price_sources = build_register_price_sources(entries);
 
-            let msg = Message::execute(
-                contracts.oracle,
-                &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
-                Coins::new(),
-            )
-            .unwrap();
             let tx = owner
                 .sign_transaction(
-                    NonEmpty::new_unchecked(vec![msg]),
+                    NonEmpty::new_unchecked(vec![
+                        Message::execute(
+                            contracts.oracle,
+                            &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
+                            Coins::new(),
+                        )
+                        .unwrap(),
+                    ]),
                     &chain_id,
                     MOCK_CLIENT_GAS_LIMIT,
                 )
                 .unwrap();
+
             self.broadcast_tx(tx)
                 .await
                 .unwrap()
@@ -304,11 +310,11 @@ where
             do_refresh_vault_orders,
         );
 
-        if !msgs.is_empty() {
-            let msgs = NonEmpty::new_unchecked(msgs);
+        if let Ok(msgs) = NonEmpty::new(msgs) {
             let tx = owner
                 .sign_transaction(msgs, &chain_id, MOCK_CLIENT_GAS_LIMIT)
                 .unwrap();
+
             self.broadcast_tx(tx)
                 .await
                 .unwrap()
@@ -346,8 +352,13 @@ where
         feeds: &[(PythId, UsdPrice, MarketSession)],
         timestamp: Option<Timestamp>,
     ) {
-        let timestamp = timestamp.unwrap_or(Timestamp::MAX);
-        self.do_oracle_actions(owner, None, Some((feeds, timestamp)), true, true)
-            .await;
+        self.do_oracle_actions(
+            owner,
+            None,
+            Some((feeds, timestamp.unwrap_or(Timestamp::MAX))),
+            true,
+            true,
+        )
+        .await;
     }
 }

--- a/dango/testing/src/pyth.rs
+++ b/dango/testing/src/pyth.rs
@@ -1,16 +1,17 @@
 use {
-    crate::{OracleTestEntry, TestSuite},
+    crate::{MockClient, OracleTestEntry, TestSuite},
     byteorder::LE,
     dango_order_book::UsdPrice,
     dango_types::{
         oracle::{self, PriceSource},
         perps,
     },
-    grug_app::{AppError, Indexer, ProposalPreparer},
+    grug_app::{AppError, Db, Indexer, ProposalPreparer, Vm},
     grug_db_memory::MemDb,
     grug_math::Fraction,
     grug_types::{
-        Binary, ByteArray, Coins, Denom, Message, NonEmpty, ResultExt, Signer, Timestamp,
+        Binary, BroadcastClient, ByteArray, Coins, Denom, Message, NonEmpty, ResultExt, Signer,
+        Timestamp,
     },
     grug_vm_rust::RustVm,
     identity::Identity256,
@@ -107,44 +108,78 @@ fn timestamp_to_micros(t: Timestamp) -> u64 {
     micros.min(u64::MAX as u128) as u64
 }
 
-// ---- OracleExt extension trait ----
+fn build_oracle_messages(
+    oracle: grug_types::Addr,
+    perps: grug_types::Addr,
+    do_feed_prices: Option<(&[(PythId, UsdPrice, MarketSession)], Timestamp)>,
+    do_refresh_index_prices: bool,
+    do_refresh_vault_orders: bool,
+) -> Vec<Message> {
+    let mut msgs = Vec::new();
 
-#[allow(async_fn_in_trait)]
-pub trait OracleExt {
-    /// Execute an arbitrary combination of oracle and perps maintenance actions.
-    async fn do_oracle_actions(
-        &mut self,
-        owner: &mut (dyn Signer + Send + Sync),
-        do_register_price_sources: Option<BTreeMap<Denom, OracleTestEntry>>,
-        do_feed_prices: Option<(&[(PythId, UsdPrice, MarketSession)], Timestamp)>,
-        do_refresh_index_prices: bool,
-        do_refresh_vault_orders: bool,
-    );
+    if let Some((feeds, timestamp)) = do_feed_prices {
+        let signer = MockPythSigner::new();
+        let message = signer.sign_prices(feeds, timestamp);
 
-    /// Register price sources, feed initial prices, and refresh index prices
-    /// and vault orders.
-    async fn seed_oracle_prices(
-        &mut self,
-        owner: &mut (dyn Signer + Send + Sync),
-        entries: BTreeMap<Denom, OracleTestEntry>,
-    );
+        msgs.push(
+            Message::execute(
+                oracle,
+                &oracle::ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message])),
+                Coins::new(),
+            )
+            .unwrap(),
+        );
+    }
 
-    /// Feed prices and refresh index prices and vault orders.
-    async fn feed_oracle_prices(
-        &mut self,
-        owner: &mut (dyn Signer + Send + Sync),
-        feeds: &[(PythId, UsdPrice, MarketSession)],
-        timestamp: Option<Timestamp>,
-    );
+    if do_refresh_index_prices {
+        msgs.push(
+            Message::execute(
+                perps,
+                &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+                Coins::new(),
+            )
+            .unwrap(),
+        );
+    }
+
+    if do_refresh_vault_orders {
+        msgs.push(
+            Message::execute(
+                perps,
+                &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
+                Coins::new(),
+            )
+            .unwrap(),
+        );
+    }
+
+    msgs
 }
 
-impl<PP, ID> OracleExt for TestSuite<MemDb, RustVm, PP, ID>
+fn build_register_price_sources(
+    entries: &BTreeMap<Denom, OracleTestEntry>,
+) -> BTreeMap<Denom, PriceSource> {
+    entries
+        .iter()
+        .map(|(denom, e)| {
+            (denom.clone(), PriceSource {
+                id: e.pyth_id,
+                channel: Channel::RealTime,
+            })
+        })
+        .collect()
+}
+
+// ---- TestSuite methods ----
+
+impl<PP, ID> TestSuite<MemDb, RustVm, PP, ID>
 where
     PP: ProposalPreparer,
     ID: Indexer,
     AppError: From<<PP as ProposalPreparer>::Error>,
 {
-    async fn do_oracle_actions(
+    /// Execute an arbitrary combination of oracle and perps maintenance actions.
+    pub async fn do_oracle_actions(
         &mut self,
         owner: &mut (dyn Signer + Send + Sync),
         do_register_price_sources: Option<BTreeMap<Denom, OracleTestEntry>>,
@@ -152,16 +187,8 @@ where
         do_refresh_index_prices: bool,
         do_refresh_vault_orders: bool,
     ) {
-        if let Some(entries) = do_register_price_sources {
-            let price_sources: BTreeMap<Denom, PriceSource> = entries
-                .iter()
-                .map(|(denom, e)| {
-                    (denom.clone(), PriceSource {
-                        id: e.pyth_id,
-                        channel: Channel::RealTime,
-                    })
-                })
-                .collect();
+        if let Some(entries) = &do_register_price_sources {
+            let price_sources = build_register_price_sources(entries);
 
             self.execute(
                 owner,
@@ -173,43 +200,13 @@ where
             .should_succeed();
         }
 
-        let mut msgs = Vec::new();
-
-        if let Some((feeds, timestamp)) = do_feed_prices {
-            let signer = MockPythSigner::new();
-            let message = signer.sign_prices(feeds, timestamp);
-
-            msgs.push(
-                Message::execute(
-                    self.contracts.oracle,
-                    &oracle::ExecuteMsg::FeedPrices(NonEmpty::new_unchecked(vec![message])),
-                    Coins::new(),
-                )
-                .unwrap(),
-            );
-        }
-
-        if do_refresh_index_prices {
-            msgs.push(
-                Message::execute(
-                    self.contracts.perps,
-                    &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
-                    Coins::new(),
-                )
-                .unwrap(),
-            );
-        }
-
-        if do_refresh_vault_orders {
-            msgs.push(
-                Message::execute(
-                    self.contracts.perps,
-                    &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
-                    Coins::new(),
-                )
-                .unwrap(),
-            );
-        }
+        let msgs = build_oracle_messages(
+            self.contracts.oracle,
+            self.contracts.perps,
+            do_feed_prices,
+            do_refresh_index_prices,
+            do_refresh_vault_orders,
+        );
 
         if !msgs.is_empty() {
             let msgs = NonEmpty::new_unchecked(msgs);
@@ -217,7 +214,9 @@ where
         }
     }
 
-    async fn seed_oracle_prices(
+    /// Register price sources, feed initial prices, and refresh index prices
+    /// and vault orders.
+    pub async fn seed_oracle_prices(
         &mut self,
         owner: &mut (dyn Signer + Send + Sync),
         entries: BTreeMap<Denom, OracleTestEntry>,
@@ -237,8 +236,112 @@ where
         .await;
     }
 
-    async fn feed_oracle_prices(
+    /// Feed prices and refresh index prices and vault orders.
+    pub async fn feed_oracle_prices(
         &mut self,
+        owner: &mut (dyn Signer + Send + Sync),
+        feeds: &[(PythId, UsdPrice, MarketSession)],
+        timestamp: Option<Timestamp>,
+    ) {
+        let timestamp = timestamp.unwrap_or(Timestamp::MAX);
+        self.do_oracle_actions(owner, None, Some((feeds, timestamp)), true, true)
+            .await;
+    }
+}
+
+// ---- MockClient methods ----
+
+const MOCK_CLIENT_GAS_LIMIT: u64 = 20_000_000;
+
+impl<DB, VM, PP, ID> MockClient<DB, VM, PP, ID>
+where
+    DB: Db + Send + Sync + 'static,
+    VM: Vm + Clone + Send + Sync + 'static,
+    PP: ProposalPreparer + Send + Sync + 'static,
+    ID: Indexer + Send + Sync + 'static,
+    AppError: From<DB::Error> + From<VM::Error> + From<PP::Error>,
+{
+    /// Execute an arbitrary combination of oracle and perps maintenance actions.
+    pub async fn do_oracle_actions(
+        &self,
+        owner: &mut (dyn Signer + Send + Sync),
+        do_register_price_sources: Option<BTreeMap<Denom, OracleTestEntry>>,
+        do_feed_prices: Option<(&[(PythId, UsdPrice, MarketSession)], Timestamp)>,
+        do_refresh_index_prices: bool,
+        do_refresh_vault_orders: bool,
+    ) {
+        let chain_id = self.chain_id().await;
+        let contracts = self.suite().await.contracts.clone();
+
+        if let Some(entries) = &do_register_price_sources {
+            let price_sources = build_register_price_sources(entries);
+
+            let msg = Message::execute(
+                contracts.oracle,
+                &oracle::ExecuteMsg::RegisterPriceSources(price_sources),
+                Coins::new(),
+            )
+            .unwrap();
+            let tx = owner
+                .sign_transaction(
+                    NonEmpty::new_unchecked(vec![msg]),
+                    &chain_id,
+                    MOCK_CLIENT_GAS_LIMIT,
+                )
+                .unwrap();
+            self.broadcast_tx(tx)
+                .await
+                .unwrap()
+                .check_tx
+                .should_succeed();
+        }
+
+        let msgs = build_oracle_messages(
+            contracts.oracle,
+            contracts.perps,
+            do_feed_prices,
+            do_refresh_index_prices,
+            do_refresh_vault_orders,
+        );
+
+        if !msgs.is_empty() {
+            let msgs = NonEmpty::new_unchecked(msgs);
+            let tx = owner
+                .sign_transaction(msgs, &chain_id, MOCK_CLIENT_GAS_LIMIT)
+                .unwrap();
+            self.broadcast_tx(tx)
+                .await
+                .unwrap()
+                .check_tx
+                .should_succeed();
+        }
+    }
+
+    /// Register price sources, feed initial prices, and refresh index prices
+    /// and vault orders.
+    pub async fn seed_oracle_prices(
+        &self,
+        owner: &mut (dyn Signer + Send + Sync),
+        entries: BTreeMap<Denom, OracleTestEntry>,
+    ) {
+        let feeds: Vec<_> = entries
+            .values()
+            .map(|e| (e.pyth_id, e.humanized_price, MarketSession::Regular))
+            .collect();
+
+        self.do_oracle_actions(
+            owner,
+            Some(entries),
+            Some((&feeds, Timestamp::MAX)),
+            true,
+            true,
+        )
+        .await;
+    }
+
+    /// Feed prices and refresh index prices and vault orders.
+    pub async fn feed_oracle_prices(
+        &self,
         owner: &mut (dyn Signer + Send + Sync),
         feeds: &[(PythId, UsdPrice, MarketSession)],
         timestamp: Option<Timestamp>,

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -3,7 +3,7 @@ use {
     dango_genesis::Contracts,
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_testing::{
-        OracleExt, OracleTestEntry, Preset, TestAccounts, TestOption, TestSuiteNaiveWithIndexer,
+        OracleTestEntry, Preset, TestAccounts, TestOption, TestSuiteNaiveWithIndexer,
         create_perps_fill, pair_id, setup_perps_env, setup_test_naive_with_indexer,
         setup_test_with_indexer_pp_and_custom_genesis,
     },

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -4,7 +4,7 @@ use {
         Dimensionless, OrderId, OrderKind, OrderRemoved, Quantity, QueryOrdersByUserResponseItem,
         ReasonForOrderRemoval, TimeInForce, UsdPrice,
     },
-    dango_testing::{OracleExt, OracleTestEntry, TestOption, pair_id, setup_test_naive},
+    dango_testing::{OracleTestEntry, TestOption, pair_id, setup_test_naive},
     dango_types::{
         constants::usdc,
         perps::{

--- a/dango/testing/tests/perps/index_price.rs
+++ b/dango/testing/tests/perps/index_price.rs
@@ -1,7 +1,7 @@
 use {
     crate::register_oracle_prices,
     dango_order_book::{OrderKind, Quantity, TimeInForce, UsdPrice},
-    dango_testing::{OracleExt, TestOption, pair_id, setup_test_naive},
+    dango_testing::{TestOption, pair_id, setup_test_naive},
     dango_types::{
         constants::usdc,
         perps::{self, PairState},

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -1,6 +1,6 @@
 use {
     dango_order_book::{Dimensionless, Quantity, UsdPrice},
-    dango_testing::{OracleExt, OracleTestEntry, TestAccounts, TestSuiteNaive, pair_id},
+    dango_testing::{OracleTestEntry, TestAccounts, TestSuiteNaive, pair_id},
     dango_types::{
         constants::usdc,
         perps::{PairParam, Param, RateSchedule},

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -2,8 +2,8 @@ use {
     crate::{default_pair_param, default_param},
     dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice, UsdValue},
     dango_testing::{
-        Factory, OracleExt, OracleTestEntry, Preset, TestAccount, TestOption, TestSuiteNaive,
-        pair_id, setup_test_naive,
+        Factory, OracleTestEntry, Preset, TestAccount, TestOption, TestSuiteNaive, pair_id,
+        setup_test_naive,
     },
     dango_types::{
         account_factory::{self, RegisterUserData},

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -4,7 +4,7 @@ use {
         Dimensionless, OrderId, OrderKind, Quantity, QueryOrdersByUserResponseItem, UsdPrice,
         UsdValue,
     },
-    dango_testing::{OracleExt, OracleTestEntry, TestOption, pair_id, setup_test_naive},
+    dango_testing::{OracleTestEntry, TestOption, pair_id, setup_test_naive},
     dango_types::{
         constants::usdc,
         oracle::QueryPriceRequest,

--- a/justfile
+++ b/justfile
@@ -35,6 +35,10 @@ test-perps:
   RUST_BACKTRACE=1 cargo test --all-features --tests -p dango-perps -- --nocapture
   RUST_BACKTRACE=1 cargo test --all-features -p dango-testing --test perps -- --nocapture
 
+# Run all dango-related tests specifically
+test-dango:
+  RUST_BACKTRACE=1 cargo test --all-features -p dango-testing -- --nocapture
+
 # Check whether the code compiles
 check:
   cargo check --bins --tests --benches --examples --all-features --all-targets


### PR DESCRIPTION
Replace the `OracleExt` trait with inherent methods on `TestSuite` (`&mut
self`) and `MockClient` (`&self`). This allows `MockClient` callers to use
`do_oracle_actions`/`seed_oracle_prices`/`feed_oracle_prices` without needing
`&mut` access or trait imports.
