### PR TITLE
feat(perps): emit protocol-owned vault order-book events

### DIFF
--- a/dango/perps/src/maintain/refresh_vault_orders.rs
+++ b/dango/perps/src/maintain/refresh_vault_orders.rs
@@ -7,11 +7,11 @@ use {
     },
     anyhow::ensure,
     dango_order_book::{
-        ASKS, BIDS, LimitOrder, NEXT_ORDER_ID, Quantity, ReasonForOrderRemoval, UsdValue,
-        increase_liquidity_depths, may_invert_price,
+        ASKS, BIDS, LimitOrder, NEXT_ORDER_ID, OrderPersisted, Quantity, ReasonForOrderRemoval,
+        UsdValue, increase_liquidity_depths, may_invert_price,
     },
     grug_math::{Number as _, NumberConst, Uint64},
-    grug_types::{MutableCtx, Order as IterationOrder, QuerierExt, Response},
+    grug_types::{EventBuilder, MutableCtx, Order as IterationOrder, QuerierExt, Response},
 };
 
 /// Entry point for vault market-making, triggered at the beginning of each
@@ -24,7 +24,8 @@ use {
 ///
 /// Mutates: `USER_STATES[contract]`, `BIDS`, `ASKS`, `NEXT_ORDER_ID`.
 ///
-/// Returns: empty `Response` (no token transfers).
+/// Returns: a `Response` carrying the vault's `OrderRemoved` (cancellations)
+/// and `OrderPersisted` (placements) events; no token transfers.
 pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
     #[cfg(feature = "metrics")]
     let start = std::time::Instant::now();
@@ -49,6 +50,11 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
         .may_load(ctx.storage, ctx.contract)?
         .unwrap_or_default();
 
+    // Vault order churn (cancellations in step 1, placements in step 3) was
+    // redacted prior to v0.21.0 (exclusive), but is no longer redacted since
+    // v0.21.0 (inclusive), as it aids debugging.
+    let mut events = EventBuilder::new();
+
     // --------------- Step 1: Cancel all existing vault orders ----------------
 
     let CancelAllOrdersOutcome {
@@ -57,7 +63,7 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
         ctx.storage,
         ctx.contract,
         &vault_state,
-        None, // Vault order churn is not user-facing — no events emitted.
+        Some(&mut events),
         ReasonForOrderRemoval::Canceled,
     )?;
 
@@ -84,7 +90,7 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
 
         LAST_VAULT_ORDERS_UPDATE.save(ctx.storage, &ctx.block.height)?;
 
-        return Ok(Response::new());
+        return Ok(Response::new().add_events(events)?);
     }
 
     // ----------- Step 3: Iterate each pair and place vault orders ------------
@@ -168,6 +174,16 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             )?;
 
             vault_state.open_order_count += 1;
+
+            events.push(OrderPersisted {
+                order_id: next_order_id,
+                pair_id: pair_id.clone(),
+                user: ctx.contract,
+                limit_price: bid_quote.price,
+                size: bid_quote.size,
+                client_order_id: None,
+            })?;
+
             next_order_id.checked_add_assign(Uint64::ONE)?;
         }
 
@@ -200,6 +216,16 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             )?;
 
             vault_state.open_order_count += 1;
+
+            events.push(OrderPersisted {
+                order_id: next_order_id,
+                pair_id: pair_id.clone(),
+                user: ctx.contract,
+                limit_price: ask_quote.price,
+                size: ask_quote.size,
+                client_order_id: None,
+            })?;
+
             next_order_id.checked_add_assign(Uint64::ONE)?;
         }
     }
@@ -231,7 +257,7 @@ pub fn refresh_vault_orders(ctx: MutableCtx) -> anyhow::Result<Response> {
             .record(start.elapsed().as_secs_f64());
     }
 
-    Ok(Response::new())
+    Ok(Response::new().add_events(events)?)
 }
 
 // ----------------------------------- tests -----------------------------------

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -1030,16 +1030,16 @@ pub fn match_order(
                         maker_pre_fill_size,
                     ));
 
-                    // Vault order removal is internal churn — suppress the event.
-                    if maker_user != contract {
-                        events.push(OrderRemoved {
-                            order_id: maker_order_id,
-                            pair_id: pair_id.clone(),
-                            user: maker_user,
-                            reason: ReasonForOrderRemoval::Filled,
-                            client_order_id: maker_client_order_id,
-                        })?;
-                    }
+                    // Vault order removals are internal churn. They were
+                    // redacted prior to v0.21.0 (exclusive), but are no longer
+                    // redacted since v0.21.0 (inclusive), as they aid debugging.
+                    events.push(OrderRemoved {
+                        order_id: maker_order_id,
+                        pair_id: pair_id.clone(),
+                        user: maker_user,
+                        reason: ReasonForOrderRemoval::Filled,
+                        client_order_id: maker_client_order_id,
+                    })?;
 
                     #[cfg(feature = "metrics")]
                     {

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -1,8 +1,8 @@
 use {
     crate::{default_pair_param, default_param, register_oracle_prices},
     dango_order_book::{
-        Dimensionless, OrderId, OrderKind, Quantity, QueryOrdersByUserResponseItem, UsdPrice,
-        UsdValue,
+        Dimensionless, OrderId, OrderKind, OrderPersisted, OrderRemoved, Quantity,
+        QueryOrdersByUserResponseItem, ReasonForOrderRemoval, UsdPrice, UsdValue,
     },
     dango_testing::{OracleTestEntry, TestOption, pair_id, setup_test_naive},
     dango_types::{
@@ -13,7 +13,8 @@ use {
     grug_app::CONTRACT_NAMESPACE,
     grug_math::{Dec128_6, NumberConst, Uint128},
     grug_types::{
-        Addressable, Coins, Duration, QuerierExt, ResultExt, Timestamp, btree_map, concat,
+        Addressable, CheckedContractEvent, Coins, Duration, JsonDeExt, QuerierExt, ResultExt,
+        SearchEvent, Timestamp, TxEvents, btree_map, concat,
     },
     pyth_types::MarketSession,
     std::{collections::BTreeMap, str::FromStr},
@@ -1009,5 +1010,217 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
     assert!(
         equity >= maintenance_margin,
         "vault should be healthy: equity ({equity}) >= maintenance_margin ({maintenance_margin})"
+    );
+}
+
+/// Extract the `order_persisted` events emitted by a transaction.
+fn order_persisted_events(events: &TxEvents) -> Vec<OrderPersisted> {
+    events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_persisted")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderPersisted>().unwrap())
+        .collect()
+}
+
+/// Extract the `order_removed` events emitted by a transaction.
+fn order_removed_events(events: &TxEvents) -> Vec<OrderRemoved> {
+    events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_removed")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderRemoved>().unwrap())
+        .collect()
+}
+
+/// The protocol-owned vault's order-book activity is no longer redacted.
+///
+/// Vault order churn was redacted prior to v0.21.0 (exclusive), but is emitted
+/// since v0.21.0 (inclusive) to aid debugging. This exercises all three sites:
+///
+/// - placements during `RefreshVaultOrders` emit `OrderPersisted`;
+/// - cancellations during a subsequent `RefreshVaultOrders` emit `OrderRemoved`
+///   with reason `Canceled`;
+/// - a user filling a vault maker order emits `OrderRemoved` with reason
+///   `Filled` for the vault.
+#[tokio::test]
+async fn vault_order_churn_emits_events() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let pair = pair_id();
+    let vault = contracts.perps;
+
+    // LP seeds the vault with $5,000 of liquidity.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Vault(perps::VaultMsg::AddLiquidity {
+                amount: UsdValue::new_int(5_000),
+                min_shares_to_mint: None,
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // Enable vault market-making: one pair, weight 1, 5% half-spread, max 2 ETH.
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: Param {
+                    vault_total_weight: Dimensionless::new_int(1),
+                    ..default_param()
+                },
+                pair_params: btree_map! {
+                    pair.clone() => PairParam {
+                        vault_liquidity_weight: Dimensionless::new_int(1),
+                        vault_half_spread: Dimensionless::new_permille(50), // 5%
+                        vault_max_quote_size: Quantity::new_int(2),
+                        ..default_pair_param()
+                    },
+                },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // --- First refresh: the vault places fresh orders. ---
+    suite.make_empty_block().await;
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    let place_events = suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    let persisted = order_persisted_events(&place_events);
+    assert!(
+        !persisted.is_empty(),
+        "vault placements should emit OrderPersisted since v0.21.0"
+    );
+    assert!(
+        persisted.iter().all(|o| o.user == vault),
+        "all OrderPersisted from RefreshVaultOrders should belong to the vault"
+    );
+
+    // --- Second refresh: prior orders are cancelled, then replaced. ---
+    suite.make_empty_block().await;
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshIndexPrices {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    let refresh_events = suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::RefreshVaultOrders {}),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    assert!(
+        order_removed_events(&refresh_events)
+            .iter()
+            .any(|o| o.user == vault && o.reason == ReasonForOrderRemoval::Canceled),
+        "refreshing vault orders should emit OrderRemoved (Canceled) for the vault since v0.21.0"
+    );
+    assert!(
+        !order_persisted_events(&refresh_events).is_empty(),
+        "refreshing vault orders should re-emit OrderPersisted"
+    );
+
+    // --- A taker fully fills the vault's bid: the vault maker order is removed. ---
+    let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: vault,
+        })
+        .should_succeed();
+    let vault_bid_size = vault_orders
+        .values()
+        .find(|o| o.size.is_positive())
+        .expect("vault should have a resting bid")
+        .size;
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    let fill_events = suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: vault_bid_size.checked_neg().unwrap(), // sell into the vault's bid
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    assert!(
+        order_removed_events(&fill_events)
+            .iter()
+            .any(|o| o.user == vault && o.reason == ReasonForOrderRemoval::Filled),
+        "filling the vault's maker order should emit OrderRemoved (Filled) for the vault since v0.21.0"
     );
 }


### PR DESCRIPTION
Vault order-book activity was previously redacted on the rationale that the vault's actions are internal to the contract. These events aid debugging, so emit them going forward:

- OrderRemoved {Filled} when a user fills a vault maker order
- OrderRemoved {Canceled} and OrderPersisted during RefreshVaultOrders, for the cancellation and placement of vault orders each block

Relevant comments note the events were redacted prior to v0.21.0 (exclusive) and are emitted since v0.21.0 (inclusive). Adds an e2e test asserting the vault now emits these events.