### PR TITLE
chore(deploy): add just restart-perp-liquidator command

### DIFF
--- a/deploy/justfile
+++ b/deploy/justfile
@@ -225,6 +225,16 @@ deploy-perp-liquidator network tag="latest":
       --limit perp-liquidator-{{network}} \
       2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-perp-liquidator.log
 
+# Restart the perp-liquidator container without pulling a new image
+# Usage: just restart-perp-liquidator devnet
+#        just restart-perp-liquidator testnet
+restart-perp-liquidator network:
+  mkdir -p {{justfile_directory()}}/logs \
+    && uv run ansible-playbook restart-perp-liquidator.yml \
+      -e dango_network={{network}} \
+      --limit perp-liquidator-{{network}} \
+      2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-restart-perp-liquidator.log
+
 # ---------------------------------- Testnet -----------------------------------
 
 deploy-testnet dango_image_tag bots_image_tag:

--- a/deploy/restart-perp-liquidator.yml
+++ b/deploy/restart-perp-liquidator.yml
@@ -1,0 +1,34 @@
+---
+- hosts: full-app
+  remote_user: "{{ deploy_user }}"
+  gather_facts: yes
+  vars_files:
+    - roles/full-app/vars/main.yml
+    - roles/full-app/defaults/main.yml
+  tasks:
+    - name: Set perp-liquidator instance index
+      set_fact:
+        perp_liquidator_instance_index: >-
+          {{ (groups['perp-liquidator-' ~ dango_network] | default(groups['perp-liquidator-devnet'] | default([]))).index(inventory_hostname) }}
+      when: inventory_hostname in (groups['perp-liquidator-' ~ dango_network] | default(groups['perp-liquidator-devnet'] | default([])))
+
+    - name: Skip hosts without a liquidator instance
+      meta: end_host
+      when: perp_liquidator_instance_index is not defined
+
+    - name: Read current deploy
+      include_role:
+        name: full-app
+        tasks_from: read_current_deploy.yml
+
+    - name: Set deployment facts
+      set_fact:
+        deployment_name: "{{ current_deployment }}"
+
+    - name: Restart perp-liquidator service
+      community.docker.docker_compose_v2:
+        project_name: "{{ current_deployment }}"
+        project_src: "{{ deployment_dir }}"
+        services:
+          - perp-liquidator
+        state: restarted


### PR DESCRIPTION
Adds a `restart-perp-liquidator <network>` recipe and matching `restart-perp-liquidator.yml` playbook that runs `docker compose restart` on only the perp-liquidator service of the active deployment, without pulling a new image or re-templating config.