### PR TITLE
refactor(taxman): remove `ExecuteMsg::Pay`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4017,12 +4017,14 @@ dependencies = [
  "dango-oracle",
  "dango-order-book",
  "dango-perps",
+ "dango-testing",
  "dango-types",
  "grug-app",
  "grug-math",
  "grug-storage",
  "grug-types",
  "pyth-types",
+ "tokio",
  "tracing",
 ]
 

--- a/book/overview/3-dango-contracts.md
+++ b/book/overview/3-dango-contracts.md
@@ -23,7 +23,7 @@ pub struct AppAddresses {
 ```
 
 Other shared types include authentication types (`Key`, `Signature`, `Credential`,
-`SignDoc`, `Metadata`), fee types (`FeeType`), and price types
+`SignDoc`, `Metadata`) and price types
 (`PrecisionlessPrice`, `PrecisionedPrice`).
 
 ## 2. Bank (`dango/bank/`)

--- a/dango/gateway/src/execute.rs
+++ b/dango/gateway/src/execute.rs
@@ -8,12 +8,11 @@ use {
             Remote, SetPersonalQuotaRequest, Traceable, WithdrawalFee,
             bridge::{self, BridgeMsg},
         },
-        taxman::{self, FeeType},
     },
     grug_math::{IsZero, Number, NumberConst, Uint128},
     grug_types::{
         Addr, Coins, Denom, Inner, Message, MutableCtx, Op, Order, QuerierExt, Response, StdError,
-        StdResult, Storage, SudoCtx, btree_map, coins,
+        StdResult, Storage, SudoCtx, coins,
     },
     std::collections::{BTreeMap, BTreeSet},
 };
@@ -308,11 +307,11 @@ fn transfer_remote(ctx: MutableCtx, remote: Remote, recipient: Addr32) -> anyhow
         remaining,
     )?;
 
-    let (bank, taxman) = ctx.querier.query_bank_and_taxman()?;
+    let (bank, owner) = ctx.querier.query_bank_and_owner()?;
 
     // 1. Call the bridge contract to make the remote transfer.
     // 2. Burn the alloyed token to be transferred (only if the token is not native on Dango).
-    // 3. Pay fee to the taxman.
+    // 3. Send the withdrawal fee to the chain owner.
     Ok(Response::new()
         .add_message(Message::execute(
             bridge,
@@ -336,16 +335,7 @@ fn transfer_remote(ctx: MutableCtx, remote: Remote, recipient: Addr32) -> anyhow
             None
         })
         .may_add_message(if let Some(fee) = maybe_fee {
-            Some(Message::execute(
-                taxman,
-                &taxman::ExecuteMsg::Pay {
-                    ty: FeeType::Withdraw,
-                    payments: btree_map! {
-                        ctx.sender => coins! { coin.denom.clone() => fee },
-                    },
-                },
-                coins! { coin.denom => fee },
-            )?)
+            Some(Message::transfer(owner, coins! { coin.denom => fee })?)
         } else {
             None
         }))

--- a/dango/taxman/src/execute.rs
+++ b/dango/taxman/src/execute.rs
@@ -3,14 +3,13 @@ use {
     anyhow::ensure,
     dango_types::{
         DangoQuerier, bank,
-        taxman::{Config, ExecuteMsg, FeeType, InstantiateMsg, ReceiveFee},
+        taxman::{Config, ExecuteMsg, InstantiateMsg},
     },
     grug_math::{IsZero, MultiplyFraction, Number, NumberConst, Uint128},
     grug_types::{
-        Addr, AuthCtx, AuthMode, Coins, ContractEvent, Message, MutableCtx, QuerierExt, Response,
-        StdResult, Tx, TxOutcome, coins,
+        AuthCtx, AuthMode, Coins, Message, MutableCtx, QuerierExt, Response, StdResult, Tx,
+        TxOutcome, coins,
     },
-    std::collections::BTreeMap,
 };
 
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> {
@@ -22,7 +21,6 @@ pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> StdResult<Response> 
 pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
     match msg {
         ExecuteMsg::Configure { new_cfg } => configure(ctx, new_cfg),
-        ExecuteMsg::Pay { ty, payments } => pay(ctx, ty, payments),
     }
 }
 
@@ -36,45 +34,6 @@ fn configure(ctx: MutableCtx, new_cfg: Config) -> anyhow::Result<Response> {
     CONFIG.save(ctx.storage, &new_cfg)?;
 
     Ok(Response::new())
-}
-
-fn pay(ctx: MutableCtx, ty: FeeType, payments: BTreeMap<Addr, Coins>) -> anyhow::Result<Response> {
-    ensure!(ctx.funds.is_non_empty(), "funds cannot be empty!");
-
-    // Ensure funds add up to the total amount of payments.
-    let total = payments
-        .values()
-        .try_fold(Coins::new(), |mut acc, coins| -> StdResult<_> {
-            acc.insert_many(coins.clone())?;
-            Ok(acc)
-        })?;
-
-    for coin in total {
-        let paid = ctx.funds.amount_of(&coin.denom);
-        ensure!(
-            paid >= coin.amount,
-            "sent fund is less than declared payment! denom: {}, declared: {}, paid: {}",
-            coin.denom,
-            coin.amount,
-            paid
-        );
-    }
-
-    // For now, nothing to do.
-    // In the future, we will implement affiliate fees.
-    let events = payments
-        .into_iter()
-        .map(|(user, amount)| {
-            ContractEvent::new(&ReceiveFee {
-                handler: ctx.sender,
-                user,
-                ty,
-                amount,
-            })
-        })
-        .collect::<StdResult<Vec<_>>>()?;
-
-    Ok(Response::new().add_events(events)?)
 }
 
 // TODO: exempt the account factory from paying fee.

--- a/dango/testing/tests/warp.rs
+++ b/dango/testing/tests/warp.rs
@@ -71,7 +71,7 @@ async fn sending_remote() {
 
     suite
         .balances()
-        .record_many([&accounts.user1.address(), &contracts.taxman]);
+        .record_many([&accounts.user1.address(), &accounts.owner.address()]);
 
     // User1 sends USDC to Ethereum.
     suite
@@ -119,12 +119,10 @@ async fn sending_remote() {
         usdc::DENOM.clone() => BalanceChange::Decreased(SEND_AMOUNT),
     });
 
-    // Taxman should have received the fee.
-    suite
-        .balances()
-        .should_change(&contracts.taxman, btree_map! {
-            usdc::DENOM.clone() => BalanceChange::Increased(ETHEREUM_USDC_WITHDRAWAL_FEE),
-        });
+    // The chain owner should have received the fee.
+    suite.balances().should_change(&accounts.owner, btree_map! {
+        usdc::DENOM.clone() => BalanceChange::Increased(ETHEREUM_USDC_WITHDRAWAL_FEE),
+    });
 
     // Gateway contract should not hold any of the synth token (should be burned).
     suite
@@ -156,7 +154,7 @@ async fn sending_remote() {
 
     // There should have been two transfers:
     // 1. Before fee amount from user to Gateway;
-    // 2. Withdrawal fee from Gateway to taxman.
+    // 2. Withdrawal fee from Gateway to the chain owner.
     assert_that!(transfers).has_length(2);
 
     assert_that!(

--- a/dango/types/src/taxman.rs
+++ b/dango/types/src/taxman.rs
@@ -1,35 +1,10 @@
-use {
-    grug_math::Udec128,
-    grug_types::{Addr, Coins, Denom},
-    std::collections::BTreeMap,
-};
+use {grug_math::Udec128, grug_types::Denom};
 
 #[grug_types::derive(Serde, Borsh)]
 pub struct Config {
     pub fee_denom: Denom,
     /// Units of the fee token for each unit of gas consumed.
     pub fee_rate: Udec128,
-}
-
-#[grug_types::derive(Serde)]
-#[derive(Copy)]
-pub enum FeeType {
-    /// Gas Fee.
-    Gas,
-    /// Protocol fee for trading.
-    Trade,
-    /// Fee for bridging assets out of Dango chain.
-    Withdraw,
-}
-
-impl FeeType {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            FeeType::Gas => "gas",
-            FeeType::Trade => "trade",
-            FeeType::Withdraw => "withdraw",
-        }
-    }
 }
 
 #[grug_types::derive(Serde)]
@@ -42,12 +17,6 @@ pub enum ExecuteMsg {
     /// Update the fee configurations.
     /// Can only be called by the chain's owner.
     Configure { new_cfg: Config },
-    /// Forward protocol fee to the taxman.
-    Pay {
-        #[serde(rename = "type")]
-        ty: FeeType,
-        payments: BTreeMap<Addr, Coins>,
-    },
 }
 
 #[grug_types::derive(Serde, QueryRequest)]
@@ -55,15 +24,4 @@ pub enum QueryMsg {
     /// Query the fee configurations.
     #[returns(Config)]
     Config {},
-}
-
-#[grug_types::derive(Serde)]
-#[grug_types::event("receive_fee")]
-pub struct ReceiveFee {
-    /// The Dango smart contract that handled this fee.
-    pub handler: Addr,
-    pub user: Addr,
-    #[serde(rename = "type")]
-    pub ty: FeeType,
-    pub amount: Coins,
 }

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -21,3 +21,7 @@ grug-types       = { workspace = true }
 grug-app         = { workspace = true }
 pyth-types       = { workspace = true }
 tracing          = { workspace = true }
+
+[dev-dependencies]
+dango-testing = { workspace = true }
+tokio         = { workspace = true, features = ["full"] }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -1,16 +1,12 @@
 mod oracle;
 mod perps;
+mod taxman;
 
 use {
     grug_app::AppResult,
     grug_types::{BlockInfo, Storage},
 };
 
-pub fn do_upgrade<VM>(_storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
-    // Nothing to do in the current version.
-
-    // oracle::do_oracle_upgrades(storage.clone())?;
-    // perps::do_perps_upgrades(storage)?;
-
-    Ok(())
+pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
+    taxman::sweep_fees_to_owner(storage)
 }

--- a/dango/upgrade/src/taxman.rs
+++ b/dango/upgrade/src/taxman.rs
@@ -1,0 +1,146 @@
+use {
+    dango_bank::BALANCES,
+    grug_app::{AppResult, CONFIG, CONTRACT_NAMESPACE, StorageProvider},
+    grug_math::{Number, NumberConst, Uint128},
+    grug_types::{Denom, Order, StdResult, Storage},
+};
+
+/// The taxman has accumulated protocol fees (tracked as token balances in the
+/// bank contract) but has no message for withdrawing them. Move all of the
+/// taxman's balances to the chain owner: credit each to the owner, then delete
+/// the taxman's entry.
+pub fn sweep_fees_to_owner(storage: Box<dyn Storage>) -> AppResult<()> {
+    let cfg = CONFIG.load(&storage)?;
+
+    // Scope storage to the bank contract, where token balances live.
+    let mut bank_storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &cfg.bank]);
+
+    // Collect the taxman's balances first, so the read borrow ends before we
+    // start writing.
+    let taxman_balances = BALANCES
+        .prefix(&cfg.taxman)
+        .range(&bank_storage, None, None, Order::Ascending)
+        .collect::<StdResult<Vec<(Denom, Uint128)>>>()?;
+
+    for (denom, amount) in taxman_balances {
+        // The owner may already hold this denom, so add rather than overwrite.
+        BALANCES.may_modify(
+            &mut bank_storage,
+            (&cfg.owner, &denom),
+            |maybe| -> StdResult<_> {
+                Ok(Some(maybe.unwrap_or(Uint128::ZERO).checked_add(amount)?))
+            },
+        )?;
+
+        // Zero out the taxman's balance.
+        BALANCES.remove(&mut bank_storage, (&cfg.taxman, &denom));
+    }
+
+    Ok(())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        dango_testing::{TestOption, setup_test_naive},
+        dango_types::constants::{eth, usdc},
+        grug_app::AppError,
+        grug_math::{IsZero, Number, NumberConst, Uint128},
+        grug_types::{QuerierExt, ResultExt, coins},
+    };
+
+    /// On mainnet the taxman holds protocol fees in multiple tokens (ETH and
+    /// USDC) while the owner holds only USDC. The chain upgrade must sweep every
+    /// balance to the owner. We reproduce that here, so the sweep is exercised
+    /// both on a denom the owner already holds (USDC, which must be merged) and
+    /// one it doesn't (ETH, which must be created).
+    #[tokio::test]
+    async fn sweeping_taxman_fees_to_owner() {
+        let usdc = usdc::DENOM.clone();
+        let eth = eth::DENOM.clone();
+
+        const USDC_SEED: u128 = 5_000_000_000;
+
+        let (mut suite, mut accounts, ..) = setup_test_naive(TestOption::default());
+
+        let taxman = suite.query_taxman().unwrap();
+
+        // The owner is funded with both USDC and ETH at genesis. Move all of its
+        // ETH, plus some USDC, into the taxman, so the taxman holds two tokens
+        // while the owner is left holding only USDC. Funds are credited by
+        // attaching them to an execute; `Configure` is the taxman's only message,
+        // so we pass its current config back unchanged.
+        let owner_eth = suite.query_balance(&accounts.owner, eth.clone()).unwrap();
+        assert!(owner_eth.is_non_zero());
+        let taxman_cfg = suite
+            .query_wasm_smart(taxman, dango_types::taxman::QueryConfigRequest {})
+            .unwrap();
+        suite
+            .execute(
+                &mut accounts.owner,
+                taxman,
+                &dango_types::taxman::ExecuteMsg::Configure {
+                    new_cfg: taxman_cfg,
+                },
+                coins! { usdc.clone() => Uint128::new(USDC_SEED), eth.clone() => owner_eth },
+            )
+            .await
+            .should_succeed();
+
+        // Schedule the upgrade, then advance to the block just before it.
+        suite
+            .upgrade(
+                &mut accounts.owner,
+                4,
+                "0.1.0",
+                None::<String>,
+                None::<String>,
+            )
+            .await
+            .should_succeed();
+        suite.make_empty_block().await;
+
+        // Record balances right before the upgrade. The taxman holds USDC (the
+        // seed plus accrued gas fees) and ETH; the owner holds only USDC.
+        let taxman_usdc = suite.query_balance(&taxman, usdc.clone()).unwrap();
+        let taxman_eth = suite.query_balance(&taxman, eth.clone()).unwrap();
+        let owner_usdc = suite.query_balance(&accounts.owner, usdc.clone()).unwrap();
+        assert!(taxman_usdc.is_non_zero());
+        assert_eq!(taxman_eth, owner_eth);
+        assert_eq!(
+            suite.query_balance(&accounts.owner, eth.clone()).unwrap(),
+            Uint128::ZERO
+        );
+
+        // The chain halts on the version mismatch; install the real upgrade
+        // handler and remake the block so the upgrade runs.
+        suite.try_make_empty_block().await.should_fail_with_error(
+            AppError::upgrade_incorrect_version("0.0.0".into(), "0.1.0".into()),
+        );
+        suite
+            .app
+            .set_cargo_version_and_upgrade_handler("0.1.0", Some(crate::do_upgrade));
+        suite.make_empty_block().await;
+
+        // The taxman has been emptied of both tokens; the owner received all of
+        // it: USDC merged into its existing balance, ETH as a brand-new one.
+        assert_eq!(
+            suite.query_balance(&taxman, usdc.clone()).unwrap(),
+            Uint128::ZERO
+        );
+        assert_eq!(
+            suite.query_balance(&taxman, eth.clone()).unwrap(),
+            Uint128::ZERO
+        );
+        assert_eq!(
+            suite.query_balance(&accounts.owner, usdc).unwrap(),
+            owner_usdc.checked_add(taxman_usdc).unwrap()
+        );
+        assert_eq!(
+            suite.query_balance(&accounts.owner, eth).unwrap(),
+            owner_eth
+        );
+    }
+}

--- a/grug/types/src/imports/querier.rs
+++ b/grug/types/src/imports/querier.rs
@@ -44,8 +44,8 @@ pub trait QuerierExt: Querier {
         self.query_config().map(|res| res.taxman)
     }
 
-    fn query_bank_and_taxman(&self) -> StdResult<(Addr, Addr)> {
-        self.query_config().map(|res| (res.bank, res.taxman))
+    fn query_bank_and_owner(&self) -> StdResult<(Addr, Addr)> {
+        self.query_config().map(|res| (res.bank, res.owner))
     }
 
     fn query_app_config<T>(&self) -> StdResult<T>


### PR DESCRIPTION
The taxman was originally intended as a one-stop shop for fee handling,
accepting `Pay` so other contracts could forward collected fees to it.
This proved impractical, and the direction is to strip functionality out
of taxman until it can be removed entirely.

Remove `ExecuteMsg::Pay` and its handler. The only remaining caller was
the gateway, which forwarded the bridge withdrawal fee; it now looks up
the chain owner and transfers the fee directly via `Message::transfer`.
Repurpose the single-caller querier helper `query_bank_and_taxman` into
`query_bank_and_owner` so the lookup remains one `query_config`. Delete
the now-orphaned `FeeType` enum and `ReceiveFee` event.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>