### PR TITLE
feat(account): add freeze and unfreeze messages

### DIFF
--- a/dango/account/src/execute.rs
+++ b/dango/account/src/execute.rs
@@ -1,6 +1,10 @@
 use {
-    dango_types::account::InstantiateMsg,
-    grug_types::{AuthCtx, MutableCtx, Response, Tx},
+    anyhow::{bail, ensure},
+    dango_types::{
+        account::{ExecuteMsg, InstantiateMsg},
+        auth::AccountStatus,
+    },
+    grug_types::{AuthCtx, MutableCtx, QuerierExt, Response, Tx},
 };
 
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
@@ -17,6 +21,29 @@ pub fn authenticate(ctx: AuthCtx, tx: Tx) -> anyhow::Result<Response> {
 
 pub fn receive(ctx: MutableCtx) -> anyhow::Result<Response> {
     dango_auth::receive_transfer(ctx)?;
+
+    Ok(Response::new())
+}
+
+pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
+    ensure!(
+        ctx.sender == ctx.querier.query_owner()?,
+        "you don't have the right, O you don't have the right"
+    );
+
+    let status = dango_auth::query_status(ctx.storage)?;
+
+    match msg {
+        ExecuteMsg::Freeze {} => {
+            dango_auth::account::STATUS.save(ctx.storage, &AccountStatus::Frozen)?;
+        },
+        ExecuteMsg::Unfreeze {} => {
+            if status != AccountStatus::Frozen {
+                bail!("can only unfreeze a frozen account; current status: {status:?}");
+            }
+            dango_auth::account::STATUS.save(ctx.storage, &AccountStatus::Active)?;
+        },
+    }
 
     Ok(Response::new())
 }

--- a/dango/genesis/src/codes.rs
+++ b/dango/genesis/src/codes.rs
@@ -32,6 +32,7 @@ impl GenesisCodes for RustVm {
         let account = ContractBuilder::new(Box::new(dango_account::instantiate))
             .with_authenticate(Box::new(dango_account::authenticate))
             .with_receive(Box::new(dango_account::receive))
+            .with_execute(Box::new(dango_account::execute))
             .with_query(Box::new(dango_account::query))
             .build();
 

--- a/dango/testing/tests/account.rs
+++ b/dango/testing/tests/account.rs
@@ -1,0 +1,166 @@
+use {
+    dango_testing::setup_test_naive,
+    dango_types::{
+        account::{self, ExecuteMsg},
+        auth::AccountStatus,
+        constants::dango,
+    },
+    grug_types::{Addressable, Coins, QuerierExt, ResultExt},
+};
+
+/// The chain's owner can freeze an active account, blocking it from sending
+/// transactions and receiving transfers. Unfreezing restores normal behavior.
+#[tokio::test]
+async fn freeze_and_unfreeze_lifecycle() {
+    let (mut suite, mut accounts, ..) = setup_test_naive(Default::default());
+
+    let target = accounts.user1.address();
+
+    // Sanity check: user1 starts in the `Active` state.
+    suite
+        .query_wasm_smart(target, account::QueryStatusRequest {})
+        .should_succeed_and_equal(AccountStatus::Active);
+
+    // Owner freezes user1's account.
+    suite
+        .execute(
+            &mut accounts.owner,
+            target,
+            &ExecuteMsg::Freeze {},
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .query_wasm_smart(target, account::QueryStatusRequest {})
+        .should_succeed_and_equal(AccountStatus::Frozen);
+
+    // user1 can no longer send transactions.
+    suite
+        .transfer(
+            &mut accounts.user1,
+            accounts.user2.address(),
+            Coins::one(dango::DENOM.clone(), 100).unwrap(),
+        )
+        .await
+        .should_fail_with_error(format!("account {target} is not active"));
+
+    // user1 can no longer receive transfers.
+    suite
+        .transfer(
+            &mut accounts.user2,
+            target,
+            Coins::one(dango::DENOM.clone(), 100).unwrap(),
+        )
+        .await
+        .should_fail_with_error(format!("account {target} is frozen"));
+
+    // Owner unfreezes user1's account.
+    suite
+        .execute(
+            &mut accounts.owner,
+            target,
+            &ExecuteMsg::Unfreeze {},
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .query_wasm_smart(target, account::QueryStatusRequest {})
+        .should_succeed_and_equal(AccountStatus::Active);
+
+    // user1 can send and receive again.
+    suite
+        .transfer(
+            &mut accounts.user1,
+            accounts.user2.address(),
+            Coins::one(dango::DENOM.clone(), 100).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .transfer(
+            &mut accounts.user2,
+            target,
+            Coins::one(dango::DENOM.clone(), 100).unwrap(),
+        )
+        .await
+        .should_succeed();
+}
+
+/// Only the chain's owner can freeze an account. A non-owner sender is
+/// rejected with the standard authorization error.
+#[tokio::test]
+async fn non_owner_cannot_freeze() {
+    let (mut suite, mut accounts, ..) = setup_test_naive(Default::default());
+
+    let target = accounts.user1.address();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            target,
+            &ExecuteMsg::Freeze {},
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error("you don't have the right, O you don't have the right");
+
+    // Status should be unchanged.
+    suite
+        .query_wasm_smart(target, account::QueryStatusRequest {})
+        .should_succeed_and_equal(AccountStatus::Active);
+}
+
+/// Freezing is idempotent: re-freezing an already-frozen account is a no-op
+/// and leaves the status unchanged.
+#[tokio::test]
+async fn freeze_is_idempotent() {
+    let (mut suite, mut accounts, ..) = setup_test_naive(Default::default());
+
+    let target = accounts.user1.address();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            target,
+            &ExecuteMsg::Freeze {},
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.owner,
+            target,
+            &ExecuteMsg::Freeze {},
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .query_wasm_smart(target, account::QueryStatusRequest {})
+        .should_succeed_and_equal(AccountStatus::Frozen);
+}
+
+/// Unfreezing an account that isn't `Frozen` (e.g. already active) is rejected.
+#[tokio::test]
+async fn unfreeze_requires_frozen_status() {
+    let (mut suite, mut accounts, ..) = setup_test_naive(Default::default());
+
+    let target = accounts.user1.address();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            target,
+            &ExecuteMsg::Unfreeze {},
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error("can only unfreeze a frozen account");
+}

--- a/dango/types/src/account.rs
+++ b/dango/types/src/account.rs
@@ -11,6 +11,20 @@ pub struct InstantiateMsg {
     pub activate: bool,
 }
 
+/// Execute messages for the single-signature account.
+///
+/// All variants are restricted to the chain's owner.
+#[grug_types::derive(Serde)]
+pub enum ExecuteMsg {
+    /// Freeze the account, preventing it from sending transactions or
+    /// receiving transfers. Requires the account to currently be in the
+    /// `Active` state.
+    Freeze {},
+    /// Unfreeze the account, restoring it to the `Active` state. Requires
+    /// the account to currently be in the `Frozen` state.
+    Unfreeze {},
+}
+
 /// Query messages for the single-signature account
 #[grug_types::derive(Serde, QueryRequest)]
 pub enum QueryMsg {

--- a/dango/types/src/auth.rs
+++ b/dango/types/src/auth.rs
@@ -19,7 +19,8 @@ pub enum AccountStatus {
     Inactive,
     /// An account is activated once it receives a sufficient initial deposit.
     Active,
-    /// an account may be frozen by the chain's owner. This feature is not implemented yet.
+    /// An account may be frozen by the chain's owner. While frozen, the
+    /// account cannot send transactions or receive transfers.
     Frozen,
 }
 


### PR DESCRIPTION
Add `ExecuteMsg::Freeze` and `ExecuteMsg::Unfreeze` to the single-signature account contract, restricted to the chain's owner. Freeze transitions an `Active` account to `Frozen`; unfreeze transitions it back. The `Frozen` status was already enforced by the auth layer but had no way to be set.