### PR TITLE
fix(perps): re-clamp reduce-only maker orders at match time

### DIFF
--- a/dango/order-book/src/matching_engine.rs
+++ b/dango/order-book/src/matching_engine.rs
@@ -21,10 +21,11 @@
 use {
     crate::{
         ASKS, BIDS, ClientOrderId, Dimensionless, LimitOrder, OrderId, PairId, Quantity,
-        ReasonForOrderRemoval, TriggerDirection, UsdPrice, check_price_band,
+        ReasonForOrderRemoval, TriggerDirection, UsdPrice, check_price_band, decompose_fill,
         is_price_constraint_violated, may_invert_price,
     },
     grug_types::{Addr, Order as IterationOrder, StdResult, Storage},
+    std::collections::BTreeMap,
 };
 
 /// One match produced by [`walk_book`] — pure data, no perp settlement
@@ -182,6 +183,24 @@ pub struct WalkBookOutcome {
 /// - `remaining_size` — signed taker-perspective size to fill. The
 ///   walk decrements this in place and returns the unfilled remainder
 ///   in `outcome.remaining_size`.
+/// - `maker_position` — returns a maker's *current* signed position size
+///   in this pair (positive long, negative short, zero if none). Used to
+///   re-clamp reduce-only maker orders so they can only move the maker's
+///   position toward zero, never grow or flip it. Must report positions
+///   from the same source the caller settles against, so the walk's
+///   simulated positions match what settlement actually applies.
+///
+/// # Reduce-only makers
+///
+/// A reduce-only maker order may only reduce the maker's position. Its size
+/// was clamped to the position when it was placed, but the position may have
+/// shrunk since (other fills, liquidation, ADL), and one taker order can
+/// sweep several of the same maker's orders. So each reduce-only maker fill
+/// is re-clamped here against the maker's *current* position (the pre-walk
+/// position from `maker_position` plus the fills already applied earlier in
+/// this same walk). A reduce-only order with nothing left to close is
+/// skipped and left resting — it must never fill, as that would open the
+/// opposite side.
 ///
 /// # Termination
 ///
@@ -202,6 +221,7 @@ pub fn walk_book(
     oracle_price: UsdPrice,
     max_limit_price_deviation: Dimensionless,
     mut remaining_size: Quantity,
+    maker_position: impl Fn(Addr) -> StdResult<Quantity>,
 ) -> StdResult<WalkBookOutcome> {
     let maker_book = if taker_is_bid {
         ASKS
@@ -215,6 +235,14 @@ pub fn walk_book(
             .range(storage, None, None, IterationOrder::Ascending);
 
     let mut steps: Vec<WalkStep> = Vec::new();
+
+    // Cumulative maker-side fill applied so far in this walk, per maker (the
+    // maker fills the opposite of the taker: -taker_fill_size). Used by the
+    // reduce-only clamp below: a maker's current position is the pre-walk
+    // position from `maker_position` plus this delta. Tracked for *every*
+    // filled maker so a later reduce-only order of the same maker reflects
+    // earlier fills, including non-reduce-only ones.
+    let mut maker_fill_deltas: BTreeMap<Addr, Quantity> = BTreeMap::new();
 
     for record in maker_orders {
         let ((stored_price, maker_order_id), maker_order) = record?;
@@ -287,8 +315,37 @@ pub fn walk_book(
         // The maker's signed size is the negative of what the taker needs:
         // a maker bid has positive size and matches a taker ask (negative
         // remaining_size), and vice versa.
+        //
+        // Reduce-only makers are additionally clamped to their current
+        // position (see the "Reduce-only makers" doc section): only the
+        // portion of the order that closes the maker's position is fillable,
+        // computed against the pre-walk position plus the fills already
+        // applied to this maker earlier in the walk.
 
-        let opposite = maker_order.size.checked_neg()?;
+        let maker_user = maker_order.user;
+
+        let fillable_maker_size = if maker_order.reduce_only {
+            let delta = maker_fill_deltas
+                .get(&maker_user)
+                .copied()
+                .unwrap_or(Quantity::ZERO);
+            let current_position = maker_position(maker_user)?.checked_add(delta)?;
+
+            let (closing, _opening) = decompose_fill(maker_order.size, current_position);
+            closing
+        } else {
+            maker_order.size
+        };
+
+        // A reduce-only order with nothing left to close is inert: skip it,
+        // leaving it resting (cleanup of such dead/oversized orders is done
+        // separately via dynamic re-sizing on position changes). It must not
+        // fill — that would open a new position.
+        if fillable_maker_size.is_zero() {
+            continue;
+        }
+
+        let opposite = fillable_maker_size.checked_neg()?;
 
         let taker_fill_size = if taker_is_bid {
             remaining_size.min(opposite)
@@ -307,7 +364,7 @@ pub fn walk_book(
 
         steps.push(WalkStep::Fill(RawFill {
             maker_order_id,
-            maker_addr: maker_order.user,
+            maker_addr: maker_user,
             maker_client_order_id: maker_order.client_order_id,
             maker_pre_fill_size: pre_fill_abs_size,
             maker_post_fill_size: post_fill_abs,
@@ -316,6 +373,14 @@ pub fn walk_book(
             fill_size: taker_fill_size,
             maker_order,
         }));
+
+        // Record this fill against the maker's running position so a later
+        // reduce-only order of the same maker clamps against the reduced
+        // size. The maker fills the opposite of the taker: -taker_fill_size.
+        maker_fill_deltas
+            .entry(maker_user)
+            .or_insert(Quantity::ZERO)
+            .checked_add_assign(taker_fill_size.checked_neg()?)?;
 
         remaining_size.checked_sub_assign(taker_fill_size)?;
     }

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -26,8 +26,8 @@ use {
     dango_types::perps::{OrderFilled, PairParam, PairState, Param, State, UserState},
     grug_math::{MathResult, Number, NumberConst},
     grug_types::{
-        Addr, EventBuilder, MutableCtx, Order as IterationOrder, QuerierWrapper, Response, Storage,
-        Timestamp,
+        Addr, EventBuilder, MutableCtx, Order as IterationOrder, QuerierWrapper, Response,
+        StdResult, Storage, Timestamp,
     },
     std::collections::{BTreeMap, btree_map::Entry},
 };
@@ -743,6 +743,23 @@ pub fn match_order(
     // PnL settlement, OI bookkeeping, OrderFilled / OrderRemoved
     // events) in the same chronological order, matching the legacy
     // interleaved engine's event sequence byte-for-byte.
+    //
+    // Reduce-only maker orders must never flip the maker's position. The
+    // walker re-clamps each reduce-only maker fill against the maker's current
+    // position; give it a lookup that mirrors the maker-state source used by
+    // the settlement loop below (`maker_states` first, then `USER_STATES`,
+    // default zero) so the walk's simulation matches what `settle_fill` sees.
+    let maker_position = |addr: Addr| -> StdResult<Quantity> {
+        if let Some(s) = maker_states.get(&addr) {
+            Ok(s.positions.get(pair_id).map(|p| p.size).unwrap_or_default())
+        } else {
+            Ok(USER_STATES
+                .may_load(storage, addr)?
+                .map(|s| s.positions.get(pair_id).map(|p| p.size).unwrap_or_default())
+                .unwrap_or_default())
+        }
+    };
+
     let WalkBookOutcome {
         steps,
         remaining_size,
@@ -756,6 +773,7 @@ pub fn match_order(
         oracle_price,
         max_limit_price_deviation,
         remaining_size,
+        maker_position,
     )?;
 
     for step in steps {

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -15,6 +15,7 @@ mod conditional_orders;
 mod index_price;
 mod liquidation;
 mod price_band;
+mod reduce_only;
 mod referral;
 mod trading;
 mod vault;

--- a/dango/testing/tests/perps/reduce_only.rs
+++ b/dango/testing/tests/perps/reduce_only.rs
@@ -1,0 +1,651 @@
+//! Tests for the reduce-only order invariant: a reduce-only order may only
+//! move the maker's position toward zero — it must never grow the position or
+//! flip it to the opposite side.
+//!
+//! The invariant is enforced at placement time (the order is clamped to the
+//! position when submitted) AND, as of the match-time clamp, every time a
+//! resting reduce-only maker order is matched. See `match_order` in
+//! `dango/perps/src/trade/submit_order.rs` and `walk_book` in
+//! `dango/order-book/src/matching_engine.rs`.
+
+use {
+    crate::register_oracle_prices,
+    dango_order_book::{
+        Dimensionless, OrderId, OrderKind, PairId, Quantity, QueryOrdersByUserResponseItem,
+        TimeInForce, UsdPrice,
+    },
+    dango_testing::{TestAccount, TestOption, TestSuiteNaive, pair_id, setup_test_naive},
+    dango_types::{
+        constants::usdc,
+        perps::{self, UserState},
+    },
+    grug_math::Uint128,
+    grug_types::{Addr, Addressable, Coins, QuerierExt, ResultExt},
+    std::collections::BTreeMap,
+};
+
+/// $50,000 USDC (6 decimals) — generous so margin never clouds the
+/// position-size assertions, while staying within each test account's balance.
+const DEPOSIT: u128 = 50_000_000_000;
+
+// --------------------------------- helpers -----------------------------------
+
+/// Deposit `amount` (USDC base units) of margin for `account`.
+async fn deposit(
+    suite: &mut TestSuiteNaive,
+    account: &mut TestAccount,
+    contract: Addr,
+    amount: u128,
+) {
+    suite
+        .execute(
+            account,
+            contract,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(amount)).unwrap(),
+        )
+        .await
+        .should_succeed();
+}
+
+/// Submit a post-only limit order, which rests on the book without matching.
+/// Positive `size` is a bid (buy), negative an ask (sell).
+async fn rest_limit(
+    suite: &mut TestSuiteNaive,
+    account: &mut TestAccount,
+    contract: Addr,
+    pair: &PairId,
+    size: i128,
+    price: i128,
+    reduce_only: bool,
+) {
+    suite
+        .execute(
+            account,
+            contract,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(size),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(price),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+}
+
+/// Submit a market order that is expected to (at least partially) fill.
+async fn market_fill(
+    suite: &mut TestSuiteNaive,
+    account: &mut TestAccount,
+    contract: Addr,
+    pair: &PairId,
+    size: i128,
+    reduce_only: bool,
+) {
+    suite
+        .execute(
+            account,
+            contract,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(size),
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+}
+
+fn user_state(suite: &TestSuiteNaive, contract: Addr, user: Addr) -> UserState {
+    suite
+        .query_wasm_smart(contract, perps::QueryUserStateRequest { user })
+        .should_succeed()
+        .unwrap()
+}
+
+/// The user's signed position size in `pair`, or `None` if the user has no
+/// position there (a position closed to exactly zero is removed from the map).
+fn position(suite: &TestSuiteNaive, contract: Addr, user: Addr, pair: &PairId) -> Option<Quantity> {
+    user_state(suite, contract, user)
+        .positions
+        .get(pair)
+        .map(|p| p.size)
+}
+
+fn open_orders(
+    suite: &TestSuiteNaive,
+    contract: Addr,
+    user: Addr,
+) -> BTreeMap<OrderId, QueryOrdersByUserResponseItem> {
+    suite
+        .query_wasm_smart(contract, perps::QueryOrdersByUserRequest { user })
+        .should_succeed()
+}
+
+// ---------------------------------- tests ------------------------------------
+
+/// Attack reproduction (defanged: 1 unit, 3 orders instead of 1 BTC / 100
+/// orders).
+///
+/// A maker opens a 1-unit long, then rests three reduce-only sells of 1 unit
+/// each. Each is clamped to the position (1) at placement, but the maker's
+/// position can change after they rest, and a single taker can sweep all
+/// three. The taker buys 3.
+///
+/// Buggy behavior (v0.21): the resting clamp was never re-checked at match
+/// time, and the maker side of a fill happily decomposed an over-large fill
+/// into a closing AND an opening portion. So all three orders fully filled:
+/// order 1 closed the long (1 -> 0), then orders 2 and 3 OPENED a short
+/// (0 -> -1 -> -2). The maker's 1-unit long was flipped into a 2-unit short
+/// with no margin check — the core of the exploit. The taker received 3.
+///
+/// Correct behavior (match-time clamp): each reduce-only fill is re-clamped to
+/// the maker's current position. Order 1 closes the long (1 -> 0); orders 2
+/// and 3 have nothing left to close, so they are clamped to zero and skipped,
+/// left resting. The maker ends flat (never short) and the taker receives only
+/// 1. (Cancelling the two now-inert resting orders is the job of the separate
+/// dynamic re-sizing work; this PR leaves them on the book.)
+#[tokio::test]
+async fn reduce_only_maker_position_flip_attack() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    // user3 rests an ask of 1 @ $2,000 so the maker can open a long.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -1,
+        2_000,
+        false,
+    )
+    .await;
+
+    // Maker (user2) market-buys 1 -> opens a 1-unit long.
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 1, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(1)),
+        "maker should be 1 long after opening"
+    );
+
+    // Maker rests three reduce-only sells of 1 each @ 2001/2002/2003. Each is
+    // clamped to the position (1) at placement and rests at -1.
+    for price in [2_001, 2_002, 2_003] {
+        rest_limit(
+            &mut suite,
+            &mut accounts.user2,
+            perps,
+            &pair,
+            -1,
+            price,
+            true,
+        )
+        .await;
+    }
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(1)),
+        "resting orders must not change the position"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        3,
+        "maker should have 3 resting reduce-only sells"
+    );
+
+    // Taker (user1) market-buys 3 -> sweeps the reduce-only sells.
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 3, false).await;
+
+    // The maker's 1-unit long was closed to flat — NOT flipped into a short.
+    // (v0.21 produced a -2 short here.)
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None,
+        "maker should be flat — never flipped short"
+    );
+
+    // The taker only got the 1 unit the maker could actually close.
+    // (v0.21 over-filled the taker to a 3-unit long.)
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(1)),
+        "taker should receive only what the maker could close"
+    );
+
+    // The two reduce-only orders that had nothing left to close are skipped but
+    // remain resting. This PR intentionally does not cancel them — dynamic
+    // re-sizing (the follow-up) will. When that lands, this assertion is
+    // expected to change (the orders should be cancelled), so it doubles as a
+    // reminder.
+    let resting = open_orders(&suite, perps, accounts.user2.address());
+    assert_eq!(
+        resting.len(),
+        2,
+        "the two unfilled reduce-only orders still rest (until dynamic re-sizing removes them)"
+    );
+    assert!(
+        resting.values().all(|o| o.reduce_only),
+        "the resting orders should be the two reduce-only sells"
+    );
+    let prices: Vec<_> = resting.values().map(|o| o.limit_price).collect();
+    assert!(prices.contains(&UsdPrice::new_int(2_002)));
+    assert!(prices.contains(&UsdPrice::new_int(2_003)));
+}
+
+/// Several of the SAME maker's orders are matched by a single taker, where an
+/// earlier (non-reduce-only) order reduces the position before a later
+/// reduce-only order is reached. The later order's clamp must reflect the
+/// earlier fill, not the stale pre-sweep position.
+///
+/// Maker is long 10 and rests:
+/// - order A: a non-reduce-only sell of 6 @ 2001 (fills first),
+/// - order B: a reduce-only sell of 10 @ 2002 (clamped to 10 at placement).
+///
+/// A taker buys 16. Order A closes 6 (10 -> 4). Order B must then clamp to the
+/// reduced position (4), filling only 4 (4 -> 0) — NOT to the pre-sweep
+/// position (10), which would flip the maker to a 6-unit short. This is the
+/// case that the per-walk fill tracking (`maker_fill_deltas`) exists to handle.
+#[tokio::test]
+async fn reduce_only_clamp_reflects_earlier_fill_in_same_sweep() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    // Maker (user2) opens a 10-unit long against user3's ask.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
+    // Order A (non-reduce-only sell 6 @ 2001) and order B (reduce-only sell 10
+    // @ 2002). A is the more senior ask (lower price), so it fills first.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -6,
+        2_001,
+        false,
+    )
+    .await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    // Taker (user1) buys 16, sweeping A then B.
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 16, false).await;
+
+    // A closed 6 (10 -> 4); B clamped to the reduced position and closed 4
+    // (4 -> 0). Maker ends flat. A naive clamp against the pre-sweep position
+    // (10) would have flipped the maker to a 6-unit short.
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None,
+        "maker should be flat — the reduce-only order clamped to the reduced position"
+    );
+
+    // Taker bought 6 (from A) + 4 (from B) = 10.
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(10)),
+        "taker filled 6 from A and 4 from B"
+    );
+
+    // Order A fully filled and was removed; order B has its (now inert)
+    // remainder resting.
+    let resting = open_orders(&suite, perps, accounts.user2.address());
+    assert_eq!(
+        resting.len(),
+        1,
+        "only the reduce-only order's remainder rests"
+    );
+    assert!(resting.values().all(|o| o.reduce_only));
+}
+
+/// A reduce-only order rests, then the maker's position shrinks (via a separate
+/// trade) before a taker reaches the order. The order's resting size is now
+/// stale (larger than the position); the match-time clamp must cap the fill to
+/// the current, smaller position.
+///
+/// Maker is long 10 with a reduce-only sell of 10 resting. The maker then sells
+/// 7 (non-reduce-only) to a third party, leaving a 3-unit long. A taker buys
+/// 10 against the stale reduce-only order, which must close only 3 (3 -> 0),
+/// not 10 (which would flip the maker to a 7-unit short).
+#[tokio::test]
+async fn reduce_only_clamps_to_stale_shrunken_position() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // Maker (user2) opens a 10-unit long against user3's ask.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
+    // Maker rests a reduce-only sell of 10 (clamped to the position, 10).
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    // Maker shrinks the long to 3 by selling 7 to user4 (non-reduce-only). This
+    // does not touch the resting reduce-only ask, which is now stale at 10.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        7,
+        2_001,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -7, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(3)),
+        "maker long should be reduced to 3"
+    );
+
+    // Taker (user1) buys 10 against the stale reduce-only ask.
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 10, false).await;
+
+    // The order closed only the 3 units the maker still had — not its stale
+    // resting size of 10 (which would have flipped the maker to a 7 short).
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None,
+        "maker should be flat — clamped to the shrunken position"
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(3)),
+        "taker received only the 3 the maker could close"
+    );
+}
+
+/// A reduce-only order whose maker has since flipped to the SAME side as the
+/// order is inert: it can only reduce, and there is nothing to reduce in the
+/// closing direction, so it must not fill at all.
+///
+/// Maker is long 10 with a reduce-only sell of 10 resting, then flips to a
+/// 5-unit short (selling 15 to a third party). The resting sell would now grow
+/// the short, so the match-time clamp drops it to zero and skips it: a taker
+/// buying against it finds no fillable liquidity, and the maker stays short 5.
+#[tokio::test]
+async fn reduce_only_inert_when_position_flipped() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // Maker (user2) opens a 10-unit long against user3's ask.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
+    // Maker rests a reduce-only sell of 10.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    // Maker flips to a 5-unit short by selling 15 to user4 (non-reduce-only:
+    // closes the 10 long and opens a 5 short).
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        15,
+        2_001,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -15, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-5)),
+        "maker should be 5 short after flipping"
+    );
+
+    // Taker (user1) tries to buy against the now-inert reduce-only ask. It is
+    // the only resting ask, and it is skipped, so the market order finds no
+    // liquidity and is rejected.
+    suite
+        .execute(
+            &mut accounts.user1,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error("no liquidity at acceptable price");
+
+    // The maker's short is untouched, and the inert order is still on the book.
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-5)),
+        "maker short must be unchanged — the reduce-only order cannot grow it"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1,
+        "the inert reduce-only order is left resting"
+    );
+}
+
+/// Regression: when the position fully covers the reduce-only order, the order
+/// fills in full and is removed — the clamp must not under-fill it.
+///
+/// Maker is long 10 with a reduce-only sell of 5 resting. A taker buys 5; the
+/// order fills completely (10 -> 5 long) and is removed.
+#[tokio::test]
+async fn reduce_only_fills_fully_when_position_sufficient() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    // Maker (user2) opens a 10-unit long against user3's ask.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
+    // Maker rests a reduce-only sell of 5 (well within the 10 long).
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_002,
+        true,
+    )
+    .await;
+
+    // Taker (user1) buys 5.
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 5, false).await;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(5)),
+        "maker long reduced from 10 to 5"
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(5)),
+        "taker bought 5"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        0,
+        "the reduce-only order fully filled and was removed"
+    );
+}
+
+/// Regression: the clamp applies ONLY to reduce-only orders. A regular
+/// (non-reduce-only) resting order may still flip the maker's position, which
+/// is normal trading behavior.
+///
+/// Maker is long 1 with a regular sell of 5 resting. A taker buys 5; the order
+/// closes the 1 long and opens a 4 short — exactly as it should.
+#[tokio::test]
+async fn non_reduce_only_order_still_flips_position() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    // Maker (user2) opens a 1-unit long against user3's ask.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -1,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 1, false).await;
+
+    // Maker rests a REGULAR (non-reduce-only) sell of 5.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_002,
+        false,
+    )
+    .await;
+
+    // Taker (user1) buys 5.
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 5, false).await;
+
+    // The regular order closed the 1 long and opened a 4 short — not clamped.
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-4)),
+        "a non-reduce-only order may flip the position"
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(5)),
+        "taker bought 5"
+    );
+}


### PR DESCRIPTION
A reduce-only order may only reduce the maker's position. This is enforced when the order is placed, but the maker's position can change while the order rests on the book, and a single taker can match several of the same maker's orders in one sweep. Re-clamp every reduce-only maker fill against the maker's current position during matching, so a reduce-only order can only ever move the position toward zero.

`walk_book` now takes a maker-position lookup and tracks each maker's running fill within the walk; `match_order` supplies the lookup, mirroring the maker-state source it settles against. A reduce-only order with nothing left to close is skipped and left resting.

Add end-to-end tests covering the match-time clamp.