### PR TITLE
fix(docker): apt upgrade in dango and cometbft images to patch GnuTLS CVEs

### DIFF
--- a/docker/cometbft/Dockerfile
+++ b/docker/cometbft/Dockerfile
@@ -20,7 +20,7 @@ FROM debian:bookworm-slim AS runtime
 LABEL org.opencontainers.image.description="CometBFT runtime for Dango"
 
 # Install dependencies.
-RUN apt update && apt install -y curl
+RUN apt update && apt upgrade -y && apt install -y curl
 
 # I changed my mind, adding a user with a specific UID/GID (in this case
 # 1001/1001) is a pain because the files created from within that container

--- a/docker/dango/Dockerfile
+++ b/docker/dango/Dockerfile
@@ -12,6 +12,7 @@ ENV GIT_COMMIT=$GIT_COMMIT
 # ENV USERNAME=${USERNAME}
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y libssl-dev pkg-config libsqlite3-0 ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

The `Rust` workflow on `main` fails at **Generate Backend SBOM and Scan Image → Enforce vulnerability policy**: Grype flags critical CVEs in the `dango` image — all in `libgnutls30 3.7.9-2+deb12u6` from the `debian:bookworm-slim` base (CVE-2026-42010, CVE-2026-33845, plus several High). The fix (`3.7.9-2+deb12u7`) is already published in the Debian security archives, but the Dockerfiles only run `apt install` and never `apt upgrade`, so packages inherited from the base image stay at their stale versions until upstream rebuilds the base.

This PR adds `apt upgrade -y` to the image builds:

- `docker/dango/Dockerfile` — the image scanned by CI (unblocks main)
- `docker/cometbft/Dockerfile` (runtime stage) — same base, same pattern

This also makes builds resilient to future CVEs patched in Debian security without waiting for the upstream base image.

## Validation

### Completed
- [x] Identified root cause from CI artifacts (`security-artifacts-27107799573` Grype report)
- [x] Confirmed fixed package versions are available in Debian security archives (per Grype `FIXED-IN` column)

### Remaining
- [ ] Backend SBOM scan job passes on this PR's image build
- [ ] Verify `libgnutls30` is at `3.7.9-2+deb12u7` in the built image

## Manual QA

None — verified by the CI vulnerability scan itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)