### PR TITLE
feat(perps): dynamically re-size reduce-only orders when positions change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,7 +4012,12 @@ dependencies = [
 name = "dango-upgrade"
 version = "0.0.0"
 dependencies = [
+ "dango-order-book",
+ "dango-perps",
+ "dango-types",
  "grug-app",
+ "grug-math",
+ "grug-storage",
  "grug-types",
  "tracing",
 ]

--- a/dango/order-book/src/events.rs
+++ b/dango/order-book/src/events.rs
@@ -18,6 +18,32 @@ pub struct OrderPersisted {
     pub client_order_id: Option<ClientOrderId>,
 }
 
+/// Event indicating a resting order's size was reduced in place (not removed).
+///
+/// Emitted by dynamic re-sizing of reduce-only orders: when a user's position
+/// shrinks, their resting reduce-only orders are clamped so that their absolute
+/// sizes sum to no more than the new position. An order whose clamped size is
+/// still non-zero is rewritten with the smaller size rather than removed (a
+/// clamp to zero removes it instead, emitting `OrderRemoved`).
+#[grug_types::event("order_resized")]
+#[grug_types::derive(Serde)]
+pub struct OrderResized {
+    pub order_id: OrderId,
+    pub pair_id: PairId,
+    pub user: Addr,
+
+    /// Signed size before the re-size.
+    pub old_size: Quantity,
+
+    /// Signed size after the re-size. Carries the same sign as `old_size`, with
+    /// a strictly smaller absolute value.
+    pub new_size: Quantity,
+
+    /// Caller-assigned id from the originally-submitted order, or `None`
+    /// if the order was submitted without one.
+    pub client_order_id: Option<ClientOrderId>,
+}
+
 /// Event indicating an order has been removed from the order book.
 #[grug_types::event("order_removed")]
 #[grug_types::derive(Serde)]
@@ -87,6 +113,14 @@ pub enum ReasonForOrderRemoval {
 
     /// The user was hit by auto-deleveraging (ADL).
     Deleveraged,
+
+    /// A resting reduce-only order was cancelled by dynamic re-sizing because
+    /// the user's position changed: it closed or flipped (the order is now on
+    /// the wrong side), or it shrank enough that this order — the worst by
+    /// price-time priority among the user's reduce-only orders — had no
+    /// remaining position left to close. Distinct from `PositionClosed`, which
+    /// is specific to conditional (TP/SL) orders.
+    ReduceOnlyResized,
 
     /// The conditional order was triggered but could not fill within the
     /// user's max_slippage tolerance (insufficient book liquidity).

--- a/dango/perps/src/cron/process_conditional_orders.rs
+++ b/dango/perps/src/cron/process_conditional_orders.rs
@@ -3,7 +3,7 @@ use {
         position_index::apply_position_index_updates,
         referral::{FeeCommissionsOutcome, apply_fee_commissions},
         state::{PAIR_IDS, PAIR_PARAMS, PAIR_STATES, PARAM, STATE, USER_STATES},
-        trade::{SubmitOrderOutcome, compute_submit_order_outcome},
+        trade::{SubmitOrderOutcome, compute_submit_order_outcome, resize_reduce_only_orders},
     },
     dango_order_book::{
         ASKS, BIDS, ConditionalOrderRemoved, ConditionalOrderTriggered, NEXT_FILL_ID,
@@ -495,6 +495,18 @@ fn process_triggered_order(
                 maker_book.remove(storage, order_key)?;
             },
         }
+    }
+
+    // Dynamic re-size of reduce-only orders. The triggered market order closed
+    // (part of) `user`'s position and may have filled makers, so every affected
+    // user's resting reduce-only orders are re-clamped to their new position.
+    // The affected users are exactly the keys of `maker_states` (the triggered
+    // user was inserted above, alongside each filled maker). We iterate the map
+    // rather than the `index_updates`, because a pure reduction leaves
+    // `(entry_price, side)` — hence the index — unchanged; re-sizing an
+    // unchanged user is a harmless no-op.
+    for user in maker_states.keys() {
+        resize_reduce_only_orders(storage, *user, pair_id, events)?;
     }
 
     Ok(TriggeredOrderOutcome { state, pair_state })

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -11,8 +11,8 @@ use {
         state::{LONGS, PAIR_PARAMS, PAIR_STATES, PARAM, SHORTS, STATE, USER_STATES},
         trade::{
             CancelAllOrdersOutcome, FeeBreakdown, MatchOrderOutcome,
-            compute_cancel_all_orders_outcome, match_order, merge_fee_breakdown, settle_fill,
-            settle_pnls,
+            compute_cancel_all_orders_outcome, match_order, merge_fee_breakdown,
+            resize_reduce_only_orders, settle_fill, settle_pnls,
         },
     },
     anyhow::ensure,
@@ -214,6 +214,23 @@ pub fn liquidate(ctx: MutableCtx, user: Addr) -> anyhow::Result<Response> {
     // -------------------- 8. Apply position index updates --------------------
 
     apply_position_index_updates(ctx.storage, &index_updates)?;
+
+    // ---------- 9. Dynamic re-size of reduce-only orders ---------------------
+    //
+    // Liquidation forcibly reduced the positions of book-fill makers and ADL
+    // counter-parties (the liquidated user's own orders were already cancelled
+    // in step 2), so each of their resting reduce-only orders is re-clamped to
+    // its new position. The affected users are the keys of `maker_states`; the
+    // pairs are those the liquidated user held (`pair_ids`), the only pairs a
+    // fill could have touched. Over-scanning (a maker not on a given pair) is a
+    // safe no-op. We iterate the maps rather than the `index_updates`, because a
+    // pure ADL reduction leaves `(entry_price, side)` — hence the index —
+    // unchanged, which is exactly the case re-sizing must catch.
+    for pair_id in &pair_ids {
+        for maker in maker_states.keys() {
+            resize_reduce_only_orders(ctx.storage, *maker, pair_id, &mut events)?;
+        }
+    }
 
     #[cfg(feature = "tracing")]
     {

--- a/dango/perps/src/trade.rs
+++ b/dango/perps/src/trade.rs
@@ -2,13 +2,14 @@ mod batch_update_orders;
 mod cancel_conditional_order;
 mod cancel_order;
 mod deposit;
+mod resize_reduce_only;
 mod submit_conditional_order;
 mod submit_order;
 mod withdraw;
 
 pub use {
     batch_update_orders::*, cancel_conditional_order::*, cancel_order::*, deposit::*,
-    submit_conditional_order::*, submit_order::*, withdraw::*,
+    resize_reduce_only::*, submit_conditional_order::*, submit_order::*, withdraw::*,
 };
 
 use {

--- a/dango/perps/src/trade/cancel_order.rs
+++ b/dango/perps/src/trade/cancel_order.rs
@@ -64,7 +64,7 @@ pub(crate) fn _cancel_one_order(
 ///   to the user state before saving.
 /// - Remove the order from the `BIDS` or `ASKS` map.
 /// - Remove liquidity depth contributed by this order.
-fn compute_cancel_one_order_outcome<F>(
+pub(crate) fn compute_cancel_one_order_outcome<F>(
     storage: &mut dyn Storage,
     user_state: &mut UserState,
     order_key: OrderKey,

--- a/dango/perps/src/trade/resize_reduce_only.rs
+++ b/dango/perps/src/trade/resize_reduce_only.rs
@@ -1,0 +1,603 @@
+//! Dynamic re-sizing of a user's resting reduce-only orders.
+//!
+//! A reduce-only order may only move its owner's position toward zero. This is
+//! enforced per-order at placement and re-checked at match time, but a user can
+//! rest several reduce-only orders whose sizes individually fit the position yet
+//! together exceed it, and the position can shrink or flip after the orders are
+//! placed (other fills, liquidation, ADL). This module restores the invariant:
+//!
+//! > For every (user, pair): the resting reduce-only orders are all on the
+//! > position-closing side, and their absolute sizes sum to no more than
+//! > `|position|`.
+//!
+//! It runs after every position change, scanning the user's reduce-only orders
+//! and greedily shrinking/cancelling the worst by price-time priority until the
+//! sum fits. A closed or flipped position leaves every reduce-only order on the
+//! wrong side, so all of them are cancelled.
+
+use {
+    super::cancel_order::compute_cancel_one_order_outcome,
+    crate::state::{PAIR_PARAMS, USER_STATES},
+    dango_order_book::{
+        ASKS, BIDS, LimitOrder, OrderId, OrderKey, OrderResized, PairId, Quantity,
+        ReasonForOrderRemoval, decrease_liquidity_depths, increase_liquidity_depths,
+        may_invert_price,
+    },
+    dango_types::perps::UserState,
+    grug_types::{Addr, EventBuilder, Order as IterationOrder, StdResult, Storage},
+};
+
+/// Owned outcome of [`compute_resize_reduce_only_outcome`]. Carries the updated
+/// `UserState` copy (the caller persists it) and the ids of orders cancelled
+/// this pass. Order-book and liquidity-depth writes happen *inside* the function
+/// — storage has tx-level rollback, so they need not be deferred — but the
+/// caller-persistable `UserState` is taken by `&` and returned owned, per
+/// `dango/perps/purity.md`.
+#[derive(Debug)]
+pub struct ResizeReduceOnlyOutcome {
+    pub user_state: UserState,
+    pub removed: Vec<OrderId>,
+}
+
+/// Re-clamp `user`'s resting reduce-only orders on `pair_id` to the current
+/// position (see the module docs for the invariant). Pure w.r.t. `UserState`:
+/// clones it, mutates the clone, and returns the updated copy; writes the order
+/// book and liquidity depth inline. The returned `removed` lists the ids
+/// cancelled this pass so the placement path can reject a just-rested order that
+/// the sum-clamp zeroed.
+pub fn compute_resize_reduce_only_outcome(
+    storage: &mut dyn Storage,
+    user: Addr,
+    pair_id: &PairId,
+    user_state: &UserState,
+    mut events: Option<&mut EventBuilder>,
+) -> StdResult<ResizeReduceOnlyOutcome> {
+    let mut user_state = user_state.clone();
+    let mut removed = Vec::new();
+
+    let position = user_state
+        .positions
+        .get(pair_id)
+        .map(|p| p.size)
+        .unwrap_or(Quantity::ZERO);
+
+    // Collect the user's reduce-only orders for this pair from each book. The
+    // `user` index ranges in primary-key order — `(pair_id, stored_price,
+    // order_id)` — so for each side this is already best-price-time-first: asks
+    // ascend by real price; bids are stored at the inverted price, so they
+    // ascend by descending real price. We rely on that ordering to allocate the
+    // position to the best orders first and shrink the worst.
+    let ro_asks = ASKS
+        .idx
+        .user
+        .prefix(user)
+        .range(storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<Vec<_>>>()?
+        .into_iter()
+        .filter(|(key, order)| &key.0 == pair_id && order.reduce_only)
+        .collect::<Vec<(OrderKey, LimitOrder)>>();
+
+    let ro_bids = BIDS
+        .idx
+        .user
+        .prefix(user)
+        .range(storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<Vec<_>>>()?
+        .into_iter()
+        .filter(|(key, order)| &key.0 == pair_id && order.reduce_only)
+        .collect::<Vec<(OrderKey, LimitOrder)>>();
+
+    // The closing side reduces the position toward zero; orders on the other
+    // side would grow it, so they are always cancelled. When the position is
+    // flat, every reduce-only order is on the wrong side.
+    let (closing, wrong): (Vec<_>, Vec<_>) = if position.is_positive() {
+        (ro_asks, ro_bids)
+    } else if position.is_negative() {
+        (ro_bids, ro_asks)
+    } else {
+        (Vec::new(), ro_asks.into_iter().chain(ro_bids).collect())
+    };
+
+    if closing.is_empty() && wrong.is_empty() {
+        return Ok(ResizeReduceOnlyOutcome {
+            user_state,
+            removed,
+        });
+    }
+
+    let pair_param = PAIR_PARAMS.load(storage, pair_id)?;
+
+    // Cancel every wrong-side order (the position closed or flipped).
+    for (order_key, order) in wrong {
+        let order_id = order_key.2;
+        compute_cancel_one_order_outcome(
+            storage,
+            &mut user_state,
+            order_key,
+            order,
+            events.as_deref_mut(),
+            ReasonForOrderRemoval::ReduceOnlyResized,
+            |_, _| Ok(pair_param.clone()),
+        )?;
+        removed.push(order_id);
+    }
+
+    // Walk the closing side best-first, allocating `|position|` as a shared
+    // budget. Each order keeps at most what is left; an order that gets nothing
+    // is cancelled, and one that gets less than its size is shrunk. Because the
+    // budget is shared, it is the *sum* of the orders that is clamped, not each
+    // order individually.
+    let mut budget = position.checked_abs()?;
+
+    for (order_key, order) in closing {
+        let order_id = order_key.2;
+        let abs_size = order.size.checked_abs()?;
+        let alloc = abs_size.min(budget);
+        budget = budget.checked_sub(alloc)?;
+
+        if alloc.is_zero() {
+            compute_cancel_one_order_outcome(
+                storage,
+                &mut user_state,
+                order_key,
+                order,
+                events.as_deref_mut(),
+                ReasonForOrderRemoval::ReduceOnlyResized,
+                |_, _| Ok(pair_param.clone()),
+            )?;
+            removed.push(order_id);
+        } else if alloc < abs_size {
+            // Shrink in place: keep the order's sign, lower only its magnitude.
+            let new_size = if order.size.is_negative() {
+                alloc.checked_neg()?
+            } else {
+                alloc
+            };
+
+            // Release reserved margin for the removed portion. Derive the
+            // release once (the proportion of the size that goes away) and
+            // subtract it from *both* the aggregate and the per-order field,
+            // mirroring the maker partial-fill in `match_order`. Recomputing the
+            // per-order value with its own `× |new| / |old|` division would let
+            // two truncating divisions disagree and strand margin.
+            let margin_to_release = order
+                .reserved_margin
+                .checked_mul(order.size.checked_sub(new_size)?)?
+                .checked_div(order.size)?;
+
+            user_state
+                .reserved_margin
+                .checked_sub_assign(margin_to_release)?;
+
+            let is_bid = order.size.is_positive();
+            let real_price = may_invert_price(order_key.1, is_bid);
+
+            // Remove the old depth contribution and re-add the new size (rather
+            // than adjusting by the delta) to avoid notional drift — see
+            // `liquidity_depth.rs::partial_fill_no_residual_depth`.
+            decrease_liquidity_depths(
+                storage,
+                pair_id,
+                is_bid,
+                real_price,
+                abs_size,
+                &pair_param.bucket_sizes,
+            )?;
+            increase_liquidity_depths(
+                storage,
+                pair_id,
+                is_bid,
+                real_price,
+                alloc,
+                &pair_param.bucket_sizes,
+            )?;
+
+            let mut updated = order.clone();
+            updated.size = new_size;
+            updated.reserved_margin = order.reserved_margin.checked_sub(margin_to_release)?;
+
+            let book = if is_bid {
+                BIDS
+            } else {
+                ASKS
+            };
+            book.save(storage, order_key, &updated)?;
+
+            if let Some(events) = events.as_deref_mut() {
+                events.push(OrderResized {
+                    order_id,
+                    pair_id: pair_id.clone(),
+                    user,
+                    old_size: order.size,
+                    new_size,
+                    client_order_id: order.client_order_id,
+                })?;
+            }
+        }
+        // else: `alloc == abs_size`, the order fits entirely — leave it as is.
+    }
+
+    Ok(ResizeReduceOnlyOutcome {
+        user_state,
+        removed,
+    })
+}
+
+/// Persist-layer wrapper over [`compute_resize_reduce_only_outcome`]. Loads the
+/// user's state (no-op if the user has none — then there are no orders to
+/// re-size), runs the core, and persists the returned state (removing it once it
+/// becomes empty). Returns the ids cancelled this pass.
+pub fn resize_reduce_only_orders(
+    storage: &mut dyn Storage,
+    user: Addr,
+    pair_id: &PairId,
+    events: &mut EventBuilder,
+) -> StdResult<Vec<OrderId>> {
+    let Some(user_state) = USER_STATES.may_load(storage, user)? else {
+        return Ok(Vec::new());
+    };
+
+    let ResizeReduceOnlyOutcome {
+        user_state,
+        removed,
+    } = compute_resize_reduce_only_outcome(storage, user, pair_id, &user_state, Some(events))?;
+
+    if user_state.is_empty() {
+        USER_STATES.remove(storage, user)?;
+    } else {
+        USER_STATES.save(storage, user, &user_state)?;
+    }
+
+    Ok(removed)
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        dango_order_book::{FundingPerUnit, UsdPrice, UsdValue},
+        dango_types::perps::{PairParam, Position},
+        grug_math::Uint64,
+        grug_types::{MockContext, Timestamp},
+        std::collections::{BTreeMap, VecDeque},
+    };
+
+    const USER: Addr = Addr::mock(1);
+
+    fn pair() -> PairId {
+        "perp/btcusd".parse().unwrap()
+    }
+
+    fn other_pair() -> PairId {
+        "perp/ethusd".parse().unwrap()
+    }
+
+    fn ensure_pair_param(storage: &mut dyn Storage, pair: &PairId) {
+        if PAIR_PARAMS.may_load(storage, pair).unwrap().is_none() {
+            PAIR_PARAMS
+                .save(storage, pair, &PairParam::default())
+                .unwrap();
+        }
+    }
+
+    /// Save a reduce-only ask (negative size) at a real `price`. For asks the
+    /// stored key price equals the real price.
+    fn save_ro_ask(
+        storage: &mut dyn Storage,
+        pair: &PairId,
+        order_id: u64,
+        price: i128,
+        size: i128,
+        reserved: i128,
+    ) {
+        ensure_pair_param(storage, pair);
+        let key = (
+            pair.clone(),
+            UsdPrice::new_int(price),
+            Uint64::new(order_id),
+        );
+        let order = LimitOrder {
+            user: USER,
+            size: Quantity::new_int(size),
+            reduce_only: true,
+            reserved_margin: UsdValue::new_int(reserved),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        };
+        ASKS.save(storage, key, &order).unwrap();
+    }
+
+    /// Save a reduce-only bid (positive size) at a real `price`. For bids the
+    /// stored key price is inverted, matching `store_limit_order`.
+    fn save_ro_bid(
+        storage: &mut dyn Storage,
+        pair: &PairId,
+        order_id: u64,
+        price: i128,
+        size: i128,
+        reserved: i128,
+    ) {
+        ensure_pair_param(storage, pair);
+        let key = (
+            pair.clone(),
+            may_invert_price(UsdPrice::new_int(price), true),
+            Uint64::new(order_id),
+        );
+        let order = LimitOrder {
+            user: USER,
+            size: Quantity::new_int(size),
+            reduce_only: true,
+            reserved_margin: UsdValue::new_int(reserved),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        };
+        BIDS.save(storage, key, &order).unwrap();
+    }
+
+    fn load_ask(
+        storage: &dyn Storage,
+        pair: &PairId,
+        price: i128,
+        order_id: u64,
+    ) -> Option<LimitOrder> {
+        ASKS.may_load(
+            storage,
+            (
+                pair.clone(),
+                UsdPrice::new_int(price),
+                Uint64::new(order_id),
+            ),
+        )
+        .unwrap()
+    }
+
+    fn load_bid(
+        storage: &dyn Storage,
+        pair: &PairId,
+        price: i128,
+        order_id: u64,
+    ) -> Option<LimitOrder> {
+        BIDS.may_load(
+            storage,
+            (
+                pair.clone(),
+                may_invert_price(UsdPrice::new_int(price), true),
+                Uint64::new(order_id),
+            ),
+        )
+        .unwrap()
+    }
+
+    /// Build a `UserState` carrying a single position (size, in `pair()`) plus
+    /// the given reserved margin and open-order count. A zero `position` leaves
+    /// the user flat (no position entry).
+    fn user_state_with(position: i128, reserved: i128, open_orders: usize) -> UserState {
+        let mut positions = BTreeMap::new();
+        if position != 0 {
+            positions.insert(pair(), Position {
+                size: Quantity::new_int(position),
+                entry_price: UsdPrice::new_int(2_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            });
+        }
+        UserState {
+            unlocks: VecDeque::new(),
+            positions,
+            reserved_margin: UsdValue::new_int(reserved),
+            open_order_count: open_orders,
+            ..Default::default()
+        }
+    }
+
+    /// Sum of the reserved margin of every reduce-only order the user has
+    /// resting across both books — used to assert nothing is orphaned.
+    fn total_resting_reserved(storage: &dyn Storage) -> UsdValue {
+        let mut total = UsdValue::ZERO;
+        for res in ASKS
+            .idx
+            .user
+            .prefix(USER)
+            .range(storage, None, None, IterationOrder::Ascending)
+        {
+            total
+                .checked_add_assign(res.unwrap().1.reserved_margin)
+                .unwrap();
+        }
+        for res in BIDS
+            .idx
+            .user
+            .prefix(USER)
+            .range(storage, None, None, IterationOrder::Ascending)
+        {
+            total
+                .checked_add_assign(res.unwrap().1.reserved_margin)
+                .unwrap();
+        }
+        total
+    }
+
+    /// Aggregate reduce-only size already fits the position ⇒ everything is left
+    /// untouched and nothing is cancelled.
+    #[test]
+    fn noop_when_within_budget() {
+        let mut ctx = MockContext::new();
+
+        // Long 10; two reduce-only sells summing to 7 ≤ 10.
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_002, -4, 40);
+        let user_state = user_state_with(10, 70, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        assert!(outcome.removed.is_empty());
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::new_int(70));
+        assert_eq!(outcome.user_state.open_order_count, 2);
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_001, 1).unwrap().size,
+            Quantity::new_int(-3)
+        );
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_002, 2).unwrap().size,
+            Quantity::new_int(-4)
+        );
+    }
+
+    /// Two reduce-only sells that each individually fit the position but together
+    /// exceed it: the budget clamps the *sum*, shrinking the worst (newest /
+    /// higher-priced) order. Also asserts margin conservation.
+    #[test]
+    fn shrink_worst_first_clamps_the_sum() {
+        let mut ctx = MockContext::new();
+
+        // Long 4; two reduce-only sells of 3 each (each ≤ 4, together 6 > 4).
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_002, -3, 30);
+        let user_state = user_state_with(4, 60, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        // @2001 (best) keeps its 3; @2002 shrinks to 1 (budget 4 − 3 = 1).
+        assert!(outcome.removed.is_empty());
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_001, 1).unwrap().size,
+            Quantity::new_int(-3)
+        );
+        let shrunk = load_ask(&ctx.storage, &pair(), 2_002, 2).unwrap();
+        assert_eq!(shrunk.size, Quantity::new_int(-1));
+        // Reserved released proportionally: 30 × 2/3 = 20, leaving 10.
+        assert_eq!(shrunk.reserved_margin, UsdValue::new_int(10));
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::new_int(40));
+        // Nothing orphaned: aggregate == Σ of resting orders' reserved.
+        assert_eq!(
+            outcome.user_state.reserved_margin,
+            total_resting_reserved(&ctx.storage)
+        );
+        // Sum of resting sizes equals the position.
+        assert_eq!(outcome.user_state.open_order_count, 2);
+    }
+
+    /// An order beyond the remaining budget is cancelled entirely (id reported in
+    /// `removed`, reserved fully released, count decremented).
+    #[test]
+    fn cancel_on_zero_budget() {
+        let mut ctx = MockContext::new();
+
+        // Long 3; two reduce-only sells of 3 — the first consumes the whole
+        // position, the second gets nothing.
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_002, -3, 30);
+        let user_state = user_state_with(3, 60, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        assert_eq!(outcome.removed, vec![Uint64::new(2)]);
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_001, 1).unwrap().size,
+            Quantity::new_int(-3)
+        );
+        assert!(load_ask(&ctx.storage, &pair(), 2_002, 2).is_none());
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::new_int(30));
+        assert_eq!(outcome.user_state.open_order_count, 1);
+    }
+
+    /// A flat position leaves every reduce-only order on the wrong side ⇒ all are
+    /// cancelled.
+    #[test]
+    fn cancel_all_when_flat() {
+        let mut ctx = MockContext::new();
+
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_002, -3, 30);
+        // Flat (no position), but the orders + reserved still on record.
+        let user_state = user_state_with(0, 60, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        assert_eq!(outcome.removed.len(), 2);
+        assert!(load_ask(&ctx.storage, &pair(), 2_001, 1).is_none());
+        assert!(load_ask(&ctx.storage, &pair(), 2_002, 2).is_none());
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::ZERO);
+        assert_eq!(outcome.user_state.open_order_count, 0);
+    }
+
+    /// After a flip to short, the reduce-only *sells* are now on the wrong side
+    /// and are cancelled, while a correctly-sided reduce-only buy is kept within
+    /// the new (short) budget.
+    #[test]
+    fn cancel_wrong_side_after_flip() {
+        let mut ctx = MockContext::new();
+
+        // Two stale reduce-only sells (wrong side for a short) and one
+        // reduce-only buy of 5 (closes the short, within the 5 budget).
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_002, -3, 30);
+        save_ro_bid(&mut ctx.storage, &pair(), 3, 1_999, 5, 50);
+        let user_state = user_state_with(-5, 110, 3);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        assert_eq!(outcome.removed.len(), 2);
+        assert!(outcome.removed.contains(&Uint64::new(1)));
+        assert!(outcome.removed.contains(&Uint64::new(2)));
+        assert!(load_ask(&ctx.storage, &pair(), 2_001, 1).is_none());
+        assert!(load_ask(&ctx.storage, &pair(), 2_002, 2).is_none());
+        // The buy survives untouched.
+        assert_eq!(
+            load_bid(&ctx.storage, &pair(), 1_999, 3).unwrap().size,
+            Quantity::new_int(5)
+        );
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::new_int(50));
+        assert_eq!(outcome.user_state.open_order_count, 1);
+    }
+
+    /// A re-size of one pair must not touch the user's reduce-only orders in
+    /// another pair.
+    #[test]
+    fn scoped_to_one_pair() {
+        let mut ctx = MockContext::new();
+
+        // Oversized reduce-only sell in `pair()` (will shrink 10 → 5) and an
+        // identical one in `other_pair()` that must be left alone.
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -10, 100);
+        save_ro_ask(&mut ctx.storage, &other_pair(), 2, 3_001, -10, 100);
+        let user_state = user_state_with(5, 200, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        // `pair()` order shrunk to 5, reserved halved.
+        let shrunk = load_ask(&ctx.storage, &pair(), 2_001, 1).unwrap();
+        assert_eq!(shrunk.size, Quantity::new_int(-5));
+        assert_eq!(shrunk.reserved_margin, UsdValue::new_int(50));
+        // `other_pair()` order byte-for-byte untouched.
+        let untouched = load_ask(&ctx.storage, &other_pair(), 3_001, 2).unwrap();
+        assert_eq!(untouched.size, Quantity::new_int(-10));
+        assert_eq!(untouched.reserved_margin, UsdValue::new_int(100));
+        // Aggregate reserved = 50 (pair) + 100 (other) = 150.
+        assert!(outcome.removed.is_empty());
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::new_int(150));
+        assert_eq!(
+            outcome.user_state.reserved_margin,
+            total_resting_reserved(&ctx.storage)
+        );
+    }
+}

--- a/dango/perps/src/trade/resize_reduce_only.rs
+++ b/dango/perps/src/trade/resize_reduce_only.rs
@@ -600,4 +600,170 @@ mod tests {
             total_resting_reserved(&ctx.storage)
         );
     }
+
+    /// Short-maker mirror of [`shrink_worst_first_clamps_the_sum`]: two
+    /// reduce-only BUYS summing over the (short) position. Exercises the
+    /// bid-side shrink path — a bid being shrunk (not merely kept or cancelled)
+    /// — which the other tests never hit (they all use long makers / asks).
+    #[test]
+    fn shrink_bid_for_short_maker() {
+        let mut ctx = MockContext::new();
+
+        // Short 4; two reduce-only buys of 3 each (each ≤ 4, together 6 > 4).
+        save_ro_bid(&mut ctx.storage, &pair(), 1, 1_999, 3, 30);
+        save_ro_bid(&mut ctx.storage, &pair(), 2, 1_998, 3, 30);
+        let user_state = user_state_with(-4, 60, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        // @1999 (best bid = highest real price) keeps 3; @1998 shrinks to 1.
+        assert!(outcome.removed.is_empty());
+        assert_eq!(
+            load_bid(&ctx.storage, &pair(), 1_999, 1).unwrap().size,
+            Quantity::new_int(3)
+        );
+        let shrunk = load_bid(&ctx.storage, &pair(), 1_998, 2).unwrap();
+        assert_eq!(shrunk.size, Quantity::new_int(1));
+        // Reserved released proportionally: 30 × 2/3 = 20, leaving 10.
+        assert_eq!(shrunk.reserved_margin, UsdValue::new_int(10));
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::new_int(40));
+        assert_eq!(
+            outcome.user_state.reserved_margin,
+            total_resting_reserved(&ctx.storage)
+        );
+        assert_eq!(outcome.user_state.open_order_count, 2);
+    }
+
+    /// Bid-side mirror of [`cancel_all_when_flat`]: a flat position cancels
+    /// reduce-only *buys* too (the only flat/wrong-side test otherwise uses
+    /// asks).
+    #[test]
+    fn cancel_wrong_side_bids_when_flat() {
+        let mut ctx = MockContext::new();
+
+        save_ro_bid(&mut ctx.storage, &pair(), 1, 1_999, 3, 30);
+        save_ro_bid(&mut ctx.storage, &pair(), 2, 1_998, 3, 30);
+        let user_state = user_state_with(0, 60, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        assert_eq!(outcome.removed.len(), 2);
+        assert!(outcome.removed.contains(&Uint64::new(1)));
+        assert!(outcome.removed.contains(&Uint64::new(2)));
+        assert!(load_bid(&ctx.storage, &pair(), 1_999, 1).is_none());
+        assert!(load_bid(&ctx.storage, &pair(), 1_998, 2).is_none());
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::ZERO);
+        assert_eq!(outcome.user_state.open_order_count, 0);
+    }
+
+    /// Three reduce-only orders summing over the budget in a single pass:
+    /// keep the best, shrink the middle, cancel the worst. The 2-order tests
+    /// never exercise keep+shrink+cancel together.
+    #[test]
+    fn shrink_and_cancel_across_three_orders() {
+        let mut ctx = MockContext::new();
+
+        // Long 5; three reduce-only sells of 3 each (Σ9 > 5).
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_002, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 3, 2_003, -3, 30);
+        let user_state = user_state_with(5, 90, 3);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        // @2001 keeps 3 (budget 5→2); @2002 shrinks to 2 (budget 2→0); @2003
+        // gets nothing and is cancelled.
+        assert_eq!(outcome.removed, vec![Uint64::new(3)]);
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_001, 1).unwrap().size,
+            Quantity::new_int(-3)
+        );
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_002, 2).unwrap().size,
+            Quantity::new_int(-2)
+        );
+        assert!(load_ask(&ctx.storage, &pair(), 2_003, 3).is_none());
+        // 90 − (10 released on the shrink) − (30 released on the cancel) = 50.
+        assert_eq!(outcome.user_state.reserved_margin, UsdValue::new_int(50));
+        assert_eq!(
+            outcome.user_state.reserved_margin,
+            total_resting_reserved(&ctx.storage)
+        );
+        assert_eq!(outcome.user_state.open_order_count, 2);
+    }
+
+    /// Two reduce-only orders at the SAME price: the budget is allocated by
+    /// price-time priority, and ties break on ascending `order_id` (older
+    /// first). The older order is kept, the newer one shrunk.
+    #[test]
+    fn tie_break_keeps_older_order_at_same_price() {
+        let mut ctx = MockContext::new();
+
+        // Long 4; two reduce-only sells of 3 each at the identical price 2_001.
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 30);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_001, -3, 30);
+        let user_state = user_state_with(4, 60, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        // Order id 1 (older) keeps 3; order id 2 (newer) shrinks to 1.
+        assert!(outcome.removed.is_empty());
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_001, 1).unwrap().size,
+            Quantity::new_int(-3)
+        );
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_001, 2).unwrap().size,
+            Quantity::new_int(-1)
+        );
+        assert_eq!(outcome.user_state.open_order_count, 2);
+    }
+
+    /// Margin conservation holds even when the proportional release truncates.
+    /// Shrinking a `-3` order to `-1` releases `10 × 2/3 = 6.666666` (Dec128_6
+    /// truncates `6.6666…`), leaving `10 − 6.666666 = 3.333334`. Because the
+    /// kept value is a single subtraction of the one truncated release (not a
+    /// second division), `kept + released == reserved` exactly and no margin is
+    /// stranded — the aggregate still equals the sum of resting reserved.
+    #[test]
+    fn shrink_margin_conserved_with_truncating_division() {
+        let mut ctx = MockContext::new();
+
+        // Long 4; two reduce-only sells of 3, each reserving an indivisible 10.
+        save_ro_ask(&mut ctx.storage, &pair(), 1, 2_001, -3, 10);
+        save_ro_ask(&mut ctx.storage, &pair(), 2, 2_002, -3, 10);
+        let user_state = user_state_with(4, 20, 2);
+
+        let outcome =
+            compute_resize_reduce_only_outcome(&mut ctx.storage, USER, &pair(), &user_state, None)
+                .unwrap();
+
+        // @2001 keeps its 10; @2002 shrinks 3→1, keeping 10 − 6.666666.
+        assert_eq!(
+            load_ask(&ctx.storage, &pair(), 2_001, 1)
+                .unwrap()
+                .reserved_margin,
+            UsdValue::new_int(10)
+        );
+        let shrunk = load_ask(&ctx.storage, &pair(), 2_002, 2).unwrap();
+        assert_eq!(shrunk.size, Quantity::new_int(-1));
+        assert_eq!(shrunk.reserved_margin, UsdValue::new_raw(3_333_334));
+        // Aggregate == Σ resting (no stranded margin) and == 10 + 3.333334.
+        assert_eq!(
+            outcome.user_state.reserved_margin,
+            UsdValue::new_raw(13_333_334)
+        );
+        assert_eq!(
+            outcome.user_state.reserved_margin,
+            total_resting_reserved(&ctx.storage)
+        );
+    }
 }

--- a/dango/perps/src/trade/submit_order.rs
+++ b/dango/perps/src/trade/submit_order.rs
@@ -12,6 +12,7 @@ use {
         query::query_volume,
         referral::{FeeCommissionsOutcome, apply_fee_commissions},
         state::{FEE_RATE_OVERRIDES, PAIR_PARAMS, PAIR_STATES, PARAM, STATE, USER_STATES},
+        trade::resize_reduce_only_orders,
     },
     anyhow::{bail, ensure},
     dango_order_book::{
@@ -215,6 +216,15 @@ pub(crate) fn _submit_order(
         }
     }
 
+    // Capture the just-placed reduce-only order's id before `order_to_store` is
+    // consumed, so the dynamic re-size below can tell whether the sum-clamp
+    // evicted it (in which case the whole placement is rejected).
+    let new_reduce_only_order_id = if reduce_only {
+        order_to_store.as_ref().map(|(_, order_id, _)| *order_id)
+    } else {
+        None
+    };
+
     if let Some((stored_price, order_id, order)) = order_to_store {
         let is_bid = size.is_positive();
         let limit_price = may_invert_price(stored_price, is_bid);
@@ -238,6 +248,42 @@ pub(crate) fn _submit_order(
             size: order.size,
             client_order_id: order.client_order_id,
         })?;
+    }
+
+    // ---------- Step 9. Dynamic re-size of reduce-only orders ----------------
+    //
+    // Every fill in this transaction may have moved a user's position, so each
+    // affected user's resting reduce-only orders are re-clamped so their sizes
+    // sum to no more than the new position (cancelling those left on the wrong
+    // side). The affected users are exactly the keys of `maker_states`:
+    // settlement inserts the taker (see `maker_states.insert(sender, ..)`
+    // above) and every filled maker into it to persist their state.
+    //
+    // We iterate `maker_states.keys()` rather than the `index_updates` the
+    // matching loop also produced. `compute_position_diff` returns `None`
+    // whenever `(entry_price, is_positive())` is unchanged, and a pure reduction
+    // changes neither — so a maker shrinking long 10 -> 3 yields no index entry,
+    // exactly the case re-sizing exists for. Over-scanning `maker_states` is
+    // complete and safe: re-sizing a user whose position did not change is a
+    // no-op because the invariant already held for them. Do NOT replace this
+    // with the index diff.
+
+    // Re-size the sender first so its just-placed order can be rejected before
+    // any other user's state is touched. A reduce-only placement whose
+    // sum-clamp leaves the new order no budget evicts it here, which we surface
+    // as a rejection (the bail rolls back the whole transaction).
+    let removed = resize_reduce_only_orders(storage, sender, &pair_id, events)?;
+    if let Some(new_order_id) = new_reduce_only_order_id
+        && removed.contains(&new_order_id)
+    {
+        bail!("reduce-only order would exceed position size");
+    }
+
+    for maker in maker_states.keys() {
+        if *maker == sender {
+            continue;
+        }
+        resize_reduce_only_orders(storage, *maker, &pair_id, events)?;
     }
 
     #[cfg(feature = "tracing")]

--- a/dango/testing/tests/perps/reduce_only.rs
+++ b/dango/testing/tests/perps/reduce_only.rs
@@ -21,14 +21,23 @@
 //!   dynamic re-size has run, each reduce-only maker fill is re-clamped against
 //!   the maker's running position.
 //!
+//! Test convention: the reduce-only order under test is owned by `user2`. That
+//! owner moves its own position either as a **taker** (it submits the
+//! position-changing order itself — `submit_order.rs` re-sizes the sender) or as
+//! a **maker** (a different user's taker fills one of user2's *other* orders —
+//! the sender's maker loop re-sizes filled makers). The re-size fires in both
+//! cases. A comment that says "user2 sells/buys …" means user2 is acting as the
+//! taker, even though user2 is the maker of the reduce-only order being asserted.
+//!
 //! See `dango/perps/src/trade/resize_reduce_only.rs`, `submit_order.rs`, and
 //! `dango/order-book/src/matching_engine.rs`.
 
 use {
     crate::{default_pair_param, default_param, register_oracle_prices},
     dango_order_book::{
-        Dimensionless, OrderId, OrderKind, OrderRemoved, OrderResized, PairId, Quantity,
-        QueryOrdersByUserResponseItem, ReasonForOrderRemoval, TimeInForce, UsdPrice,
+        ChildOrder, Dimensionless, OrderId, OrderKind, OrderRemoved, OrderResized, PairId,
+        Quantity, QueryOrdersByUserResponseItem, ReasonForOrderRemoval, TimeInForce,
+        TriggerDirection, UsdPrice,
     },
     dango_testing::{TestAccount, TestOption, TestSuiteNaive, pair_id, setup_test_naive},
     dango_types::{
@@ -37,8 +46,8 @@ use {
     },
     grug_math::Uint128,
     grug_types::{
-        Addr, Addressable, CheckedContractEvent, Coins, JsonDeExt, QuerierExt, ResultExt,
-        SearchEvent, btree_map,
+        Addr, Addressable, CheckedContractEvent, Coins, Duration, JsonDeExt, NonEmpty, QuerierExt,
+        ResultExt, SearchEvent, btree_map,
     },
     std::collections::BTreeMap,
 };
@@ -525,7 +534,8 @@ async fn reduce_only_resize_on_taker_fill_then_clamp_is_noop() {
 
     let reserved_before = user_state(&suite, perps, accounts.user2.address()).reserved_margin;
 
-    // Maker shrinks the long to 4 by selling 6 into user4's bid.
+    // The owner (user2), acting as the taker, shrinks its own long to 4 by
+    // selling 6 into user4's bid.
     rest_limit(
         &mut suite,
         &mut accounts.user4,
@@ -674,6 +684,16 @@ async fn reduce_only_resize_on_maker_fill_shrinks_order() {
     assert_eq!(resized[0].user, accounts.user2.address());
     assert_eq!(resized[0].old_size, Quantity::new_int(-10));
     assert_eq!(resized[0].new_size, Quantity::new_int(-4));
+    // The remaining event fields identify the order: it is the reduce-only sell
+    // still resting at 2_003, placed without a client_order_id.
+    assert_eq!(resized[0].pair_id, pair);
+    assert_eq!(resized[0].client_order_id, None);
+    let resized_order_id = open_orders(&suite, perps, accounts.user2.address())
+        .into_iter()
+        .find(|(_, o)| o.limit_price == UsdPrice::new_int(2_003))
+        .map(|(id, _)| id)
+        .expect("reduce-only order still resting at 2_003");
+    assert_eq!(resized[0].order_id, resized_order_id);
 }
 
 /// When the owner's position flips, every reduce-only order is on the wrong side
@@ -717,7 +737,8 @@ async fn reduce_only_resize_cancels_on_flip() {
     )
     .await;
 
-    // Maker flips to a 5-unit short by selling 15 into user4's bid.
+    // The owner (user2), acting as the taker, flips its own position to a
+    // 5-unit short by selling 15 into user4's bid.
     rest_limit(
         &mut suite,
         &mut accounts.user4,
@@ -835,7 +856,16 @@ async fn reduce_only_resize_after_earlier_order_flips_maker() {
     )
     .await;
 
-    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 20, false).await;
+    let events = suite
+        .execute(
+            &mut accounts.user1,
+            perps,
+            &market(&pair, 20, false),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
 
     // A flipped the maker 5 -> -5; B (reduce-only) was skipped then cancelled.
     assert_eq!(
@@ -850,6 +880,25 @@ async fn reduce_only_resize_after_earlier_order_flips_maker() {
         open_orders(&suite, perps, accounts.user2.address()).is_empty(),
         "the inert reduce-only order is cancelled by re-sizing"
     );
+
+    // The cancel here is caused by a MAKER fill (user2's senior order flips the
+    // position mid-sweep), not a taker action — assert the post-sweep re-size
+    // emitted `OrderRemoved{ReduceOnlyResized}` for user2's inert order.
+    let removed = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_removed")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderRemoved>().unwrap())
+        .filter(|e| e.reason == ReasonForOrderRemoval::ReduceOnlyResized)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        removed.len(),
+        1,
+        "one reduce-only order cancelled by re-sizing"
+    );
+    assert_eq!(removed[0].user, accounts.user2.address());
 
     let ps = pair_state(&suite, perps, &pair);
     assert_eq!(ps.long_oi, Quantity::new_int(10));
@@ -1075,7 +1124,8 @@ async fn reduce_only_position_growth_leaves_order() {
     )
     .await;
 
-    // Maker grows the long to 10 by buying 5 from user4.
+    // The owner (user2), acting as the taker, grows its own long to 10 by
+    // buying 5 from user4.
     rest_limit(
         &mut suite,
         &mut accounts.user4,
@@ -1321,5 +1371,982 @@ async fn reduce_only_resize_on_adl_counterparty() {
     assert_eq!(
         user_state(&suite, perps, accounts.user3.address()).open_order_count,
         1
+    );
+}
+
+// ------------------------- short-maker dynamic re-size -----------------------
+
+/// Short-maker mirror of [`reduce_only_resize_on_maker_fill_shrinks_order`]: a
+/// SHORT maker's reduce-only BUY is shrunk when its position is reduced by one
+/// of its own non-reduce-only orders filling. Closes the bid-side gap left by
+/// the rewrite (every other dynamic test uses a long maker / reduce-only sells).
+#[tokio::test]
+async fn reduce_only_resize_short_maker_buy_shrinks() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    // user2 opens a 10-unit short against user3's bid.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -10, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-10))
+    );
+
+    // Non-reduce-only BUY of 6 (senior, best bid 1999) and reduce-only BUY of 10.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        6,
+        1_999,
+        false,
+    )
+    .await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        10,
+        1_997,
+        true,
+    )
+    .await;
+
+    // Taker sells 6 — fills only the non-RO buy, lifting the short to -4.
+    let events = suite
+        .execute(
+            &mut accounts.user1,
+            perps,
+            &market(&pair, -6, false),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-4))
+    );
+
+    // The non-RO buy filled and was removed; the reduce-only buy resized 10 -> 4.
+    assert!(order_at(&suite, perps, accounts.user2.address(), 1_999).is_none());
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 1_997)
+            .unwrap()
+            .size,
+        Quantity::new_int(4),
+        "short maker's reduce-only buy tracks the reduced short"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+
+    let resized = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_resized")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderResized>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(resized.len(), 1);
+    assert_eq!(resized[0].old_size, Quantity::new_int(10));
+    assert_eq!(resized[0].new_size, Quantity::new_int(4));
+}
+
+/// Short-maker mirror of [`reduce_only_resize_cancels_on_flip`]: when a short
+/// flips to long, the reduce-only BUY is on the wrong side (buys grow a long)
+/// and is cancelled.
+#[tokio::test]
+async fn reduce_only_resize_short_maker_cancels_on_flip() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // user2 opens a 10-unit short and rests a reduce-only buy of 10.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -10, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        10,
+        1_998,
+        true,
+    )
+    .await;
+
+    // The owner (user2), acting as the taker, flips its short to a 5-unit long by
+    // buying 15 from user4's ask.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        -15,
+        1_999,
+        false,
+    )
+    .await;
+    let events = suite
+        .execute(
+            &mut accounts.user2,
+            perps,
+            &market(&pair, 15, false),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(5))
+    );
+    assert!(
+        open_orders(&suite, perps, accounts.user2.address()).is_empty(),
+        "the wrong-side reduce-only buy is cancelled on the flip"
+    );
+
+    let removed = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_removed")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderRemoved>().unwrap())
+        .filter(|e| e.reason == ReasonForOrderRemoval::ReduceOnlyResized)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        removed.len(),
+        1,
+        "one reduce-only order cancelled by re-sizing"
+    );
+    assert_eq!(removed[0].user, accounts.user2.address());
+}
+
+// ------------------------------ batch + rollback -----------------------------
+
+/// `batch_update_orders` runs the same re-size hook as a plain submit: an action
+/// that reduces the sender's position inside a batch shrinks its resting
+/// reduce-only order.
+#[tokio::test]
+async fn reduce_only_resize_within_batch() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // user2 opens a 10-unit long and rests a reduce-only sell of 10.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    // user4 rests a bid so the batch's sell can fill on the book.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        6,
+        1_999,
+        false,
+    )
+    .await;
+
+    // A batch whose action reduces user2's long to 4 must trigger the re-size
+    // hook reached via BatchUpdateOrders -> _submit_order.
+    suite
+        .execute(
+            &mut accounts.user2,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::BatchUpdateOrders(
+                NonEmpty::new(vec![perps::SubmitOrCancelOrderRequest::Submit(
+                    perps::SubmitOrderRequest {
+                        pair_id: pair.clone(),
+                        size: Quantity::new_int(-6),
+                        kind: OrderKind::Market {
+                            max_slippage: Dimensionless::new_percent(50),
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
+                    },
+                )])
+                .unwrap(),
+            )),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(4))
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_002)
+            .unwrap()
+            .size,
+        Quantity::new_int(-4),
+        "reduce-only sell re-sized inside the batch"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+}
+
+/// A reduce-only placement rejection rolls back the *whole* batch, including an
+/// earlier action's fill. Single-submit can't reach this (a filling reduce-only
+/// order is always best-priced, so it is kept, never rejected); the batch makes
+/// the fill and the rejected post-only separate actions.
+#[tokio::test]
+async fn reduce_only_batch_rejection_rolls_back_fill() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // user2 long 10 with a reduce-only sell of 10 at the better price 2001.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_001,
+        true,
+    )
+    .await;
+
+    // user4 bid for the batch's first action to fill against.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        4,
+        1_999,
+        false,
+    )
+    .await;
+
+    // Batch: action 1 sells 4 (fills user4, long 10 -> 6, re-sizes the 2001 order
+    // to -6); action 2 is a post-only reduce-only sell at the WORSE price 2005,
+    // which the now-exhausted budget (6, fully held by the 2001 order) zeroes ->
+    // reject. The reject must roll back action 1's fill too.
+    suite
+        .execute(
+            &mut accounts.user2,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::BatchUpdateOrders(
+                NonEmpty::new(vec![
+                    perps::SubmitOrCancelOrderRequest::Submit(perps::SubmitOrderRequest {
+                        pair_id: pair.clone(),
+                        size: Quantity::new_int(-4),
+                        kind: OrderKind::Market {
+                            max_slippage: Dimensionless::new_percent(50),
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
+                    }),
+                    perps::SubmitOrCancelOrderRequest::Submit(perps::SubmitOrderRequest {
+                        pair_id: pair.clone(),
+                        size: Quantity::new_int(-10),
+                        kind: OrderKind::Limit {
+                            limit_price: UsdPrice::new_int(2_005),
+                            time_in_force: TimeInForce::PostOnly,
+                            client_order_id: None,
+                        },
+                        reduce_only: true,
+                        tp: None,
+                        sl: None,
+                    }),
+                ])
+                .unwrap(),
+            )),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error("reduce-only order would exceed position size");
+
+    // Whole batch rolled back: position still 10, the RO sell still -10 at 2001,
+    // and user4's bid untouched (the fill was undone).
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(10))
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_001)
+            .unwrap()
+            .size,
+        Quantity::new_int(-10)
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user4.address(), 1_999)
+            .unwrap()
+            .size,
+        Quantity::new_int(4),
+        "user4's bid fill was rolled back"
+    );
+}
+
+/// A single GTC reduce-only order that partially fills is necessarily the
+/// best-priced reduce-only order, so the sum-clamp keeps it and EVICTS the
+/// user's older worse-priced one — it is never itself rejected, and the fill
+/// stands. (Complements the post-only eviction test, which never fills.)
+#[tokio::test]
+async fn reduce_only_partial_fill_evicts_worse_order() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    // user2 long 10 with a reduce-only sell of 10 at the WORSE price 2003.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_003,
+        true,
+    )
+    .await;
+
+    // user3 rests a bid of 3 at 2000 for the new order to partially fill against.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        3,
+        2_000,
+        false,
+    )
+    .await;
+
+    // user2 submits a GTC reduce-only sell of 10 at the BETTER price 1999: it
+    // crosses the bid (fills 3, long 10 -> 7) and rests the remaining 7.
+    suite
+        .execute(
+            &mut accounts.user2,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(1_999),
+                    time_in_force: TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
+                },
+                reduce_only: true,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(7)),
+        "the partial fill stands"
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 1_999)
+            .unwrap()
+            .size,
+        Quantity::new_int(-7),
+        "the new order rests at its remainder"
+    );
+    assert!(
+        order_at(&suite, perps, accounts.user2.address(), 2_003).is_none(),
+        "the older worse-priced order was evicted"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+}
+
+// -------------------------- depth / zombie guards ----------------------------
+
+/// After a reduce-only order is shrunk, the book really holds only the shrunk
+/// size at that price — a taker that tries to fill the original size gets only
+/// the smaller amount.
+#[tokio::test]
+async fn reduce_only_depth_correct_after_shrink() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // user2 long 10, reduce-only sell of 10 at 2002.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    // user2 sells 6 (as taker) into user4's bid -> long 4, RO sell shrinks to -4.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        6,
+        2_001,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -6, false).await;
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_002)
+            .unwrap()
+            .size,
+        Quantity::new_int(-4)
+    );
+
+    // A taker buying 10 gets only the shrunk 4 — the book holds 4 at 2002, not
+    // the pre-shrink 10. The remaining 6 finds no liquidity (discarded).
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 10, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(4)),
+        "only the shrunk 4 was available"
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None,
+        "user2 closed flat"
+    );
+    assert!(open_orders(&suite, perps, accounts.user2.address()).is_empty());
+
+    let ps = pair_state(&suite, perps, &pair);
+    assert_eq!(ps.long_oi, ps.short_oi, "OI must net");
+}
+
+/// Regression guard: after a position-changing tx leaves the owner flat, no
+/// stale reduce-only order is left behind (the inert-cleanup must not depend on
+/// the reduce-only order itself having filled).
+#[tokio::test]
+async fn reduce_only_no_zombie_after_position_change() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // user2 long 5 with a reduce-only sell parked high (won't fill).
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -5,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 5, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_005,
+        true,
+    )
+    .await;
+
+    // user2 closes its long to flat via a SEPARATE non-RO sell (not the RO order
+    // filling) -> the now-stale reduce-only sell must be cancelled.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        5,
+        1_999,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -5, false).await;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None,
+        "user2 is flat"
+    );
+    assert!(
+        open_orders(&suite, perps, accounts.user2.address()).is_empty(),
+        "no zombie reduce-only order remains after closing to flat"
+    );
+}
+
+// ----------------------- conditional-order trigger path ----------------------
+
+/// A conditional (TP) trigger that partially closes a position re-sizes the
+/// owner's *other* resting reduce-only order. Covers the
+/// `process_conditional_orders` hook, which no other test exercises.
+#[tokio::test]
+async fn reduce_only_resize_on_conditional_trigger() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    // user1 opens a 10-unit long.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 10, false).await;
+
+    // user1 rests a reduce-only sell of 10 above the TP maker bid (won't fill).
+    rest_limit(
+        &mut suite,
+        &mut accounts.user1,
+        perps,
+        &pair,
+        -10,
+        2_150,
+        true,
+    )
+    .await;
+
+    // user1 attaches a partial take-profit: sell 6 when oracle >= 2100.
+    suite
+        .execute(
+            &mut accounts.user1,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitConditionalOrder {
+                pair_id: pair.clone(),
+                size: Some(Quantity::new_int(-6)),
+                trigger_price: UsdPrice::new_int(2_100),
+                trigger_direction: TriggerDirection::Above,
+                max_slippage: Dimensionless::new_percent(1),
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // user2 rests a bid of 6 at 2100 for the triggered market sell to fill.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        6,
+        2_100,
+        false,
+    )
+    .await;
+
+    // Oracle rises to the trigger and a block fires the cron. (`increase_time`
+    // discards the outcome, so inline its body to read the cron events.)
+    register_oracle_prices(&mut suite, &mut accounts, 2_100).await;
+    let old_block_time = suite.block_time;
+    suite.block_time = Duration::from_minutes(2);
+    let outcome = suite.make_empty_block().await;
+    suite.block_time = old_block_time;
+
+    // TP closed 6 of user1's long; the reduce-only sell re-sized 10 -> 4.
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(4))
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user1.address(), 2_150)
+            .unwrap()
+            .size,
+        Quantity::new_int(-4),
+        "reduce-only sell tracks the TP-reduced position"
+    );
+
+    // The trigger and the re-size both surfaced in the cron block. (`search_event`
+    // consumes the outcome, so clone it for the first of the two searches.)
+    let triggered = outcome
+        .block_outcome
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "conditional_order_triggered")
+        .take()
+        .all();
+    assert_eq!(triggered.len(), 1, "the TP fired");
+    let resized = outcome
+        .block_outcome
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_resized")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderResized>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(resized.len(), 1);
+    assert_eq!(resized[0].new_size, Quantity::new_int(-4));
+}
+
+// --------------------------- liquidation book fill ---------------------------
+
+/// A maker who provides BOOK liquidity for a liquidation (not ADL) has its own
+/// position reduced by that fill, re-sizing its resting reduce-only order. The
+/// existing liquidation test only covers the ADL counter-party path.
+#[tokio::test]
+async fn reduce_only_resize_on_liquidation_book_maker() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    // Widen the band so Carol's far-OTM reduce-only ask survives the oracle move.
+    suite
+        .execute(
+            &mut accounts.owner,
+            perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: default_param(),
+                pair_params: btree_map! {
+                    pair.clone() => PairParam {
+                        max_limit_price_deviation: Dimensionless::new_permille(999),
+                        ..default_pair_param()
+                    },
+                },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user1, perps, 700_000_000).await;
+
+    // Carol (user3) long 5; user1 short 3, user4 short 2.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        5,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, -3, false).await;
+    market_fill(&mut suite, &mut accounts.user4, perps, &pair, -2, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user3.address(), &pair),
+        Some(Quantity::new_int(5))
+    );
+
+    // Carol rests a reduce-only sell of 5 far OTM (won't fill).
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -5,
+        3_900,
+        true,
+    )
+    .await;
+
+    // Oracle rises: user1's short is now underwater.
+    register_oracle_prices(&mut suite, &mut accounts, 2_300).await;
+
+    // Carol rests an IN-RANGE regular ask of 3 (below the liquidation buy target),
+    // so user1's liquidation fills on the BOOK rather than ADL.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -3,
+        2_250,
+        false,
+    )
+    .await;
+
+    // Liquidate user1: it buys 3, filling Carol's 2250 ask -> Carol long 5 -> 2.
+    suite
+        .execute(
+            &mut accounts.owner,
+            perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Liquidate {
+                user: accounts.user1.address(),
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    assert_eq!(
+        position(&suite, perps, accounts.user3.address(), &pair),
+        Some(Quantity::new_int(2)),
+        "Carol's long was reduced to 2 by the book fill"
+    );
+    // The book fill consumed Carol's 2250 ask (proves book path, not ADL)...
+    assert!(
+        order_at(&suite, perps, accounts.user3.address(), 2_250).is_none(),
+        "the in-range ask was filled by the liquidation (book path)"
+    );
+    // ...and her reduce-only order tracked the reduced position.
+    assert_eq!(
+        order_at(&suite, perps, accounts.user3.address(), 3_900)
+            .unwrap()
+            .size,
+        Quantity::new_int(-2),
+        "the reduce-only order tracks the book-fill-reduced position"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user3.address()).open_order_count,
+        1
+    );
+}
+
+// ------------------------------- child orders --------------------------------
+
+/// A reduce-only order carrying tp/sl child orders keeps them through a shrink
+/// and is cleanly removed (no orphan) on cancel.
+#[tokio::test]
+async fn reduce_only_child_orders_on_resized_order() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // user2 opens a 10-unit long.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
+    // user2 rests a reduce-only sell of 10 carrying tp/sl child orders.
+    suite
+        .execute(
+            &mut accounts.user2,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_002),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: true,
+                tp: Some(ChildOrder {
+                    trigger_price: UsdPrice::new_int(2_500),
+                    max_slippage: Dimensionless::new_percent(1),
+                    size: None,
+                }),
+                sl: Some(ChildOrder {
+                    trigger_price: UsdPrice::new_int(1_500),
+                    max_slippage: Dimensionless::new_percent(1),
+                    size: None,
+                }),
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+    assert!(
+        order_at(&suite, perps, accounts.user2.address(), 2_002)
+            .unwrap()
+            .tp
+            .is_some(),
+        "child orders attached to the resting reduce-only order"
+    );
+
+    // Shrink it: user2 sells 6 (as taker) into user4's bid -> long 4, RO -> -4.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        6,
+        2_001,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -6, false).await;
+    let shrunk = order_at(&suite, perps, accounts.user2.address(), 2_002).unwrap();
+    assert_eq!(shrunk.size, Quantity::new_int(-4));
+    assert!(
+        shrunk.tp.is_some() && shrunk.sl.is_some(),
+        "child orders are preserved through a shrink"
+    );
+
+    // Close to flat: the reduce-only order (with its children) is cleanly removed.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        4,
+        1_999,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -4, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None
+    );
+    assert!(
+        open_orders(&suite, perps, accounts.user2.address()).is_empty(),
+        "no orphan order or child left after cancel"
     );
 }

--- a/dango/testing/tests/perps/reduce_only.rs
+++ b/dango/testing/tests/perps/reduce_only.rs
@@ -47,7 +47,7 @@ use {
     grug_math::Uint128,
     grug_types::{
         Addr, Addressable, CheckedContractEvent, Coins, Duration, JsonDeExt, NonEmpty, QuerierExt,
-        ResultExt, SearchEvent, btree_map,
+        ResultExt, SearchEvent, btree_map, btree_set,
     },
     std::collections::BTreeMap,
 };
@@ -1871,8 +1871,8 @@ async fn reduce_only_partial_fill_evicts_worse_order() {
 // -------------------------- depth / zombie guards ----------------------------
 
 /// After a reduce-only order is shrunk, the book really holds only the shrunk
-/// size at that price — a taker that tries to fill the original size gets only
-/// the smaller amount.
+/// size at that price. Asserts the liquidity-depth map directly — it reports 4,
+/// not the pre-shrink 10 — and that a taker can fill only the smaller amount.
 #[tokio::test]
 async fn reduce_only_depth_correct_after_shrink() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
@@ -1881,10 +1881,44 @@ async fn reduce_only_depth_correct_after_shrink() {
     let perps = contracts.perps;
     let pair = pair_id();
 
+    // Configure a $1 depth bucket so an order's price is its own bucket key.
+    suite
+        .execute(
+            &mut accounts.owner,
+            perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: default_param(),
+                pair_params: btree_map! {
+                    pair.clone() => PairParam {
+                        bucket_sizes: btree_set! { UsdPrice::new_int(1) },
+                        ..default_pair_param()
+                    },
+                },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
     deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
     deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
     deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
     deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // Absolute ask depth at `price` (the $1 bucket key is the price itself), or
+    // `None` if the book holds nothing there.
+    let ask_depth_at = |suite: &TestSuiteNaive, price: i128| -> Option<Quantity> {
+        suite
+            .query_wasm_smart(perps, perps::QueryLiquidityDepthRequest {
+                pair_id: pair.clone(),
+                bucket_size: UsdPrice::new_int(1),
+                limit: None,
+            })
+            .should_succeed()
+            .asks
+            .get(&UsdPrice::new_int(price))
+            .map(|d| d.size)
+    };
 
     // user2 long 10, reduce-only sell of 10 at 2002.
     rest_limit(
@@ -1909,6 +1943,9 @@ async fn reduce_only_depth_correct_after_shrink() {
     )
     .await;
 
+    // The depth map reports the full 10 at the 2002 ask bucket.
+    assert_eq!(ask_depth_at(&suite, 2_002), Some(Quantity::new_int(10)));
+
     // user2 sells 6 (as taker) into user4's bid -> long 4, RO sell shrinks to -4.
     rest_limit(
         &mut suite,
@@ -1928,8 +1965,15 @@ async fn reduce_only_depth_correct_after_shrink() {
         Quantity::new_int(-4)
     );
 
-    // A taker buying 10 gets only the shrunk 4 — the book holds 4 at 2002, not
-    // the pre-shrink 10. The remaining 6 finds no liquidity (discarded).
+    // The depth map now reports only 4 at 2002 — the shrink decremented it.
+    assert_eq!(
+        ask_depth_at(&suite, 2_002),
+        Some(Quantity::new_int(4)),
+        "liquidity depth tracks the shrunk size"
+    );
+
+    // And behaviourally: a taker buying 10 fills only the shrunk 4; the remaining
+    // 6 finds no liquidity (discarded).
     market_fill(&mut suite, &mut accounts.user1, perps, &pair, 10, false).await;
     assert_eq!(
         position(&suite, perps, accounts.user1.address(), &pair),
@@ -1942,6 +1986,13 @@ async fn reduce_only_depth_correct_after_shrink() {
         "user2 closed flat"
     );
     assert!(open_orders(&suite, perps, accounts.user2.address()).is_empty());
+
+    // The order fully filled, so the book holds nothing at 2002 now.
+    assert_eq!(
+        ask_depth_at(&suite, 2_002),
+        None,
+        "depth cleared after the fill"
+    );
 
     let ps = pair_state(&suite, perps, &pair);
     assert_eq!(ps.long_oi, ps.short_oi, "OI must net");

--- a/dango/testing/tests/perps/reduce_only.rs
+++ b/dango/testing/tests/perps/reduce_only.rs
@@ -1,26 +1,45 @@
-//! Tests for the reduce-only order invariant: a reduce-only order may only
-//! move the maker's position toward zero — it must never grow the position or
-//! flip it to the opposite side.
+//! Tests for the reduce-only order invariant: a user's resting reduce-only
+//! orders may only move their position toward zero — never grow it, never flip
+//! it. The invariant is:
 //!
-//! The invariant is enforced at placement time (the order is clamped to the
-//! position when submitted) AND, as of the match-time clamp, every time a
-//! resting reduce-only maker order is matched. See `match_order` in
-//! `dango/perps/src/trade/submit_order.rs` and `walk_book` in
+//! > For every (user, pair): the resting reduce-only orders are all on the
+//! > position-closing side, and their absolute sizes sum to no more than the
+//! > `|position|`.
+//!
+//! It is enforced by three cooperating layers:
+//!
+//! - **Placement** (`compute_submit_order_outcome` + the re-size in
+//!   `_submit_order`): a new reduce-only order is clamped to the *remaining*
+//!   budget after the user's other reduce-only orders; if the sum-clamp leaves
+//!   it nothing, the transaction is rejected. A better-priced new order instead
+//!   evicts the user's worse-priced ones.
+//! - **Dynamic re-size** (`resize_reduce_only_orders`): after every position
+//!   change — a fill (as taker or maker), liquidation, or ADL — the user's
+//!   resting reduce-only orders are re-clamped to the new position, shrinking or
+//!   cancelling the worst by price-time priority.
+//! - **Match-time clamp** (`walk_book`): within a single sweep, before the
+//!   dynamic re-size has run, each reduce-only maker fill is re-clamped against
+//!   the maker's running position.
+//!
+//! See `dango/perps/src/trade/resize_reduce_only.rs`, `submit_order.rs`, and
 //! `dango/order-book/src/matching_engine.rs`.
 
 use {
-    crate::register_oracle_prices,
+    crate::{default_pair_param, default_param, register_oracle_prices},
     dango_order_book::{
-        Dimensionless, OrderId, OrderKind, PairId, Quantity, QueryOrdersByUserResponseItem,
-        TimeInForce, UsdPrice,
+        Dimensionless, OrderId, OrderKind, OrderRemoved, OrderResized, PairId, Quantity,
+        QueryOrdersByUserResponseItem, ReasonForOrderRemoval, TimeInForce, UsdPrice,
     },
     dango_testing::{TestAccount, TestOption, TestSuiteNaive, pair_id, setup_test_naive},
     dango_types::{
         constants::usdc,
-        perps::{self, PairState, UserState},
+        perps::{self, PairParam, PairState, UserState},
     },
     grug_math::Uint128,
-    grug_types::{Addr, Addressable, Coins, QuerierExt, ResultExt},
+    grug_types::{
+        Addr, Addressable, CheckedContractEvent, Coins, JsonDeExt, QuerierExt, ResultExt,
+        SearchEvent, btree_map,
+    },
     std::collections::BTreeMap,
 };
 
@@ -63,22 +82,41 @@ async fn rest_limit(
         .execute(
             account,
             contract,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
-                pair_id: pair.clone(),
-                size: Quantity::new_int(size),
-                kind: OrderKind::Limit {
-                    limit_price: UsdPrice::new_int(price),
-                    time_in_force: TimeInForce::PostOnly,
-                    client_order_id: None,
-                },
-                reduce_only,
-                tp: None,
-                sl: None,
-            })),
+            &post_only(pair, size, price, reduce_only),
             Coins::new(),
         )
         .await
         .should_succeed();
+}
+
+/// Build a post-only limit order request (positive `size` is a bid).
+fn post_only(pair: &PairId, size: i128, price: i128, reduce_only: bool) -> perps::ExecuteMsg {
+    perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+        pair_id: pair.clone(),
+        size: Quantity::new_int(size),
+        kind: OrderKind::Limit {
+            limit_price: UsdPrice::new_int(price),
+            time_in_force: TimeInForce::PostOnly,
+            client_order_id: None,
+        },
+        reduce_only,
+        tp: None,
+        sl: None,
+    }))
+}
+
+/// Build a market order request with a generous 50% slippage tolerance.
+fn market(pair: &PairId, size: i128, reduce_only: bool) -> perps::ExecuteMsg {
+    perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+        pair_id: pair.clone(),
+        size: Quantity::new_int(size),
+        kind: OrderKind::Market {
+            max_slippage: Dimensionless::new_percent(50),
+        },
+        reduce_only,
+        tp: None,
+        sl: None,
+    }))
 }
 
 /// Submit a market order that is expected to (at least partially) fill.
@@ -94,16 +132,7 @@ async fn market_fill(
         .execute(
             account,
             contract,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
-                pair_id: pair.clone(),
-                size: Quantity::new_int(size),
-                kind: OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
-                },
-                reduce_only,
-                tp: None,
-                sl: None,
-            })),
+            &market(pair, size, reduce_only),
             Coins::new(),
         )
         .await
@@ -136,6 +165,18 @@ fn open_orders(
         .should_succeed()
 }
 
+/// The user's single resting order at `price`, if any.
+fn order_at(
+    suite: &TestSuiteNaive,
+    contract: Addr,
+    user: Addr,
+    price: i128,
+) -> Option<QueryOrdersByUserResponseItem> {
+    open_orders(suite, contract, user)
+        .into_values()
+        .find(|o| o.limit_price == UsdPrice::new_int(price))
+}
+
 /// The pair's state, carrying `long_oi` / `short_oi`. Open interest is a strong
 /// cross-check on the clamp: a fill that wrongly opened a position would inflate
 /// OI, and after every fill the invariant `long_oi == short_oi` must hold.
@@ -148,31 +189,18 @@ fn pair_state(suite: &TestSuiteNaive, contract: Addr, pair: &PairId) -> PairStat
         .unwrap()
 }
 
-// ---------------------------------- tests ------------------------------------
+// ----------------------------- placement clamp -------------------------------
 
-/// Attack reproduction (defanged: 1 unit, 3 orders instead of 1 BTC / 100
-/// orders).
+/// Placement rejects a reduce-only order whose size, summed with the user's
+/// existing reduce-only orders, would exceed the position. This is the
+/// defense-in-depth that kills the "many copies of a 1-unit reduce-only order"
+/// attack at the source: the second copy can never rest.
 ///
-/// A maker opens a 1-unit long, then rests three reduce-only sells of 1 unit
-/// each. Each is clamped to the position (1) at placement, but the maker's
-/// position can change after they rest, and a single taker can sweep all
-/// three. The taker buys 3.
-///
-/// Buggy behavior (v0.21): the resting clamp was never re-checked at match
-/// time, and the maker side of a fill happily decomposed an over-large fill
-/// into a closing AND an opening portion. So all three orders fully filled:
-/// order 1 closed the long (1 -> 0), then orders 2 and 3 OPENED a short
-/// (0 -> -1 -> -2). The maker's 1-unit long was flipped into a 2-unit short
-/// with no margin check — the core of the exploit. The taker received 3.
-///
-/// Correct behavior (match-time clamp): each reduce-only fill is re-clamped to
-/// the maker's current position. Order 1 closes the long (1 -> 0); orders 2
-/// and 3 have nothing left to close, so they are clamped to zero and skipped,
-/// left resting. The maker ends flat (never short) and the taker receives only
-/// 1. (Cancelling the two now-inert resting orders is the job of the separate
-/// dynamic re-sizing work; this PR leaves them on the book.)
+/// A maker opens a 1-unit long and rests a reduce-only sell of 1 (the whole
+/// position). A second reduce-only sell of 1 is rejected — there is no position
+/// budget left for it. The single resting order then closes the long normally.
 #[tokio::test]
-async fn reduce_only_maker_position_flip_attack() {
+async fn reduce_only_placement_rejects_when_sum_exceeds_position() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
     register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
@@ -183,7 +211,7 @@ async fn reduce_only_maker_position_flip_attack() {
     deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
     deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
 
-    // user3 rests an ask of 1 @ $2,000 so the maker can open a long.
+    // user3 rests an ask of 1 so the maker can open a long.
     rest_limit(
         &mut suite,
         &mut accounts.user3,
@@ -194,108 +222,64 @@ async fn reduce_only_maker_position_flip_attack() {
         false,
     )
     .await;
-
-    // Maker (user2) market-buys 1 -> opens a 1-unit long.
     market_fill(&mut suite, &mut accounts.user2, perps, &pair, 1, false).await;
     assert_eq!(
         position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(1)),
-        "maker should be 1 long after opening"
+        Some(Quantity::new_int(1))
     );
 
-    // Maker rests three reduce-only sells of 1 each @ 2001/2002/2003. Each is
-    // clamped to the position (1) at placement and rests at -1.
-    for price in [2_001, 2_002, 2_003] {
-        rest_limit(
-            &mut suite,
+    // First reduce-only sell of 1 rests — it exactly fills the position budget.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -1,
+        2_001,
+        true,
+    )
+    .await;
+
+    // Second reduce-only sell of 1 is rejected: the sum (2) would exceed the
+    // position (1). It is a post-only order — i.e. one that *would* rest — so
+    // the sum-clamp actually fires (an IOC/market order would just not fill).
+    suite
+        .execute(
             &mut accounts.user2,
             perps,
-            &pair,
-            -1,
-            price,
-            true,
+            &post_only(&pair, -1, 2_002, true),
+            Coins::new(),
         )
-        .await;
-    }
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(1)),
-        "resting orders must not change the position"
-    );
+        .await
+        .should_fail_with_error("reduce-only order would exceed position size");
+
     assert_eq!(
         user_state(&suite, perps, accounts.user2.address()).open_order_count,
-        3,
-        "maker should have 3 resting reduce-only sells"
+        1,
+        "only the first reduce-only order rests; the second was rejected"
     );
 
-    // Taker (user1) market-buys 3 -> sweeps the reduce-only sells.
-    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 3, false).await;
-
-    // The maker's 1-unit long was closed to flat — NOT flipped into a short.
-    // (v0.21 produced a -2 short here.)
+    // The one valid order closes the long normally.
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 1, false).await;
     assert_eq!(
         position(&suite, perps, accounts.user2.address(), &pair),
-        None,
-        "maker should be flat — never flipped short"
+        None
     );
-
-    // The taker only got the 1 unit the maker could actually close.
-    // (v0.21 over-filled the taker to a 3-unit long.)
     assert_eq!(
         position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(1)),
-        "taker should receive only what the maker could close"
+        Some(Quantity::new_int(1))
     );
+    assert!(open_orders(&suite, perps, accounts.user2.address()).is_empty());
 
-    // The two reduce-only orders that had nothing left to close are skipped but
-    // remain resting. This PR intentionally does not cancel them — dynamic
-    // re-sizing (the follow-up) will. When that lands, this assertion is
-    // expected to change (the orders should be cancelled), so it doubles as a
-    // reminder.
-    let resting = open_orders(&suite, perps, accounts.user2.address());
-    assert_eq!(
-        resting.len(),
-        2,
-        "the two unfilled reduce-only orders still rest (until dynamic re-sizing removes them)"
-    );
-    assert!(
-        resting.values().all(|o| o.reduce_only),
-        "the resting orders should be the two reduce-only sells"
-    );
-    let prices: Vec<_> = resting.values().map(|o| o.limit_price).collect();
-    assert!(prices.contains(&UsdPrice::new_int(2_002)));
-    assert!(prices.contains(&UsdPrice::new_int(2_003)));
-
-    // Each skipped order keeps its full original -1 size on the book (the clamp
-    // skips inert orders untouched; it does not rewrite them).
-    assert!(
-        resting.values().all(|o| o.size == Quantity::new_int(-1)),
-        "skipped reduce-only sells keep their original -1 size"
-    );
-
-    // Open interest reflects only the single closing fill: the taker's 1 long
-    // against user3's 1 short. (v0.21 inflated both to 3 by opening the maker's
-    // 2-unit short and over-filling the taker.)
     let ps = pair_state(&suite, perps, &pair);
-    assert_eq!(ps.long_oi, Quantity::new_int(1), "only the taker's 1 long");
-    assert_eq!(ps.short_oi, Quantity::new_int(1), "only user3's 1 short");
+    assert_eq!(ps.long_oi, Quantity::new_int(1));
+    assert_eq!(ps.short_oi, Quantity::new_int(1));
 }
 
-/// Several of the SAME maker's orders are matched by a single taker, where an
-/// earlier (non-reduce-only) order reduces the position before a later
-/// reduce-only order is reached. The later order's clamp must reflect the
-/// earlier fill, not the stale pre-sweep position.
-///
-/// Maker is long 10 and rests:
-/// - order A: a non-reduce-only sell of 6 @ 2001 (fills first),
-/// - order B: a reduce-only sell of 10 @ 2002 (clamped to 10 at placement).
-///
-/// A taker buys 16. Order A closes 6 (10 -> 4). Order B must then clamp to the
-/// reduced position (4), filling only 4 (4 -> 0) — NOT to the pre-sweep
-/// position (10), which would flip the maker to a 6-unit short. This is the
-/// case that the per-walk fill tracking (`maker_fill_deltas`) exists to handle.
+/// Short-maker mirror of [`reduce_only_placement_rejects_when_sum_exceeds_position`]:
+/// a 1-unit short with reduce-only *buys*. The second buy is rejected.
 #[tokio::test]
-async fn reduce_only_clamp_reflects_earlier_fill_in_same_sweep() {
+async fn reduce_only_placement_rejects_short_maker() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
     register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
@@ -306,7 +290,143 @@ async fn reduce_only_clamp_reflects_earlier_fill_in_same_sweep() {
     deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
     deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
 
-    // Maker (user2) opens a 10-unit long against user3's ask.
+    // user3 rests a bid of 1 so the maker can open a short.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        1,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -1, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-1))
+    );
+
+    // First reduce-only buy of 1 rests; the second is rejected.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        1,
+        1_999,
+        true,
+    )
+    .await;
+    suite
+        .execute(
+            &mut accounts.user2,
+            perps,
+            &post_only(&pair, 1, 1_998, true),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error("reduce-only order would exceed position size");
+
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, -1, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(-1))
+    );
+}
+
+/// A better-priced new reduce-only order evicts the user's own worse-priced
+/// one: re-quoting at a price more likely to fill. The new order takes the whole
+/// budget; the stale one is cancelled.
+///
+/// Maker is long 5 with a reduce-only sell of 5 resting at 2005. A new
+/// reduce-only sell of 5 at 2002 (better — a lower ask fills first) takes the
+/// whole 5-unit budget, so the 2005 order is cancelled.
+#[tokio::test]
+async fn reduce_only_placement_better_price_replaces_worse() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -5,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 5, false).await;
+
+    // Worse-priced reduce-only sell first, then a better-priced one.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_005,
+        true,
+    )
+    .await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_002,
+        true,
+    )
+    .await;
+
+    // Only the better-priced order survives; the worse one was evicted.
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_002)
+            .unwrap()
+            .size,
+        Quantity::new_int(-5)
+    );
+    assert!(order_at(&suite, perps, accounts.user2.address(), 2_005).is_none());
+}
+
+/// A new reduce-only order is shrunk to the budget left by the user's existing
+/// reduce-only orders, rather than rejected, when that budget is positive.
+///
+/// Maker is long 10 with a reduce-only sell of 6 at 2001 (better). A new
+/// reduce-only sell of 10 at 2002 (worse) is shrunk to 4 — the budget left after
+/// the 6 — and both rest.
+#[tokio::test]
+async fn reduce_only_placement_partial_budget_shrinks_new() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
     rest_limit(
         &mut suite,
         &mut accounts.user3,
@@ -319,8 +439,457 @@ async fn reduce_only_clamp_reflects_earlier_fill_in_same_sweep() {
     .await;
     market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
 
-    // Order A (non-reduce-only sell 6 @ 2001) and order B (reduce-only sell 10
-    // @ 2002). A is the more senior ask (lower price), so it fills first.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -6,
+        2_001,
+        true,
+    )
+    .await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        2
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_001)
+            .unwrap()
+            .size,
+        Quantity::new_int(-6)
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_002)
+            .unwrap()
+            .size,
+        Quantity::new_int(-4),
+        "the worse order is shrunk to the remaining budget (10 - 6)"
+    );
+}
+
+// --------------------------- dynamic re-sizing -------------------------------
+
+/// A reduce-only order is re-sized down when its owner's position shrinks via a
+/// separate (taker) fill — *before* any taker reaches it. With the order then
+/// already right-sized, the match-time clamp has nothing left to do: a taker
+/// buying exactly the resized amount fills it in full, with no mid-sweep skip.
+/// This is the layering thesis — eager re-sizing makes the match-time clamp
+/// redundant outside a single sweep.
+#[tokio::test]
+async fn reduce_only_resize_on_taker_fill_then_clamp_is_noop() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    // Maker (user2) opens a 10-unit long and rests a reduce-only sell of 10.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    let reserved_before = user_state(&suite, perps, accounts.user2.address()).reserved_margin;
+
+    // Maker shrinks the long to 4 by selling 6 into user4's bid.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        6,
+        2_001,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -6, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(4))
+    );
+
+    // The reduce-only order was re-sized 10 -> 4 the instant the position
+    // shrank, with reserved margin released proportionally.
+    let resting = order_at(&suite, perps, accounts.user2.address(), 2_002).unwrap();
+    assert_eq!(
+        resting.size,
+        Quantity::new_int(-4),
+        "re-sized to the new position"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+    assert!(
+        user_state(&suite, perps, accounts.user2.address()).reserved_margin < reserved_before,
+        "shrinking the order released part of its reserved margin"
+    );
+
+    // A taker buys exactly 4: the order is already right-sized, so it fills in
+    // full and is removed — the match-time clamp had nothing to clamp.
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 4, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        None
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(4))
+    );
+    assert!(open_orders(&suite, perps, accounts.user2.address()).is_empty());
+
+    let ps = pair_state(&suite, perps, &pair);
+    assert_eq!(ps.long_oi, ps.short_oi, "OI must net");
+    assert_eq!(ps.long_oi, Quantity::new_int(10));
+}
+
+/// A reduce-only order is re-sized when its owner's position shrinks because one
+/// of their *other*, non-reduce-only orders is filled (the owner is the maker,
+/// not the taker). Also asserts the `OrderResized` event.
+///
+/// Maker is long 10, resting a non-reduce-only sell of 6 (at 2001) and a
+/// reduce-only sell of 10 (at 2003). A taker buys 6, filling only the non-RO
+/// order; the maker drops to long 4, and its reduce-only order is re-sized to 4.
+#[tokio::test]
+async fn reduce_only_resize_on_maker_fill_shrinks_order() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
+    // Non-reduce-only sell of 6 (senior) and reduce-only sell of 10.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -6,
+        2_001,
+        false,
+    )
+    .await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_003,
+        true,
+    )
+    .await;
+
+    // Taker buys 6 — fills only the non-RO order, dropping the maker to long 4.
+    let events = suite
+        .execute(
+            &mut accounts.user1,
+            perps,
+            &market(&pair, 6, false),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(4))
+    );
+
+    // The non-RO order filled and was removed; the reduce-only order was re-sized
+    // 10 -> 4.
+    assert!(order_at(&suite, perps, accounts.user2.address(), 2_001).is_none());
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_003)
+            .unwrap()
+            .size,
+        Quantity::new_int(-4)
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+
+    // The re-size emitted an `OrderResized` event carrying old and new size.
+    let resized = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_resized")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderResized>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(resized.len(), 1, "exactly one order was shrunk");
+    assert_eq!(resized[0].user, accounts.user2.address());
+    assert_eq!(resized[0].old_size, Quantity::new_int(-10));
+    assert_eq!(resized[0].new_size, Quantity::new_int(-4));
+}
+
+/// When the owner's position flips, every reduce-only order is on the wrong side
+/// and is cancelled (not merely skipped). Asserts the `OrderRemoved` event with
+/// the `ReduceOnlyResized` reason, and that a taker then finds no liquidity.
+///
+/// Maker is long 10 with a reduce-only sell of 10 resting, then flips to a 5-unit
+/// short. The reduce-only sell would now grow the short, so it is cancelled.
+#[tokio::test]
+async fn reduce_only_resize_cancels_on_flip() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_002,
+        true,
+    )
+    .await;
+
+    // Maker flips to a 5-unit short by selling 15 into user4's bid.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        15,
+        2_001,
+        false,
+    )
+    .await;
+    let events = suite
+        .execute(
+            &mut accounts.user2,
+            perps,
+            &market(&pair, -15, false),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-5))
+    );
+
+    // The reduce-only sell was cancelled — not left resting.
+    assert!(
+        open_orders(&suite, perps, accounts.user2.address()).is_empty(),
+        "the wrong-side reduce-only order is cancelled on the flip"
+    );
+
+    let removed = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_removed")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderRemoved>().unwrap())
+        .filter(|e| e.reason == ReasonForOrderRemoval::ReduceOnlyResized)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        removed.len(),
+        1,
+        "one reduce-only order cancelled by re-sizing"
+    );
+    assert_eq!(removed[0].user, accounts.user2.address());
+
+    // A taker now finds no resting ask to hit.
+    suite
+        .execute(
+            &mut accounts.user1,
+            perps,
+            &market(&pair, 10, false),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error("no liquidity at acceptable price");
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-5)),
+        "the short is untouched"
+    );
+}
+
+/// Within a single sweep, an earlier non-reduce-only order flips the maker past
+/// zero; the reduce-only order reached later is skipped by the match-time clamp,
+/// then cancelled by the post-sweep re-size.
+///
+/// Maker is long 5, resting a non-reduce-only sell of 10 (senior) and a
+/// reduce-only sell of 5. A taker buys 20: the non-RO order fills 10, flipping
+/// the maker to a 5-unit short; the reduce-only order is inert and is cancelled.
+#[tokio::test]
+async fn reduce_only_resize_after_earlier_order_flips_maker() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -5,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 5, false).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -10,
+        2_001,
+        false,
+    )
+    .await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_002,
+        true,
+    )
+    .await;
+
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 20, false).await;
+
+    // A flipped the maker 5 -> -5; B (reduce-only) was skipped then cancelled.
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-5))
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(10))
+    );
+    assert!(
+        open_orders(&suite, perps, accounts.user2.address()).is_empty(),
+        "the inert reduce-only order is cancelled by re-sizing"
+    );
+
+    let ps = pair_state(&suite, perps, &pair);
+    assert_eq!(ps.long_oi, Quantity::new_int(10));
+    assert_eq!(ps.short_oi, Quantity::new_int(10));
+}
+
+/// Several of the SAME maker's orders are matched in one sweep, where an earlier
+/// non-reduce-only order reduces the position before a later reduce-only order is
+/// reached. The reduce-only order's match-time clamp reflects the earlier fill
+/// (filling only what remains), and the post-sweep re-size cancels its now-inert
+/// remainder.
+///
+/// Maker is long 10, resting a non-reduce-only sell of 6 (senior) and a
+/// reduce-only sell of 10. A taker buys 16: the non-RO closes 6 (-> 4), the
+/// reduce-only clamps to 4 and closes it (-> 0), and its -6 remainder is then
+/// cancelled.
+#[tokio::test]
+async fn reduce_only_clamp_reflects_earlier_fill_in_same_sweep() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
     rest_limit(
         &mut suite,
         &mut accounts.user2,
@@ -342,587 +911,37 @@ async fn reduce_only_clamp_reflects_earlier_fill_in_same_sweep() {
     )
     .await;
 
-    // Taker (user1) buys 16, sweeping A then B.
     market_fill(&mut suite, &mut accounts.user1, perps, &pair, 16, false).await;
 
-    // A closed 6 (10 -> 4); B clamped to the reduced position and closed 4
-    // (4 -> 0). Maker ends flat. A naive clamp against the pre-sweep position
-    // (10) would have flipped the maker to a 6-unit short.
+    // Maker ends flat; the reduce-only order clamped to the reduced position
+    // (filling 4) and its -6 remainder was cancelled — not left resting.
     assert_eq!(
         position(&suite, perps, accounts.user2.address(), &pair),
-        None,
-        "maker should be flat — the reduce-only order clamped to the reduced position"
-    );
-
-    // Taker bought 6 (from A) + 4 (from B) = 10.
-    assert_eq!(
-        position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(10)),
-        "taker filled 6 from A and 4 from B"
-    );
-
-    // Order A fully filled and was removed; order B has its (now inert)
-    // remainder resting.
-    let resting = open_orders(&suite, perps, accounts.user2.address());
-    assert_eq!(
-        resting.len(),
-        1,
-        "only the reduce-only order's remainder rests"
-    );
-    let order_b = resting.values().next().unwrap();
-    assert!(order_b.reduce_only);
-    // Order B was -10 and closed 4, so its remainder is -10 - (-4) = -6. It is
-    // now oversized relative to the maker's (flat) position, but rests untouched.
-    assert_eq!(
-        order_b.size,
-        Quantity::new_int(-6),
-        "order B's remainder is its original -10 minus the 4 it closed"
-    );
-
-    // OI nets to the taker's 10 long against user3's 10 short — the maker is
-    // flat and contributes nothing. (A pre-sweep-position clamp would have
-    // opened a 6-unit short here, inflating short OI.)
-    let ps = pair_state(&suite, perps, &pair);
-    assert_eq!(ps.long_oi, Quantity::new_int(10));
-    assert_eq!(ps.short_oi, Quantity::new_int(10));
-}
-
-/// A reduce-only order rests, then the maker's position shrinks (via a separate
-/// trade) before a taker reaches the order. The order's resting size is now
-/// stale (larger than the position); the match-time clamp must cap the fill to
-/// the current, smaller position.
-///
-/// Maker is long 10 with a reduce-only sell of 10 resting. The maker then sells
-/// 7 (non-reduce-only) to a third party, leaving a 3-unit long. A taker buys
-/// 10 against the stale reduce-only order, which must close only 3 (3 -> 0),
-/// not 10 (which would flip the maker to a 7-unit short).
-#[tokio::test]
-async fn reduce_only_clamps_to_stale_shrunken_position() {
-    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
-
-    let perps = contracts.perps;
-    let pair = pair_id();
-
-    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
-
-    // Maker (user2) opens a 10-unit long against user3's ask.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user3,
-        perps,
-        &pair,
-        -10,
-        2_000,
-        false,
-    )
-    .await;
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
-
-    // Maker rests a reduce-only sell of 10 (clamped to the position, 10).
-    rest_limit(
-        &mut suite,
-        &mut accounts.user2,
-        perps,
-        &pair,
-        -10,
-        2_002,
-        true,
-    )
-    .await;
-
-    // Maker shrinks the long to 3 by selling 7 to user4 (non-reduce-only). This
-    // does not touch the resting reduce-only ask, which is now stale at 10.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user4,
-        perps,
-        &pair,
-        7,
-        2_001,
-        false,
-    )
-    .await;
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -7, false).await;
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(3)),
-        "maker long should be reduced to 3"
-    );
-
-    // Taker (user1) buys 10 against the stale reduce-only ask.
-    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 10, false).await;
-
-    // The order closed only the 3 units the maker still had — not its stale
-    // resting size of 10 (which would have flipped the maker to a 7 short).
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        None,
-        "maker should be flat — clamped to the shrunken position"
+        None
     );
     assert_eq!(
         position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(3)),
-        "taker received only the 3 the maker could close"
-    );
-
-    // The stale order was -10 and closed 3, so its remainder is -10 - (-3) = -7,
-    // left resting (oversized) — exactly one order still open for the maker.
-    let resting = open_orders(&suite, perps, accounts.user2.address());
-    assert_eq!(
-        resting.len(),
-        1,
-        "the stale reduce-only order's remainder rests"
-    );
-    assert_eq!(
-        resting.values().next().unwrap().size,
-        Quantity::new_int(-7),
-        "remainder is the original -10 minus the 3 it closed"
-    );
-    assert_eq!(
-        user_state(&suite, perps, accounts.user2.address()).open_order_count,
-        1,
-        "open_order_count tracks the single remaining order"
-    );
-}
-
-/// A reduce-only order whose maker has since flipped to the SAME side as the
-/// order is inert: it can only reduce, and there is nothing to reduce in the
-/// closing direction, so it must not fill at all.
-///
-/// Maker is long 10 with a reduce-only sell of 10 resting, then flips to a
-/// 5-unit short (selling 15 to a third party). The resting sell would now grow
-/// the short, so the match-time clamp drops it to zero and skips it: a taker
-/// buying against it finds no fillable liquidity, and the maker stays short 5.
-#[tokio::test]
-async fn reduce_only_inert_when_position_flipped() {
-    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
-
-    let perps = contracts.perps;
-    let pair = pair_id();
-
-    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
-
-    // Maker (user2) opens a 10-unit long against user3's ask.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user3,
-        perps,
-        &pair,
-        -10,
-        2_000,
-        false,
-    )
-    .await;
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
-
-    // Maker rests a reduce-only sell of 10.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user2,
-        perps,
-        &pair,
-        -10,
-        2_002,
-        true,
-    )
-    .await;
-
-    // Maker flips to a 5-unit short by selling 15 to user4 (non-reduce-only:
-    // closes the 10 long and opens a 5 short).
-    rest_limit(
-        &mut suite,
-        &mut accounts.user4,
-        perps,
-        &pair,
-        15,
-        2_001,
-        false,
-    )
-    .await;
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -15, false).await;
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(-5)),
-        "maker should be 5 short after flipping"
-    );
-
-    // Taker (user1) tries to buy against the now-inert reduce-only ask. It is
-    // the only resting ask, and it is skipped, so the market order finds no
-    // liquidity and is rejected.
-    suite
-        .execute(
-            &mut accounts.user1,
-            perps,
-            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
-                pair_id: pair.clone(),
-                size: Quantity::new_int(10),
-                kind: OrderKind::Market {
-                    max_slippage: Dimensionless::new_percent(50),
-                },
-                reduce_only: false,
-                tp: None,
-                sl: None,
-            })),
-            Coins::new(),
-        )
-        .await
-        .should_fail_with_error("no liquidity at acceptable price");
-
-    // The maker's short is untouched, and the inert order is still on the book.
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(-5)),
-        "maker short must be unchanged — the reduce-only order cannot grow it"
-    );
-    assert_eq!(
-        user_state(&suite, perps, accounts.user2.address()).open_order_count,
-        1,
-        "the inert reduce-only order is left resting"
-    );
-}
-
-/// Regression: when the position fully covers the reduce-only order, the order
-/// fills in full and is removed — the clamp must not under-fill it.
-///
-/// Maker is long 10 with a reduce-only sell of 5 resting. A taker buys 5; the
-/// order fills completely (10 -> 5 long) and is removed.
-#[tokio::test]
-async fn reduce_only_fills_fully_when_position_sufficient() {
-    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
-
-    let perps = contracts.perps;
-    let pair = pair_id();
-
-    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
-
-    // Maker (user2) opens a 10-unit long against user3's ask.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user3,
-        perps,
-        &pair,
-        -10,
-        2_000,
-        false,
-    )
-    .await;
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
-
-    // Maker rests a reduce-only sell of 5 (well within the 10 long).
-    rest_limit(
-        &mut suite,
-        &mut accounts.user2,
-        perps,
-        &pair,
-        -5,
-        2_002,
-        true,
-    )
-    .await;
-
-    // Taker (user1) buys 5.
-    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 5, false).await;
-
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(5)),
-        "maker long reduced from 10 to 5"
-    );
-    assert_eq!(
-        position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(5)),
-        "taker bought 5"
-    );
-    assert_eq!(
-        user_state(&suite, perps, accounts.user2.address()).open_order_count,
-        0,
-        "the reduce-only order fully filled and was removed"
-    );
-}
-
-/// Regression: the clamp applies ONLY to reduce-only orders. A regular
-/// (non-reduce-only) resting order may still flip the maker's position, which
-/// is normal trading behavior.
-///
-/// Maker is long 1 with a regular sell of 5 resting. A taker buys 5; the order
-/// closes the 1 long and opens a 4 short — exactly as it should.
-#[tokio::test]
-async fn non_reduce_only_order_still_flips_position() {
-    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
-
-    let perps = contracts.perps;
-    let pair = pair_id();
-
-    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
-
-    // Maker (user2) opens a 1-unit long against user3's ask.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user3,
-        perps,
-        &pair,
-        -1,
-        2_000,
-        false,
-    )
-    .await;
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 1, false).await;
-
-    // Maker rests a REGULAR (non-reduce-only) sell of 5.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user2,
-        perps,
-        &pair,
-        -5,
-        2_002,
-        false,
-    )
-    .await;
-
-    // Taker (user1) buys 5.
-    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 5, false).await;
-
-    // The regular order closed the 1 long and opened a 4 short — not clamped.
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(-4)),
-        "a non-reduce-only order may flip the position"
-    );
-    assert_eq!(
-        position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(5)),
-        "taker bought 5"
-    );
-}
-
-/// Short-maker mirror of `reduce_only_maker_position_flip_attack`. Every other
-/// test here uses a long maker with reduce-only *sells*; this is the symmetric
-/// case — a short maker with reduce-only *buys* — which exercises the other
-/// `decompose_fill` branch (a buy closing a short) and the other matching branch
-/// (the taker is the ask, walking bids). The invariant is identical: a
-/// reduce-only order may only move the maker toward zero, never flip it (here
-/// short -> long).
-///
-/// A maker opens a 1-unit short, then rests three reduce-only buys of 1 each. A
-/// single taker sells 3. Order 1 closes the short (-1 -> 0); orders 2 and 3 have
-/// nothing left to close, so they are skipped and left resting. The maker ends
-/// flat (never long) and the taker receives only 1.
-#[tokio::test]
-async fn reduce_only_maker_position_flip_attack_short_maker() {
-    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
-
-    let perps = contracts.perps;
-    let pair = pair_id();
-
-    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
-
-    // user3 rests a bid of 1 @ $2,000 so the maker can open a short.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user3,
-        perps,
-        &pair,
-        1,
-        2_000,
-        false,
-    )
-    .await;
-
-    // Maker (user2) market-sells 1 -> opens a 1-unit short.
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, -1, false).await;
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(-1)),
-        "maker should be 1 short after opening"
-    );
-
-    // Maker rests three reduce-only buys of 1 each @ 1999/1998/1997. Each is
-    // clamped to the position (short 1) at placement and rests at +1.
-    for price in [1_999, 1_998, 1_997] {
-        rest_limit(
-            &mut suite,
-            &mut accounts.user2,
-            perps,
-            &pair,
-            1,
-            price,
-            true,
-        )
-        .await;
-    }
-    assert_eq!(
-        user_state(&suite, perps, accounts.user2.address()).open_order_count,
-        3,
-        "maker should have 3 resting reduce-only buys"
-    );
-
-    // Taker (user1) market-sells 3 -> sweeps the reduce-only buys.
-    market_fill(&mut suite, &mut accounts.user1, perps, &pair, -3, false).await;
-
-    // The maker's 1-unit short was closed to flat — NOT flipped into a long.
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        None,
-        "maker should be flat — never flipped long"
-    );
-
-    // The taker only got the 1 unit the maker could actually close.
-    assert_eq!(
-        position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(-1)),
-        "taker should receive only what the maker could close"
-    );
-
-    // The two reduce-only buys with nothing left to close are skipped but remain
-    // resting at their full +1 size (orders @1998/1997; @1999 closed the short).
-    let resting = open_orders(&suite, perps, accounts.user2.address());
-    assert_eq!(
-        resting.len(),
-        2,
-        "the two unfilled reduce-only buys still rest"
+        Some(Quantity::new_int(10))
     );
     assert!(
-        resting
-            .values()
-            .all(|o| o.reduce_only && o.size == Quantity::new_int(1)),
-        "the resting orders are the two reduce-only buys at +1"
-    );
-    let prices: Vec<_> = resting.values().map(|o| o.limit_price).collect();
-    assert!(prices.contains(&UsdPrice::new_int(1_998)));
-    assert!(prices.contains(&UsdPrice::new_int(1_997)));
-
-    // OI nets to the taker's 1 short against user3's 1 long — the maker is flat.
-    let ps = pair_state(&suite, perps, &pair);
-    assert_eq!(ps.long_oi, Quantity::new_int(1), "only user3's 1 long");
-    assert_eq!(
-        ps.short_oi,
-        Quantity::new_int(1),
-        "only the taker's 1 short"
-    );
-}
-
-/// An earlier *non-reduce-only* order flips the maker past zero, and a later
-/// reduce-only order of the same maker — reached in the same sweep — must then
-/// be inert. This guards the per-walk delta (`maker_fill_deltas`), which is
-/// updated for *every* fill (reduce-only or not), so the reduce-only clamp sees
-/// the already-flipped position rather than the stale pre-sweep one.
-///
-/// Maker is long 5 and rests order A (non-reduce-only sell 10 @ 2001, senior)
-/// and order B (reduce-only sell 5 @ 2002). A taker buys 20. Order A fills 10,
-/// flipping the maker 5 -> -5 (legitimate for a non-reduce-only order). Order B
-/// then sees current = 5 + (-10) = -5 and a sell cannot reduce a short, so it is
-/// skipped. The maker ends 5 short (only A's flip), the taker bought only 10.
-#[tokio::test]
-async fn reduce_only_skips_after_earlier_order_flips_maker() {
-    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
-    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
-
-    let perps = contracts.perps;
-    let pair = pair_id();
-
-    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
-    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
-
-    // Maker (user2) opens a 5-unit long against user3's ask.
-    rest_limit(
-        &mut suite,
-        &mut accounts.user3,
-        perps,
-        &pair,
-        -5,
-        2_000,
-        false,
-    )
-    .await;
-    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 5, false).await;
-
-    // Order A: non-reduce-only sell 10 @ 2001 (senior, fills first).
-    rest_limit(
-        &mut suite,
-        &mut accounts.user2,
-        perps,
-        &pair,
-        -10,
-        2_001,
-        false,
-    )
-    .await;
-    // Order B: reduce-only sell 5 @ 2002 (clamped to the long 5 at placement).
-    rest_limit(
-        &mut suite,
-        &mut accounts.user2,
-        perps,
-        &pair,
-        -5,
-        2_002,
-        true,
-    )
-    .await;
-
-    // Taker (user1) buys 20, reaching A then B.
-    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 20, false).await;
-
-    // A flipped the maker 5 -> -5; B saw the flipped (short) position and skipped.
-    assert_eq!(
-        position(&suite, perps, accounts.user2.address(), &pair),
-        Some(Quantity::new_int(-5)),
-        "maker is 5 short from order A's flip — B did not grow the short"
-    );
-    assert_eq!(
-        position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(10)),
-        "taker filled only against order A"
+        open_orders(&suite, perps, accounts.user2.address()).is_empty(),
+        "the inert remainder is cancelled by re-sizing"
     );
 
-    // Order A fully filled and was removed; order B rests untouched at -5.
-    let resting = open_orders(&suite, perps, accounts.user2.address());
-    assert_eq!(resting.len(), 1, "only the skipped reduce-only order rests");
-    let order_b = resting.values().next().unwrap();
-    assert!(order_b.reduce_only);
-    assert_eq!(
-        order_b.size,
-        Quantity::new_int(-5),
-        "the skipped reduce-only order keeps its full -5 size"
-    );
-
-    // OI is the taker's 10 long against user2's 5 short + user3's 5 short.
     let ps = pair_state(&suite, perps, &pair);
     assert_eq!(ps.long_oi, Quantity::new_int(10));
     assert_eq!(ps.short_oi, Quantity::new_int(10));
 }
 
-/// One taker sweeps reduce-only orders from two *different* makers in a single
-/// pass; each must clamp to its OWN position. Per-maker state (the fill delta,
-/// and the base position read during the walk) is keyed by address, so this
-/// guards against one maker's position leaking into another's clamp.
+/// One taker sweeps reduce-only orders from two different makers; each must clamp
+/// to its OWN position. One maker's order was already re-sized down when that
+/// maker's position shrank, so the sweep sees the correct, smaller order.
 ///
-/// Both user2 and user3 open a 5-unit long and rest a reduce-only sell of 5.
-/// user3 then shrinks its long to 1 (selling 4 into user4's bid), leaving its
-/// resting reduce-only sell stale/oversized. A taker buys 10. user2's order
-/// closes its full 5; user3's order must clamp to user3's *current* position (1)
-/// and close only 1 — not user2's 5. Mixing the two would over-fill user3,
-/// flipping it short. user2 ends flat; user3 ends flat with a -4 remainder.
+/// user2 and user3 each open a 5-unit long and rest a reduce-only sell of 5.
+/// user3 then shrinks to 1 — re-sizing its order to 1. A taker buys 10: user2
+/// closes its full 5, user3 closes its 1; both end flat.
 #[tokio::test]
-async fn reduce_only_clamp_per_maker_across_two_makers() {
+async fn reduce_only_resize_per_maker_across_two_makers() {
     let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
     register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
 
@@ -934,7 +953,7 @@ async fn reduce_only_clamp_per_maker_across_two_makers() {
     deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
     deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
 
-    // user4 rests an ask of 10 @ $2,000; user2 and user3 each buy 5 against it.
+    // user4 sells 10; user2 and user3 each buy 5.
     rest_limit(
         &mut suite,
         &mut accounts.user4,
@@ -948,7 +967,6 @@ async fn reduce_only_clamp_per_maker_across_two_makers() {
     market_fill(&mut suite, &mut accounts.user2, perps, &pair, 5, false).await;
     market_fill(&mut suite, &mut accounts.user3, perps, &pair, 5, false).await;
 
-    // Both makers rest a reduce-only sell of 5 (sized to their long) @ 2001.
     rest_limit(
         &mut suite,
         &mut accounts.user2,
@@ -970,8 +988,8 @@ async fn reduce_only_clamp_per_maker_across_two_makers() {
     )
     .await;
 
-    // user3 shrinks its long to 1 by selling 4 into user4's bid — its resting
-    // reduce-only sell is now stale (oversized at 5 against a 1-unit position).
+    // user3 shrinks its long to 1 by selling 4 into user4's bid — its reduce-only
+    // order is re-sized 5 -> 1 at that moment.
     rest_limit(
         &mut suite,
         &mut accounts.user4,
@@ -985,47 +1003,323 @@ async fn reduce_only_clamp_per_maker_across_two_makers() {
     market_fill(&mut suite, &mut accounts.user3, perps, &pair, -4, false).await;
     assert_eq!(
         position(&suite, perps, accounts.user3.address(), &pair),
-        Some(Quantity::new_int(1)),
-        "user3 long shrunk to 1"
+        Some(Quantity::new_int(1))
+    );
+    assert_eq!(
+        order_at(&suite, perps, accounts.user3.address(), 2_001)
+            .unwrap()
+            .size,
+        Quantity::new_int(-1),
+        "user3's reduce-only order was re-sized to its new position"
     );
 
-    // Taker (user1) buys 10, sweeping both makers' reduce-only sells.
+    // Taker buys 10: user2's 5 (senior) then user3's 1.
     market_fill(&mut suite, &mut accounts.user1, perps, &pair, 10, false).await;
 
-    // Each maker clamped to ITS OWN position: user2 closed its full 5, user3
-    // closed only its current 1 — never user2's 5. Both end flat; neither flips.
     assert_eq!(
         position(&suite, perps, accounts.user2.address(), &pair),
-        None,
-        "user2 closed its full 5 to flat"
+        None
     );
     assert_eq!(
         position(&suite, perps, accounts.user3.address(), &pair),
-        None,
-        "user3 clamped to its own 1 and closed flat — not over-filled to short"
+        None
     );
     assert_eq!(
         position(&suite, perps, accounts.user1.address(), &pair),
-        Some(Quantity::new_int(6)),
-        "taker bought 5 from user2 and 1 from user3"
+        Some(Quantity::new_int(6))
     );
-
-    // user2's order fully filled and was removed; user3's leftover (-5 + 1) rests.
     assert!(open_orders(&suite, perps, accounts.user2.address()).is_empty());
-    let resting = open_orders(&suite, perps, accounts.user3.address());
-    assert_eq!(
-        resting.len(),
-        1,
-        "user3's oversized reduce-only remainder rests"
-    );
-    assert_eq!(
-        resting.values().next().unwrap().size,
-        Quantity::new_int(-4),
-        "remainder is the original -5 minus the 1 it closed"
-    );
+    assert!(open_orders(&suite, perps, accounts.user3.address()).is_empty());
 
-    // OI nets to the taker's 6 long against user4's 6 short.
     let ps = pair_state(&suite, perps, &pair);
     assert_eq!(ps.long_oi, Quantity::new_int(6));
     assert_eq!(ps.short_oi, Quantity::new_int(6));
+}
+
+/// Re-sizing only ever shrinks/cancels — it never grows a reduce-only order. When
+/// the position grows, the order is left exactly as it was (no resurrection).
+///
+/// Maker is long 5 with a reduce-only sell of 5; the maker buys 5 more (long 10).
+/// The order stays at 5.
+#[tokio::test]
+async fn reduce_only_position_growth_leaves_order() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -5,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 5, false).await;
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_002,
+        true,
+    )
+    .await;
+
+    // Maker grows the long to 10 by buying 5 from user4.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user4,
+        perps,
+        &pair,
+        -5,
+        2_001,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 5, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(10))
+    );
+
+    // The reduce-only order is untouched.
+    assert_eq!(
+        order_at(&suite, perps, accounts.user2.address(), 2_002)
+            .unwrap()
+            .size,
+        Quantity::new_int(-5),
+        "growth never grows or resurrects the order"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        1
+    );
+}
+
+// ------------------------------- regression ----------------------------------
+
+/// Regression: when the position fully covers the reduce-only order, the order
+/// fills in full and is removed — the clamp must not under-fill it.
+#[tokio::test]
+async fn reduce_only_fills_fully_when_position_sufficient() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -10,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 10, false).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_002,
+        true,
+    )
+    .await;
+
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 5, false).await;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(5))
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(5))
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user2.address()).open_order_count,
+        0
+    );
+}
+
+/// Regression: the clamp applies ONLY to reduce-only orders. A regular resting
+/// order may still flip the maker's position — normal trading behavior.
+#[tokio::test]
+async fn non_reduce_only_order_still_flips_position() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    deposit(&mut suite, &mut accounts.user1, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user2, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -1,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user2, perps, &pair, 1, false).await;
+
+    rest_limit(
+        &mut suite,
+        &mut accounts.user2,
+        perps,
+        &pair,
+        -5,
+        2_002,
+        false,
+    )
+    .await;
+
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, 5, false).await;
+
+    assert_eq!(
+        position(&suite, perps, accounts.user2.address(), &pair),
+        Some(Quantity::new_int(-4)),
+        "a non-reduce-only order may flip the position"
+    );
+    assert_eq!(
+        position(&suite, perps, accounts.user1.address(), &pair),
+        Some(Quantity::new_int(5))
+    );
+}
+
+// ----------------------------- liquidation / ADL -----------------------------
+
+/// A reduce-only order is re-sized when its owner's position is forcibly reduced
+/// as an ADL counter-party during someone else's liquidation. This is the
+/// liquidation-path trigger for dynamic re-sizing.
+///
+/// Carol (user3) is long 5 with a reduce-only sell of 5 resting far out of the
+/// money. user1 holds a 3-unit short that goes underwater and is liquidated;
+/// with no in-range book liquidity, all 3 are ADL'd against Carol's long, taking
+/// it to 2. Carol's reduce-only order is re-sized 5 -> 2.
+#[tokio::test]
+async fn reduce_only_resize_on_adl_counterparty() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let perps = contracts.perps;
+    let pair = pair_id();
+
+    // Widen the price band so Carol's far-OTM reduce-only ask can be placed and,
+    // crucially, so the liquidation's market buy skips it (it sits above the
+    // oracle-clamped target price) and falls through to ADL.
+    suite
+        .execute(
+            &mut accounts.owner,
+            perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: default_param(),
+                pair_params: btree_map! {
+                    pair.clone() => PairParam {
+                        max_limit_price_deviation: Dimensionless::new_permille(999),
+                        ..default_pair_param()
+                    },
+                },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // Carol (user3) and user4 are well funded; user1 (the short) is funded just
+    // enough to open and be liquidatable when the oracle rises.
+    deposit(&mut suite, &mut accounts.user3, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user4, perps, DEPOSIT).await;
+    deposit(&mut suite, &mut accounts.user1, perps, 700_000_000).await;
+
+    // Carol rests a bid of 5; user1 sells 3 and user4 sells 2 into it, leaving
+    // Carol long 5, user1 short 3, user4 short 2 (OI balanced).
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        5,
+        2_000,
+        false,
+    )
+    .await;
+    market_fill(&mut suite, &mut accounts.user1, perps, &pair, -3, false).await;
+    market_fill(&mut suite, &mut accounts.user4, perps, &pair, -2, false).await;
+    assert_eq!(
+        position(&suite, perps, accounts.user3.address(), &pair),
+        Some(Quantity::new_int(5))
+    );
+
+    // Carol rests a reduce-only sell of 5 far out of the money.
+    rest_limit(
+        &mut suite,
+        &mut accounts.user3,
+        perps,
+        &pair,
+        -5,
+        3_900,
+        true,
+    )
+    .await;
+
+    // Oracle rises: user1's short is now underwater.
+    register_oracle_prices(&mut suite, &mut accounts, 2_300).await;
+
+    // Liquidate user1. No in-range asks (Carol's is at 3,900, above the oracle
+    // target), so all 3 are ADL'd against Carol's long (5 -> 2).
+    suite
+        .execute(
+            &mut accounts.owner,
+            perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Liquidate {
+                user: accounts.user1.address(),
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    assert_eq!(
+        position(&suite, perps, accounts.user3.address(), &pair),
+        Some(Quantity::new_int(2)),
+        "Carol's long was reduced to 2 by ADL"
+    );
+
+    // Carol's reduce-only order was re-sized to her new position.
+    assert_eq!(
+        order_at(&suite, perps, accounts.user3.address(), 3_900)
+            .unwrap()
+            .size,
+        Quantity::new_int(-2),
+        "the reduce-only order tracks the ADL'd-down position"
+    );
+    assert_eq!(
+        user_state(&suite, perps, accounts.user3.address()).open_order_count,
+        1
+    );
 }

--- a/dango/upgrade/Cargo.toml
+++ b/dango/upgrade/Cargo.toml
@@ -9,6 +9,13 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 
 [dependencies]
-grug-app   = { workspace = true }
-grug-types = { workspace = true }
-tracing    = { workspace = true }
+dango-perps  = { workspace = true }
+dango-types  = { workspace = true }
+grug-app     = { workspace = true }
+grug-storage = { workspace = true }
+grug-types   = { workspace = true }
+tracing      = { workspace = true }
+
+[dev-dependencies]
+dango-order-book = { workspace = true }
+grug-math        = { workspace = true }

--- a/dango/upgrade/src/lib.rs
+++ b/dango/upgrade/src/lib.rs
@@ -5,10 +5,10 @@ use {
     grug_types::{BlockInfo, Storage},
 };
 
-pub fn do_upgrade<VM>(_storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
-    // Call relevant upgrade functions here.
+pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
+    tracing::info!("running perps reduce-only order cleanup migration");
 
-    tracing::info!("Nothing to do for this upgrade");
+    perps::do_perps_upgrades(storage)?;
 
     Ok(())
 }

--- a/dango/upgrade/src/perps.rs
+++ b/dango/upgrade/src/perps.rs
@@ -80,9 +80,28 @@ fn sweep_reduce_only_orders(storage: &mut dyn Storage) -> StdResult<()> {
         // order count are account-wide, so thread the running `state` across all
         // pairs and persist once at the end.
         for pair in pairs {
-            let ResizeReduceOnlyOutcome { user_state, .. } =
-                compute_resize_reduce_only_outcome(storage, user, pair, &state, None)?;
+            let ResizeReduceOnlyOutcome {
+                user_state,
+                removed,
+            } = compute_resize_reduce_only_outcome(storage, user, pair, &state, None)?;
+
             state = user_state;
+
+            // Audit trail of what the sweep cancelled (shrinks are not reported
+            // in `removed`). Skipped when nothing was cancelled, to avoid a log
+            // line per (user, pair) — most users hold no reduce-only orders.
+            if !removed.is_empty() {
+                // `OrderId`'s derived `Debug` renders `Int(123)`; map to the
+                // inner number so the log reads `[123, 456]`.
+                let cancelled = removed.iter().map(|id| id.0).collect::<Vec<u64>>();
+
+                tracing::info!(
+                    user = %user,
+                    pair = %pair,
+                    ?cancelled,
+                    "cancelled reduce-only orders during upgrade sweep"
+                );
+            }
         }
 
         // Only write back users we actually changed — most hold no reduce-only

--- a/dango/upgrade/src/perps.rs
+++ b/dango/upgrade/src/perps.rs
@@ -1,9 +1,15 @@
-// This file contains only the boilerplate.
+//! Perps storage migrations applied during chain upgrades.
+
 #![allow(dead_code)]
 
 use {
+    dango_perps::{
+        state::USER_STATES,
+        trade::{ResizeReduceOnlyOutcome, compute_resize_reduce_only_outcome},
+    },
+    dango_types::constants::{perp_btc, perp_eth, perp_hype, perp_sol, perp_xag, perp_xau},
     grug_app::{AppResult, CHAIN_ID, CONTRACT_NAMESPACE, StorageProvider},
-    grug_types::{Addr, Storage, addr},
+    grug_types::{Addr, Order, StdResult, Storage, addr},
 };
 
 const MAINNET_CHAIN_ID: &str = "dango-1";
@@ -27,9 +33,68 @@ pub fn do_perps_upgrades(storage: Box<dyn Storage>) -> AppResult<()> {
         }
     };
 
-    let mut _perps_storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
+    let mut perps_storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
 
-    // Add migration logic here.
+    sweep_reduce_only_orders(&mut perps_storage)?;
+
+    Ok(())
+}
+
+/// Re-clamp every user's resting reduce-only orders to their current position,
+/// across all 6 perp pairs — a one-time cleanup of the reduce-only "ghost"
+/// orders that the match-time clamp left resting on the book (a flat user's
+/// inert reduce-only orders are never swept by the per-transaction re-size,
+/// since they produce no fill and so never enter the affected-user set).
+///
+/// Reuses the same scanner the contract runs on every position change
+/// (`compute_resize_reduce_only_outcome`): a flat user has every reduce-only
+/// order cancelled, an over-extended one has them shrunk to the position, and a
+/// healthy one is left untouched. Events are suppressed — the upgrade handler
+/// has no event channel, and order-book events are not indexed; consumers read
+/// chain state, which this corrects (orders removed, liquidity depth and
+/// reserved margin released).
+fn sweep_reduce_only_orders(storage: &mut dyn Storage) -> StdResult<()> {
+    let pairs = [
+        &*perp_btc::DENOM,
+        &*perp_eth::DENOM,
+        &*perp_sol::DENOM,
+        &*perp_hype::DENOM,
+        &*perp_xau::DENOM,
+        &*perp_xag::DENOM,
+    ];
+
+    // Collect the user set first: the loop below mutates `USER_STATES`, so we
+    // must not hold an iterator over it while doing so (mirrors
+    // `compute_cancel_all_orders_outcome`).
+    let users = USER_STATES
+        .range(storage, None, None, Order::Ascending)
+        .map(|res| res.map(|(addr, _)| addr))
+        .collect::<StdResult<Vec<Addr>>>()?;
+
+    for user in users {
+        let original = USER_STATES.load(storage, user)?;
+        let mut state = original.clone();
+
+        // The scanner reads the position for `pair` from `state` and the orders
+        // from storage, mutating the book in place. Reserved margin and the open
+        // order count are account-wide, so thread the running `state` across all
+        // pairs and persist once at the end.
+        for pair in pairs {
+            let ResizeReduceOnlyOutcome { user_state, .. } =
+                compute_resize_reduce_only_outcome(storage, user, pair, &state, None)?;
+            state = user_state;
+        }
+
+        // Only write back users we actually changed — most hold no reduce-only
+        // orders, so the scanner left them untouched.
+        if state != original {
+            if state.is_empty() {
+                USER_STATES.remove(storage, user)?;
+            } else {
+                USER_STATES.save(storage, user, &state)?;
+            }
+        }
+    }
 
     Ok(())
 }
@@ -38,5 +103,150 @@ pub fn do_perps_upgrades(storage: Box<dyn Storage>) -> AppResult<()> {
 
 #[cfg(test)]
 mod tests {
-    // Add tests here.
+    use {
+        super::*,
+        dango_order_book::{ASKS, FundingPerUnit, LimitOrder, Quantity, UsdPrice, UsdValue},
+        dango_perps::state::PAIR_PARAMS,
+        dango_types::perps::{PairParam, Position, UserState},
+        grug_math::Uint64,
+        grug_types::{MockContext, Timestamp},
+        std::collections::BTreeMap,
+    };
+
+    // Three accounts: a flat one carrying stale reduce-only orders, a correctly
+    // sized one, and an over-extended one.
+    const FLAT: Addr = Addr::mock(1);
+    const HEALTHY: Addr = Addr::mock(2);
+    const OVERSIZED: Addr = Addr::mock(3);
+
+    /// Save a reduce-only `perp/btcusd` ask.
+    fn save_ro_ask(
+        storage: &mut dyn Storage,
+        user: Addr,
+        order_id: u64,
+        price: i128,
+        size: i128,
+        reserved: i128,
+    ) {
+        let key = (
+            perp_btc::DENOM.clone(),
+            UsdPrice::new_int(price),
+            Uint64::new(order_id),
+        );
+        let order = LimitOrder {
+            user,
+            size: Quantity::new_int(size),
+            reduce_only: true,
+            reserved_margin: UsdValue::new_int(reserved),
+            created_at: Timestamp::from_nanos(0),
+            tp: None,
+            sl: None,
+            client_order_id: None,
+        };
+        ASKS.save(storage, key, &order).unwrap();
+    }
+
+    /// A `perp/btcusd` long of the given (integer) size.
+    fn long(size: i128) -> BTreeMap<dango_order_book::PairId, Position> {
+        BTreeMap::from([(perp_btc::DENOM.clone(), Position {
+            size: Quantity::new_int(size),
+            entry_price: UsdPrice::new_int(2_000),
+            entry_funding_per_unit: FundingPerUnit::ZERO,
+            conditional_order_above: None,
+            conditional_order_below: None,
+        })])
+    }
+
+    fn seed_user(
+        storage: &mut dyn Storage,
+        user: Addr,
+        margin: i128,
+        reserved: i128,
+        open_order_count: usize,
+        positions: BTreeMap<dango_order_book::PairId, Position>,
+    ) {
+        let state = UserState {
+            margin: UsdValue::new_int(margin),
+            positions,
+            reserved_margin: UsdValue::new_int(reserved),
+            open_order_count,
+            ..Default::default()
+        };
+        USER_STATES.save(storage, user, &state).unwrap();
+    }
+
+    /// The user's resting asks, in book order.
+    fn asks_of(storage: &dyn Storage, user: Addr) -> Vec<LimitOrder> {
+        ASKS.idx
+            .user
+            .prefix(user)
+            .range(storage, None, None, Order::Ascending)
+            .map(|res| res.unwrap().1)
+            .collect()
+    }
+
+    /// A flat account carrying many identical reduce-only asks — their sizes
+    /// summing far above its (zero) position — has every order cancelled and its
+    /// reserved margin released. A correctly-sized account is left untouched, and
+    /// an over-extended one is shrunk to its position.
+    #[test]
+    fn sweeps_reduce_only_ghosts() {
+        let mut ctx = MockContext::new();
+        let storage = &mut ctx.storage;
+
+        PAIR_PARAMS
+            .save(storage, &*perp_btc::DENOM, &PairParam::default())
+            .unwrap();
+
+        // FLAT: no position, but 50 reduce-only sells of -1 still resting, each
+        // reserving 6 — total 300 reserved against only 10 margin.
+        for i in 0..50u64 {
+            save_ro_ask(storage, FLAT, i + 1, 60_000, -1, 6);
+        }
+        seed_user(storage, FLAT, 10, 300, 50, BTreeMap::new());
+
+        // HEALTHY: long 5 with a correctly-sized reduce-only sell of -5.
+        save_ro_ask(storage, HEALTHY, 1_000, 60_000, -5, 30);
+        seed_user(storage, HEALTHY, 100, 30, 1, long(5));
+
+        // OVERSIZED: long 3 with an over-extended reduce-only sell of -10.
+        save_ro_ask(storage, OVERSIZED, 2_000, 60_000, -10, 60);
+        seed_user(storage, OVERSIZED, 100, 60, 1, long(3));
+
+        sweep_reduce_only_orders(storage).unwrap();
+
+        // FLAT: every order swept, reserved margin released, margin untouched.
+        // The account survives (margin is non-zero), just with a clean book.
+        assert!(
+            asks_of(storage, FLAT).is_empty(),
+            "all stale orders cancelled"
+        );
+        let flat = USER_STATES.load(storage, FLAT).unwrap();
+        assert_eq!(flat.open_order_count, 0);
+        assert_eq!(flat.reserved_margin, UsdValue::ZERO);
+        assert_eq!(flat.margin, UsdValue::new_int(10), "margin untouched");
+        assert!(flat.positions.is_empty());
+
+        // HEALTHY: the correctly-sized order is left exactly as it was.
+        let healthy = asks_of(storage, HEALTHY);
+        assert_eq!(healthy.len(), 1);
+        assert_eq!(healthy[0].size, Quantity::new_int(-5));
+        assert_eq!(
+            USER_STATES.load(storage, HEALTHY).unwrap().open_order_count,
+            1
+        );
+
+        // OVERSIZED: the order is shrunk from -10 to the position (-3).
+        let oversized = asks_of(storage, OVERSIZED);
+        assert_eq!(oversized.len(), 1);
+        assert_eq!(
+            oversized[0].size,
+            Quantity::new_int(-3),
+            "shrunk to position"
+        );
+        assert!(
+            oversized[0].reserved_margin < UsdValue::new_int(60),
+            "reserved margin released proportionally"
+        );
+    }
 }


### PR DESCRIPTION
A user's resting reduce-only orders must only ever move their position toward zero. Enforce this as a standing invariant: for each (user, pair), the resting reduce-only orders are all on the position-closing side, and their absolute sizes sum to no more than the position.

Add a shared re-size pass (`resize_reduce_only_orders`) that re-clamps a user's resting reduce-only orders to their current position, shrinking or cancelling the worst by price-time priority. Run it after every position change — a fill (as taker or maker), liquidation, and ADL — and at placement, where a new reduce-only order is clamped to the budget left by the user's other reduce-only orders: rejected if none remains, or evicting worse-priced orders if it is better priced. This complements the existing match-time clamp in walk_book.

Split the scanner into a pure core (`compute_resize_reduce_only_outcome`) and a persist entry, and cover it with unit tests. Add an `OrderResized` event and a `ReduceOnlyResized` order-removal reason, and integration tests for placement rejection/eviction, re-size on taker and maker fills, position flip, and ADL counter-party.