### PR TITLE
fix: bankruptcy price

### DIFF
--- a/book/perps/4-liquidation-and-adl.md
+++ b/book/perps/4-liquidation-and-adl.md
@@ -55,6 +55,8 @@ Each entry in the close schedule is executed in two phases:
 
 The close is submitted as a **market order** against the on-chain order book. It matches resting limit orders at price-time priority. Any filled amount is settled normally (mark-to-market PnL between the entry price and the fill price).
 
+The order carries a price limit: the **bankruptcy price** (defined in [§3b](#3b-auto-deleveraging-adl)) when the account is solvent ($\mathtt{equity} > 0$), or the **oracle price** when insolvent. Resting orders on the wrong side of the limit are not matched — this prevents the close from sweeping through stale or absurdly-priced orders.
+
 ### 3b. Auto-deleveraging (ADL)
 
 If any quantity remains **unfilled** after the order book is exhausted, the system automatically deleverages against counter-parties. The unfilled remainder is closed against the **most profitable counter-positions** at the liquidated user's **bankruptcy price**.
@@ -63,17 +65,22 @@ If any quantity remains **unfilled** after the order book is exhausted, the syst
 
 [^1]: This does not perfectly rank by total PnL since it ignores accumulated funding fees, but is a reasonable and efficient approximation.
 
-**Bankruptcy price:** The fill price at which the liquidated user's total equity would be exactly zero:
+**Bankruptcy price:** A position's bankruptcy price (BP) is the fill price at which, if the **entire** position were closed at it, the user's total account equity would be exactly zero:
 
 $$
-\mathtt{bp} = \mathtt{oraclePrice} - \frac{\mathtt{equity}}{\mathtt{closeAmount}} \quad (\text{for longs})
+\mathtt{bp} = \mathtt{oraclePrice} - \frac{\mathtt{equity}}{|\mathtt{positionSize}|} \quad (\text{for longs})
 $$
 
 $$
-\mathtt{bp} = \mathtt{oraclePrice} + \frac{\mathtt{equity}}{\mathtt{closeAmount}} \quad (\text{for shorts})
+\mathtt{bp} = \mathtt{oraclePrice} + \frac{\mathtt{equity}}{|\mathtt{positionSize}|} \quad (\text{for shorts})
 $$
 
-Since equity is typically negative for liquidatable users, the bankruptcy price is worse than the oracle price — the counter-party receives a favourable fill. The counter-party's resting limit orders are not affected by ADL; only their position is force-reduced.
+The divisor is always the position's **full current size**, even when the close schedule closes only part of the position. An ADL fill at this price therefore moves exactly $\mathtt{equity} / |\mathtt{positionSize}|$ per unit closed from the user to the counter-party:
+
+- If the user is **solvent** ($\mathtt{equity} > 0$), the BP sits slightly on the favourable side of the oracle for the counter-party (below oracle when closing a long, above when closing a short). The counter-party receives the user's per-unit equity share as compensation for the forced close; the user keeps the equity attributable to the unclosed remainder, and never goes negative.
+- If the user is **insolvent** ($\mathtt{equity} \le 0$), the BP overshoots the oracle in the user's favour (above oracle when closing a long, below when closing a short). The counter-party is force-closed at a worse-than-oracle price — it absorbs what would otherwise be bad debt. The close schedule fully closes every position of an insolvent account, so a pure-ADL liquidation leaves the account at exactly zero equity.
+
+The counter-party's resting limit orders are not affected by ADL; only their position is force-reduced.
 
 Liquidation fills (both order-book and ADL) carry **zero trading fees** for both taker and maker.
 
@@ -119,7 +126,7 @@ $$
 
 The insurance fund may go negative. A negative insurance fund represents unresolved bad debt — future liquidation fees will replenish it.
 
-Note: when positions are fully ADL'd at the bankruptcy price, the user's equity is zeroed by construction. Bad debt from ADL fills is therefore zero. Bad debt arises only from **book fills** at prices worse than the bankruptcy price (e.g., thin order books with deep bids/asks far from oracle).
+Note: when an insolvent account's positions are fully ADL'd at their bankruptcy prices — each computed from the account's equity at the moment that position is processed — the user's equity is zeroed by construction. Bad debt from ADL fills is therefore zero. Bad debt arises only from **book fills** at prices worse than the bankruptcy price (e.g., thin order books with deep bids/asks far from oracle); see [Example 4](#example-4--insolvent-close-fully-absorbed-by-the-book).
 
 ## 7. Insurance fund
 
@@ -137,224 +144,438 @@ Other users' bad debt and liquidation fees never touch the vault's margin — th
 
 All examples use:
 
-| Parameter                      | Value       |
-| ------------------------------ | ----------- |
-| Pair                           | BTC / USD   |
-| Maintenance-margin ratio (mmr) | 5 %         |
-| Liquidation-fee rate           | 0.1 %       |
-| Settlement currency            | USDC at \$1 |
+| Parameter                      | Value                                 |
+| ------------------------------ | ------------------------------------- |
+| Pairs                          | ETH / USD (1–6); plus BTC / USD (7–8) |
+| Maintenance-margin ratio (mmr) | 5 % — both pairs                      |
+| Liquidation-fee rate           | 0.1 %                                 |
+| Liquidation buffer ratio ($b$) | 0                                     |
+| Settlement currency            | USDC at \$1                           |
 
-### Example 1 — Clean liquidation on book (no bad debt)
+Cast: **Alice** is the account being liquidated. **Bob** holds the exact opposite position(s), opened against Alice at her entry price — being the most profitable counter-position, he is the ADL counter-party. **Carol** is a third-party maker who supplies order-book liquidity where stated.
+
+Examples 1–6 cover a single position, ordered from the most ideal situation to the least: Alice solvent (1–3) then insolvent (4–6), with the order book absorbing all (1, 4), part (2, 5), or none (3, 6) of the close. Examples 7–8 cover an account with two positions.
+
+### Example 1 — Solvent; close fully absorbed by the book
 
 **Setup**
 
-|             | Alice      | Bob (maker)          |
-| ----------- | ---------- | -------------------- |
-| Direction   | Long 1 BTC | Bid 1 BTC @ \$47,500 |
-| Entry price | \$50,000   | —                    |
-| Margin      | \$3,000    | \$10,000             |
+|             | Alice       | Bob          | Carol               |
+| ----------- | ----------- | ------------ | ------------------- |
+| Position    | Long 10 ETH | Short 10 ETH | Bid 8 ETH @ \$1,800 |
+| Entry price | \$2,000     | \$2,000      | —                   |
+| Margin      | \$2,180     | \$10,000     | —                   |
 
-**BTC drops to \$47,500**
+**ETH drops to \$1,800**
 
 _Alice's account_
 
 $$
-\mathtt{equity} = \$3{,}000 + 1 \times (\$47{,}500 - \$50{,}000) = \$3{,}000 - \$2{,}500 = \$500
+\mathtt{equity} = \$2{,}180 + 10 \times (\$1{,}800 - \$2{,}000) = \$180
 $$
 
 $$
-\mathtt{MM} = 1 \times \$47{,}500 \times 5\% = \$2{,}375
+\mathtt{MM} = 10 \times \$1{,}800 \times 5\% = \$900
 $$
 
 $$
-\$500 < \$2{,}375 \;\Rightarrow\; \text{liquidatable}
+\$180 < \$900 \;\Rightarrow\; \text{liquidatable (solvent)}
 $$
 
 _Close schedule_
 
-Alice has one position; the full 1 BTC long is scheduled for closure.
+$$
+\mathtt{deficit} = \$900 - \$180 = \$720
+$$
+
+$$
+\mathtt{closeSize} = \left\lceil \frac{\$720}{\$1{,}800 \times 5\%} \right\rceil = 8 \text{ ETH} \quad (\text{partial close; 2 ETH remain})
+$$
+
+_Bankruptcy price_
+
+$$
+\mathtt{bp} = \$1{,}800 - \frac{\$180}{10} = \$1{,}782
+$$
+
+Alice is solvent, so the close order's price limit is the BP.
 
 _Execution_
 
-The long is closed (sold) into Bob's resting bid at \$47,500.
+Carol's bid at \$1,800 is above the \$1,782 limit, so the entire 8 ETH close fills at \$1,800. No ADL.
 
 $$
-\mathtt{AlicePnL} = 1 \times (\$47{,}500 - \$50{,}000) = -\$2{,}500
-$$
-
-_Liquidation fee_
-
-$$
-\mathtt{closedNotional} = 1 \times \$47{,}500 = \$47{,}500
-$$
-
-$$
-\mathtt{rawFee} = \$47{,}500 \times 0.1\% = \$47.50
-$$
-
-$$
-\mathtt{remainingMargin} = \max(0,\; \$3{,}000 - \$2{,}500) = \$500
-$$
-
-$$
-\mathtt{fee} = \min(\$47.50,\; \$500) = \$47.50
-$$
-
-_Settlement (margin arithmetic)_
-
-Alice's margin starts at \$3,000.
-
-$$
-\mathtt{margin} \mathrel{-}= \$47.50 \quad (\text{fee}) \;\Rightarrow\; \$2{,}952.50
-$$
-
-$$
-\mathtt{margin} \mathrel{+}= (-\$2{,}500) \quad (\text{PnL}) \;\Rightarrow\; \$452.50
-$$
-
-Final margin is positive — no bad debt.
-
-$$
-\mathtt{insuranceFund} \mathrel{+}= \$47.50 \quad (\text{fee revenue})
-$$
-
-### Example 2 — ADL at bankruptcy price (no book liquidity)
-
-**Setup**
-
-|             | Charlie    | Dana        |
-| ----------- | ---------- | ----------- |
-| Direction   | Long 1 BTC | Short 1 BTC |
-| Entry price | \$50,000   | \$55,000    |
-| Margin      | \$3,000    | \$10,000    |
-
-**BTC drops to \$46,000**
-
-_Charlie's account_
-
-$$
-\mathtt{equity} = \$3{,}000 + 1 \times (\$46{,}000 - \$50{,}000) = \$3{,}000 - \$4{,}000 = -\$1{,}000
-$$
-
-$$
-\mathtt{MM} = 1 \times \$46{,}000 \times 5\% = \$2{,}300
-$$
-
-$$
--\$1{,}000 < \$2{,}300 \;\Rightarrow\; \text{liquidatable}
-$$
-
-_Close schedule_
-
-Charlie's full 1 BTC long is scheduled for closure.
-
-_Order book matching_
-
-No bids on the book — the full 1 BTC is unfilled.
-
-_ADL_
-
-Bankruptcy price for Charlie's long:
-
-$$
-\mathtt{bp} = \$46{,}000 - \frac{-\$1{,}000}{1} = \$46{,}000 + \$1{,}000 = \$47{,}000
-$$
-
-Dana holds the most profitable short (entry \$55,000, current oracle \$46,000). Her position is force-closed at \$47,000.
-
-Charlie's PnL at bankruptcy price:
-
-$$
-\mathtt{CharliePnL} = 1 \times (\$47{,}000 - \$50{,}000) = -\$3{,}000
-$$
-
-$$
-\mathtt{margin}: \$3{,}000 + (-\$3{,}000) = \$0 \quad \text{(zeroed by construction)}
-$$
-
-Dana's PnL at bankruptcy price:
-
-$$
-\mathtt{DanaPnL} = -1 \times (\$47{,}000 - \$55{,}000) = \$8{,}000
-$$
-
-$$
-\mathtt{DanaMargin}: \$10{,}000 + \$8{,}000 = \$18{,}000
+\mathtt{AlicePnL} = 8 \times (\$1{,}800 - \$2{,}000) = -\$1{,}600
 $$
 
 _Liquidation fee_
 
 $$
-\mathtt{remainingMargin} = \max(0,\; \$3{,}000 - \$3{,}000) = \$0
+\mathtt{closedNotional} = 8 \times \$1{,}800 = \$14{,}400 \quad (\text{valued at the oracle price})
 $$
 
 $$
-\mathtt{fee} = \$0 \quad \text{(no margin left)}
+\mathtt{rawFee} = \$14{,}400 \times 0.1\% = \$14.40
 $$
 
-No bad debt, no insurance fund impact. Dana receives the full PnL at the bankruptcy price, which is better than the oracle price for her.
+$$
+\mathtt{remainingMargin} = \max(0,\; \$2{,}180 - \$1{,}600) = \$580
+$$
+
+$$
+\mathtt{fee} = \min(\$14.40,\; \$580) = \$14.40
+$$
 
 **Final state**
 
-|                | Balance                 |
-| -------------- | ----------------------- |
-| Charlie        | \$0 (fully liquidated)  |
-| Dana           | \$18,000 (profit at bp) |
-| Insurance fund | unchanged               |
+|                | Position                 | Margin / balance                       |
+| -------------- | ------------------------ | -------------------------------------- |
+| Alice          | Long 2 ETH @ \$2,000     | \$2,180 − \$1,600 − \$14.40 = \$565.60 |
+| Bob            | Short 10 ETH (untouched) | \$10,000                               |
+| Carol          | Long 8 ETH @ \$1,800     | —                                      |
+| Insurance fund | —                        | +\$14.40                               |
 
-### Example 3 — Book fill creates bad debt
+No ADL, no bad debt. Alice keeps 2 ETH and equity of \$565.60 − 2 × \$200 = \$165.60.
+
+### Example 2 — Solvent; close partially absorbed by the book, remainder ADL'd
+
+Same as Example 1, except Carol's bid is only **5 ETH** @ \$1,800.
+
+_Execution_
+
+- Book: 5 ETH fill Carol's bid at \$1,800.
+- ADL: the remaining 3 ETH close against Bob — the most profitable short — at the bankruptcy price, \$1,782.
+
+$$
+\mathtt{AlicePnL} = 5 \times (\$1{,}800 - \$2{,}000) + 3 \times (\$1{,}782 - \$2{,}000) = -\$1{,}000 - \$654 = -\$1{,}654
+$$
+
+$$
+\mathtt{BobPnL} = -3 \times (\$1{,}782 - \$2{,}000) = +\$654
+$$
+
+Closing 3 ETH at the oracle would have realized $3 \times (\$2{,}000 - \$1{,}800) = \$600$ for Bob; the extra \$54 is Alice's per-unit equity concession, $3 \times \$180 / 10 = \$54$.
+
+_Liquidation fee_
+
+Same closed notional as Example 1 (8 ETH valued at the \$1,800 oracle) → fee \$14.40.
+
+**Final state**
+
+|                | Position              | Margin / balance                       |
+| -------------- | --------------------- | -------------------------------------- |
+| Alice          | Long 2 ETH @ \$2,000  | \$2,180 − \$1,654 − \$14.40 = \$511.60 |
+| Bob            | Short 7 ETH @ \$2,000 | \$10,000 + \$654 = \$10,654            |
+| Carol          | Long 5 ETH @ \$1,800  | —                                      |
+| Insurance fund | —                     | +\$14.40                               |
+
+No bad debt.
+
+### Example 3 — Solvent; book empty, whole close ADL'd
+
+Same as Example 1, but the order book is empty.
+
+_Execution_
+
+The entire 8 ETH close is ADL'd against Bob at the bankruptcy price, \$1,782.
+
+$$
+\mathtt{AlicePnL} = 8 \times (\$1{,}782 - \$2{,}000) = -\$1{,}744
+$$
+
+$$
+\mathtt{BobPnL} = -8 \times (\$1{,}782 - \$2{,}000) = +\$1{,}744
+$$
+
+_Liquidation fee_
+
+\$14.40 as before.
+
+**Final state**
+
+|                | Position              | Margin / balance                       |
+| -------------- | --------------------- | -------------------------------------- |
+| Alice          | Long 2 ETH @ \$2,000  | \$2,180 − \$1,744 − \$14.40 = \$421.60 |
+| Bob            | Short 2 ETH @ \$2,000 | \$10,000 + \$1,744 = \$11,744          |
+| Insurance fund | —                     | +\$14.40                               |
+
+No bad debt: Alice concedes $8 \times \$18 = \$144$ of her \$180 equity to Bob and keeps the rest.
+
+### Example 4 — Insolvent; close fully absorbed by the book
 
 **Setup**
 
-|                | Charlie    | Bob (maker)          |
-| -------------- | ---------- | -------------------- |
-| Direction      | Long 1 BTC | Bid 1 BTC @ \$46,000 |
-| Entry price    | \$50,000   | —                    |
-| Margin         | \$3,000    | \$50,000             |
-| Insurance fund | \$500      |                      |
+|             | Alice       | Bob          | Carol                |
+| ----------- | ----------- | ------------ | -------------------- |
+| Position    | Long 10 ETH | Short 10 ETH | Bid 10 ETH @ \$1,700 |
+| Entry price | \$2,000     | \$2,000      | —                    |
+| Margin      | \$2,800     | \$10,000     | —                    |
 
-**BTC drops to \$46,000**
+**ETH drops to \$1,700**
 
-_Charlie's liquidation_
-
-Same equity and MM as Example 2. Liquidatable.
-
-_Order book matching_
-
-The bid at \$46,000 fills Charlie's full 1 BTC sell.
+_Alice's account_
 
 $$
-\mathtt{CharliePnL} = 1 \times (\$46{,}000 - \$50{,}000) = -\$4{,}000
+\mathtt{equity} = \$2{,}800 + 10 \times (\$1{,}700 - \$2{,}000) = -\$200
+$$
+
+$$
+\mathtt{MM} = 10 \times \$1{,}700 \times 5\% = \$850
+$$
+
+Equity is negative — Alice is liquidatable and insolvent.
+
+_Close schedule_
+
+$$
+\mathtt{deficit} = \$850 - (-\$200) = \$1{,}050 \geq \mathtt{MM} \;\Rightarrow\; \text{full close of all 10 ETH}
+$$
+
+_Bankruptcy price_
+
+$$
+\mathtt{bp} = \$1{,}700 - \frac{-\$200}{10} = \$1{,}720
+$$
+
+Alice is insolvent, so the close order's price limit is the oracle price (\$1,700), not the BP.
+
+_Execution_
+
+Carol's bid at \$1,700 fills the entire 10 ETH — at a price **lower than the BP**. No ADL.
+
+$$
+\mathtt{AlicePnL} = 10 \times (\$1{,}700 - \$2{,}000) = -\$3{,}000
 $$
 
 _Liquidation fee_
 
 $$
-\mathtt{remainingMargin} = \max(0,\; \$3{,}000 - \$4{,}000) = \$0
-$$
-
-$$
-\mathtt{fee} = \$0
+\mathtt{remainingMargin} = \max(0,\; \$2{,}800 - \$3{,}000) = \$0 \;\Rightarrow\; \mathtt{fee} = \$0
 $$
 
 _Bad debt_
 
-Charlie's margin after PnL: $\$3{,}000 - \$4{,}000 = -\$1{,}000$.
-
 $$
-\mathtt{badDebt} = \$1{,}000, \quad \mathtt{margin} \gets \$0
+\mathtt{badDebt} = |\min(0,\; \$2{,}800 - \$3{,}000)| = \$200
 $$
 
-$$
-\mathtt{insuranceFund}: \$500 - \$1{,}000 = -\$500
-$$
-
-The insurance fund goes negative. Future liquidation fees will replenish it.
+Equivalently: each of the 10 ETH filled \$20 below the \$1,720 BP. Alice's margin is floored to zero and the insurance fund covers the \$200.
 
 **Final state**
 
-|                | Balance                          |
-| -------------- | -------------------------------- |
-| Charlie        | \$0 (fully liquidated)           |
-| Insurance fund | −\$500 (unresolved bad debt)     |
-| Vault          | unchanged (isolated from losses) |
+|                | Position                 | Margin / balance |
+| -------------- | ------------------------ | ---------------- |
+| Alice          | — (fully liquidated)     | \$0              |
+| Bob            | Short 10 ETH (untouched) | \$10,000         |
+| Carol          | Long 10 ETH @ \$1,700    | —                |
+| Insurance fund | —                        | −\$200           |
+
+### Example 5 — Insolvent; close partially absorbed by the book, remainder ADL'd
+
+Same as Example 4, except Carol's bid is only **4 ETH** @ \$1,700.
+
+_Execution_
+
+- Book: 4 ETH fill at \$1,700 (below the \$1,720 BP).
+- ADL: the remaining 6 ETH close against Bob at the BP, \$1,720.
+
+$$
+\mathtt{AlicePnL} = 4 \times (\$1{,}700 - \$2{,}000) + 6 \times (\$1{,}720 - \$2{,}000) = -\$1{,}200 - \$1{,}680 = -\$2{,}880
+$$
+
+$$
+\mathtt{BobPnL} = -6 \times (\$1{,}720 - \$2{,}000) = +\$1{,}680
+$$
+
+Bob is force-closed \$20 above oracle on 6 ETH — he absorbs \$120 of Alice's insolvency that would otherwise become bad debt.
+
+_Bad debt_
+
+$$
+\mathtt{margin} = \$2{,}800 - \$2{,}880 = -\$80 \;\Rightarrow\; \mathtt{badDebt} = \$80
+$$
+
+The \$80 equals the book-filled portion's shortfall from the BP: $4 \times (\$1{,}720 - \$1{,}700)$. The fee is \$0 (no remaining margin).
+
+**Final state**
+
+|                | Position              | Margin / balance              |
+| -------------- | --------------------- | ----------------------------- |
+| Alice          | — (fully liquidated)  | \$0                           |
+| Bob            | Short 4 ETH @ \$2,000 | \$10,000 + \$1,680 = \$11,680 |
+| Carol          | Long 4 ETH @ \$1,700  | —                             |
+| Insurance fund | —                     | −\$80                         |
+
+### Example 6 — Insolvent; book empty, whole close ADL'd
+
+Same as Example 4, but the order book is empty.
+
+_Execution_
+
+All 10 ETH are ADL'd against Bob at the BP, \$1,720.
+
+$$
+\mathtt{AlicePnL} = 10 \times (\$1{,}720 - \$2{,}000) = -\$2{,}800
+$$
+
+$$
+\mathtt{margin} = \$2{,}800 - \$2{,}800 = \$0
+$$
+
+Alice's equity is zeroed **by construction** — no bad debt, despite her insolvency. Bob absorbs the whole \$200 shortfall by buying back 10 ETH at \$20 above oracle:
+
+$$
+\mathtt{BobPnL} = -10 \times (\$1{,}720 - \$2{,}000) = +\$2{,}800
+$$
+
+(\$200 less than the \$3,000 he would realize closing at the oracle.) The fee is \$0.
+
+**Final state**
+
+|                | Position             | Margin / balance              |
+| -------------- | -------------------- | ----------------------------- |
+| Alice          | — (fully liquidated) | \$0                           |
+| Bob            | — (fully ADL'd)      | \$10,000 + \$2,800 = \$12,800 |
+| Insurance fund | —                    | unchanged                     |
+
+### Example 7 — Two positions, solvent
+
+Alice now holds two longs; Bob holds the exact opposite shorts. The order book is empty in this example and the next, so all closes go to ADL.
+
+**Setup**
+
+|             | Alice                     | Bob                       |
+| ----------- | ------------------------- | ------------------------- |
+| Positions   | Long 10 ETH, long 1 BTC   | Short 10 ETH, short 1 BTC |
+| Entry price | ETH \$2,000; BTC \$50,000 | ETH \$2,000; BTC \$50,000 |
+| Margin      | \$7,065                   | \$12,000                  |
+
+**ETH drops to \$1,900; BTC drops to \$47,000**
+
+_Alice's account_
+
+$$
+\mathtt{equity} = \$7{,}065 + 10 \times (-\$100) + 1 \times (-\$3{,}000) = \$3{,}065
+$$
+
+$$
+\mathtt{MM} = 10 \times \$1{,}900 \times 5\% + 1 \times \$47{,}000 \times 5\% = \$950 + \$2{,}350 = \$3{,}300
+$$
+
+$$
+\$3{,}065 < \$3{,}300 \;\Rightarrow\; \text{liquidatable (solvent)}
+$$
+
+_Close schedule_
+
+$$
+\mathtt{deficit} = \$3{,}300 - \$3{,}065 = \$235
+$$
+
+Positions are processed in descending order of MM contribution: BTC (\$2,350) before ETH (\$950).
+
+$$
+\mathtt{closeSize_{BTC}} = \left\lceil \frac{\$235}{\$47{,}000 \times 5\%} \right\rceil = 0.1 \text{ BTC}
+$$
+
+Closing 0.1 BTC removes $0.1 \times \$2{,}350 = \$235$ of MM — the deficit is fully covered, so the ETH position is not scheduled at all.
+
+_Bankruptcy price (BTC)_
+
+$$
+\mathtt{bp} = \$47{,}000 - \frac{\$3{,}065}{1} = \$43{,}935
+$$
+
+The numerator is the **whole-account** equity — including the ETH position's unrealized PnL — divided by the BTC position's full size (1 BTC).
+
+_Execution_
+
+0.1 BTC is ADL'd against Bob at \$43,935.
+
+$$
+\mathtt{AlicePnL} = 0.1 \times (\$43{,}935 - \$50{,}000) = -\$606.50
+$$
+
+$$
+\mathtt{BobPnL} = +\$606.50
+$$
+
+_Liquidation fee_
+
+$$
+\mathtt{fee} = 0.1 \times \$47{,}000 \times 0.1\% = \$4.70
+$$
+
+**Final state**
+
+|                | Positions                   | Margin / balance                         |
+| -------------- | --------------------------- | ---------------------------------------- |
+| Alice          | Long 10 ETH, long 0.9 BTC   | \$7,065 − \$606.50 − \$4.70 = \$6,453.80 |
+| Bob            | Short 10 ETH, short 0.9 BTC | \$12,000 + \$606.50 = \$12,606.50        |
+| Insurance fund | —                           | +\$4.70                                  |
+
+No bad debt. Alice's equity is \$6,453.80 − \$1,000 − 0.9 × \$3,000 = \$2,753.80.
+
+### Example 8 — Two positions, insolvent
+
+Same positions and margins as Example 7; prices fall further.
+
+**ETH drops to \$1,800; BTC drops to \$44,000**
+
+_Alice's account_
+
+$$
+\mathtt{equity} = \$7{,}065 + 10 \times (-\$200) + 1 \times (-\$6{,}000) = -\$935
+$$
+
+$$
+\mathtt{MM} = 10 \times \$1{,}800 \times 5\% + 1 \times \$44{,}000 \times 5\% = \$900 + \$2{,}200 = \$3{,}100
+$$
+
+_Close schedule_
+
+$$
+\mathtt{deficit} = \$3{,}100 - (-\$935) = \$4{,}035 \geq \mathtt{MM} \;\Rightarrow\; \text{both positions fully closed, BTC first}
+$$
+
+_Entry 1: BTC_
+
+$$
+\mathtt{bp_{BTC}} = \$44{,}000 - \frac{-\$935}{1} = \$44{,}935
+$$
+
+The full 1 BTC is ADL'd against Bob at \$44,935:
+
+$$
+\mathtt{margin}: \$7{,}065 + 1 \times (\$44{,}935 - \$50{,}000) = \$2{,}000
+$$
+
+Alice's equity is now $\$2{,}000 + 10 \times (\$1{,}800 - \$2{,}000) = \$0$ — the first position's ADL absorbed the entire account shortfall.
+
+_Entry 2: ETH_
+
+The BP is recomputed from the account's **current** equity, which is now zero:
+
+$$
+\mathtt{bp_{ETH}} = \$1{,}800 - \frac{\$0}{10} = \$1{,}800 = \text{oracle price}
+$$
+
+All 10 ETH are ADL'd against Bob at \$1,800:
+
+$$
+\mathtt{margin}: \$2{,}000 + 10 \times (\$1{,}800 - \$2{,}000) = \$0
+$$
+
+_Liquidation fee and bad debt_
+
+Remaining margin is \$0, so the fee is \$0; the margin is exactly zero, so there is **no bad debt**.
+
+**Final state**
+
+|                | Positions            | Margin / balance                        |
+| -------------- | -------------------- | --------------------------------------- |
+| Alice          | — (fully liquidated) | \$0                                     |
+| Bob            | — (fully ADL'd)      | \$12,000 + \$5,065 + \$2,000 = \$19,065 |
+| Insurance fund | —                    | unchanged                               |
+
+Bob's two ADL fills realize $1 \times (\$50{,}000 - \$44{,}935) = \$5{,}065$ on BTC and $10 \times (\$2{,}000 - \$1{,}800) = \$2{,}000$ on ETH. Alice's \$935 shortfall is absorbed entirely by the BTC fill's above-oracle premium.

--- a/book/perps/4-liquidation-and-adl.md
+++ b/book/perps/4-liquidation-and-adl.md
@@ -53,9 +53,7 @@ Each entry in the close schedule is executed in two phases:
 
 ### 3a. Order book matching
 
-The close is submitted as a **market order** against the on-chain order book. It matches resting limit orders at price-time priority. Any filled amount is settled normally (mark-to-market PnL between the entry price and the fill price).
-
-The order carries a price limit: the **bankruptcy price** (defined in [§3b](#3b-auto-deleveraging-adl)) when the account is solvent ($\mathtt{equity} > 0$), or the **oracle price** when insolvent. Resting orders on the wrong side of the limit are not matched — this prevents the close from sweeping through stale or absurdly-priced orders.
+The close is submitted as an **immediate-or-cancel (IOC) limit order** against the on-chain order book. The order's limit price is the **bankruptcy price** (defined in [§3b](#3b-auto-deleveraging-adl)) when the account is solvent ($\mathtt{equity} > 0$), or the **oracle price** when insolvent. It matches resting limit orders at price-time priority. Any filled amount is settled normally (mark-to-market PnL between the entry price and the fill price).
 
 ### 3b. Auto-deleveraging (ADL)
 
@@ -80,7 +78,7 @@ The divisor is always the position's **full current size**, even when the close 
 - If the user is **solvent** ($\mathtt{equity} > 0$), the BP sits slightly on the favourable side of the oracle for the counter-party (below oracle when closing a long, above when closing a short). The counter-party receives the user's per-unit equity share as compensation for the forced close; the user keeps the equity attributable to the unclosed remainder, and never goes negative.
 - If the user is **insolvent** ($\mathtt{equity} \le 0$), the BP overshoots the oracle in the user's favour (above oracle when closing a long, below when closing a short). The counter-party is force-closed at a worse-than-oracle price — it absorbs what would otherwise be bad debt. The close schedule fully closes every position of an insolvent account, so a pure-ADL liquidation leaves the account at exactly zero equity.
 
-The counter-party's resting limit orders are not affected by ADL; only their position is force-reduced.
+ADL does not fill the counter-party's resting limit orders; their position is force-reduced directly. The shrunken position can, however, cause their resting **reduce-only** orders to be resized or cancelled, maintaining the invariant that the total size of a user's reduce-only orders never exceeds their position size.
 
 Liquidation fills (both order-book and ADL) carry **zero trading fees** for both taker and maker.
 
@@ -152,9 +150,15 @@ All examples use:
 | Liquidation buffer ratio ($b$) | 0                                     |
 | Settlement currency            | USDC at \$1                           |
 
-Cast: **Alice** is the account being liquidated. **Bob** holds the exact opposite position(s), opened against Alice at her entry price — being the most profitable counter-position, he is the ADL counter-party. **Carol** is a third-party maker who supplies order-book liquidity where stated.
+Cast:
+
+- **Alice** is the account being liquidated.
+- **Bob** holds the exact opposite position(s), opened against Alice at her entry price — being the most profitable counter-position, he is the ADL counter-party.
+- **Carol** is a third-party maker who supplies order-book liquidity where stated.
 
 Examples 1–6 cover a single position, ordered from the most ideal situation to the least: Alice solvent (1–3) then insolvent (4–6), with the order book absorbing all (1, 4), part (2, 5), or none (3, 6) of the close. Examples 7–8 cover an account with two positions.
+
+All eight examples — plus mirrored variants with the sides flipped — are implemented as end-to-end tests in [`dango/testing/tests/perps/liquidation_spec.rs`](https://github.com/left-curve/left-curve/blob/main/dango/testing/tests/perps/liquidation_spec.rs), asserting every figure below exactly.
 
 ### Example 1 — Solvent; close fully absorbed by the book
 
@@ -198,7 +202,7 @@ $$
 \mathtt{bp} = \$1{,}800 - \frac{\$180}{10} = \$1{,}782
 $$
 
-Alice is solvent, so the close order's price limit is the BP.
+Alice is solvent, so the close order's limit price is the BP.
 
 _Execution_
 
@@ -337,7 +341,7 @@ $$
 \mathtt{bp} = \$1{,}700 - \frac{-\$200}{10} = \$1{,}720
 $$
 
-Alice is insolvent, so the close order's price limit is the oracle price (\$1,700), not the BP.
+Alice is insolvent, so the close order's limit price is the oracle price (\$1,700), not the BP.
 
 _Execution_
 

--- a/dango/perps/src/core/closure.rs
+++ b/dango/perps/src/core/closure.rs
@@ -181,17 +181,28 @@ pub fn compute_user_equity_with_pnl(
     Ok(equity)
 }
 
-/// Compute the bankruptcy price for a position being closed during liquidation.
+/// Compute the bankruptcy price of a position during liquidation.
 ///
 /// This is the fill price at which the user's total equity would be exactly
-/// zero after closing `close_amount` of the position.
+/// zero if the **entire** position were closed at it:
 ///
-/// For longs:  bp = oracle_price - equity / close_amount
-/// For shorts: bp = oracle_price + equity / close_amount
+/// For longs:  bp = oracle_price - equity / |size|
+/// For shorts: bp = oracle_price + equity / |size|
+///
+/// The divisor is always the full current position size, regardless of how
+/// much of the position the close schedule intends to close. A partial close
+/// at this price concedes `equity / |size|` per unit closed, so equity after
+/// closing `c` units is `equity × (1 - c / |size|)` — non-negative whenever
+/// equity is non-negative, and exactly zero when the whole position is
+/// closed.
+///
+/// For a single-position account the offset is bounded: liquidatable means
+/// `equity < |size| × oracle × mmr`, hence `equity / |size| < oracle × mmr`
+/// and the bankruptcy price stays within the maintenance-margin band of the
+/// oracle.
 pub fn compute_bankruptcy_price(
     user_state: &UserState,
     pair_id: &PairId,
-    close_amount: Quantity,
     oracle_prices: &BTreeMap<PairId, UsdPrice>,
     user_pnl: UsdValue,
     user_fees: UsdValue,
@@ -200,7 +211,7 @@ pub fn compute_bankruptcy_price(
 
     let position = &user_state.positions[pair_id];
     let oracle_price = oracle_prices[pair_id];
-    let offset = equity.checked_div(close_amount)?;
+    let offset = equity.checked_div(position.size.checked_abs()?)?;
 
     if position.size.is_positive() {
         oracle_price.checked_sub(offset)
@@ -1058,7 +1069,6 @@ mod tests {
         let bp = compute_bankruptcy_price(
             &user_state,
             &pair_btc(),
-            Quantity::new_int(1),
             &oracle_prices,
             UsdValue::ZERO,
             UsdValue::ZERO,
@@ -1090,7 +1100,6 @@ mod tests {
         let bp = compute_bankruptcy_price(
             &user_state,
             &pair_btc(),
-            Quantity::new_int(1),
             &oracle_prices,
             UsdValue::ZERO,
             UsdValue::ZERO,
@@ -1108,6 +1117,11 @@ mod tests {
         // Unrealized ETH = 10*(3.2k-3k) = 2k.
         // Equity = 5k + (-4k) + 2k = 3k.
         // bp = 46k - 3k/1 = 43k.
+        //
+        // The offset divides the WHOLE-ACCOUNT equity (including the ETH
+        // position's unrealized PnL) by the BTC position's full size. Under
+        // the pre-fix formula, a 0.1 BTC scheduled close would have produced
+        // bp = 46k - 3k/0.1 = 16k.
         let user_state = UserState {
             margin: UsdValue::new_int(5_000),
             positions: BTreeMap::from([
@@ -1137,7 +1151,6 @@ mod tests {
         let bp = compute_bankruptcy_price(
             &user_state,
             &pair_btc(),
-            Quantity::new_int(1),
             &oracle_prices,
             UsdValue::ZERO,
             UsdValue::ZERO,
@@ -1145,5 +1158,94 @@ mod tests {
         .unwrap();
 
         assert_eq!(bp, UsdPrice::new_int(43_000));
+    }
+
+    /// Regression test for the testnet incident at block 32500262 (and the
+    /// mainnet ETH cluster on 2026-06-05): the bankruptcy price of a
+    /// position scheduled for a **partial** close.
+    ///
+    /// The bug: the bankruptcy price divided the account's *whole* equity by
+    /// the scheduled close amount. The close schedule sizes the close to cure
+    /// the maintenance-margin deficit, so for a solvent account it is only a
+    /// fraction of the position; the amplified offset `equity / close_amount`
+    /// threw the price far from the oracle (here: 1,875 − 750/2 = 1,500,
+    /// −20%; on testnet, SOL fills as low as −$0.596944 against a $76.32
+    /// oracle), confiscating the account's entire equity through that one
+    /// partial fill.
+    ///
+    /// The bankruptcy price now divides by the full position size — by
+    /// definition, it is the price at which closing the *whole* position
+    /// zeroes the account's equity — and is independent of how much the
+    /// schedule intends to close.
+    ///
+    /// Setup: long 10 BTC @ $2,000, margin $2,000, oracle $1,875.
+    /// Equity = 2,000 + 10 × (1,875 − 2,000) = 750 (solvent; the
+    /// deficit-curing close for mmr 5% would be 2 of the 10 BTC).
+    ///
+    ///   bp = 1,875 − 750/10 = 1,800
+    #[test]
+    fn bankruptcy_price_partial_close_long() {
+        let user_state = UserState {
+            margin: UsdValue::new_int(2_000),
+            positions: BTreeMap::from([(pair_btc(), Position {
+                size: Quantity::new_int(10),
+                entry_price: UsdPrice::new_int(2_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            })]),
+            ..Default::default()
+        };
+
+        let oracle_prices = BTreeMap::from([(pair_btc(), UsdPrice::new_int(1_875))]);
+
+        let bp = compute_bankruptcy_price(
+            &user_state,
+            &pair_btc(),
+            &oracle_prices,
+            UsdValue::ZERO,
+            UsdValue::ZERO,
+        )
+        .unwrap();
+
+        assert_eq!(bp, UsdPrice::new_int(1_800));
+    }
+
+    /// Short-side mirror of `bankruptcy_price_partial_close_long`.
+    ///
+    /// Setup: short 10 BTC @ $2,000, margin $2,000, oracle $2,125.
+    /// Equity = 2,000 + (−10) × (2,125 − 2,000) = 750 (solvent).
+    ///
+    /// Under the bug, a partial close of 2 would have been priced at
+    /// 2,125 + 750/2 = 2,500 (+17.6% from oracle). With the full position
+    /// size:
+    ///
+    ///   bp = 2,125 + 750/10 = 2,200
+    #[test]
+    fn bankruptcy_price_partial_close_short() {
+        let user_state = UserState {
+            margin: UsdValue::new_int(2_000),
+            positions: BTreeMap::from([(pair_btc(), Position {
+                size: Quantity::new_int(-10),
+                entry_price: UsdPrice::new_int(2_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            })]),
+            ..Default::default()
+        };
+
+        let oracle_prices = BTreeMap::from([(pair_btc(), UsdPrice::new_int(2_125))]);
+
+        let bp = compute_bankruptcy_price(
+            &user_state,
+            &pair_btc(),
+            &oracle_prices,
+            UsdValue::ZERO,
+            UsdValue::ZERO,
+        )
+        .unwrap();
+
+        assert_eq!(bp, UsdPrice::new_int(2_200));
     }
 }

--- a/dango/perps/src/maintain/liquidate.rs
+++ b/dango/perps/src/maintain/liquidate.rs
@@ -511,18 +511,30 @@ fn execute_close_schedule(
 
         let taker_is_bid = close_size.is_positive();
 
-        // Compute the bankruptcy price BEFORE book fills, using the total
-        // scheduled close amount. This price serves two roles:
+        // Compute the bankruptcy price BEFORE book fills. It divides the
+        // user's total equity by the position's FULL size — not the scheduled
+        // close amount — so a partial close at this price concedes only the
+        // closed fraction's share of equity (`equity / |size|` per unit),
+        // never more. Dividing by a deficit-sized partial close instead would
+        // amplify the offset and let a single small fill confiscate the whole
+        // account's equity, which is the bug behind the testnet block
+        // 32500262 liquidation cascade.
         //
-        // 1. When equity > 0 (timely liquidation): bp sits between oracle and
-        //    the entry price, and is used as both the target_price for book
-        //    matching AND the ADL fill price. This prevents matching against
-        //    absurd resting orders and guarantees equity_after >= 0.
+        // The price serves two roles:
+        //
+        // 1. When equity > 0 (timely liquidation): bp sits within the
+        //    maintenance-margin band below oracle (above for shorts), and is
+        //    used as both the target_price for book matching AND the ADL fill
+        //    price. This prevents matching against absurd resting orders and
+        //    guarantees equity_after >= 0: closing `c` of `|size|` units
+        //    leaves equity × (1 - c/|size|).
         //
         // 2. When equity <= 0 (late liquidation): bp overshoots oracle (above
         //    oracle for longs, below for shorts), which would block valid
         //    oracle-adjacent book fills. In this case we fall back to the
-        //    oracle price as target_price and use bp only for ADL.
+        //    oracle price as target_price and use bp only for ADL. The
+        //    schedule fully closes the position in this case (deficit >= MM),
+        //    so a pure-ADL close at bp zeroes equity exactly — no bad debt.
         //
         // Per-fill settlement inside `match_order` has already applied
         // realized PnLs and fees (zero during liquidation) from earlier
@@ -532,7 +544,6 @@ fn execute_close_schedule(
         let bankruptcy_price = compute_bankruptcy_price(
             user_state,
             pair_id,
-            close_size.checked_abs()?,
             oracle_prices,
             UsdValue::ZERO,
             UsdValue::ZERO,

--- a/dango/testing/tests/perps/bankruptcy_bug_reproduction.rs
+++ b/dango/testing/tests/perps/bankruptcy_bug_reproduction.rs
@@ -1,0 +1,331 @@
+//! # Bankruptcy price bug — reproduction of the 2026-06-03 testnet incident
+//!
+//! ## The bug
+//!
+//! `compute_bankruptcy_price` divides the account's **whole** equity by the
+//! **scheduled close amount**. The close schedule sizes the close to cure the
+//! maintenance-margin deficit, so for a solvent account (`0 < equity < MM`)
+//! the close is only a fraction of the position. Dividing whole-account
+//! equity by that fraction amplifies the offset, throwing the bankruptcy
+//! price far from the oracle — and the ADL leg settles at that price,
+//! confiscating the account's entire equity through a single partial fill
+//! and handing it to the ADL counter-party.
+//!
+//! ## The testnet incident (block 32500262)
+//!
+//! During a sharp market-wide drop, several solvent accounts with large SOL
+//! positions fell slightly below maintenance margin. Their deficit-curing
+//! closes were small fractions of their positions, the book was thin, and
+//! the remainders were ADL'd at bankruptcy prices ranging from $59.86 down
+//! to **−$0.596944** against a $76.32 oracle. The same defect fired on
+//! mainnet on 2026-06-05 (ETH at $1,558.63 against a $1,687.41 oracle),
+//! merely on smaller positions.
+//!
+//! ## This test
+//!
+//! The minimal reproduction of that signature: a solvent long, marginally
+//! below maintenance margin, an empty book, and a partial scheduled close
+//! that goes entirely to ADL.
+//!
+//! - Alice opens LONG 10 ETH @ $2,000 with exactly $2,000 margin (10x, the
+//!   initial-margin boundary). Bob holds the opposite SHORT 10 ETH.
+//! - Oracle drops to $1,875:
+//!   - equity = 2,000 + 10 × (1,875 − 2,000) = $750 (solvent)
+//!   - MM = 10 × 1,875 × 5% = $937.50 → liquidatable
+//!   - deficit = 937.50 − 750 = $187.50
+//!   - close = 187.50 / (1,875 × 5%) = exactly 2 ETH (partial)
+//! - The book is empty, so the full 2 ETH goes to ADL against Bob.
+//!
+//! Trading and liquidation fees are zeroed so the figures isolate the
+//! bankruptcy-price arithmetic.
+//!
+//! ## The buggy behavior (pre-fix)
+//!
+//! ```plain
+//! bp = 1,875 − 750/2 = $1,500   (−20% from the oracle)
+//! ```
+//!
+//! Alice's 2-ETH fill at $1,500 realized −$1,000, wiping her equity to
+//! exactly zero even though she was solvent and 8 ETH of her position
+//! remained. Bob pocketed the difference: 2 × (2,000 − 1,500) = +$1,000.
+//!
+//! ## Correct behavior, asserted below
+//!
+//! The bankruptcy price divides by the **full position size** — by
+//! definition, it is the price at which closing the whole position zeroes
+//! the account's equity:
+//!
+//! ```plain
+//! bp = 1,875 − 750/10 = $1,800   (within the 5% mmr band)
+//! ```
+//!
+//! Alice concedes equity/size = $75 per ADL'd unit (2 × 75 = $150), keeping
+//! equity of $600 = 750 × (1 − 2/10).
+
+use {
+    crate::{default_pair_param, default_param, register_oracle_prices},
+    dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice, UsdValue},
+    dango_testing::{TestOption, pair_id, setup_test_naive},
+    dango_types::{
+        constants::usdc,
+        perps::{self, Deleveraged, Liquidated, Param, RateSchedule, UserState},
+    },
+    grug_math::Uint128,
+    grug_types::{
+        Addressable, CheckedContractEvent, Coins, JsonDeExt, QuerierExt, ResultExt, SearchEvent,
+        btree_map,
+    },
+};
+
+#[tokio::test]
+async fn solvent_partial_close_adl_price() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    let pair = pair_id();
+
+    // Zero trading and liquidation fees; default pair params (5% mmr, 10% imr).
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: Param {
+                    taker_fee_rates: RateSchedule::default(),
+                    liquidation_fee_rate: Dimensionless::ZERO,
+                    ..default_param()
+                },
+                pair_params: btree_map! { pair.clone() => default_pair_param() },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    // ------------------------------------------------------------------------
+    // Bob (user2) deposits $10,000 and asks 10 ETH @ $2,000. Alice (user1)
+    // deposits $2,000 and market-buys 10 ETH. With zero fees:
+    //   Alice: long 10 @ $2,000, margin $2,000 (exactly the 10% IMR).
+    //   Bob:   short 10 @ $2,000, margin $10,000.
+    // ------------------------------------------------------------------------
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(2_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    let alice: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+    assert_eq!(alice.margin, UsdValue::new_int(2_000));
+    assert_eq!(alice.positions[&pair].size, Quantity::new_int(10));
+
+    // ------------------------------------------------------------------------
+    // Oracle drops to $1,875. Alice is solvent (equity $750 > 0) but below
+    // maintenance margin ($937.50). The scheduled close is exactly 2 ETH.
+    // ------------------------------------------------------------------------
+
+    register_oracle_prices(&mut suite, &mut accounts, 1_875).await;
+
+    // ------------------------------------------------------------------------
+    // Liquidate. The book is empty (Bob's opening ask was fully consumed),
+    // so the entire 2-ETH close is ADL'd against Bob — at the bankruptcy
+    // price.
+    // ------------------------------------------------------------------------
+
+    let events = suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Liquidate {
+                user: accounts.user1.address(),
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    // ------------------------------------------------------------------------
+    // The Liquidated event. The 2-ETH partial close is priced by dividing
+    // Alice's whole $750 equity by her FULL 10-ETH position:
+    //
+    //   bp = 1,875 − 750/10 = $1,800
+    //
+    // (Pre-fix, the divisor was the 2-ETH close amount: bp = $1,500.)
+    // ------------------------------------------------------------------------
+
+    let liquidated_events = events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "liquidated")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Liquidated>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(liquidated_events.len(), 1, "exactly one Liquidated event");
+    let liquidated = &liquidated_events[0];
+    assert_eq!(liquidated.user, accounts.user1.address());
+    assert_eq!(liquidated.adl_size, Quantity::new_int(-2));
+    assert_eq!(
+        liquidated.adl_price,
+        Some(UsdPrice::new_int(1_800)),
+        "bankruptcy price must divide equity by the full position size"
+    );
+    assert_eq!(liquidated.adl_realized_pnl, UsdValue::new_int(-400));
+
+    // ------------------------------------------------------------------------
+    // The Deleveraged event (Bob). He buys back 2 ETH of his $2,000-entry
+    // short at $1,800, realizing 2 × (2,000 − 1,800) = +$400: his
+    // mark-to-market profit plus Alice's $75-per-unit equity concession.
+    // ------------------------------------------------------------------------
+
+    let deleveraged_events = events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "deleveraged")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Deleveraged>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        deleveraged_events.len(),
+        1,
+        "single ADL counter-party (Bob)"
+    );
+    let deleveraged = &deleveraged_events[0];
+    assert_eq!(deleveraged.user, accounts.user2.address());
+    assert_eq!(deleveraged.closing_size, Quantity::new_int(2));
+    assert_eq!(deleveraged.fill_price, UsdPrice::new_int(1_800));
+    assert_eq!(deleveraged.realized_pnl, UsdValue::new_int(400));
+
+    // ------------------------------------------------------------------------
+    // No bad debt: a solvent account's equity stays positive through a
+    // partial ADL at the bankruptcy price.
+    // ------------------------------------------------------------------------
+
+    let bad_debt_events = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "bad_debt_covered")
+        .take()
+        .all();
+    assert!(bad_debt_events.is_empty(), "no bad debt in this scenario");
+
+    let global_state: perps::State = suite
+        .query_wasm_smart(contracts.perps, perps::QueryStateRequest {})
+        .should_succeed();
+    assert_eq!(global_state.insurance_fund, UsdValue::ZERO);
+
+    // ------------------------------------------------------------------------
+    // Alice's state: margin = 2,000 + 2 × (1,800 − 2,000) = $1,600; her
+    // remaining 8 ETH carries −$1,000 unrealized at the oracle, so her
+    // equity is $600 = 750 × (1 − 2/10) — she concedes only the closed
+    // fraction's share of her equity.
+    //
+    // (Pre-fix: margin $1,000, equity exactly ZERO — fully confiscated
+    // despite being solvent.)
+    // ------------------------------------------------------------------------
+
+    let alice: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed()
+        .unwrap();
+    assert_eq!(alice.margin, UsdValue::new_int(1_600));
+    assert_eq!(alice.positions[&pair].size, Quantity::new_int(8));
+    assert_eq!(alice.positions[&pair].entry_price, UsdPrice::new_int(2_000));
+
+    let alice_unrealized = alice.positions[&pair]
+        .size
+        .checked_mul(
+            UsdPrice::new_int(1_875)
+                .checked_sub(UsdPrice::new_int(2_000))
+                .unwrap(),
+        )
+        .unwrap();
+    let alice_equity = alice.margin.checked_add(alice_unrealized).unwrap();
+    assert_eq!(
+        alice_equity,
+        UsdValue::new_int(600),
+        "a solvent account keeps the unclosed fraction of its equity"
+    );
+
+    // ------------------------------------------------------------------------
+    // Bob's state: margin = 10,000 + 400 = $10,400, short 8 left.
+    //
+    // (Pre-fix: margin $11,000 — Alice's entire equity.)
+    // ------------------------------------------------------------------------
+
+    let bob: UserState = suite
+        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
+            user: accounts.user2.address(),
+        })
+        .should_succeed()
+        .unwrap();
+    assert_eq!(bob.margin, UsdValue::new_int(10_400));
+    assert_eq!(bob.positions[&pair].size, Quantity::new_int(-8));
+}

--- a/dango/testing/tests/perps/liquidation_spec.rs
+++ b/dango/testing/tests/perps/liquidation_spec.rs
@@ -1,0 +1,1115 @@
+//! # Liquidation & ADL — spec example transcriptions
+//!
+//! End-to-end tests asserting the exact figures of the worked examples in
+//! `book/perps/4-liquidation-and-adl.md` ("Examples" section). Examples 1–8
+//! follow the spec verbatim (Alice long, Bob short); examples 9–16 mirror
+//! them with the sides flipped (Alice short, Bob long).
+//!
+//! Cast, as in the spec: **Alice** (`user1`) is liquidated; **Bob** (`user2`)
+//! holds the exact opposite position(s) and is the ADL counter-party;
+//! **Carol** (`user3`) supplies order-book liquidity where the example calls
+//! for it.
+//!
+//! Parameters, as in the spec: 5% maintenance margin ratio, 10% initial
+//! margin ratio, 0.1% liquidation fee, zero trading fees (the spec's
+//! examples start from already-open positions with given margins, so opening
+//! fees would shift every figure), zero liquidation buffer.
+//!
+//! | #      | Alice                  | Margin        | Oracle moves to           | Book (Carol)  | Outcome                                                                                 |
+//! | ------ | ---------------------- | ------------- | ------------------------- | ------------- | --------------------------------------------------------------------------------------- |
+//! | 1 (9)  | long (short) 10 ETH    | 2,180 (2,220) | 1,800 (2,200)             | 8 @ oracle    | book fills 8; no ADL; no bad debt                                                       |
+//! | 2 (10) | long (short) 10 ETH    | 2,180 (2,220) | 1,800 (2,200)             | 5 @ oracle    | book 5 + ADL 3 @ bp 1,782 (2,222)                                                       |
+//! | 3 (11) | long (short) 10 ETH    | 2,180 (2,220) | 1,800 (2,200)             | —             | ADL 8 @ bp 1,782 (2,222)                                                                |
+//! | 4 (12) | long (short) 10 ETH    | 2,800         | 1,700 (2,300)             | 10 @ oracle   | book fills 10 below bp; bad debt 200                                                    |
+//! | 5 (13) | long (short) 10 ETH    | 2,800         | 1,700 (2,300)             | 4 @ oracle    | book 4 + ADL 6 @ bp 1,720 (2,280); bad debt 80                                          |
+//! | 6 (14) | long (short) 10 ETH    | 2,800         | 1,700 (2,300)             | —             | ADL 10 @ bp; margin zeroed exactly; no bad debt                                         |
+//! | 7 (15) | 10 ETH + 1 BTC         | 7,065 (7,435) | 1,900 / 47k (2,100 / 53k) | —             | ADL 0.1 BTC @ bp 43,935 (56,435); ETH untouched                                         |
+//! | 8 (16) | 10 ETH + 1 BTC         | 7,065 (7,435) | 1,800 / 44k (2,200 / 56k) | —             | BTC fully ADL'd @ bp 44,935 (55,435), equity → 0, then ETH ADL'd at oracle; no bad debt |
+
+use {
+    crate::{default_pair_param, default_param},
+    dango_order_book::{Dimensionless, OrderKind, Quantity, TimeInForce, UsdPrice, UsdValue},
+    dango_testing::{
+        OracleTestEntry, TestAccount, TestAccounts, TestOption, TestSuiteNaive, pair_id,
+        setup_test_naive,
+    },
+    dango_types::{
+        constants::usdc,
+        perps::{self, BadDebtCovered, Deleveraged, Liquidated, Param, RateSchedule, UserState},
+    },
+    grug_math::Uint128,
+    grug_types::{
+        Addr, Addressable, CheckedContractEvent, Coins, Denom, JsonDeExt, QuerierExt, ResultExt,
+        SearchEvent, TxEvents, btree_map,
+    },
+};
+
+const ENTRY_ETH: i128 = 2_000;
+const ENTRY_BTC: i128 = 50_000;
+const BOB_MARGIN_SINGLE: i128 = 10_000;
+const BOB_MARGIN_DOUBLE: i128 = 12_000;
+const CAROL_MARGIN: i128 = 5_000;
+
+fn btc_pair_id() -> Denom {
+    "perp/btcusd".parse().unwrap()
+}
+
+/// The spec's parameters: zero trading fees, 0.1% liquidation fee.
+fn spec_param() -> Param {
+    Param {
+        taker_fee_rates: RateSchedule::default(),
+        liquidation_fee_rate: Dimensionless::new_permille(1), // 0.1%
+        ..default_param()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Side {
+    Long,
+    Short,
+}
+
+impl Side {
+    /// Sign of Alice's position; Bob's is the opposite.
+    fn sign(self) -> i128 {
+        match self {
+            Side::Long => 1,
+            Side::Short => -1,
+        }
+    }
+}
+
+/// The ADL leg expected from a liquidation, if any.
+struct Adl {
+    /// Absolute ADL'd amount, in raw (1e-6) position units.
+    size_raw: i128,
+    /// The bankruptcy price (whole dollars).
+    price: i128,
+}
+
+// ---------------------------- shared helpers ---------------------------------
+
+async fn deposit(
+    suite: &mut TestSuiteNaive,
+    account: &mut TestAccount,
+    perps: Addr,
+    dollars: i128,
+) {
+    suite
+        .execute(
+            account,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(
+                usdc::DENOM.clone(),
+                Uint128::new(dollars as u128 * 1_000_000),
+            )
+            .unwrap(),
+        )
+        .await
+        .should_succeed();
+}
+
+async fn submit_limit(
+    suite: &mut TestSuiteNaive,
+    account: &mut TestAccount,
+    perps: Addr,
+    pair: &Denom,
+    size: i128,
+    price: i128,
+) {
+    suite
+        .execute(
+            account,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(size),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(price),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+}
+
+async fn submit_market(
+    suite: &mut TestSuiteNaive,
+    account: &mut TestAccount,
+    perps: Addr,
+    pair: &Denom,
+    size: i128,
+) {
+    suite
+        .execute(
+            account,
+            perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(size),
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+}
+
+/// Seed oracle prices for USDC, ETH, and (optionally) BTC.
+async fn seed_prices(
+    suite: &mut TestSuiteNaive,
+    accounts: &mut TestAccounts,
+    eth_price: i128,
+    btc_price: Option<i128>,
+) {
+    let mut entries = btree_map! {
+        usdc::DENOM.clone() => OracleTestEntry {
+            pyth_id: 1,
+            humanized_price: UsdPrice::new_int(1),
+        },
+        pair_id() => OracleTestEntry {
+            pyth_id: 2,
+            humanized_price: UsdPrice::new_int(eth_price),
+        },
+    };
+
+    if let Some(btc_price) = btc_price {
+        entries.insert(btc_pair_id(), OracleTestEntry {
+            pyth_id: 3,
+            humanized_price: UsdPrice::new_int(btc_price),
+        });
+    }
+
+    suite.seed_oracle_prices(&mut accounts.owner, entries).await;
+}
+
+/// Configure the spec params for the ETH pair and, when `with_btc`, also the
+/// BTC pair. Both pairs must be configured in a single call: the contract
+/// replaces its pair list wholesale with the message's keys. The BTC pair is
+/// new (not in the test genesis), so its oracle price must be seeded before
+/// this call — the contract initializes the pair's state from the oracle.
+async fn configure(
+    suite: &mut TestSuiteNaive,
+    accounts: &mut TestAccounts,
+    perps: Addr,
+    with_btc: bool,
+) {
+    let mut pair_params = btree_map! { pair_id() => default_pair_param() };
+
+    if with_btc {
+        pair_params.insert(btc_pair_id(), default_pair_param());
+    }
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: spec_param(),
+                pair_params,
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+}
+
+async fn liquidate(
+    suite: &mut TestSuiteNaive,
+    accounts: &mut TestAccounts,
+    perps: Addr,
+) -> TxEvents {
+    suite
+        .execute(
+            &mut accounts.owner,
+            perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Liquidate {
+                user: accounts.user1.address(),
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events
+}
+
+fn search_liquidated(events: &TxEvents) -> Vec<Liquidated> {
+    events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "liquidated")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Liquidated>().unwrap())
+        .collect()
+}
+
+fn search_deleveraged(events: &TxEvents) -> Vec<Deleveraged> {
+    events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "deleveraged")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Deleveraged>().unwrap())
+        .collect()
+}
+
+fn search_bad_debt(events: &TxEvents) -> Vec<BadDebtCovered> {
+    events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "bad_debt_covered")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<BadDebtCovered>().unwrap())
+        .collect()
+}
+
+async fn query_user(suite: &mut TestSuiteNaive, perps: Addr, user: Addr) -> Option<UserState> {
+    suite
+        .query_wasm_smart(perps, perps::QueryUserStateRequest { user })
+        .should_succeed()
+}
+
+async fn assert_insurance_fund(suite: &mut TestSuiteNaive, perps: Addr, expected_raw: i128) {
+    let state: perps::State = suite
+        .query_wasm_smart(perps, perps::QueryStateRequest {})
+        .should_succeed();
+
+    assert_eq!(
+        state.insurance_fund,
+        UsdValue::new_raw(expected_raw),
+        "insurance fund mismatch"
+    );
+}
+
+// --------------------- single-position runner (1-6, 9-14) --------------------
+
+struct SingleCase {
+    side: Side,
+    /// Alice's deposit. Bob's is `BOB_MARGIN_SINGLE`.
+    alice_margin: i128,
+    /// ETH oracle price after the move (entry is `ENTRY_ETH`).
+    oracle: i128,
+    /// Carol's resting order size at the post-move oracle price, on the side
+    /// the liquidation close will hit. Zero means an empty book.
+    carol_size: i128,
+    /// The expected ADL leg; `None` when the book absorbs the whole close.
+    adl: Option<Adl>,
+    /// Alice's post-liquidation margin, raw (1e-6 dollars).
+    alice_margin_raw: i128,
+    /// Alice's remaining position size (signed, whole units); 0 = wiped.
+    alice_pos: i128,
+    /// Bob's post-liquidation margin, raw.
+    bob_margin_raw: i128,
+    /// Bob's remaining position size (signed, whole units); 0 = fully ADL'd.
+    bob_pos: i128,
+    /// Insurance fund after liquidation, raw (fees in, bad debt out).
+    insurance_fund_raw: i128,
+    /// Expected bad debt in whole dollars, if any.
+    bad_debt: Option<i128>,
+}
+
+async fn run_single(case: SingleCase) {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    let pair = pair_id();
+    let sign = case.side.sign();
+
+    seed_prices(&mut suite, &mut accounts, ENTRY_ETH, None).await;
+    configure(&mut suite, &mut accounts, contracts.perps, false).await;
+
+    // Open the positions: Bob makes at the entry price, Alice takes.
+    deposit(
+        &mut suite,
+        &mut accounts.user2,
+        contracts.perps,
+        BOB_MARGIN_SINGLE,
+    )
+    .await;
+    submit_limit(
+        &mut suite,
+        &mut accounts.user2,
+        contracts.perps,
+        &pair,
+        -10 * sign,
+        ENTRY_ETH,
+    )
+    .await;
+
+    deposit(
+        &mut suite,
+        &mut accounts.user1,
+        contracts.perps,
+        case.alice_margin,
+    )
+    .await;
+    submit_market(
+        &mut suite,
+        &mut accounts.user1,
+        contracts.perps,
+        &pair,
+        10 * sign,
+    )
+    .await;
+
+    // Sanity: zero-fee opens leave margins untouched.
+    let alice = query_user(&mut suite, contracts.perps, accounts.user1.address())
+        .await
+        .unwrap();
+    assert_eq!(alice.margin, UsdValue::new_int(case.alice_margin));
+    assert_eq!(alice.positions[&pair].size, Quantity::new_int(10 * sign));
+
+    // Move the oracle; Alice becomes liquidatable.
+    seed_prices(&mut suite, &mut accounts, case.oracle, None).await;
+
+    // Carol's book liquidity, resting at the post-move oracle price on the
+    // side the close will hit (bids for a long's close, asks for a short's).
+    if case.carol_size > 0 {
+        deposit(
+            &mut suite,
+            &mut accounts.user3,
+            contracts.perps,
+            CAROL_MARGIN,
+        )
+        .await;
+        submit_limit(
+            &mut suite,
+            &mut accounts.user3,
+            contracts.perps,
+            &pair,
+            case.carol_size * sign,
+            case.oracle,
+        )
+        .await;
+    }
+
+    let events = liquidate(&mut suite, &mut accounts, contracts.perps).await;
+
+    // ---- Liquidated event (exactly one; single pair) ----
+    let liquidated = search_liquidated(&events);
+    assert_eq!(liquidated.len(), 1, "exactly one Liquidated event");
+    assert_eq!(liquidated[0].user, accounts.user1.address());
+
+    match &case.adl {
+        Some(adl) => {
+            // Alice's ADL closes against her position: negative for a long.
+            assert_eq!(
+                liquidated[0].adl_size,
+                Quantity::new_raw(-adl.size_raw * sign)
+            );
+            assert_eq!(liquidated[0].adl_price, Some(UsdPrice::new_int(adl.price)));
+
+            // Alice's realized PnL on the ADL leg, per unit: fill price vs
+            // entry for a long, entry vs fill price for a short.
+            let alice_adl_pnl = adl.size_raw * (adl.price - ENTRY_ETH) * sign;
+            assert_eq!(
+                liquidated[0].adl_realized_pnl,
+                UsdValue::new_raw(alice_adl_pnl)
+            );
+
+            // ---- Deleveraged event (Bob, the only counter-party) ----
+            let deleveraged = search_deleveraged(&events);
+            assert_eq!(deleveraged.len(), 1, "single ADL counter-party (Bob)");
+            assert_eq!(deleveraged[0].user, accounts.user2.address());
+            assert_eq!(
+                deleveraged[0].closing_size,
+                Quantity::new_raw(adl.size_raw * sign)
+            );
+            assert_eq!(deleveraged[0].fill_price, UsdPrice::new_int(adl.price));
+            // Zero-sum: Bob's gain is Alice's loss on the ADL leg.
+            assert_eq!(
+                deleveraged[0].realized_pnl,
+                UsdValue::new_raw(-alice_adl_pnl)
+            );
+        },
+        None => {
+            assert_eq!(liquidated[0].adl_size, Quantity::ZERO);
+            assert_eq!(liquidated[0].adl_price, None);
+            assert!(
+                search_deleveraged(&events).is_empty(),
+                "no ADL ⇒ no Deleveraged event"
+            );
+        },
+    }
+
+    // ---- Bad debt ----
+    let bad_debt = search_bad_debt(&events);
+    match case.bad_debt {
+        Some(amount) => {
+            assert_eq!(bad_debt.len(), 1, "expected a BadDebtCovered event");
+            assert_eq!(bad_debt[0].liquidated_user, accounts.user1.address());
+            assert_eq!(bad_debt[0].amount, UsdValue::new_int(amount));
+            assert_eq!(
+                bad_debt[0].insurance_fund_remaining,
+                UsdValue::new_raw(case.insurance_fund_raw)
+            );
+        },
+        None => assert!(bad_debt.is_empty(), "no bad debt expected"),
+    }
+
+    // ---- Alice ----
+    let alice = query_user(&mut suite, contracts.perps, accounts.user1.address()).await;
+    if case.alice_pos == 0 {
+        // Fully closed; the state entry may survive with zero margin or be
+        // pruned entirely.
+        if let Some(alice) = alice {
+            assert!(alice.positions.is_empty(), "Alice should hold no position");
+            assert_eq!(alice.margin, UsdValue::new_raw(case.alice_margin_raw));
+        }
+        assert_eq!(
+            case.alice_margin_raw, 0,
+            "wiped Alice must have zero margin"
+        );
+    } else {
+        let alice = alice.expect("Alice retains a position");
+        assert_eq!(alice.margin, UsdValue::new_raw(case.alice_margin_raw));
+        assert_eq!(
+            alice.positions[&pair].size,
+            Quantity::new_int(case.alice_pos)
+        );
+        assert_eq!(
+            alice.positions[&pair].entry_price,
+            UsdPrice::new_int(ENTRY_ETH)
+        );
+    }
+
+    // ---- Bob ----
+    let bob = query_user(&mut suite, contracts.perps, accounts.user2.address())
+        .await
+        .unwrap();
+    assert_eq!(bob.margin, UsdValue::new_raw(case.bob_margin_raw));
+    if case.bob_pos == 0 {
+        assert!(bob.positions.is_empty(), "Bob fully ADL'd");
+    } else {
+        assert_eq!(bob.positions[&pair].size, Quantity::new_int(case.bob_pos));
+        assert_eq!(
+            bob.positions[&pair].entry_price,
+            UsdPrice::new_int(ENTRY_ETH)
+        );
+    }
+
+    // ---- Carol ----
+    if case.carol_size > 0 {
+        let carol = query_user(&mut suite, contracts.perps, accounts.user3.address())
+            .await
+            .unwrap();
+        assert_eq!(
+            carol.positions[&pair].size,
+            Quantity::new_int(case.carol_size * sign),
+            "Carol's resting order absorbs the book leg in full"
+        );
+        assert_eq!(
+            carol.positions[&pair].entry_price,
+            UsdPrice::new_int(case.oracle)
+        );
+    }
+
+    // ---- Insurance fund ----
+    assert_insurance_fund(&mut suite, contracts.perps, case.insurance_fund_raw).await;
+}
+
+// ---------------------- two-position runner (7-8, 15-16) ---------------------
+
+struct DoubleCase {
+    side: Side,
+    /// Alice's deposit. Bob's is `BOB_MARGIN_DOUBLE`.
+    alice_margin: i128,
+    /// Post-move oracle prices (entries are `ENTRY_ETH` / `ENTRY_BTC`).
+    oracle_eth: i128,
+    oracle_btc: i128,
+    /// The BTC ADL leg (always present: BTC has the larger MM contribution,
+    /// so it is scheduled first; the book is empty in these examples).
+    btc_adl: Adl,
+    /// The ETH ADL leg; `None` when the BTC close cures the whole deficit
+    /// and ETH is never scheduled.
+    eth_adl: Option<Adl>,
+    /// Alice's post-liquidation margin, raw.
+    alice_margin_raw: i128,
+    /// Bob's post-liquidation margin, raw.
+    bob_margin_raw: i128,
+    /// Insurance fund after liquidation, raw.
+    insurance_fund_raw: i128,
+}
+
+async fn run_double(case: DoubleCase) {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    let eth = pair_id();
+    let btc = btc_pair_id();
+    let sign = case.side.sign();
+
+    // The BTC pair is not in the test genesis: seed its oracle price first,
+    // then register it via Configure.
+    seed_prices(&mut suite, &mut accounts, ENTRY_ETH, Some(ENTRY_BTC)).await;
+    configure(&mut suite, &mut accounts, contracts.perps, true).await;
+
+    // Open both pairs: Bob makes at entry, Alice takes.
+    deposit(
+        &mut suite,
+        &mut accounts.user2,
+        contracts.perps,
+        BOB_MARGIN_DOUBLE,
+    )
+    .await;
+    submit_limit(
+        &mut suite,
+        &mut accounts.user2,
+        contracts.perps,
+        &eth,
+        -10 * sign,
+        ENTRY_ETH,
+    )
+    .await;
+    submit_limit(
+        &mut suite,
+        &mut accounts.user2,
+        contracts.perps,
+        &btc,
+        -sign,
+        ENTRY_BTC,
+    )
+    .await;
+
+    deposit(
+        &mut suite,
+        &mut accounts.user1,
+        contracts.perps,
+        case.alice_margin,
+    )
+    .await;
+    submit_market(
+        &mut suite,
+        &mut accounts.user1,
+        contracts.perps,
+        &eth,
+        10 * sign,
+    )
+    .await;
+    submit_market(&mut suite, &mut accounts.user1, contracts.perps, &btc, sign).await;
+
+    let alice = query_user(&mut suite, contracts.perps, accounts.user1.address())
+        .await
+        .unwrap();
+    assert_eq!(alice.margin, UsdValue::new_int(case.alice_margin));
+    assert_eq!(alice.positions[&eth].size, Quantity::new_int(10 * sign));
+    assert_eq!(alice.positions[&btc].size, Quantity::new_int(sign));
+
+    // Move both oracles; Alice becomes liquidatable. The book is empty.
+    seed_prices(
+        &mut suite,
+        &mut accounts,
+        case.oracle_eth,
+        Some(case.oracle_btc),
+    )
+    .await;
+
+    let events = liquidate(&mut suite, &mut accounts, contracts.perps).await;
+
+    // ---- Liquidated events, in schedule order: BTC (larger MM) first ----
+    let liquidated = search_liquidated(&events);
+    let expected_count = 1 + case.eth_adl.is_some() as usize;
+    assert_eq!(
+        liquidated.len(),
+        expected_count,
+        "one Liquidated event per scheduled pair"
+    );
+
+    assert_eq!(liquidated[0].pair_id, btc);
+    assert_eq!(liquidated[0].user, accounts.user1.address());
+    assert_eq!(
+        liquidated[0].adl_size,
+        Quantity::new_raw(-case.btc_adl.size_raw * sign)
+    );
+    assert_eq!(
+        liquidated[0].adl_price,
+        Some(UsdPrice::new_int(case.btc_adl.price))
+    );
+    let alice_btc_pnl = case.btc_adl.size_raw * (case.btc_adl.price - ENTRY_BTC) * sign;
+    assert_eq!(
+        liquidated[0].adl_realized_pnl,
+        UsdValue::new_raw(alice_btc_pnl)
+    );
+
+    if let Some(eth_adl) = &case.eth_adl {
+        assert_eq!(liquidated[1].pair_id, eth);
+        assert_eq!(
+            liquidated[1].adl_size,
+            Quantity::new_raw(-eth_adl.size_raw * sign)
+        );
+        assert_eq!(
+            liquidated[1].adl_price,
+            Some(UsdPrice::new_int(eth_adl.price))
+        );
+    }
+
+    // ---- Deleveraged events (all against Bob) ----
+    let deleveraged = search_deleveraged(&events);
+    assert_eq!(deleveraged.len(), expected_count);
+
+    assert_eq!(deleveraged[0].user, accounts.user2.address());
+    assert_eq!(deleveraged[0].pair_id, btc);
+    assert_eq!(
+        deleveraged[0].closing_size,
+        Quantity::new_raw(case.btc_adl.size_raw * sign)
+    );
+    assert_eq!(
+        deleveraged[0].fill_price,
+        UsdPrice::new_int(case.btc_adl.price)
+    );
+    assert_eq!(
+        deleveraged[0].realized_pnl,
+        UsdValue::new_raw(-alice_btc_pnl)
+    );
+
+    if let Some(eth_adl) = &case.eth_adl {
+        let alice_eth_pnl = eth_adl.size_raw * (eth_adl.price - ENTRY_ETH) * sign;
+        assert_eq!(deleveraged[1].user, accounts.user2.address());
+        assert_eq!(deleveraged[1].pair_id, eth);
+        assert_eq!(deleveraged[1].fill_price, UsdPrice::new_int(eth_adl.price));
+        assert_eq!(
+            deleveraged[1].realized_pnl,
+            UsdValue::new_raw(-alice_eth_pnl)
+        );
+    }
+
+    // ---- No bad debt in any two-position example ----
+    assert!(search_bad_debt(&events).is_empty(), "no bad debt expected");
+
+    // ---- Alice ----
+    let alice = query_user(&mut suite, contracts.perps, accounts.user1.address()).await;
+    if case.eth_adl.is_some() {
+        // Both positions fully closed.
+        if let Some(alice) = alice {
+            assert!(alice.positions.is_empty());
+            assert_eq!(alice.margin, UsdValue::new_raw(case.alice_margin_raw));
+        }
+        assert_eq!(
+            case.alice_margin_raw, 0,
+            "wiped Alice must have zero margin"
+        );
+    } else {
+        // ETH untouched; BTC partially closed.
+        let alice = alice.expect("Alice retains positions");
+        assert_eq!(alice.margin, UsdValue::new_raw(case.alice_margin_raw));
+        assert_eq!(alice.positions[&eth].size, Quantity::new_int(10 * sign));
+        assert_eq!(
+            alice.positions[&btc].size,
+            Quantity::new_raw((1_000_000 - case.btc_adl.size_raw) * sign)
+        );
+    }
+
+    // ---- Bob (mirror) ----
+    let bob = query_user(&mut suite, contracts.perps, accounts.user2.address())
+        .await
+        .unwrap();
+    assert_eq!(bob.margin, UsdValue::new_raw(case.bob_margin_raw));
+    if case.eth_adl.is_some() {
+        assert!(bob.positions.is_empty(), "Bob fully ADL'd on both pairs");
+    } else {
+        assert_eq!(bob.positions[&eth].size, Quantity::new_int(-10 * sign));
+        assert_eq!(
+            bob.positions[&btc].size,
+            Quantity::new_raw(-(1_000_000 - case.btc_adl.size_raw) * sign)
+        );
+    }
+
+    // ---- Insurance fund ----
+    assert_insurance_fund(&mut suite, contracts.perps, case.insurance_fund_raw).await;
+}
+
+// ------------------------- examples 1-6: Alice long --------------------------
+
+/// Example 1 — solvent; the book absorbs the whole close.
+///
+/// Equity 180, MM 900, deficit 720 → close 8 of 10 ETH; bp 1,782. Carol's
+/// 8-ETH bid at the 1,800 oracle fills everything: no ADL. Margin
+/// 2,180 − 1,600 − 14.40 (fee) = 565.60; Alice keeps 2 ETH.
+#[tokio::test]
+async fn example_1_solvent_full_book() {
+    run_single(SingleCase {
+        side: Side::Long,
+        alice_margin: 2_180,
+        oracle: 1_800,
+        carol_size: 8,
+        adl: None,
+        alice_margin_raw: 565_600_000,
+        alice_pos: 2,
+        bob_margin_raw: 10_000_000_000,
+        bob_pos: -10,
+        insurance_fund_raw: 14_400_000,
+        bad_debt: None,
+    })
+    .await;
+}
+
+/// Example 2 — solvent; book absorbs 5, the remaining 3 ADL'd at bp 1,782.
+///
+/// Margin 2,180 − 1,000 − 654 − 14.40 = 511.60. Bob gains 654 (600
+/// mark-to-market + Alice's 54 concession), keeps short 7.
+#[tokio::test]
+async fn example_2_solvent_partial_book() {
+    run_single(SingleCase {
+        side: Side::Long,
+        alice_margin: 2_180,
+        oracle: 1_800,
+        carol_size: 5,
+        adl: Some(Adl {
+            size_raw: 3_000_000,
+            price: 1_782,
+        }),
+        alice_margin_raw: 511_600_000,
+        alice_pos: 2,
+        bob_margin_raw: 10_654_000_000,
+        bob_pos: -7,
+        insurance_fund_raw: 14_400_000,
+        bad_debt: None,
+    })
+    .await;
+}
+
+/// Example 3 — solvent; empty book, the whole 8-ETH close ADL'd at bp 1,782.
+///
+/// Margin 2,180 − 1,744 − 14.40 = 421.60. Bob gains 1,744, keeps short 2.
+#[tokio::test]
+async fn example_3_solvent_empty_book() {
+    run_single(SingleCase {
+        side: Side::Long,
+        alice_margin: 2_180,
+        oracle: 1_800,
+        carol_size: 0,
+        adl: Some(Adl {
+            size_raw: 8_000_000,
+            price: 1_782,
+        }),
+        alice_margin_raw: 421_600_000,
+        alice_pos: 2,
+        bob_margin_raw: 11_744_000_000,
+        bob_pos: -2,
+        insurance_fund_raw: 14_400_000,
+        bad_debt: None,
+    })
+    .await;
+}
+
+/// Example 4 — insolvent (equity −200); full close fills on the book at the
+/// 1,700 oracle, below the 1,720 bp. Fee 0; bad debt 200 to the insurance
+/// fund; Alice wiped; Bob untouched.
+#[tokio::test]
+async fn example_4_insolvent_full_book() {
+    run_single(SingleCase {
+        side: Side::Long,
+        alice_margin: 2_800,
+        oracle: 1_700,
+        carol_size: 10,
+        adl: None,
+        alice_margin_raw: 0,
+        alice_pos: 0,
+        bob_margin_raw: 10_000_000_000,
+        bob_pos: -10,
+        insurance_fund_raw: -200_000_000,
+        bad_debt: Some(200),
+    })
+    .await;
+}
+
+/// Example 5 — insolvent; book absorbs 4 at 1,700, the remaining 6 ADL'd at
+/// bp 1,720. Bad debt 80 = the book-filled 4 × (bp − fill). Bob absorbs 120
+/// by buying 6 at $20 above oracle, keeps short 4.
+#[tokio::test]
+async fn example_5_insolvent_partial_book() {
+    run_single(SingleCase {
+        side: Side::Long,
+        alice_margin: 2_800,
+        oracle: 1_700,
+        carol_size: 4,
+        adl: Some(Adl {
+            size_raw: 6_000_000,
+            price: 1_720,
+        }),
+        alice_margin_raw: 0,
+        alice_pos: 0,
+        bob_margin_raw: 11_680_000_000,
+        bob_pos: -4,
+        insurance_fund_raw: -80_000_000,
+        bad_debt: Some(80),
+    })
+    .await;
+}
+
+/// Example 6 — insolvent; empty book, all 10 ETH ADL'd at bp 1,720. Alice's
+/// margin lands at exactly zero by construction — no bad debt despite her
+/// insolvency; Bob absorbs the 200 shortfall.
+#[tokio::test]
+async fn example_6_insolvent_empty_book() {
+    run_single(SingleCase {
+        side: Side::Long,
+        alice_margin: 2_800,
+        oracle: 1_700,
+        carol_size: 0,
+        adl: Some(Adl {
+            size_raw: 10_000_000,
+            price: 1_720,
+        }),
+        alice_margin_raw: 0,
+        alice_pos: 0,
+        bob_margin_raw: 12_800_000_000,
+        bob_pos: 0,
+        insurance_fund_raw: 0,
+        bad_debt: None,
+    })
+    .await;
+}
+
+// ---------------------- examples 7-8: two positions, long --------------------
+
+/// Example 7 — two longs (10 ETH + 1 BTC), solvent. Equity 3,065, MM 3,300,
+/// deficit 235. BTC (MM contribution 2,350 > ETH's 950) is scheduled first;
+/// closing 0.1 BTC cures the whole deficit, ETH is never touched. Empty book
+/// → ADL 0.1 BTC at bp = 47,000 − 3,065/1 = 43,935 (whole-account equity
+/// over the BTC position's full size). Margin 7,065 − 606.50 − 4.70 (fee)
+/// = 6,453.80.
+#[tokio::test]
+async fn example_7_two_positions_solvent() {
+    run_double(DoubleCase {
+        side: Side::Long,
+        alice_margin: 7_065,
+        oracle_eth: 1_900,
+        oracle_btc: 47_000,
+        btc_adl: Adl {
+            size_raw: 100_000,
+            price: 43_935,
+        },
+        eth_adl: None,
+        alice_margin_raw: 6_453_800_000,
+        bob_margin_raw: 12_606_500_000,
+        insurance_fund_raw: 4_700_000,
+    })
+    .await;
+}
+
+/// Example 8 — two longs, insolvent (equity −935). Both positions fully
+/// closed, BTC first: 1 BTC ADL'd at bp = 44,000 + 935 = 44,935, which
+/// brings the account's equity to exactly zero; the ETH bp is then
+/// recomputed from zero equity and equals the 1,800 oracle. Fee 0, no bad
+/// debt; Bob nets Alice's whole 7,065 margin across the two fills.
+#[tokio::test]
+async fn example_8_two_positions_insolvent() {
+    run_double(DoubleCase {
+        side: Side::Long,
+        alice_margin: 7_065,
+        oracle_eth: 1_800,
+        oracle_btc: 44_000,
+        btc_adl: Adl {
+            size_raw: 1_000_000,
+            price: 44_935,
+        },
+        eth_adl: Some(Adl {
+            size_raw: 10_000_000,
+            price: 1_800,
+        }),
+        alice_margin_raw: 0,
+        bob_margin_raw: 19_065_000_000,
+        insurance_fund_raw: 0,
+    })
+    .await;
+}
+
+// ------------------ examples 9-16: short mirrors of 1-8 ----------------------
+
+/// Example 9 — mirror of example 1: Alice short 10 ETH, oracle rises to
+/// 2,200. Equity 220, MM 1,100, deficit 880 → close 8; bp 2,222. Carol's
+/// 8-ETH ask at oracle fills everything. Margin 2,220 − 1,600 − 17.60 =
+/// 602.40.
+#[tokio::test]
+async fn example_9_solvent_full_book_short() {
+    run_single(SingleCase {
+        side: Side::Short,
+        alice_margin: 2_220,
+        oracle: 2_200,
+        carol_size: 8,
+        adl: None,
+        alice_margin_raw: 602_400_000,
+        alice_pos: -2,
+        bob_margin_raw: 10_000_000_000,
+        bob_pos: 10,
+        insurance_fund_raw: 17_600_000,
+        bad_debt: None,
+    })
+    .await;
+}
+
+/// Example 10 — mirror of example 2: book absorbs 5, 3 ADL'd at bp 2,222.
+#[tokio::test]
+async fn example_10_solvent_partial_book_short() {
+    run_single(SingleCase {
+        side: Side::Short,
+        alice_margin: 2_220,
+        oracle: 2_200,
+        carol_size: 5,
+        adl: Some(Adl {
+            size_raw: 3_000_000,
+            price: 2_222,
+        }),
+        alice_margin_raw: 536_400_000,
+        alice_pos: -2,
+        bob_margin_raw: 10_666_000_000,
+        bob_pos: 7,
+        insurance_fund_raw: 17_600_000,
+        bad_debt: None,
+    })
+    .await;
+}
+
+/// Example 11 — mirror of example 3: empty book, 8 ADL'd at bp 2,222.
+#[tokio::test]
+async fn example_11_solvent_empty_book_short() {
+    run_single(SingleCase {
+        side: Side::Short,
+        alice_margin: 2_220,
+        oracle: 2_200,
+        carol_size: 0,
+        adl: Some(Adl {
+            size_raw: 8_000_000,
+            price: 2_222,
+        }),
+        alice_margin_raw: 426_400_000,
+        alice_pos: -2,
+        bob_margin_raw: 11_776_000_000,
+        bob_pos: 2,
+        insurance_fund_raw: 17_600_000,
+        bad_debt: None,
+    })
+    .await;
+}
+
+/// Example 12 — mirror of example 4: insolvent short (equity −200), oracle
+/// 2,300, bp 2,280. Carol's 10-ETH ask at oracle fills everything above the
+/// bp; bad debt 200.
+#[tokio::test]
+async fn example_12_insolvent_full_book_short() {
+    run_single(SingleCase {
+        side: Side::Short,
+        alice_margin: 2_800,
+        oracle: 2_300,
+        carol_size: 10,
+        adl: None,
+        alice_margin_raw: 0,
+        alice_pos: 0,
+        bob_margin_raw: 10_000_000_000,
+        bob_pos: 10,
+        insurance_fund_raw: -200_000_000,
+        bad_debt: Some(200),
+    })
+    .await;
+}
+
+/// Example 13 — mirror of example 5: book absorbs 4 at 2,300, 6 ADL'd at bp
+/// 2,280; bad debt 80.
+#[tokio::test]
+async fn example_13_insolvent_partial_book_short() {
+    run_single(SingleCase {
+        side: Side::Short,
+        alice_margin: 2_800,
+        oracle: 2_300,
+        carol_size: 4,
+        adl: Some(Adl {
+            size_raw: 6_000_000,
+            price: 2_280,
+        }),
+        alice_margin_raw: 0,
+        alice_pos: 0,
+        bob_margin_raw: 11_680_000_000,
+        bob_pos: 4,
+        insurance_fund_raw: -80_000_000,
+        bad_debt: Some(80),
+    })
+    .await;
+}
+
+/// Example 14 — mirror of example 6: empty book, all 10 ADL'd at bp 2,280;
+/// margin zeroed exactly, no bad debt.
+#[tokio::test]
+async fn example_14_insolvent_empty_book_short() {
+    run_single(SingleCase {
+        side: Side::Short,
+        alice_margin: 2_800,
+        oracle: 2_300,
+        carol_size: 0,
+        adl: Some(Adl {
+            size_raw: 10_000_000,
+            price: 2_280,
+        }),
+        alice_margin_raw: 0,
+        alice_pos: 0,
+        bob_margin_raw: 12_800_000_000,
+        bob_pos: 0,
+        insurance_fund_raw: 0,
+        bad_debt: None,
+    })
+    .await;
+}
+
+/// Example 15 — mirror of example 7: two shorts, solvent. Equity 3,435, MM
+/// 3,700, deficit 265 → close 0.1 BTC at bp = 53,000 + 3,435 = 56,435.
+/// Margin 7,435 − 643.50 − 5.30 (fee) = 6,786.20.
+#[tokio::test]
+async fn example_15_two_positions_solvent_short() {
+    run_double(DoubleCase {
+        side: Side::Short,
+        alice_margin: 7_435,
+        oracle_eth: 2_100,
+        oracle_btc: 53_000,
+        btc_adl: Adl {
+            size_raw: 100_000,
+            price: 56_435,
+        },
+        eth_adl: None,
+        alice_margin_raw: 6_786_200_000,
+        bob_margin_raw: 12_643_500_000,
+        insurance_fund_raw: 5_300_000,
+    })
+    .await;
+}
+
+/// Example 16 — mirror of example 8: two shorts, insolvent (equity −565).
+/// BTC fully ADL'd at bp = 56,000 − 565 = 55,435 (zeroing equity), then ETH
+/// ADL'd at the 2,200 oracle. No bad debt; Bob nets Alice's whole 7,435
+/// margin.
+#[tokio::test]
+async fn example_16_two_positions_insolvent_short() {
+    run_double(DoubleCase {
+        side: Side::Short,
+        alice_margin: 7_435,
+        oracle_eth: 2_200,
+        oracle_btc: 56_000,
+        btc_adl: Adl {
+            size_raw: 1_000_000,
+            price: 55_435,
+        },
+        eth_adl: Some(Adl {
+            size_raw: 10_000_000,
+            price: 2_200,
+        }),
+        alice_margin_raw: 0,
+        bob_margin_raw: 19_435_000_000,
+        insurance_fund_raw: 0,
+    })
+    .await;
+}

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -9,6 +9,7 @@ use {
 };
 
 mod adl_bug_reproduction;
+mod bankruptcy_bug_reproduction;
 mod batch_update_orders;
 mod client_order_id;
 mod conditional_orders;

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -15,6 +15,7 @@ mod client_order_id;
 mod conditional_orders;
 mod index_price;
 mod liquidation;
+mod liquidation_spec;
 mod price_band;
 mod reduce_only;
 mod referral;


### PR DESCRIPTION
The bankruptcy price of a position is, by definition, the fill price at
which closing the entire position brings the account's equity to exactly
zero. Divide the account's equity by the position's full size accordingly,
so that closing any fraction of the position at this price concedes
exactly that fraction's share of equity.

Also add unit and end-to-end regression tests covering bankruptcy prices
of partially closed positions.