### PR TITLE
ui(fix): horizontal lines rendering

### DIFF
--- a/ui/portal/web/src/components/dex/helpers/chartLines.ts
+++ b/ui/portal/web/src/components/dex/helpers/chartLines.ts
@@ -86,22 +86,20 @@ export const drawLines = (() => {
       }
 
       for (const { price, color, linestyle } of lines) {
-        await chart.createShape(
-          { price, time: Math.floor(Date.now() / 1000) },
-          {
-            shape: "horizontal_line",
-            lock: true,
-            disableSelection: true,
-            disableSave: true,
-            overrides: {
-              showLabel: false,
-              showPrice: true,
-              linecolor: color,
-              linestyle,
-              linewidth: 1,
-            },
+        // TradingView rejects horizontal_line when a time point is included.
+        await chart.createShape({ price } as TV.ShapePoint, {
+          shape: "horizontal_line",
+          lock: true,
+          disableSelection: true,
+          disableSave: true,
+          overrides: {
+            showLabel: false,
+            showPrice: true,
+            linecolor: color,
+            linestyle,
+            linewidth: 1,
           },
-        );
+        });
       }
     });
   };

--- a/ui/portal/web/tests/chart-lines.test.tsx
+++ b/ui/portal/web/tests/chart-lines.test.tsx
@@ -158,7 +158,6 @@ describe("DEX chart lines", () => {
     expect(chart.createShape).toHaveBeenCalledWith(
       {
         price: 30000,
-        time: expect.any(Number),
       },
       expect.objectContaining({
         disableSave: true,

--- a/ui/portal/web/tests/trading-view-datafeed.test.tsx
+++ b/ui/portal/web/tests/trading-view-datafeed.test.tsx
@@ -27,9 +27,10 @@ function candle(overrides: Partial<PerpsCandle>): PerpsCandle {
   };
 }
 
-function createDatafeedFixture() {
+function createDatafeedFixture({ accountAddress }: { accountAddress?: string } = {}) {
   const client = {
     queryPerpsCandles: vi.fn(),
+    queryPerpsEvents: vi.fn(),
   };
   const queryClient = {
     fetchQuery: vi.fn(async ({ queryFn }: { queryFn: () => Promise<unknown> }) => queryFn()),
@@ -42,6 +43,7 @@ function createDatafeedFixture() {
     client,
     datafeed: createPerpsDataFeed({
       client: client as never,
+      getAccountAddress: () => accountAddress,
       queryClient: queryClient as never,
       subscriptions: subscriptions as never,
     }),
@@ -226,5 +228,72 @@ describe("TradingView perps datafeed", () => {
       volume: 5000,
     });
     expect(secondUnsubscribe).not.toHaveBeenCalled();
+  });
+
+  it("returns fill marks only for connected accounts and order_filled events", async () => {
+    const { client, datafeed } = createDatafeedFixture({
+      accountAddress: "0xuser",
+    });
+    const onMarks = vi.fn();
+    client.queryPerpsEvents.mockResolvedValue({
+      nodes: [
+        {
+          blockHeight: 123,
+          createdAt: "2026-06-09T00:07:12.000Z",
+          data: {
+            closing_size: "0.000000",
+            fee: "6.500000",
+            fill_id: "17",
+            fill_price: "65000.000000",
+            fill_size: "0.100000",
+            is_maker: false,
+            opening_size: "0.100000",
+            order_id: "42",
+            pair_id: "perp/btcusd",
+            realized_funding: "0.000000",
+            realized_pnl: "0.000000",
+            user: "0xuser",
+          },
+          eventType: "order_filled",
+          idx: 7,
+          pairId: "perp/btcusd",
+          txHash: "0x1234567890abcdef1234567890abcdef12345678",
+          userAddr: "0xuser",
+        },
+      ],
+    });
+
+    datafeed.getMarks(
+      { name: "BTC-USD" } as never,
+      Date.parse("2026-06-09T00:00:00.000Z") / 1000,
+      Date.parse("2026-06-09T01:00:00.000Z") / 1000,
+      onMarks,
+      "5" as never,
+    );
+    await vi.runAllTimersAsync();
+
+    expect(client.queryPerpsEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "order_filled",
+        pairId: "perp/btcusd",
+        userAddr: "0xuser",
+      }),
+    );
+    expect(onMarks).toHaveBeenCalledWith([
+      expect.objectContaining({
+        label: "B",
+        time: Date.parse("2026-06-09T00:05:00.000Z") / 1000,
+      }),
+    ]);
+  });
+
+  it("returns no fill marks when there is no connected account", () => {
+    const { client, datafeed } = createDatafeedFixture();
+    const onMarks = vi.fn();
+
+    datafeed.getMarks({ name: "BTC-USD" } as never, 1, 2, onMarks, "5" as never);
+
+    expect(onMarks).toHaveBeenCalledWith([]);
+    expect(client.queryPerpsEvents).not.toHaveBeenCalled();
   });
 });

--- a/ui/portal/web/tests/trading-view.test.tsx
+++ b/ui/portal/web/tests/trading-view.test.tsx
@@ -251,7 +251,6 @@ describe("TradingView", () => {
       expect(widget.chartApi.createShape).toHaveBeenCalledWith(
         {
           price: 2100,
-          time: expect.any(Number),
         },
         expect.objectContaining({
           overrides: expect.objectContaining({
@@ -263,7 +262,6 @@ describe("TradingView", () => {
       expect(widget.chartApi.createShape).toHaveBeenCalledWith(
         {
           price: 2225,
-          time: expect.any(Number),
         },
         expect.objectContaining({
           overrides: expect.objectContaining({


### PR DESCRIPTION
## Summary

Fixes TradingView chart fill rendering by ensuring price-level horizontal lines are created with `{ price }` only. TradingView rejects `horizontal_line` shapes when they are created with a `{ time, price }` point, which produced the browser error `Cannot create "horizontal_line" shape`.

This also adds focused coverage around fill markers so marks are sourced from actual `order_filled` perps events for the connected account instead of any moving PnL behavior.

## Validation

### Completed

- [x] `pnpm -C ui/portal/web exec vitest run tests/chart-lines.test.tsx tests/trading-view.test.tsx tests/trading-view-datafeed.test.tsx src/components/dex/helpers/fillMarkers.test.ts`
- [x] `pnpm -C ui/portal/web exec biome check src/components/dex/helpers/chartLines.ts tests/chart-lines.test.tsx tests/trading-view.test.tsx tests/trading-view-datafeed.test.tsx`
- [x] `git diff --check`
- [x] Manual browser verification on testnet with `debugAs=155`, confirming `Account #159` and visible TradingView B/S fill markers without the prior horizontal-line error

### Remaining

- [ ] Full portal typecheck in CI; local `tsc --noEmit` was blocked by unbuilt workspace package declarations unrelated to this patch

## Manual QA

Opened `http://localhost:5080/trade/BTC-USD?debugAs=155` with `CONFIG_ENVIRONMENT=test`, logged in via the debug flow, verified the header showed `Account #159`, and visually confirmed fill markers on the BTC-USD TradingView chart. Browser console did not show the previous `Cannot create "horizontal_line" shape` error.