### PR TITLE
feat(oracle): add `ExecuteMsg::RemovePriceSources`

### DIFF
--- a/dango/oracle/src/execute.rs
+++ b/dango/oracle/src/execute.rs
@@ -7,7 +7,7 @@ use {
         QuerierExt, Response, Storage, Timestamp, Tx,
     },
     pyth_types::{LeEcdsaMessage, PayloadData, PriceUpdate},
-    std::collections::BTreeMap,
+    std::collections::{BTreeMap, BTreeSet},
 };
 
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
@@ -64,6 +64,7 @@ pub fn execute(ctx: MutableCtx, msg: ExecuteMsg) -> anyhow::Result<Response> {
         ExecuteMsg::RegisterPriceSources(price_sources) => {
             register_price_sources(ctx, price_sources)
         },
+        ExecuteMsg::RemovePriceSources(denoms) => remove_price_sources(ctx, denoms),
         ExecuteMsg::RegisterTrustedSigner {
             public_key,
             expires_at,
@@ -86,6 +87,24 @@ fn register_price_sources(
     for (denom, config) in price_sources {
         config.validate()?;
         PRICE_SOURCES.save(ctx.storage, &denom, &config)?;
+    }
+
+    Ok(Response::new())
+}
+
+fn remove_price_sources(ctx: MutableCtx, denoms: BTreeSet<Denom>) -> anyhow::Result<Response> {
+    // Only chain owner can remove a denom.
+    ensure!(
+        ctx.sender == ctx.querier.query_owner()?,
+        "you don't have the right, O you don't have the right"
+    );
+
+    // No check is performed on whether the denoms actually have a price
+    // source; `Map::remove` is a no-op for an absent key. We also trust the
+    // owner to have ensured no other contract still relies on the price
+    // sources being removed, so no usage check either.
+    for denom in denoms {
+        PRICE_SOURCES.remove(ctx.storage, &denom);
     }
 
     Ok(Response::new())

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -4,13 +4,14 @@ use {
     dango_types::{
         constants::{eth, perp_btc},
         oracle::{
-            ExecuteMsg, PriceConfig, PriceSource, QueryPriceRequest, QueryTrustedSignersRequest,
+            ExecuteMsg, PriceConfig, PriceSource, QueryPriceRequest, QueryPriceSourceRequest,
+            QueryPriceSourcesRequest, QueryTrustedSignersRequest,
         },
     },
     grug_math::Dec128_6,
     grug_types::{
-        Addr, Binary, ByteArray, Coins, Duration, NonEmpty, QuerierExt, ResultExt, Timestamp,
-        btree_map,
+        Addr, Binary, ByteArray, Coins, Denom, Duration, NonEmpty, QuerierExt, ResultExt,
+        Timestamp, btree_map, btree_set,
     },
     pyth_types::{Channel, LeEcdsaMessage, MarketSession, constants::LAZER_TRUSTED_SIGNER},
     std::str::FromStr,
@@ -178,4 +179,102 @@ async fn pyth_lazer() {
     );
     assert_eq!(price.timestamp, Timestamp::from_micros(1758539671000000));
     assert_eq!(price.market_session, MarketSession::Other);
+}
+
+#[tokio::test]
+async fn remove_price_sources() {
+    let (mut suite, mut accounts, oracle) = setup_oracle_test();
+
+    let test_denom = Denom::from_str("test").unwrap();
+
+    // Register a price source for a fresh denom, so that we can remove it
+    // later in the test.
+    suite
+        .execute(
+            &mut accounts.owner,
+            oracle,
+            &ExecuteMsg::RegisterPriceSources(btree_map! {
+                test_denom.clone() => PriceConfig::Single(PriceSource {
+                    id: 1,
+                    channel: Channel::RealTime,
+                }),
+            }),
+            Coins::default(),
+        )
+        .await
+        .should_succeed();
+
+    // Sanity check: both the fresh denom and `eth`, which is registered at
+    // genesis, have a price source.
+    for denom in [test_denom.clone(), eth::DENOM.clone()] {
+        suite
+            .query_wasm_smart(oracle, QueryPriceSourceRequest { denom })
+            .should_succeed();
+    }
+
+    // Attempt to remove a price source as a non-owner. Should fail with the
+    // access control error.
+    suite
+        .execute(
+            &mut accounts.user1,
+            oracle,
+            &ExecuteMsg::RemovePriceSources(btree_set! { test_denom.clone() }),
+            Coins::default(),
+        )
+        .await
+        .should_fail_with_error("you don't have the right");
+
+    // The price source should be unaffected by the failed removal.
+    suite
+        .query_wasm_smart(oracle, QueryPriceSourceRequest {
+            denom: test_denom.clone(),
+        })
+        .should_succeed();
+
+    // Remove two price sources as the owner: one registered earlier in this
+    // test, one registered at genesis.
+    suite
+        .execute(
+            &mut accounts.owner,
+            oracle,
+            &ExecuteMsg::RemovePriceSources(btree_set! {
+                test_denom.clone(),
+                eth::DENOM.clone(),
+            }),
+            Coins::default(),
+        )
+        .await
+        .should_succeed();
+
+    // Both price sources should be gone, from both the single-denom query and
+    // the enumeration.
+    for denom in [test_denom.clone(), eth::DENOM.clone()] {
+        suite
+            .query_wasm_smart(oracle, QueryPriceSourceRequest {
+                denom: denom.clone(),
+            })
+            .should_fail_with_error("data not found");
+
+        suite
+            .query_wasm_smart(oracle, QueryPriceSourcesRequest {
+                start_after: None,
+                limit: Some(u32::MAX),
+            })
+            .should_succeed_and(|sources| !sources.contains_key(&denom));
+    }
+
+    // Removing denoms that don't have a price source — one just removed, one
+    // never registered — is a no-op that should succeed silently.
+    suite
+        .execute(
+            &mut accounts.owner,
+            oracle,
+            &ExecuteMsg::RemovePriceSources(btree_set! {
+                test_denom,
+                Denom::from_str("nonexistent").unwrap(),
+            }),
+            Coins::default(),
+        )
+        .await
+        .should_succeed();
 }

--- a/dango/types/src/oracle/msg.rs
+++ b/dango/types/src/oracle/msg.rs
@@ -2,12 +2,13 @@ use {
     crate::oracle::{Price, PriceConfig},
     grug_types::{Binary, Denom, Timestamp},
     pyth_types::PriceUpdate,
-    std::collections::BTreeMap,
+    std::collections::{BTreeMap, BTreeSet},
 };
 
 #[grug_types::derive(Serde)]
 pub struct InstantiateMsg {
     pub price_sources: BTreeMap<Denom, PriceConfig>,
+
     /// Pyth Lazer trusted signers: public keys and expiration timestamps.
     pub trusted_signers: BTreeMap<Binary, Timestamp>,
 }
@@ -16,13 +17,24 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     /// Set the price sources for the given denoms.
     RegisterPriceSources(BTreeMap<Denom, PriceConfig>),
+
+    /// Remove the price sources for the given denoms.
+    ///
+    /// No check is performed on whether the denoms currently have a price
+    /// source; removing a non-existent one is simply a no-op. Additionally,
+    /// the owner is trusted to have ensured no other contract still relies
+    /// on the price sources being removed.
+    RemovePriceSources(BTreeSet<Denom>),
+
     /// Register a trusted signer for Pyth Lazer.
     RegisterTrustedSigner {
         public_key: Binary,
         expires_at: Timestamp,
     },
+
     /// Remove a trusted signer for Pyth Lazer.
     RemoveTrustedSigner { public_key: Binary },
+
     /// Submit price data from Pyth Network.
     FeedPrices(PriceUpdate),
 }
@@ -35,18 +47,22 @@ pub enum QueryMsg {
         start_after: Option<Binary>,
         limit: Option<u32>,
     },
+
     /// Query the price of the given denom.
     #[returns(Price)]
     Price { denom: Denom },
+
     /// Enumerate the prices of all supported denoms.
     #[returns(BTreeMap<Denom, Price>)]
     Prices {
         start_after: Option<Denom>,
         limit: Option<u32>,
     },
+
     /// Query the price config of the given denom.
     #[returns(PriceConfig)]
     PriceSource { denom: Denom },
+
     /// Enumerate the price configs of all supported denoms.
     #[returns(BTreeMap<Denom, PriceConfig>)]
     PriceSources {


### PR DESCRIPTION
Price sources were previously additive-only: `RegisterPriceSources` can add or overwrite entries, but nothing could delete one. Add an owner-only `RemovePriceSources` method that deletes the price sources of the given denoms.

No existence or usage check is performed; removing an absent entry is a no-op, and the owner is trusted to have ensured no other contract still relies on the price sources being removed.