### PR TITLE
fix(ui): hide debug connector in destination wallet

### DIFF
--- a/ui/portal/web/src/components/modals/DestinationWallet.tsx
+++ b/ui/portal/web/src/components/modals/DestinationWallet.tsx
@@ -26,6 +26,8 @@ type DestinationWalletProps = {
 
 type Step = "list" | "warning" | "input";
 
+const HIDDEN_CONNECTOR_TYPES = ["passkey", "session", "privy", "debug"];
+
 export const DestinationWallet = forwardRef<ModalRef, DestinationWalletProps>(
   ({ network, onAddressSet }, ref) => {
     const { hideModal } = useApp();
@@ -37,9 +39,7 @@ export const DestinationWallet = forwardRef<ModalRef, DestinationWalletProps>(
       triggerOnClose: () => {},
     }));
 
-    const filteredConnectors = connectors.filter(
-      (c) => c.type !== "passkey" && c.type !== "session" && c.type !== "privy",
-    );
+    const filteredConnectors = connectors.filter((c) => !HIDDEN_CONNECTOR_TYPES.includes(c.type));
 
     const networkName = m["bridge.network"]({ network });
 


### PR DESCRIPTION
## Summary
- Hide the `debug` connector alongside other unsupported connector types in the destination wallet modal
- Replace the inline filter chain with a shared hidden-connector list for easier maintenance
