### PR TITLE
feat(indexer): add perps_events2 realtime subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4037,6 +4037,7 @@ dependencies = [
  "dango-indexer-cache",
  "dango-indexer-clickhouse",
  "dango-indexer-sql",
+ "dango-indexer-stream",
  "dango-primitives",
  "tokio",
  "tracing",
@@ -4060,6 +4061,7 @@ dependencies = [
  "dango-indexer-cache",
  "dango-indexer-clickhouse",
  "dango-indexer-sql",
+ "dango-indexer-stream",
  "dango-primitives",
  "dango-types",
  "futures",
@@ -4119,6 +4121,25 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "dango-indexer-stream"
+version = "0.0.0"
+dependencies = [
+ "async-graphql",
+ "async-stream",
+ "async-trait",
+ "dango-app",
+ "dango-primitives",
+ "dango-types",
+ "futures-util",
+ "metrics",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "dango/indexer/httpd",
   "dango/indexer/metrics",
   "dango/indexer/sql",
+  "dango/indexer/stream",
   "dango/pyth/client",
   "dango/pyth/types",
   "dango/sdk",
@@ -208,6 +209,7 @@ dango-indexer-hooked        = { path = "dango/indexer/hooked" }
 dango-indexer-httpd         = { path = "dango/indexer/httpd", features = ["tracing"] }
 dango-indexer-metrics       = { path = "dango/indexer/metrics" }
 dango-indexer-sql           = { path = "dango/indexer/sql" }
+dango-indexer-stream        = { path = "dango/indexer/stream" }
 dango-jmt                   = { path = "dango/core/jellyfish-merkle" }
 dango-macros                = { path = "dango/core/macros" }
 dango-math                  = { path = "dango/core/math" }

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -888,7 +888,7 @@ query {
 
 **Encoding.** `Hash256` is parsed strictly as 64 hex characters, **uppercase, without the `0x` prefix** (see [§10.2](#102-identifiers)). EVM tooling typically displays message IDs as `0x`-prefixed lowercase — strip the prefix and uppercase the rest, otherwise the query fails with a deserialization error.
 
-For continuous monitoring, poll this query at a block interval using the `queryApp` subscription ([§8.3](#83-contract-query-polling)). Alternatively, subscribe to the event stream ([§8.5](#85-event-stream)) filtered to the `mailbox_process_id` event, which the mailbox emits upon delivery; the filter value must use the same uppercase, unprefixed format:
+For continuous monitoring, poll this query at a block interval using the `queryApp` subscription ([§8.4](#84-contract-query-polling)). Alternatively, subscribe to the event stream ([§8.6](#86-event-stream)) filtered to the `mailbox_process_id` event, which the mailbox emits upon delivery; the filter value must use the same uppercase, unprefixed format:
 
 ```graphql
 subscription {
@@ -2266,7 +2266,62 @@ subscription {
 | `tradeIdx`    | `Int`      | Index within the block                                                                                   |
 | `isMaker`     | `Boolean?` | True for the maker side of a match, false for the taker side; null for trades executed before v0.16.0    |
 
-### 8.3 Contract query polling
+### 8.3 Perps events
+
+Stream every event emitted by the perps contract — order lifecycle, fills, liquidations, and deleveraging — grouped per block. It is the richer superset of [§8.2](#82-perps-trades) (which streams fills only), and a perps-scoped, lower-latency alternative to the generic event stream ([§8.6](#86-event-stream)). It is served from an in-memory window of the most recent blocks, so deep history is not available here — use the `perpsEvents` query ([§5.5](#55-trade-history)) for that.
+
+```graphql
+subscription {
+  perpsEvents2(
+    eventTypes: ["order_filled", "liquidated"],
+    pairIds: ["perp/btcusd"],
+    users: ["0x1234...abcd"]
+  ) {
+    blockHeight
+    createdAt
+    events {
+      idx
+      eventType
+      user
+      pairId
+      data
+    }
+  }
+}
+```
+
+Each message carries one block's worth of matching events. Only blocks that contain at least one matching event are delivered.
+
+| Parameter          | Type        | Description                                                             |
+| ------------------ | ----------- | ---------------------------------------------------------------------- |
+| `sinceBlockHeight` | `Int`       | Replay retained blocks from this height on connect; omit for live-only |
+| `eventTypes`       | `[String!]` | Keep only these event types (see [§9](#9-events-reference))            |
+| `pairIds`          | `[String!]` | Keep only these trading pairs                                          |
+| `users`            | `[String!]` | Keep only events whose `user` is one of these addresses                |
+
+**Filter semantics.** The three filters AND together. Omitting a filter does not filter on that field (matches everything); passing an _empty_ list matches nothing. Addresses are matched verbatim against each event's canonical address string, so pass the same `0x`-prefixed form the API returns elsewhere.
+
+**PerpsEvent2Batch fields:**
+
+| Field         | Type            | Description                       |
+| ------------- | --------------- | --------------------------------- |
+| `blockHeight` | `Int`           | Block height                      |
+| `createdAt`   | `String`        | Block timestamp (ISO 8601)        |
+| `events`      | `[PerpsEvent2]` | The block's matching perps events |
+
+**PerpsEvent2 fields:**
+
+| Field       | Type      | Description                                                  |
+| ----------- | --------- | ----------------------------------------------------------- |
+| `idx`       | `Int`     | Ordinal of this event within the block                      |
+| `eventType` | `String`  | Event type name (see [§9](#9-events-reference))             |
+| `user`      | `String?` | The event's subject address, if it has a `user` field       |
+| `pairId`    | `String?` | The event's trading pair, if it has a `pair_id` field       |
+| `data`      | `JSON`    | Raw event payload (same shape as [§9](#9-events-reference)) |
+
+**Reconnect.** Pass `sinceBlockHeight` to replay events missed while disconnected. The in-memory window retains only recent blocks; if `sinceBlockHeight` is older than the window, the subscription fails to start with a "resync required" error — reconnect with a newer height and backfill the gap from the `perpsEvents` query ([§5.5](#55-trade-history)).
+
+### 8.4 Contract query polling
 
 Poll any contract query at a regular block interval:
 
@@ -2302,7 +2357,7 @@ Common use cases:
 - **Order book depth** — track bid/ask levels.
 - **Pair states** — monitor open interest and funding.
 
-### 8.4 Block stream
+### 8.5 Block stream
 
 Subscribe to new blocks as they are finalized:
 
@@ -2317,7 +2372,7 @@ subscription {
 }
 ```
 
-### 8.5 Event stream
+### 8.6 Event stream
 
 Subscribe to events with optional filtering:
 
@@ -2358,7 +2413,7 @@ subscription {
 
 ## 9. Events reference
 
-The perps contract emits the following events. These can be queried via `perpsEvents` ([§5.5](#55-trade-history)) or streamed via the `events` subscription ([§8.5](#85-event-stream)).
+The perps contract emits the following events. These can be queried via `perpsEvents` ([§5.5](#55-trade-history)) or streamed in real time via the `perpsEvents2` subscription ([§8.3](#83-perps-events)) or the generic `events` subscription ([§8.6](#86-event-stream)).
 
 ### Margin events
 

--- a/dango/cli/src/start.rs
+++ b/dango/cli/src/start.rs
@@ -299,6 +299,7 @@ impl StartCmd {
             indexer_cache_context,
             sql_context,
             clickhouse_context,
+            hooked_indexer.stream.context(),
             app.clone(),
             Arc::new(TendermintRpcClient::new(tendermint_rpc_addr)?),
             cfg.httpd.static_files_path.clone(),

--- a/dango/indexer/graphql-types/src/lib.rs
+++ b/dango/indexer/graphql-types/src/lib.rs
@@ -191,6 +191,10 @@ generate_subscription_types! {
         path: "src/schemas/subscriptions/perpsTrades.graphql",
     },
     {
+        name: SubscribePerpsEvents2,
+        path: "src/schemas/subscriptions/perpsEvents2.graphql",
+    },
+    {
         name: SubscribeQueryApp,
         path: "src/schemas/subscriptions/queryApp.graphql",
     },

--- a/dango/indexer/graphql-types/src/schemas/schema.graphql
+++ b/dango/indexer/graphql-types/src/schemas/schema.graphql
@@ -379,6 +379,48 @@ type PerpsEvent {
 	createdAt: String!
 }
 
+"""
+A single perps-contract event, as streamed to clients.
+"""
+type PerpsEvent2 {
+	"""
+	Per-block ordinal across all perps-contract events in the block.
+	"""
+	idx: Int!
+	"""
+	Raw on-chain event type string, e.g. `"order_filled"`, `"liquidated"`.
+	"""
+	eventType: String!
+	"""
+	The event's subject address (its `user` field), if present. Each perps
+	event names a single participant — a fill's two sides are separate
+	events — so this is what the `user` filter matches on. `None` for events
+	without a `user` field (e.g. fee distribution).
+	"""
+	user: String
+	"""
+	The market the event pertains to (its `pair_id` field), if present.
+	"""
+	pairId: String
+	"""
+	The raw event payload.
+	"""
+	data: JSON!
+}
+
+"""
+All perps-contract events emitted in one block. Doubles as the ring item
+(holding every event) and the streamed output (holding the filtered subset).
+"""
+type PerpsEvent2Batch {
+	blockHeight: Int!
+	"""
+	Block timestamp, RFC 3339.
+	"""
+	createdAt: String!
+	events: [PerpsEvent2!]!
+}
+
 type PerpsEventConnection {
 	"""
 	Information to aid in pagination.
@@ -866,6 +908,22 @@ type Subscription {
 	Returns cached recent trades first, then streams new trades as they occur.
 	"""
 	perpsTrades(pairId: String!): PerpsTrade!
+	"""
+	Stream perps-exchange contract events (e.g. `order_filled`, `liquidated`,
+	`deleveraged`, `order_persisted`, `order_removed`) in real time, grouped
+	per block.
+	
+	The feed is served from an in-memory window on the validator (lowest
+	latency). It first replays recent retained blocks — from
+	`sinceBlockHeight` if given, otherwise none — then streams the live tail.
+	The `eventTypes`, `pairIds`, and `users` filters AND together; for each,
+	omitting it matches everything, while passing an empty list matches
+	nothing. If `sinceBlockHeight` predates the retained window, the
+	subscription fails to start with a "resync required" error — reconnect
+	with a newer `sinceBlockHeight` (deep history is available via the
+	`perpsEvents` query on the indexer node).
+	"""
+	perpsEvents2(sinceBlockHeight: Int, eventTypes: [String!], pairIds: [String!], users: [String!]): PerpsEvent2Batch!
 }
 
 type Transaction {

--- a/dango/indexer/graphql-types/src/schemas/subscriptions/perpsEvents2.graphql
+++ b/dango/indexer/graphql-types/src/schemas/subscriptions/perpsEvents2.graphql
@@ -1,0 +1,23 @@
+subscription SubscribePerpsEvents2(
+  $sinceBlockHeight: Int
+  $eventTypes: [String!]
+  $pairIds: [String!]
+  $users: [String!]
+) {
+  perpsEvents2(
+    sinceBlockHeight: $sinceBlockHeight
+    eventTypes: $eventTypes
+    pairIds: $pairIds
+    users: $users
+  ) {
+    blockHeight
+    createdAt
+    events {
+      idx
+      eventType
+      user
+      pairId
+      data
+    }
+  }
+}

--- a/dango/indexer/hooked/Cargo.toml
+++ b/dango/indexer/hooked/Cargo.toml
@@ -23,6 +23,7 @@ dango-app                = { workspace = true }
 dango-indexer-cache      = { workspace = true }
 dango-indexer-clickhouse = { workspace = true }
 dango-indexer-sql        = { workspace = true }
+dango-indexer-stream     = { workspace = true }
 dango-primitives         = { workspace = true }
 tokio                    = { workspace = true }
 tracing                  = { workspace = true, optional = true }

--- a/dango/indexer/hooked/src/lib.rs
+++ b/dango/indexer/hooked/src/lib.rs
@@ -35,6 +35,16 @@ pub struct HookedIndexer {
     pub file: dango_indexer_cache::Cache,
     pub sql: dango_indexer_sql::Indexer,
     pub clickhouse: dango_indexer_clickhouse::Indexer,
+    /// In-memory, validator-side realtime feed backing the `perps_events2`
+    /// GraphQL subscription. Unlike the other three components it does no
+    /// durable indexing — it only keeps a ring of recent perps-contract events
+    /// and broadcasts them live, in-process (lowest latency).
+    ///
+    /// FUTURE: this component will also host a "new blocks" subscription
+    /// consumed by the dedicated indexer node, and will eventually REPLACE this
+    /// `HookedIndexer` entirely once block files / Postgres / ClickHouse move to
+    /// that node.
+    pub stream: dango_indexer_stream::Indexer,
     /// Set to true between `start` and `shutdown`.
     is_running: Arc<AtomicBool>,
     /// One join handle per in-flight `post_indexing` block. Inserted when the
@@ -52,6 +62,7 @@ impl HookedIndexer {
             file,
             sql,
             clickhouse,
+            stream: dango_indexer_stream::Indexer::new(dango_indexer_stream::DEFAULT_RING_CAPACITY),
             is_running: Arc::new(AtomicBool::new(false)),
             post_indexing_tasks: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -118,6 +129,10 @@ impl HookedIndexer {
             return Ok(());
         }
 
+        // The realtime stream (`perps_events2`) is intentionally NOT replayed
+        // here: it is an ephemeral, live-only feed with no subscribers during a
+        // cold catch-up, and this replay path has no `BlockOutcome` to extract
+        // events from (it only reloads the cached payload for SQL/Clickhouse).
         for block_height in (min_height + 1)..=block.height {
             // Cache loads the cached file into its in-memory map.
             self.file.pre_indexing(block_height).await?;
@@ -151,6 +166,7 @@ impl Indexer for HookedIndexer {
         self.file.start(storage).await?;
         self.sql.start(storage).await?;
         self.clickhouse.start(storage).await?;
+        self.stream.start(storage).await?;
 
         self.reindex(storage).await?;
 
@@ -185,6 +201,11 @@ impl Indexer for HookedIndexer {
         if let Err(err) = self.file.shutdown().await {
             #[cfg(feature = "tracing")]
             tracing::error!(err = %err, indexer = "file", "Error in shutdown");
+            errors.push(err.to_string());
+        }
+        if let Err(err) = self.stream.shutdown().await {
+            #[cfg(feature = "tracing")]
+            tracing::error!(err = %err, indexer = "stream", "Error in shutdown");
             errors.push(err.to_string());
         }
 
@@ -222,6 +243,14 @@ impl Indexer for HookedIndexer {
         // in-memory map for `post_indexing`.
         self.file.index_block(block, block_outcome).await?;
 
+        // Realtime feed: stash the outcome so `post_indexing` can extract and
+        // publish the perps events in height order. Best-effort: a failure here
+        // must not abort the block.
+        if let Err(_err) = self.stream.index_block(block, block_outcome).await {
+            #[cfg(feature = "tracing")]
+            tracing::error!(err = %_err, "stream index_block failed");
+        }
+
         Ok(())
     }
 
@@ -239,6 +268,22 @@ impl Indexer for HookedIndexer {
     ) -> IndexerResult<()> {
         if !self.is_running.load(Ordering::Relaxed) {
             return Err(IndexerError::not_running());
+        }
+
+        // Realtime feed: extract perps events and append them to the in-memory
+        // ring + broadcast, INLINE and IN STRICT HEIGHT ORDER (the app awaits
+        // this method per height), BEFORE the spawned task below. Running it
+        // here — not inside the spawn — is what keeps `perps_events2` free of
+        // the out-of-order publishing that the spawned SQL/Clickhouse path is
+        // subject to. Best-effort: errors are logged, never propagated, so the
+        // realtime feed can never affect consensus.
+        if let Err(_err) = self
+            .stream
+            .post_indexing(block_height, cfg.clone(), app_cfg.clone())
+            .await
+        {
+            #[cfg(feature = "tracing")]
+            tracing::error!(err = %_err, block_height, "stream post_indexing failed");
         }
 
         let file = self.file.clone();
@@ -347,6 +392,7 @@ impl Indexer for HookedIndexer {
         self.file.wait_for_finish().await?;
         self.sql.wait_for_finish().await?;
         self.clickhouse.wait_for_finish().await?;
+        self.stream.wait_for_finish().await?;
 
         Ok(())
     }

--- a/dango/indexer/httpd/Cargo.toml
+++ b/dango/indexer/httpd/Cargo.toml
@@ -31,6 +31,7 @@ dango-backtrace          = { workspace = true }
 dango-indexer-cache      = { workspace = true }
 dango-indexer-clickhouse = { workspace = true, features = ["async-graphql"] }
 dango-indexer-sql        = { workspace = true, features = ["async-graphql"] }
+dango-indexer-stream     = { workspace = true }
 dango-primitives         = { workspace = true, features = ["async-graphql", "chrono", "tendermint"] }
 dango-types              = { workspace = true, features = ["async-graphql"] }
 futures                  = { workspace = true }

--- a/dango/indexer/httpd/src/context.rs
+++ b/dango/indexer/httpd/src/context.rs
@@ -28,6 +28,9 @@ pub struct FullContext {
     pub sql_context: dango_indexer_sql::Context,
     pub indexer_cache_context: dango_indexer_cache::Context,
     pub clickhouse_context: dango_indexer_clickhouse::context::Context,
+    /// Reader handle to the validator-side realtime stream backing the
+    /// `perps_events2` subscription.
+    pub stream_context: dango_indexer_stream::Context,
     pub base: MinimalContext,
     pub db: DatabaseConnection,
     pub pubsub: Arc<dyn PubSub<u64> + Send + Sync>,
@@ -43,6 +46,7 @@ impl FullContext {
         indexer_cache_context: dango_indexer_cache::Context,
         ctx: dango_indexer_sql::Context,
         clickhouse_context: dango_indexer_clickhouse::context::Context,
+        stream_context: dango_indexer_stream::Context,
         dango_app: Arc<dyn QueryApp + Send + Sync>,
         consensus_client: Arc<dyn ConsensusClient + Send + Sync>,
         static_files_path: Option<String>,
@@ -50,6 +54,7 @@ impl FullContext {
         Self {
             indexer_cache_context,
             clickhouse_context,
+            stream_context,
             db: ctx.db.clone(),
             pubsub: ctx.pubsub.clone(),
             perps_trade_pubsub: ctx.perps_trade_pubsub.clone(),

--- a/dango/indexer/httpd/src/graphql.rs
+++ b/dango/indexer/httpd/src/graphql.rs
@@ -102,6 +102,7 @@ pub fn build_full_schema(app_ctx: FullContext) -> FullSchema {
 
     schema_builder
         .data(app_ctx.clickhouse_context.clone())
+        .data(app_ctx.stream_context.clone())
         .data(app_ctx.db.clone())
         .data(app_ctx.base.clone())
         .data(app_ctx)

--- a/dango/indexer/httpd/src/graphql/subscription.rs
+++ b/dango/indexer/httpd/src/graphql/subscription.rs
@@ -1,8 +1,9 @@
 use {
     account::AccountSubscription, async_graphql::*, block::BlockSubscription,
     clickhouse::ClickhouseSubscription, core::CoreSubscription, event::EventSubscription,
-    message::MessageSubscription, perps_trade::PerpsTradeSubscription,
-    transaction::TransactionSubscription, transfer::TransferSubscription,
+    message::MessageSubscription, perps_events2::PerpsEvents2Subscription,
+    perps_trade::PerpsTradeSubscription, transaction::TransactionSubscription,
+    transfer::TransferSubscription,
 };
 
 pub mod account;
@@ -11,6 +12,7 @@ pub mod clickhouse;
 pub mod core;
 pub mod event;
 pub mod message;
+pub mod perps_events2;
 pub mod perps_trade;
 pub mod transaction;
 pub mod transfer;
@@ -34,4 +36,5 @@ pub struct FullSubscription(
     AccountSubscription,
     TransferSubscription,
     PerpsTradeSubscription,
+    PerpsEvents2Subscription,
 );

--- a/dango/indexer/httpd/src/graphql/subscription/perps_events2.rs
+++ b/dango/indexer/httpd/src/graphql/subscription/perps_events2.rs
@@ -1,0 +1,50 @@
+use {
+    crate::subscription_limiter::{acquire_subscription, guard_subscription_stream},
+    async_graphql::{futures_util::stream::Stream, *},
+    dango_indexer_stream::{PerpsEventBlock, make_perps_filter},
+    std::collections::HashSet,
+};
+
+#[derive(Default)]
+pub struct PerpsEvents2Subscription;
+
+#[Subscription]
+impl PerpsEvents2Subscription {
+    /// Stream perps-exchange contract events (e.g. `order_filled`, `liquidated`,
+    /// `deleveraged`, `order_persisted`, `order_removed`) in real time, grouped
+    /// per block.
+    ///
+    /// The feed is served from an in-memory window on the validator (lowest
+    /// latency). It first replays recent retained blocks — from
+    /// `sinceBlockHeight` if given, otherwise none — then streams the live tail.
+    /// The `eventTypes`, `pairIds`, and `users` filters AND together; for each,
+    /// omitting it matches everything, while passing an empty list matches
+    /// nothing. If `sinceBlockHeight` predates the retained window, the
+    /// subscription fails to start with a "resync required" error — reconnect
+    /// with a newer `sinceBlockHeight` (deep history is available via the
+    /// `perpsEvents` query on the indexer node).
+    async fn perps_events2<'a>(
+        &self,
+        ctx: &async_graphql::Context<'a>,
+        #[graphql(name = "sinceBlockHeight")] since_block_height: Option<u64>,
+        #[graphql(name = "eventTypes")] event_types: Option<HashSet<String>>,
+        #[graphql(name = "pairIds")] pair_ids: Option<HashSet<String>>,
+        users: Option<HashSet<String>>,
+    ) -> Result<impl Stream<Item = PerpsEventBlock> + 'a> {
+        let sub_guard = acquire_subscription(ctx)?;
+        let stream_ctx = ctx.data::<dango_indexer_stream::Context>()?;
+
+        // All three filters are opaque string sets: `None` does not filter,
+        // `Some(empty)` matches nothing. `users` are matched verbatim against
+        // each event's canonical address string — not parsed/validated, so the
+        // treatment is consistent with `event_types` and `pair_ids`.
+        let filter = make_perps_filter(event_types, pair_ids, users);
+
+        let stream = stream_ctx
+            .perps()
+            .subscribe(since_block_height, filter)
+            .map_err(|resync| Error::new(resync.to_string()))?;
+
+        Ok(guard_subscription_stream(stream, sub_guard))
+    }
+}

--- a/dango/indexer/stream/Cargo.toml
+++ b/dango/indexer/stream/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+authors       = { workspace = true }
+categories    = { workspace = true }
+documentation = { workspace = true }
+edition       = { workspace = true }
+homepage      = { workspace = true }
+keywords      = { workspace = true }
+license       = { workspace = true }
+name          = "dango-indexer-stream"
+repository    = { workspace = true }
+rust-version  = { workspace = true }
+version       = { workspace = true }
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = ["metrics", "tracing"]
+metrics = ["dep:metrics"]
+tracing = ["dep:tracing"]
+
+[dependencies]
+async-graphql    = { workspace = true }
+async-stream     = { workspace = true }
+async-trait      = { workspace = true }
+dango-app        = { workspace = true }
+dango-primitives = { workspace = true, features = ["chrono"] }
+dango-types      = { workspace = true }
+futures-util     = { workspace = true }
+metrics          = { workspace = true, optional = true }
+serde            = { workspace = true }
+serde_json       = { workspace = true }
+thiserror        = { workspace = true }
+tokio            = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync"] }
+tracing          = { workspace = true, optional = true }

--- a/dango/indexer/stream/src/context.rs
+++ b/dango/indexer/stream/src/context.rs
@@ -1,0 +1,24 @@
+use crate::{perps_events::PerpsEventBlock, recent_stream::RecentStream};
+
+/// A cheap-to-clone reader handle to the realtime stream's in-memory state,
+/// held by the httpd server and registered as GraphQL schema data. The
+/// `perps_events2` subscription resolver uses it to open subscriptions.
+///
+/// Cloning shares the underlying ring + broadcast with the live [`Indexer`].
+///
+/// [`Indexer`]: crate::Indexer
+#[derive(Clone)]
+pub struct Context {
+    perps: RecentStream<PerpsEventBlock>,
+}
+
+impl Context {
+    pub(crate) fn new(perps: RecentStream<PerpsEventBlock>) -> Self {
+        Self { perps }
+    }
+
+    /// The perps-events stream backing the `perps_events2` subscription.
+    pub fn perps(&self) -> &RecentStream<PerpsEventBlock> {
+        &self.perps
+    }
+}

--- a/dango/indexer/stream/src/indexer.rs
+++ b/dango/indexer/stream/src/indexer.rs
@@ -1,0 +1,163 @@
+use {
+    crate::{
+        context::Context,
+        perps_events::{PerpsEventBlock, extract_perps_event_block},
+        recent_stream::RecentStream,
+    },
+    async_trait::async_trait,
+    dango_app::IndexerResult,
+    dango_primitives::{Block, BlockOutcome, Config, Json, JsonDeExt},
+    dango_types::config::AppConfig,
+    std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    },
+};
+
+/// Number of recent blocks the realtime stream retains in memory — both the
+/// reconnect/recovery window for `perps_events2` and the live broadcast buffer.
+///
+/// Bounds memory (one `PerpsEventBlock` per height, including empty ones) and
+/// the maximum reconnect depth. Deeper history is the indexer node's job (the
+/// durable `perps_events` table / `perpsEvents` query), not this ephemeral,
+/// validator-side feed. Promote to a config field if ops needs to tune it.
+pub const DEFAULT_RING_CAPACITY: usize = 1000;
+
+/// The validator-side realtime indexer. Despite implementing
+/// [`dango_app::Indexer`], it does no durable indexing: it maintains an
+/// in-memory ring of recent perps-contract events and broadcasts them to
+/// `perps_events2` subscribers, entirely in-process (lowest latency, no
+/// validator -> indexer-node hop).
+///
+/// FUTURE: this crate will gain a second [`RecentStream`] — `RecentStream<..>`
+/// over full blocks — to serve a "new blocks" subscription consumed by the
+/// indexer node. The [`RecentStream`] primitive is generic precisely so that
+/// drops onto the same machinery.
+///
+/// FUTURE: once block files / Postgres / ClickHouse move to a dedicated indexer
+/// node, this indexer will REPLACE `HookedIndexer` as the validator's sole,
+/// thin indexer. For now it rides alongside the others as a `HookedIndexer`
+/// field.
+#[derive(Clone)]
+pub struct Indexer {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    perps: RecentStream<PerpsEventBlock>,
+
+    /// `index_block` -> `post_indexing` hand-off. The `Indexer` trait's
+    /// `post_indexing` does not receive the `BlockOutcome` (only `app_cfg`,
+    /// which carries the perps address), so we stash the outcome + block
+    /// timestamp at `index_block` and drain it at `post_indexing`. At most one
+    /// entry is in flight: CometBFT runs FinalizeBlock(N) then Commit(N) before
+    /// FinalizeBlock(N+1). The lock is held only for the map op, never across
+    /// an `.await`.
+    pending: Mutex<HashMap<u64, PendingBlock>>,
+}
+
+struct PendingBlock {
+    created_at: String,
+    outcome: BlockOutcome,
+}
+
+impl Indexer {
+    pub fn new(ring_capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                perps: RecentStream::new(ring_capacity),
+                pending: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// A cheap-to-clone reader handle for the httpd server.
+    pub fn context(&self) -> Context {
+        Context::new(self.inner.perps.clone())
+    }
+}
+
+#[async_trait]
+impl dango_app::Indexer for Indexer {
+    fn name(&self) -> &'static str {
+        "dango-indexer-stream"
+    }
+
+    // `start`, `shutdown`, `pre_indexing`, `wait_for_finish` use the trait's
+    // default no-op impls: there is no durable store to migrate or drain.
+
+    async fn index_block(&self, block: &Block, block_outcome: &BlockOutcome) -> IndexerResult<()> {
+        // Stash only. The perps address lives in `app_cfg`, which `index_block`
+        // does not receive, so the actual extraction + publish happens INLINE
+        // and in height order in `post_indexing` (see HookedIndexer).
+        let pending = PendingBlock {
+            created_at: block.info.timestamp.to_rfc3339_string(),
+            outcome: block_outcome.clone(),
+        };
+
+        self.inner
+            .pending
+            .lock()
+            .unwrap()
+            .insert(block.info.height, pending);
+
+        Ok(())
+    }
+
+    async fn post_indexing(
+        &self,
+        block_height: u64,
+        _cfg: Config,
+        app_cfg: Json,
+    ) -> IndexerResult<()> {
+        let Some(PendingBlock {
+            created_at,
+            outcome,
+        }) = self.inner.pending.lock().unwrap().remove(&block_height)
+        else {
+            // No stash — e.g. the `reindex` cold-catch-up path skips
+            // `index_block`. The realtime feed is live-only + in-memory; there
+            // is nothing to backfill here, and no live subscribers during a
+            // cold catch-up. Intentionally a no-op.
+            return Ok(());
+        };
+
+        // Best-effort: a malformed/absent `app_cfg` (e.g. grug-only test
+        // harnesses that don't write APP_CONFIG) must never abort indexing or
+        // panic consensus. Log and skip this block's events.
+        let app_cfg: AppConfig = match app_cfg.deserialize_json() {
+            Ok(cfg) => cfg,
+            Err(_err) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    block_height,
+                    err = %_err,
+                    "skipping perps_events2 publish: app_cfg deserialize failed"
+                );
+
+                return Ok(());
+            },
+        };
+
+        let batch =
+            extract_perps_event_block(block_height, created_at, outcome, app_cfg.addresses.perps);
+
+        #[cfg(feature = "metrics")]
+        {
+            metrics::counter!("indexer_stream.blocks.published.total").increment(1);
+
+            metrics::counter!("indexer_stream.events.published.total")
+                .increment(batch.events.len() as u64);
+        }
+
+        // Append every block (including empty ones) so subscriber heights stay
+        // contiguous and gap detection stays exact.
+        self.inner.perps.append(Arc::new(batch));
+
+        Ok(())
+    }
+
+    async fn last_indexed_block_height(&self) -> IndexerResult<Option<u64>> {
+        Ok(self.inner.perps.tip())
+    }
+}

--- a/dango/indexer/stream/src/lib.rs
+++ b/dango/indexer/stream/src/lib.rs
@@ -1,0 +1,42 @@
+//! Validator-side, in-memory, low-latency event streaming for Dango.
+//!
+//! This crate provides the `perps_events2` GraphQL subscription: an ephemeral,
+//! purely in-memory ring of the last `N` blocks of perps-exchange contract
+//! events, broadcast live to bots and algo-traders. It runs in-process with the
+//! state machine (no validator -> indexer-node hop), which is what makes it the
+//! lowest-latency surface for real-time perps data.
+//!
+//! It implements [`dango_app::Indexer`] — but, despite the name, it does no
+//! durable indexing. It only maintains in-memory state for real-time
+//! subscriptions. It is wired into `HookedIndexer` as one more field for now.
+//!
+//! # Architecture
+//!
+//! - [`RecentStream`] — the generic in-memory ring + live broadcast, with a
+//!   reliable subscription builder (snapshot then live, in strict height order,
+//!   no silent drops). It fixes the `event_by_addresses` failure modes; see its
+//!   module docs.
+//! - [`Indexer`] — extracts perps-contract events from each block and appends
+//!   them to the ring, INLINE and in height order, from `post_indexing`.
+//! - [`Context`] — the reader handle the httpd holds; the `perps_events2`
+//!   resolver lives in the httpd crate and drives [`RecentStream::subscribe`].
+//!
+//! # Future direction
+//!
+//! - A "new blocks" subscription (consumed by the dedicated indexer node) will
+//!   be a second [`RecentStream`] instantiation over full blocks — the
+//!   primitive is generic for exactly this.
+//! - Once block files / Postgres / ClickHouse move to the indexer node, this
+//!   crate will REPLACE `HookedIndexer` as the validator's sole, thin indexer.
+
+mod context;
+mod indexer;
+mod perps_events;
+mod recent_stream;
+
+pub use {
+    context::Context,
+    indexer::{DEFAULT_RING_CAPACITY, Indexer},
+    perps_events::{PerpsEvent, PerpsEventBlock, extract_perps_event_block, make_perps_filter},
+    recent_stream::{HasHeight, RecentStream, ResyncRequired},
+};

--- a/dango/indexer/stream/src/perps_events.rs
+++ b/dango/indexer/stream/src/perps_events.rs
@@ -1,0 +1,308 @@
+//! Perps-exchange event types, extraction from a `BlockOutcome`, and the
+//! client-supplied filter, for the `perps_events2` subscription.
+//!
+//! Every event emitted by the perps contract is captured (filtered only by
+//! emitting contract address) — there is no event-name whitelist, so new perps
+//! event types appear in the feed automatically. Clients narrow the feed with
+//! the `event_types` / `pair_ids` / `users` filter.
+
+use {
+    crate::recent_stream::HasHeight,
+    async_graphql::SimpleObject,
+    dango_primitives::{
+        Addr, BlockOutcome, CheckedContractEvent, Denom, FlatCommitmentStatus, FlatEvent, Inner,
+        JsonDeExt, SearchEvent,
+    },
+    std::collections::HashSet,
+};
+
+/// A single perps-contract event, as streamed to clients.
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "PerpsEvent2")]
+pub struct PerpsEvent {
+    /// Per-block ordinal across all perps-contract events in the block.
+    pub idx: u32,
+
+    /// Raw on-chain event type string, e.g. `"order_filled"`, `"liquidated"`.
+    #[graphql(name = "eventType")]
+    pub event_type: String,
+
+    /// The event's subject address (its `user` field), if present. Each perps
+    /// event names a single participant — a fill's two sides are separate
+    /// events — so this is what the `user` filter matches on. `None` for events
+    /// without a `user` field (e.g. fee distribution).
+    pub user: Option<String>,
+
+    /// The market the event pertains to (its `pair_id` field), if present.
+    #[graphql(name = "pairId")]
+    pub pair_id: Option<String>,
+
+    /// The raw event payload.
+    pub data: async_graphql::Json<serde_json::Value>,
+}
+
+/// All perps-contract events emitted in one block. Doubles as the ring item
+/// (holding every event) and the streamed output (holding the filtered subset).
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "PerpsEvent2Batch")]
+pub struct PerpsEventBlock {
+    #[graphql(name = "blockHeight")]
+    pub block_height: u64,
+
+    /// Block timestamp, RFC 3339.
+    #[graphql(name = "createdAt")]
+    pub created_at: String,
+
+    pub events: Vec<PerpsEvent>,
+}
+
+impl HasHeight for PerpsEventBlock {
+    fn height(&self) -> u64 {
+        self.block_height
+    }
+}
+
+/// Extract every committed perps-contract event from a block's outcome.
+///
+/// `BlockOutcome::flat()` folds both tx and cron outcomes into one ordered
+/// list, so liquidations/ADL emitted in cron context are captured alongside
+/// user-submitted order events.
+pub fn extract_perps_event_block(
+    block_height: u64,
+    created_at: String,
+    outcome: BlockOutcome,
+    perps_addr: Addr,
+) -> PerpsEventBlock {
+    let mut events = Vec::new();
+    let mut idx = 0u32;
+
+    for flat in outcome.flat() {
+        if flat.commitment_status != FlatCommitmentStatus::Committed {
+            continue;
+        }
+
+        let FlatEvent::ContractEvent(ref contract_event) = flat.event else {
+            continue;
+        };
+
+        if contract_event.contract != perps_addr {
+            continue;
+        }
+
+        let (user, pair_id) = extract_user_and_pair(contract_event);
+
+        events.push(PerpsEvent {
+            idx,
+            event_type: contract_event.ty.clone(),
+            user,
+            pair_id,
+            data: async_graphql::Json(contract_event.data.clone().into_inner()),
+        });
+
+        idx += 1;
+    }
+
+    PerpsEventBlock {
+        block_height,
+        created_at,
+        events,
+    }
+}
+
+/// Best-effort extraction of the `user` and `pair_id` fields shared by most
+/// perps events. Events lacking either field simply yield `None` there (they
+/// can still match an `event_type` filter).
+fn extract_user_and_pair(event: &CheckedContractEvent) -> (Option<String>, Option<String>) {
+    #[derive(Default, serde::Deserialize)]
+    struct UserAndPair {
+        #[serde(default)]
+        user: Option<Addr>,
+
+        #[serde(default)]
+        pair_id: Option<Denom>,
+    }
+
+    let parsed: UserAndPair = event.data.clone().deserialize_json().unwrap_or_default();
+
+    (
+        parsed.user.map(|a| a.to_string()),
+        parsed.pair_id.map(|d| d.to_string()),
+    )
+}
+
+/// Build the per-block projection closure for a `perps_events2` subscription.
+///
+/// The three predicates AND together. For each, `None` means "do not filter on
+/// this field" (matches everything), while `Some(set)` keeps only events whose
+/// field is in the set — so an empty set matches nothing. A block with no
+/// matching events projects to `None` (it is suppressed, never emitted as an
+/// empty batch).
+pub fn make_perps_filter(
+    event_types: Option<HashSet<String>>,
+    pair_ids: Option<HashSet<String>>,
+    users: Option<HashSet<String>>,
+) -> impl Fn(&PerpsEventBlock) -> Option<PerpsEventBlock> + Send + 'static {
+    move |block: &PerpsEventBlock| {
+        let matched = block
+            .events
+            .iter()
+            .filter(|event| {
+                if let Some(event_types) = &event_types
+                    && !event_types.contains(&event.event_type)
+                {
+                    return false;
+                }
+
+                // An event without a `pair_id` cannot match a pair filter.
+                if let Some(pair_ids) = &pair_ids {
+                    let Some(pair_id) = &event.pair_id else {
+                        return false;
+                    };
+
+                    if !pair_ids.contains(pair_id) {
+                        return false;
+                    }
+                }
+
+                // An event without a `user` cannot match a user filter.
+                if let Some(users) = &users {
+                    let Some(user) = &event.user else {
+                        return false;
+                    };
+
+                    if !users.contains(user) {
+                        return false;
+                    }
+                }
+
+                true
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if matched.is_empty() {
+            None
+        } else {
+            Some(PerpsEventBlock {
+                block_height: block.block_height,
+                created_at: block.created_at.clone(),
+                events: matched,
+            })
+        }
+    }
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(idx: u32, ty: &str, pair: Option<&str>, user: Option<u8>) -> PerpsEvent {
+        PerpsEvent {
+            idx,
+            event_type: ty.to_string(),
+            user: user.map(|i| Addr::mock(i).to_string()),
+            pair_id: pair.map(ToString::to_string),
+            data: async_graphql::Json(serde_json::json!({})),
+        }
+    }
+
+    fn block() -> PerpsEventBlock {
+        PerpsEventBlock {
+            block_height: 7,
+            created_at: "2026-06-18T00:00:00Z".to_string(),
+            events: vec![
+                event(0, "order_filled", Some("perp/btcusd"), Some(1)),
+                event(1, "liquidated", Some("perp/ethusd"), Some(3)),
+                event(2, "order_persisted", Some("perp/btcusd"), Some(1)),
+            ],
+        }
+    }
+
+    fn types(names: &[&str]) -> Option<HashSet<String>> {
+        Some(names.iter().map(ToString::to_string).collect())
+    }
+
+    fn pairs(names: &[&str]) -> Option<HashSet<String>> {
+        Some(names.iter().map(ToString::to_string).collect())
+    }
+
+    fn users(idxs: &[u8]) -> Option<HashSet<String>> {
+        Some(idxs.iter().map(|i| Addr::mock(*i).to_string()).collect())
+    }
+
+    #[test]
+    fn no_filter_matches_whole_block() {
+        let f = make_perps_filter(None, None, None);
+        let out = f(&block()).unwrap();
+        assert_eq!(out.events.len(), 3);
+        assert_eq!(out.block_height, 7);
+    }
+
+    #[test]
+    fn event_type_filter_is_a_set() {
+        let f = make_perps_filter(types(&["order_filled", "liquidated"]), None, None);
+        let out = f(&block()).unwrap();
+        assert_eq!(
+            out.events
+                .iter()
+                .map(|e| e.event_type.as_str())
+                .collect::<Vec<_>>(),
+            vec!["order_filled", "liquidated"]
+        );
+    }
+
+    #[test]
+    fn pair_filter() {
+        let f = make_perps_filter(None, pairs(&["perp/btcusd"]), None);
+        let out = f(&block()).unwrap();
+        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
+            0, 2
+        ]);
+    }
+
+    #[test]
+    fn user_filter_matches_user_field() {
+        // mock(1) is the `user` of both the order_filled and order_persisted.
+        let f = make_perps_filter(None, None, users(&[1]));
+        let out = f(&block()).unwrap();
+        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
+            0, 2
+        ]);
+
+        // mock(2) is not the `user` of any event here.
+        let f = make_perps_filter(None, None, users(&[2]));
+        assert!(f(&block()).is_none());
+    }
+
+    #[test]
+    fn combined_filters_and_together() {
+        let f = make_perps_filter(
+            types(&["order_persisted"]),
+            pairs(&["perp/btcusd"]),
+            users(&[1]),
+        );
+        let out = f(&block()).unwrap();
+        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
+            2
+        ]);
+    }
+
+    #[test]
+    fn no_match_suppresses_block() {
+        let f = make_perps_filter(types(&["deleveraged"]), None, None);
+        assert!(f(&block()).is_none());
+    }
+
+    #[test]
+    fn empty_set_matches_nothing() {
+        // `Some(empty)` means "filter on this field, but no value qualifies" —
+        // distinct from `None` (do not filter). It must suppress the block.
+        let f = make_perps_filter(Some(HashSet::new()), None, None);
+        assert!(f(&block()).is_none());
+
+        let f = make_perps_filter(None, None, Some(HashSet::new()));
+        assert!(f(&block()).is_none());
+    }
+}

--- a/dango/indexer/stream/src/recent_stream.rs
+++ b/dango/indexer/stream/src/recent_stream.rs
@@ -1,0 +1,538 @@
+//! A generic, in-memory "recent blocks" stream: a bounded ring of the last `N`
+//! per-block items plus a live broadcast tail, with a reliable subscription
+//! builder that delivers a connect-time snapshot followed by the live tail,
+//! in strict block-height order, with no silent drops.
+//!
+//! This is the reusable core behind the `perps_events2` subscription. The
+//! future "new blocks" subscription (see crate docs) is a second instantiation
+//! `RecentStream<BlockAndOutcome>` — it drops onto this same primitive.
+//!
+//! Design notes (why this avoids the `event_by_addresses` failure modes):
+//!
+//! - The producer calls [`RecentStream::append`] INLINE and IN STRICT HEIGHT
+//!   ORDER (one per block, including blocks with no matching events, so heights
+//!   stay contiguous). There is no per-block task race, so the broadcast never
+//!   publishes out of order.
+//! - A subscriber's watermark advances ONLY to a height it has actually
+//!   processed (via the snapshot or a live item), never blindly to a doorbell
+//!   value, and never backward — so a block is never skipped unread.
+//! - `broadcast::error::RecvError::Lagged` is surfaced, not swallowed. The
+//!   broadcast buffer and the ring share the same capacity `N`: a consumer that
+//!   is at most `N` blocks behind catches up through the broadcast's own
+//!   buffered `Ok` delivery; one that falls further behind gets an explicit
+//!   [`ResyncRequired`] (the in-memory window cannot serve it — deep history
+//!   lives on the indexer node), rather than a silent hole.
+
+use {
+    futures_util::stream::Stream,
+    std::{
+        collections::VecDeque,
+        fmt,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, AtomicU64, Ordering},
+        },
+    },
+    tokio::sync::broadcast,
+};
+
+/// A value stored in a [`RecentStream`] that knows the block height it belongs
+/// to. One value per block height.
+pub trait HasHeight: Send + Sync + 'static {
+    fn height(&self) -> u64;
+}
+
+/// Returned when a subscriber requests — or falls behind to — a block height
+/// older than the oldest block still retained in the ring. The client must
+/// reconnect (optionally with a newer cursor); the ephemeral in-memory window
+/// cannot serve the requested range. Deep history lives on the indexer node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResyncRequired {
+    /// The earliest block height the subscriber still needs.
+    pub requested_from: u64,
+
+    /// The earliest block height still retained in the ring.
+    pub ring_floor: u64,
+}
+
+impl fmt::Display for ResyncRequired {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "resync required: requested from block {} but the oldest retained block is {}",
+            self.requested_from, self.ring_floor
+        )
+    }
+}
+
+impl std::error::Error for ResyncRequired {}
+
+// ---------------------------------- stream -----------------------------------
+
+/// A cheaply-clonable handle (the clone shares one ring + broadcast) to an
+/// in-memory recent-block stream.
+pub struct RecentStream<T> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> Clone for RecentStream<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+struct Inner<T> {
+    /// Ring of the last `capacity` per-block items, ordered oldest -> newest by
+    /// height. Guarded by a std `Mutex` held only for O(1) push / synchronous
+    /// clone-scan — never across an `.await`.
+    ring: Mutex<VecDeque<Arc<T>>>,
+
+    /// Max blocks retained in the ring AND the broadcast channel capacity. A
+    /// consumer at most `capacity` blocks behind catches up via the broadcast;
+    /// further behind => `ResyncRequired`.
+    capacity: usize,
+
+    /// Highest height ever appended; lets a fresh subscriber learn the tip
+    /// without locking the ring.
+    tip: AtomicU64,
+    has_tip: AtomicBool,
+
+    tx: broadcast::Sender<Arc<T>>,
+}
+
+impl<T> Inner<T>
+where
+    T: HasHeight,
+{
+    fn tip(&self) -> Option<u64> {
+        if self.has_tip.load(Ordering::Acquire) {
+            Some(self.tip.load(Ordering::Acquire))
+        } else {
+            None
+        }
+    }
+
+    /// Clone every retained block whose height is in `lo..=hi`, ascending.
+    /// Errors if the bottom of the requested range was already evicted.
+    fn read_range(&self, lo: u64, hi: u64) -> Result<Vec<Arc<T>>, ResyncRequired> {
+        if lo > hi {
+            return Ok(Vec::new());
+        }
+
+        let ring = self.ring.lock().unwrap();
+
+        if let Some(front) = ring.front() {
+            let floor = front.height();
+            if lo < floor {
+                return Err(ResyncRequired {
+                    requested_from: lo,
+                    ring_floor: floor,
+                });
+            }
+        }
+
+        Ok(ring
+            .iter()
+            .filter(|item| {
+                let h = item.height();
+                h >= lo && h <= hi
+            })
+            .cloned()
+            .collect())
+    }
+}
+
+impl<T> RecentStream<T>
+where
+    T: HasHeight,
+{
+    /// `capacity` is the number of recent blocks retained in memory — both the
+    /// reconnect/recovery window and the broadcast buffer.
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        let (tx, _rx) = broadcast::channel(capacity);
+
+        Self {
+            inner: Arc::new(Inner {
+                ring: Mutex::new(VecDeque::with_capacity(capacity)),
+                capacity,
+                tx,
+                tip: AtomicU64::new(0),
+                has_tip: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Append one per-block item and broadcast it to live subscribers.
+    ///
+    /// MUST be called in strict, gap-free height order by a single producer
+    /// (the indexer's `post_indexing`, which the app awaits per height). A
+    /// non-monotonic or duplicate height is a bug; it is logged and skipped
+    /// rather than allowed to corrupt the ring ordering.
+    pub fn append(&self, item: Arc<T>) {
+        let height = item.height();
+
+        {
+            let mut ring = self.inner.ring.lock().unwrap();
+
+            if let Some(last) = ring.back()
+                && height <= last.height()
+            {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    height,
+                    last = last.height(),
+                    "non-monotonic append to RecentStream; skipping"
+                );
+
+                return;
+            }
+
+            ring.push_back(item.clone());
+
+            while ring.len() > self.inner.capacity {
+                ring.pop_front();
+            }
+        }
+
+        self.inner.tip.store(height, Ordering::Release);
+        self.inner.has_tip.store(true, Ordering::Release);
+
+        // `Err` only means there are no live subscribers — fine, the ring still
+        // retains the block for future subscribers and reconnects.
+        let _ = self.inner.tx.send(item);
+    }
+
+    /// Highest height ever appended (`None` if nothing has been appended).
+    pub fn tip(&self) -> Option<u64> {
+        self.inner.tip()
+    }
+
+    /// Lowest height still retained in the ring (`None` if empty).
+    pub fn floor(&self) -> Option<u64> {
+        self.inner.ring.lock().unwrap().front().map(|i| i.height())
+    }
+
+    /// Build a reliable subscription.
+    ///
+    /// - `since`: `None` streams only blocks newer than the current tip (live
+    ///   from now). `Some(h)` additionally backfills retained blocks from `h`.
+    /// - `filter`: applied to every block (snapshot and live). Returns the
+    ///   client-facing projection of that block, or `None` to suppress a block
+    ///   with no matching content (no empty items are emitted). The watermark
+    ///   advances over suppressed blocks all the same, so they are never
+    ///   re-examined.
+    ///
+    /// Returns `Err(ResyncRequired)` at connect time if `since` predates the
+    /// retained window. A mid-stream lag past the window ends the stream
+    /// (logged); the client should reconnect with a newer `since`.
+    pub fn subscribe<R, F>(
+        &self,
+        since: Option<u64>,
+        filter: F,
+    ) -> Result<impl Stream<Item = R> + Send + 'static, ResyncRequired>
+    where
+        F: Fn(&T) -> Option<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        // Subscribe to the live tail FIRST, so any block appended between here
+        // and the snapshot read below is buffered for us (closing the
+        // snapshot/live gap). Overlap is de-duplicated by the watermark.
+        let mut rx = self.inner.tx.subscribe();
+        let inner = self.inner.clone();
+
+        // Snapshot the ring (and validate `since` against the floor).
+        let (snapshot, mut watermark): (Vec<Arc<T>>, Option<u64>) = {
+            let ring = inner.ring.lock().unwrap();
+            let floor = ring.front().map(|i| i.height());
+            let tip = ring.back().map(|i| i.height());
+
+            match since {
+                Some(from) => {
+                    if let Some(fl) = floor
+                        && from < fl
+                    {
+                        return Err(ResyncRequired {
+                            requested_from: from,
+                            ring_floor: fl,
+                        });
+                    }
+
+                    let snap = ring
+                        .iter()
+                        .filter(|i| i.height() >= from)
+                        .cloned()
+                        .collect::<Vec<_>>();
+
+                    // If the snapshot is empty (e.g. `from` is in the future),
+                    // start the live phase from `from`.
+                    (snap, Some(from.saturating_sub(1)))
+                },
+
+                // Live-only: no historical backfill. `None` watermark means the
+                // first live block establishes the baseline (no spurious gap on
+                // a cold, empty ring).
+                None => (Vec::new(), tip),
+            }
+        };
+
+        let stream = async_stream::stream! {
+            // Snapshot phase: emit matching blocks; advance the watermark over
+            // the whole snapshot range (suppressed blocks included).
+            let snapshot_tip = snapshot.last().map(|b| b.height());
+            for item in snapshot {
+                if let Some(projected) = filter(item.as_ref()) {
+                    yield projected;
+                }
+            }
+            if let Some(t) = snapshot_tip {
+                watermark = Some(t);
+            }
+
+            // Live phase.
+            loop {
+                match rx.recv().await {
+                    Ok(item) => {
+                        let h = item.height();
+
+                        match watermark {
+                            None => {
+                                // Cold start with `since = None`: this first
+                                // block sets the baseline.
+                                if let Some(projected) = filter(item.as_ref()) {
+                                    yield projected;
+                                }
+
+                                watermark = Some(h);
+                            },
+                            Some(w) => {
+                                if h <= w {
+                                    // Already delivered (snapshot/live overlap)
+                                    // or a stale re-send; never move backward.
+                                    continue;
+                                }
+
+                                // Defensive: a gap in the Ok stream only arises
+                                // if the producer skipped a height (it should
+                                // not). Backfill what the ring still holds.
+                                if h > w + 1 {
+                                    match inner.read_range(w + 1, h - 1) {
+                                        Ok(blocks) => {
+                                            for b in blocks {
+                                                if let Some(projected) = filter(b.as_ref()) {
+                                                    yield projected;
+                                                }
+                                            }
+                                        },
+                                        Err(_resync) => {
+                                            #[cfg(feature = "tracing")]
+                                            tracing::warn!(%_resync, "ending subscription: gap older than retained window");
+
+                                            return;
+                                        },
+                                    }
+                                }
+
+                                if let Some(projected) = filter(item.as_ref()) {
+                                    yield projected;
+                                }
+
+                                watermark = Some(h);
+                            },
+                        }
+                    },
+                    Err(broadcast::error::RecvError::Lagged(_n)) => {
+                        // We fell behind the broadcast buffer. Recover the
+                        // skipped range from the ring, or resync if it has
+                        // already been evicted past what we need.
+                        #[cfg(feature = "metrics")]
+                        metrics::counter!("indexer_stream.subscription.lagged.total").increment(1);
+
+                        let tip = match inner.tip() {
+                            Some(t) => t,
+                            None => continue,
+                        };
+
+                        let from = match watermark {
+                            Some(w) => w + 1,
+                            // Cold start that lagged before any block: adopt the
+                            // current tip as the baseline and carry on.
+                            None => {
+                                watermark = Some(tip);
+                                continue;
+                            },
+                        };
+
+                        match inner.read_range(from, tip) {
+                            Ok(blocks) => {
+                                for b in blocks {
+                                    if let Some(projected) = filter(b.as_ref()) {
+                                        yield projected;
+                                    }
+                                }
+
+                                watermark = Some(tip);
+                            },
+                            Err(_resync) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::warn!(%_resync, "ending subscription: lagged past retained window");
+
+                                return;
+                            },
+                        }
+                    },
+                    Err(broadcast::error::RecvError::Closed) => return,
+                }
+            }
+        };
+
+        Ok(stream)
+    }
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {super::*, futures_util::stream::StreamExt};
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct TestBlock {
+        height: u64,
+    }
+
+    impl HasHeight for TestBlock {
+        fn height(&self) -> u64 {
+            self.height
+        }
+    }
+
+    fn block(height: u64) -> Arc<TestBlock> {
+        Arc::new(TestBlock { height })
+    }
+
+    // Identity projection: every block matches, projecting to its height.
+    fn id(b: &TestBlock) -> Option<u64> {
+        Some(b.height)
+    }
+
+    #[tokio::test]
+    async fn snapshot_then_live_in_order_no_duplicates() {
+        let rs = RecentStream::new(10);
+        rs.append(block(1));
+        rs.append(block(2));
+        rs.append(block(3));
+
+        let stream = rs.subscribe(Some(1), id).unwrap();
+
+        rs.append(block(4));
+        rs.append(block(5));
+
+        let got: Vec<u64> = stream.take(5).collect().await;
+        // Snapshot 1,2,3 (rx cursor starts after 3, so live never re-sends
+        // them) then live 4,5 — strictly ascending, no duplicates.
+        assert_eq!(got, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn live_only_when_since_is_none() {
+        let rs = RecentStream::new(10);
+        rs.append(block(1));
+        rs.append(block(2));
+
+        let stream = rs.subscribe(None, id).unwrap();
+
+        rs.append(block(3));
+        rs.append(block(4));
+
+        // No historical backfill: only blocks after the connect-time tip.
+        let got: Vec<u64> = stream.take(2).collect().await;
+        assert_eq!(got, vec![3, 4]);
+    }
+
+    #[tokio::test]
+    async fn eviction_advances_floor_and_tip() {
+        let rs = RecentStream::new(3);
+        for h in 1..=5 {
+            rs.append(block(h));
+        }
+        assert_eq!(rs.floor(), Some(3));
+        assert_eq!(rs.tip(), Some(5));
+    }
+
+    #[tokio::test]
+    async fn since_older_than_window_is_resync_at_connect() {
+        let rs = RecentStream::new(3);
+        for h in 1..=5 {
+            rs.append(block(h));
+        }
+        // Ring holds 3,4,5; asking from 2 cannot be served.
+        let err = rs.subscribe(Some(2), id).err().unwrap();
+        assert_eq!(err, ResyncRequired {
+            requested_from: 2,
+            ring_floor: 3,
+        });
+    }
+
+    #[tokio::test]
+    async fn lagging_past_window_ends_stream() {
+        let rs = RecentStream::new(4);
+        for h in 1..=4 {
+            rs.append(block(h));
+        }
+
+        let stream = rs.subscribe(Some(1), id).unwrap();
+
+        // Burst far past the broadcast buffer (and ring) without polling, so
+        // the receiver lags and the skipped range is already evicted.
+        for h in 5..=20 {
+            rs.append(block(h));
+        }
+
+        // The snapshot (1..=4) is delivered; the live phase then hits Lagged,
+        // finds the gap evicted, and ends the stream — no silent skip.
+        let got: Vec<u64> = stream.collect().await;
+        assert_eq!(got, vec![1, 2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn slow_consumer_within_window_drops_nothing() {
+        // The failure mode of `event_by_addresses`: a subscriber that is behind
+        // when blocks are produced has its watermark advanced past blocks it
+        // never read, silently losing them. `RecentStream` must NOT do that — a
+        // consumer that lags by less than the window catches up through the
+        // broadcast buffer and receives every block, in order, none dropped.
+        let rs = RecentStream::new(8);
+        let stream = rs.subscribe(None, id).unwrap();
+
+        // Produce a full window's worth of blocks before the stream is ever
+        // polled (the subscriber is "behind"), all within the buffer.
+        for h in 1..=8 {
+            rs.append(block(h));
+        }
+
+        let got: Vec<u64> = stream.take(8).collect().await;
+        assert_eq!(got, (1..=8).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn filter_suppresses_non_matching_blocks() {
+        let rs = RecentStream::new(10);
+        for h in 1..=5 {
+            rs.append(block(h));
+        }
+
+        // Keep only even heights; odd blocks are suppressed but the watermark
+        // still advances over them.
+        let stream = rs
+            .subscribe(Some(1), |b: &TestBlock| {
+                b.height.is_multiple_of(2).then_some(b.height)
+            })
+            .unwrap();
+
+        let got: Vec<u64> = stream.take(2).collect().await;
+        assert_eq!(got, vec![2, 4]);
+    }
+}

--- a/dango/testing/src/httpd.rs
+++ b/dango/testing/src/httpd.rs
@@ -116,6 +116,9 @@ where
         dango_indexer_clickhouse::indexer::Indexer::new(indexer_clickhouse_context.clone());
 
     let hooked_indexer = HookedIndexer::new(indexer_cache, indexer, clickhouse_indexer);
+    // Capture the realtime reader handle before `hooked_indexer` is moved into
+    // the suite; it shares the ring + broadcast the indexer publishes to.
+    let stream_context = hooked_indexer.stream.context();
 
     let (suite, test, codes, contracts, mock_validator_sets) = setup_suite_with_db_and_vm(
         MemDb::<SimpleCommitment>::new(),
@@ -145,6 +148,7 @@ where
         indexer_cache_context,
         sql_context,
         indexer_clickhouse_context,
+        stream_context,
         Arc::new(app),
         Arc::new(mock_client),
         None,

--- a/dango/testing/src/setup.rs
+++ b/dango/testing/src/setup.rs
@@ -294,6 +294,9 @@ where
         dango_indexer_clickhouse::indexer::Indexer::new(clickhouse_context.clone());
 
     let hooked_indexer = HookedIndexer::new(indexer_cache, indexer, clickhouse_indexer);
+    // Capture the realtime reader handle before `hooked_indexer` is moved into
+    // the suite; it shares the ring + broadcast the indexer publishes to.
+    let stream_context = hooked_indexer.stream.context();
 
     let (suite, accounts, codes, contracts, validator_sets) = setup_suite_with_db_and_vm(
         MemDb::new(),
@@ -315,6 +318,7 @@ where
         indexer_cache_context.clone(),
         sql_context,
         clickhouse_context.clone(),
+        stream_context,
         Arc::new(suite.app.clone_without_indexer()),
         consensus_client,
         None,

--- a/dango/testing/tests/httpd/perps_events.rs
+++ b/dango/testing/tests/httpd/perps_events.rs
@@ -1,11 +1,15 @@
 use {
     assertor::*,
     dango_app::Indexer,
-    dango_indexer_graphql_types::{PerpsEvents, perps_events},
+    dango_indexer_graphql_types::{
+        PerpsEvents, SubscribeEventByAddresses, SubscribePerpsEvents2, perps_events,
+        subscribe_event_by_addresses, subscribe_perps_events2,
+    },
     dango_primitives::Addressable,
     dango_testing::{
-        TestOption, call_graphql_query_with_context, create_perps_fill, pair_id, setup_perps_env,
-        setup_test_naive_with_indexer,
+        GraphQLCustomRequest, TestOption, build_app_service, call_graphql_query_with_context,
+        call_ws_graphql_stream, create_perps_fill, pair_id, parse_graphql_subscription_response,
+        setup_perps_env, setup_test_naive_with_indexer,
     },
     graphql_client::GraphQLQuery,
 };
@@ -89,6 +93,237 @@ async fn query_perps_events_user_lifecycle() -> anyhow::Result<()> {
                 let nodes_desc = response_desc.data.unwrap().perps_events.nodes;
                 assert_that!(nodes_desc).has_length(1);
                 assert_eq!(nodes_desc[0].event_type, "order_filled");
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+/// Subscribe to `perps_events2` and verify the in-memory, validator-side feed
+/// replays a fill's perps events (filtered by pair), end-to-end over the
+/// WebSocket GraphQL transport.
+#[tokio::test(flavor = "multi_thread")]
+async fn graphql_subscribe_to_perps_events2() -> anyhow::Result<()> {
+    let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default()).await;
+
+    let pair = pair_id();
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
+
+    // user2 places a limit ask → user1 fills it via market buy, emitting
+    // order_persisted (placement) and order_filled (the match).
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 3).await;
+
+    suite.app.indexer.wait_for_finish().await?;
+
+    // Replay from the oldest retained block (snapshot path — no live-timing
+    // race): the fills already landed in the in-memory ring.
+    let since = dango_httpd_context
+        .stream_context
+        .perps()
+        .floor()
+        .map(|h| h as i64);
+
+    let request_body = GraphQLCustomRequest::from_query_body(
+        SubscribePerpsEvents2::build_query(subscribe_perps_events2::Variables {
+            since_block_height: since,
+            pair_ids: Some(vec![pair.to_string()]),
+            event_types: None,
+            users: None,
+        }),
+        "perpsEvents2",
+    );
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let name = request_body.name;
+                let (_srv, _ws, mut framed) =
+                    call_ws_graphql_stream(dango_httpd_context, build_app_service, request_body)
+                        .await?;
+
+                // The snapshot streams one batch per matching block; read until
+                // we hit the block carrying the order_filled events.
+                loop {
+                    let response = parse_graphql_subscription_response::<
+                        subscribe_perps_events2::SubscribePerpsEvents2PerpsEvents2,
+                    >(&mut framed, name)
+                    .await?;
+
+                    let batch = response.data;
+
+                    // Every event in a pair-filtered batch is for that pair.
+                    for event in &batch.events {
+                        assert_eq!(event.pair_id.as_deref(), Some(pair.to_string().as_str()));
+                    }
+
+                    let Some(fill) = batch.events.iter().find(|e| e.event_type == "order_filled")
+                    else {
+                        continue;
+                    };
+
+                    // The fill carries the real perps payload at price 2000.
+                    assert!(
+                        fill.data.get("fill_size").is_some(),
+                        "order_filled should carry fill_size: {}",
+                        fill.data
+                    );
+                    assert!(
+                        fill.data.to_string().contains("2000"),
+                        "fill should reference price 2000: {}",
+                        fill.data
+                    );
+
+                    break;
+                }
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+/// Deterministically reproduce the `event_by_addresses` drop bug that
+/// `perps_events2` was designed to avoid.
+///
+/// The root cause is in the *producer*: `HookedIndexer::post_indexing` spawns
+/// one `tokio::spawn` per block, so block N+1's events can be written to the
+/// event cache and published before block N's. The subscription then advances
+/// its watermark to N+1 on the unconditional `received_height.store(...)` and
+/// discards the late N notification via the `block_height < current_received`
+/// drop-guard — losing N's events silently.
+///
+/// We induce that exact ordering by hand: write block L+2 to the event cache
+/// and publish it, then write and publish L+1. The subscription receives L+2,
+/// advances past it, and drops L+1.
+///
+/// IGNORED: this asserts the *correct* behavior (L+1 is delivered), which the
+/// current code violates. Fixing the producer ordering is out of scope for this
+/// PR; un-ignore once `post_indexing` publishes in strict height order.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "reproduces a known event_by_addresses drop; the fix is out of scope for this PR"]
+async fn event_by_addresses_drops_out_of_order_block() -> anyhow::Result<()> {
+    use {
+        dango_indexer_sql::entity::events::{EventStatus, Model as EventModel},
+        dango_primitives::{Addr, FlatCommitmentStatus, Timestamp},
+        sea_orm::prelude::Uuid,
+        std::{collections::HashMap, sync::Arc, time::Duration},
+    };
+
+    let (mut suite, mut accounts, _, contracts, _, dango_httpd_context, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default()).await;
+
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair_id(), 2_000, 3).await;
+    suite.app.indexer.wait_for_finish().await?;
+
+    // Handles to inject events out of order: the subscription's event-cache
+    // reader shares this writer's state, and it subscribes to this pubsub.
+    let pubsub = dango_httpd_context.pubsub.clone();
+    let event_cache = dango_httpd_context.sql_context.event_cache.clone();
+    let latest = dango_httpd_context
+        .stream_context
+        .perps()
+        .tip()
+        .unwrap_or_default() as i64;
+
+    // A fresh address with no real events, so the only deliveries are the two
+    // we inject below.
+    let addr = Addr::mock(0xEE);
+
+    let fake_event = |height: i64| -> Arc<EventModel> {
+        Arc::new(EventModel {
+            id: Uuid::from_u128(height as u128),
+            parent_id: None,
+            transaction_id: None,
+            message_id: None,
+            created_at: Timestamp::from_seconds(0).to_naive_date_time(),
+            r#type: "drop_repro".to_string(),
+            method: None,
+            event_status: EventStatus::Ok,
+            commitment_status: FlatCommitmentStatus::Committed,
+            transaction_type: 0,
+            transaction_idx: 0,
+            message_idx: None,
+            event_idx: 0,
+            data: serde_json::json!({ "height": height }),
+            block_height: height,
+        })
+    };
+
+    let request_body = GraphQLCustomRequest::from_query_body(
+        SubscribeEventByAddresses::build_query(subscribe_event_by_addresses::Variables {
+            addresses: vec![addr.to_string()],
+            since_block_height: None,
+        }),
+        "eventByAddresses",
+    );
+
+    let local_set = tokio::task::LocalSet::new();
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let name = request_body.name;
+                let (_srv, _ws, mut framed) =
+                    call_ws_graphql_stream(dango_httpd_context, build_app_service, request_body)
+                        .await?;
+
+                // Let the subscription register on the pubsub before publishing.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+
+                let hi = latest + 2;
+                let lo = latest + 1;
+
+                // Publish L+2 (in the cache) before L+1 — the out-of-order
+                // delivery the bug hinges on.
+                event_cache
+                    .save_events(hi as u64, HashMap::from([(addr, vec![fake_event(hi)])]))
+                    .await;
+                pubsub.publish(hi as u64).await.ok();
+
+                // The subscriber processes L+2 and advances its watermark to it.
+                let resp_hi = parse_graphql_subscription_response::<
+                    Vec<subscribe_event_by_addresses::SubscribeEventByAddressesEventByAddresses>,
+                >(&mut framed, name)
+                .await?;
+                assert_eq!(resp_hi.data.len(), 1);
+                assert_eq!(resp_hi.data[0].block_height, hi);
+
+                // Now L+1 lands and is published. Correct behavior: it is
+                // delivered. Buggy behavior: the watermark is already at L+2, so
+                // the drop-guard discards it.
+                event_cache
+                    .save_events(lo as u64, HashMap::from([(addr, vec![fake_event(lo)])]))
+                    .await;
+                pubsub.publish(lo as u64).await.ok();
+
+                let resp_lo = tokio::time::timeout(
+                    Duration::from_secs(3),
+                    parse_graphql_subscription_response::<
+                        Vec<
+                            subscribe_event_by_addresses::SubscribeEventByAddressesEventByAddresses,
+                        >,
+                    >(&mut framed, name),
+                )
+                .await;
+
+                match resp_lo {
+                    Ok(Ok(resp)) => {
+                        assert_eq!(resp.data.len(), 1);
+                        assert_eq!(
+                            resp.data[0].block_height, lo,
+                            "expected block L+1 to be delivered"
+                        );
+                    },
+                    _ => panic!(
+                        "block L+1 was dropped — event_by_addresses lost an out-of-order block"
+                    ),
+                }
 
                 Ok::<(), anyhow::Error>(())
             })


### PR DESCRIPTION
Add `dango-indexer-stream`, a validator-side, in-memory indexer backing a new `perps_events2` GraphQL subscription: a low-latency, in-process feed of perps-exchange contract events for bots and algo traders.

The core is a generic `RecentStream<T>` — a bounded ring of the last N blocks plus a live broadcast tail, with a reliable subscription builder (connect-time snapshot then live tail, strict height order, no silent drops). Events are appended inline and in height order from `post_indexing`, so the feed avoids the out-of-order-publish and unconditional-watermark-advance failure modes of the existing `event_by_addresses` subscription.

The new indexer is wired into `HookedIndexer` as an additional field for now; in the future it will also host a "new blocks" subscription and may replace `HookedIndexer` once durable indexing moves to a dedicated node.

Clients filter by event_types, pair_ids, and users — each an optional set (absent = no filter, empty = match nothing). The feed is served in-process on the validator for lowest latency; deep history remains available via the durable `perpsEvents` query on the indexer node.

Includes an ignored, deterministic reproduction of the existing `event_by_addresses` out-of-order drop bug for future reference.