### PR TITLE
feat(app): prune CometBFT historical blocks via `retain_height`

### DIFF
--- a/dango/cli/src/config.rs
+++ b/dango/cli/src/config.rs
@@ -89,6 +89,7 @@ impl Default for IndexerDatabaseConfig {
 pub struct TendermintConfig {
     pub rpc_addr: String,
     pub abci_addr: String,
+
     /// Number of most-recent blocks for CometBFT to retain; older blocks are
     /// pruned. `0` retains all blocks.
     #[serde(default)]

--- a/dango/cli/src/config.rs
+++ b/dango/cli/src/config.rs
@@ -89,6 +89,10 @@ impl Default for IndexerDatabaseConfig {
 pub struct TendermintConfig {
     pub rpc_addr: String,
     pub abci_addr: String,
+    /// Number of most-recent blocks for CometBFT to retain; older blocks are
+    /// pruned. `0` retains all blocks.
+    #[serde(default)]
+    pub retain_recent_blocks: u64,
 }
 
 impl Default for TendermintConfig {
@@ -96,6 +100,7 @@ impl Default for TendermintConfig {
         Self {
             rpc_addr: "http://localhost:26657".to_string(),
             abci_addr: "http://localhost:26658".to_string(),
+            retain_recent_blocks: 0,
         }
     }
 }

--- a/dango/cli/src/start.rs
+++ b/dango/cli/src/start.rs
@@ -455,7 +455,8 @@ impl StartCmd {
                 Some(dango_upgrade::do_upgrade), // Important: set the upgrade handler.
                 env!("CARGO_PKG_VERSION"),
             )
-            .with_shutdown_trigger(halt_tx),
+            .with_shutdown_trigger(halt_tx)
+            .with_retain_recent_blocks(tendermint_cfg.retain_recent_blocks),
         );
 
         let (consensus, mempool, snapshot, info) = split::service(service, 1);

--- a/dango/core/app/src/abci.rs
+++ b/dango/core/app/src/abci.rs
@@ -196,12 +196,11 @@ where
     #[cfg_attr(feature = "tracing", tracing::instrument("abci::commit", skip_all))]
     async fn tower_commit(&self) -> AppResult<response::Commit> {
         match self.do_commit().await {
-            Ok(()) => Ok(response::Commit {
+            Ok(version) => Ok(response::Commit {
                 // This field is ignored since CometBFT 0.38.
-                // TODO: Can we omit this?????
                 data: Default::default(),
-                // TODO: what this means??
-                retain_height: Height::default(),
+                // CometBFT prunes its block and state stores below this height.
+                retain_height: retain_height(version, self.retain_recent_blocks),
             }),
             Err(err) => panic!("failed to commit: {err}"),
         }
@@ -374,6 +373,26 @@ where
     }
 }
 
+/// Compute the `retain_height` to return in the ABCI `Commit` response, given
+/// the just-committed block height (`version`) and the configured number of
+/// recent blocks to keep.
+///
+/// CometBFT prunes blocks below the returned height. A height of `0` means
+/// "retain all" (no pruning); we use it both when pruning is disabled
+/// (`retain_recent_blocks == 0`) and while the chain is younger than the
+/// retention window (`version <= retain_recent_blocks`).
+fn retain_height(version: u64, retain_recent_blocks: u64) -> Height {
+    let height = if retain_recent_blocks == 0 {
+        0
+    } else {
+        version.saturating_sub(retain_recent_blocks)
+    };
+
+    // Fallible only if `height > i64::MAX`, which is unreachable for real block
+    // heights (CometBFT itself rejects heights above `i64::MAX`).
+    Height::try_from(height).expect("retain height exceeds i64::MAX")
+}
+
 fn from_tm_block(height: u64, time: Time, hash: Option<Hash>) -> BlockInfo {
     BlockInfo {
         height,
@@ -440,4 +459,22 @@ fn into_tm_code_error(code: u32) -> Code {
     Code::Err(NonZeroU32::new(code).unwrap_or_else(|| {
         panic!("expected non-zero error code, got {code}");
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retain_height_works() {
+        // Once past the retention window, keep exactly the most recent N blocks.
+        assert_eq!(retain_height(1500, 1000).value(), 500);
+        // Right at the boundary: nothing to prune yet.
+        assert_eq!(retain_height(1000, 1000).value(), 0);
+        // Younger than the window: retain everything.
+        assert_eq!(retain_height(500, 1000).value(), 0);
+        // Pruning disabled (`retain_recent_blocks == 0`): retain everything,
+        // regardless of how tall the chain is.
+        assert_eq!(retain_height(1500, 0).value(), 0);
+    }
 }

--- a/dango/core/app/src/abci.rs
+++ b/dango/core/app/src/abci.rs
@@ -461,6 +461,8 @@ fn into_tm_code_error(code: u32) -> Code {
     }))
 }
 
+// ----------------------------------- tests -----------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -469,10 +471,13 @@ mod tests {
     fn retain_height_works() {
         // Once past the retention window, keep exactly the most recent N blocks.
         assert_eq!(retain_height(1500, 1000).value(), 500);
+
         // Right at the boundary: nothing to prune yet.
         assert_eq!(retain_height(1000, 1000).value(), 0);
+
         // Younger than the window: retain everything.
         assert_eq!(retain_height(500, 1000).value(), 0);
+
         // Pruning disabled (`retain_recent_blocks == 0`): retain everything,
         // regardless of how tall the chain is.
         assert_eq!(retain_height(1500, 0).value(), 0);

--- a/dango/core/app/src/app.rs
+++ b/dango/core/app/src/app.rs
@@ -60,6 +60,7 @@ pub struct App<DB, VM, PP = NaiveProposalPreparer, ID = NullIndexer> {
     vm: VM,
     pp: PP,
     pub indexer: ID,
+
     /// The gas limit when serving ABCI `Query` calls.
     ///
     /// Prevents the situation where an attacker deploys a contract that
@@ -73,10 +74,13 @@ pub struct App<DB, VM, PP = NaiveProposalPreparer, ID = NullIndexer> {
     /// Related config in CosmWasm:
     /// <https://github.com/CosmWasm/wasmd/blob/v0.51.0/x/wasm/types/types.go#L322-L323>
     query_gas_limit: u64,
+
     /// The action to take to perform a chain upgrade.
     upgrade_handler: Option<UpgradeHandler<VM>>,
+
     /// Current cargo version of the app. Used in chain upgrades.
     cargo_version: String,
+
     /// If set, the app can request a graceful shutdown of the host process
     /// by sending a [`HaltReason`] through this channel (e.g. when
     /// `finalize_block` hits an upgrade height with the wrong binary).
@@ -84,6 +88,7 @@ pub struct App<DB, VM, PP = NaiveProposalPreparer, ID = NullIndexer> {
     /// `None` in tests and in the read-only `App` instance used by the HTTP
     /// server, which never finalize blocks and therefore never halt.
     shutdown_trigger: Option<ShutdownTrigger>,
+
     /// Number of most-recent blocks CometBFT should retain; older blocks are
     /// pruned. `0` disables pruning (retain all blocks).
     ///

--- a/dango/core/app/src/app.rs
+++ b/dango/core/app/src/app.rs
@@ -84,6 +84,14 @@ pub struct App<DB, VM, PP = NaiveProposalPreparer, ID = NullIndexer> {
     /// `None` in tests and in the read-only `App` instance used by the HTTP
     /// server, which never finalize blocks and therefore never halt.
     shutdown_trigger: Option<ShutdownTrigger>,
+    /// Number of most-recent blocks CometBFT should retain; older blocks are
+    /// pruned. `0` disables pruning (retain all blocks).
+    ///
+    /// Surfaced to CometBFT as the `retain_height` in the ABCI `Commit`
+    /// response (`retain_height = latest_height - retain_recent_blocks`).
+    /// Dango doesn't need CometBFT to keep historical blocks, as the embedded
+    /// indexer persists every block to disk independently.
+    pub(crate) retain_recent_blocks: u64,
 }
 
 impl<DB, VM, PP, ID> App<DB, VM, PP, ID> {
@@ -113,6 +121,7 @@ impl<DB, VM, PP, ID> App<DB, VM, PP, ID> {
             upgrade_handler,
             cargo_version: cargo_version.into(),
             shutdown_trigger: None,
+            retain_recent_blocks: 0,
         }
     }
 
@@ -124,6 +133,17 @@ impl<DB, VM, PP, ID> App<DB, VM, PP, ID> {
     #[must_use]
     pub fn with_shutdown_trigger(mut self, trigger: ShutdownTrigger) -> Self {
         self.shutdown_trigger = Some(trigger);
+        self
+    }
+
+    /// Set the number of most-recent blocks for CometBFT to retain; older
+    /// blocks are pruned. `0` (the default) disables pruning.
+    ///
+    /// Intended to be called by the binary's `start` command right after
+    /// `App::new`; tests and the HTTP-only `App` instance leave this unset.
+    #[must_use]
+    pub fn with_retain_recent_blocks(mut self, retain_recent_blocks: u64) -> Self {
+        self.retain_recent_blocks = retain_recent_blocks;
         self
     }
 }
@@ -162,6 +182,7 @@ where
             upgrade_handler: self.upgrade_handler,
             cargo_version: self.cargo_version.clone(),
             shutdown_trigger: self.shutdown_trigger.clone(),
+            retain_recent_blocks: self.retain_recent_blocks,
         }
     }
 }
@@ -686,7 +707,7 @@ where
         Ok(block_outcome)
     }
 
-    pub async fn do_commit(&self) -> AppResult<()> {
+    pub async fn do_commit(&self) -> AppResult<u64> {
         #[cfg(feature = "tracing")]
         {
             tracing::info!("Received Commit request");
@@ -722,7 +743,7 @@ where
                 .record(commit_duration.elapsed().as_secs_f64());
         }
 
-        Ok(())
+        Ok(version)
     }
 
     // For `CheckTx`, we only do the first two steps of the transaction

--- a/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
+++ b/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
@@ -494,7 +494,7 @@ peer_query_maj23_sleep_duration      = "2s"
 # considerable amount of disk space. Set to false to ensure ABCI responses are
 # persisted. ABCI responses are required for /block_results RPC queries, and to
 # reindex events in the command-line tool.
-discard_abci_responses = false
+discard_abci_responses = true
 
 # The representation of keys in the database.
 # The current representation of keys in Comet's stores is considered to be v1

--- a/deploy/roles/full-app/templates/config/dango/app.toml
+++ b/deploy/roles/full-app/templates/config/dango/app.toml
@@ -148,6 +148,10 @@ rpc_addr = "http://cometbft:26657"
 # Tendermint ABCI listening address.
 abci_addr = "0.0.0.0:26658"
 
+# Number of most-recent blocks for CometBFT to retain; older blocks are pruned.
+# 0 retains all blocks.
+retain_recent_blocks = 1000
+
 ################################################################################
 ###                        Transaction Configuration                         ###
 ################################################################################

--- a/deploy/roles/full-app/templates/config/dango/app.toml
+++ b/deploy/roles/full-app/templates/config/dango/app.toml
@@ -148,9 +148,18 @@ rpc_addr = "http://cometbft:26657"
 # Tendermint ABCI listening address.
 abci_addr = "0.0.0.0:26658"
 
-# Number of most-recent blocks for CometBFT to retain; older blocks are pruned.
-# 0 retains all blocks.
-retain_recent_blocks = 1000
+# Number of most-recent blocks CometBFT keeps the full data (block parts) for.
+# Below this height, block parts are pruned at each commit; lightweight block
+# headers are still retained within the evidence window (genesis params:
+# max_age_num_blocks = 100000, max_age_duration = 48h) so equivocation evidence
+# stays verifiable. This therefore governs the peer block-sync catch-up window,
+# not the evidence retention. 0 retains all blocks.
+#
+# Caveat: CometBFT only prunes logically here; on v0.38 (goleveldb, no forced
+# `compact`) the freed disk space is reclaimed lazily by background compaction,
+# so usage drops gradually rather than immediately. Full history is persisted
+# independently by the indexer. 100000 ~= 10h of blocks at our ~350ms block time.
+retain_recent_blocks = 100000
 
 ################################################################################
 ###                        Transaction Configuration                         ###

--- a/localdango/configs/cometbft/config/config.toml
+++ b/localdango/configs/cometbft/config/config.toml
@@ -492,7 +492,7 @@ peer_query_maj23_sleep_duration      = "2s"
 # considerable amount of disk space. Set to false to ensure ABCI responses are
 # persisted. ABCI responses are required for /block_results RPC queries, and to
 # reindex events in the command-line tool.
-discard_abci_responses = false
+discard_abci_responses = true
 
 # The representation of keys in the database.
 # The current representation of keys in Comet's stores is considered to be v1

--- a/localdango/configs/dango/config/app.toml
+++ b/localdango/configs/dango/config/app.toml
@@ -148,6 +148,10 @@ rpc_addr = "http://cometbft:26657"
 # Tendermint ABCI listening address.
 abci_addr = "0.0.0.0:26658"
 
+# Number of most-recent blocks for CometBFT to retain; older blocks are pruned.
+# 0 retains all blocks.
+retain_recent_blocks = 1000
+
 ################################################################################
 ###                        Transaction Configuration                         ###
 ################################################################################

--- a/localdango/configs/dango/config/app.toml
+++ b/localdango/configs/dango/config/app.toml
@@ -148,9 +148,18 @@ rpc_addr = "http://cometbft:26657"
 # Tendermint ABCI listening address.
 abci_addr = "0.0.0.0:26658"
 
-# Number of most-recent blocks for CometBFT to retain; older blocks are pruned.
-# 0 retains all blocks.
-retain_recent_blocks = 1000
+# Number of most-recent blocks CometBFT keeps the full data (block parts) for.
+# Below this height, block parts are pruned at each commit; lightweight block
+# headers are still retained within the evidence window (genesis params:
+# max_age_num_blocks = 100000, max_age_duration = 48h) so equivocation evidence
+# stays verifiable. This therefore governs the peer block-sync catch-up window,
+# not the evidence retention. 0 retains all blocks.
+#
+# Caveat: CometBFT only prunes logically here; on v0.38 (goleveldb, no forced
+# `compact`) the freed disk space is reclaimed lazily by background compaction,
+# so usage drops gradually rather than immediately. Full history is persisted
+# independently by the indexer. 100000 ~= 10h of blocks at our ~350ms block time.
+retain_recent_blocks = 100000
 
 ################################################################################
 ###                        Transaction Configuration                         ###


### PR DESCRIPTION
CometBFT currently retains every block forever, because the app returns `retain_height` = 0 in its ABCI Commit response. Dango doesn't need this: the embedded indexer persists every block to disk independently (and backs it up), so CometBFT only needs a short recent window.

Return `retain_height` = `latest_height - retain_recent_blocks` from the Commit response. `retain_recent_blocks` is a new node-operator config field under the `[tendermint]` section of `app.toml`; 0 (the default) retains all blocks, and the shipped configs set it to 1000. On CometBFT v0.38 a non-zero `retain_height` prunes both the block store and the state store below that height.

Also set `discard_abci_responses` = true in the CometBFT config to stop persisting ABCI responses, which no Dango component reads (historical block/result reads are served from the indexer, not CometBFT RPC).

- `App::do_commit` now returns the committed height.
- App gains a `retain_recent_blocks` field and a `with_retain_recent_blocks` builder, wired from `TendermintConfig` in the start command.