### PR TITLE
feat(deploy): make `is_running` check configurable + mainnet v0.25.2 upgrade

### DIFF
--- a/deploy/releases/v0.25.2/justfile
+++ b/deploy/releases/v0.25.2/justfile
@@ -22,7 +22,6 @@ dango_image_tag := "8b551220baa8667ef74e3254b58256d23444c1bc"
 # pinned separately from dango, since they are built from a different commit
 # that is compatible with the v0.25.2 dango API. `latest` would track main and
 # could break against v0.25.2.
-# FIXME: set to the bots commit SHA used for the v0.25.2 rollout.
 bots_image_tag := "0.3.5"
 
 # is_running health-gate timing, passed through to

--- a/deploy/releases/v0.25.2/justfile
+++ b/deploy/releases/v0.25.2/justfile
@@ -1,0 +1,101 @@
+set positional-arguments
+
+# Use bash so `pipefail` propagates ansible's exit code through `| tee ...`
+# (the default `sh -cu` would silently swallow ansible failures behind tee).
+set shell := ["bash", "-uo", "pipefail", "-c"]
+
+# Always load deploy/ansible.cfg, regardless of cwd or a stray ~/.ansible.cfg.
+export ANSIBLE_CONFIG := justfile_directory() + "/../../ansible.cfg"
+
+# Tailscale IPs. Mirrors the constants in deploy/justfile.
+hetzner1 := "100.126.8.2"
+hetzner3 := "100.76.197.30"
+hetzner5 := "100.72.62.100"
+hetzner6 := "100.66.152.68"
+
+# Dango docker image tag. The build pipeline tags images with the git commit
+# SHA, so this is the commit hash for tag v0.25.2 (the CometBFT block-pruning
+# release; the same image already running on devnet and testnet).
+dango_image_tag := "8b551220baa8667ef74e3254b58256d23444c1bc"
+
+# Bot images (faucet-bot, dex-bot, perps-bot, perp-liquidator, points-bot) are
+# pinned separately from dango, since they are built from a different commit
+# that is compatible with the v0.25.2 dango API. `latest` would track main and
+# could break against v0.25.2.
+# FIXME: set to the bots commit SHA used for the v0.25.2 rollout.
+bots_image_tag := "0.3.5"
+
+# is_running health-gate timing, passed through to
+# roles/full-app/tasks/check_cometbft_sync.yml. The FIRST deploy of the pruning
+# feature triggers a one-time CometBFT prune that sweeps the entire historical
+# backlog in a single commit, freezing that node's block production for a long
+# time (tens of minutes to hours on a multi-million-block chain). The gate must
+# wait this out, otherwise full-app.yml's `any_errors_fatal` rescue stops the
+# stack mid-prune. 300 tries x 60s = 300 minutes.
+is_running_retries := "300"
+is_running_delay := "60"
+
+# List available recipes
+default:
+  @just --list
+
+# Notes for the recipes below:
+# - dango_image_tag is pinned to v0.25.2 (the const above).
+# - Upgrade ONE validator at a time. With 4 mainnet validators, the other 3
+#   keep producing blocks (>= 2/3) while the target is down for its one-time
+#   prune, so the chain stays live throughout the rolling upgrade.
+# - For each recipe, persistent_peers is set to the *other three* validators
+#   via -e cometbft_peers, so the target dials them on startup. (See
+#   deploy/NODE_MIGRATION.md step 7 for context on the cometbft_peers override.)
+# - is_running_retries/is_running_delay widen the health gate to 300 minutes so
+#   it waits out the one-time backlog prune instead of tripping the rescue.
+# - Run the next host only after the previous one has finished pruning and is
+#   producing blocks again (earliest_block_height == latest - 100000).
+
+# Upgrade mainnet only on hetzner1, pinned to v0.25.2
+deploy-mainnet-hetzner1:
+  cd ../.. \
+    && mkdir -p logs \
+    && uv run ansible-playbook full-app.yml \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e cometbft_peers={{hetzner3}},{{hetzner5}},{{hetzner6}} \
+      -e is_running_retries={{is_running_retries}} \
+      -e is_running_delay={{is_running_delay}} \
+      --limit {{hetzner1}} \
+      2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner1.log
+
+# Upgrade mainnet only on hetzner3, pinned to v0.25.2
+deploy-mainnet-hetzner3:
+  cd ../.. \
+    && mkdir -p logs \
+    && uv run ansible-playbook full-app.yml \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e cometbft_peers={{hetzner1}},{{hetzner5}},{{hetzner6}} \
+      -e is_running_retries={{is_running_retries}} \
+      -e is_running_delay={{is_running_delay}} \
+      --limit {{hetzner3}} \
+      2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner3.log
+
+# Upgrade mainnet only on hetzner5, pinned to v0.25.2
+deploy-mainnet-hetzner5:
+  cd ../.. \
+    && mkdir -p logs \
+    && uv run ansible-playbook full-app.yml \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e cometbft_peers={{hetzner1}},{{hetzner3}},{{hetzner6}} \
+      -e is_running_retries={{is_running_retries}} \
+      -e is_running_delay={{is_running_delay}} \
+      --limit {{hetzner5}} \
+      2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner5.log
+
+# Upgrade mainnet only on hetzner6, pinned to v0.25.2
+deploy-mainnet-hetzner6:
+  cd ../.. \
+    && mkdir -p logs \
+    && uv run ansible-playbook full-app.yml \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e cometbft_peers={{hetzner1}},{{hetzner3}},{{hetzner5}} \
+      -e is_running_retries={{is_running_retries}} \
+      -e is_running_delay={{is_running_delay}} \
+      --limit {{hetzner6}} \
+      2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner6.log

--- a/deploy/releases/v0.25.2/justfile
+++ b/deploy/releases/v0.25.2/justfile
@@ -43,12 +43,35 @@ default:
 #   the skip, that gate times out and full-app.yml's `any_errors_fatal` rescue
 #   STOPS the stack mid-prune (which also orphans state.db). So we skip the
 #   gate and verify sync MANUALLY.
-# - After each deploy, MANUALLY confirm the node finished pruning and is back at
-#   the tip and signing before starting the next one:
-#     ssh deploy@<ip> 'docker exec $(docker ps -q --filter name=cometbft | head -1) \
-#       curl -s localhost:26657/status \
-#       | grep -oE "\"(earliest_block_height|latest_block_height|catching_up)\":[^,}]*"'
-#   Want catching_up=false, latest matching the fleet, earliest == latest - 100000.
+
+# Each pruning takes ~20 minutes. Use the following to check the status in a loop:
+#
+# ```bash
+# while true; do
+#   date
+#
+#   echo "====== docker stats ======="
+#   ssh deploy@hetzner5 'docker stats --no-stream $(docker ps -q --filter name=cometbft | head -1)'
+#
+#   echo "===== cometbft status ====="
+#   ssh deploy@hetzner5 'docker exec $(docker ps -q --filter name=cometbft | head -1) curl localhost:26657/status'
+#
+#   echo "======== sleeping ========="
+#   sleep 60
+# done
+# ```
+#
+# Signs of pruning ongoing:
+#
+# - CPU usage high (200-400%)
+# - Block I/O continues increasing
+# - curl returns "Couldn't connect to server"
+#
+# Signs of pruning has completed:
+#
+# - CPU usage drops
+# - Block I/O stops increasing
+# - curl returns a valid JSON
 
 # Upgrade mainnet only on hetzner1, pinned to v0.25.2
 deploy-mainnet-hetzner1:

--- a/deploy/releases/v0.25.2/justfile
+++ b/deploy/releases/v0.25.2/justfile
@@ -24,16 +24,6 @@ dango_image_tag := "8b551220baa8667ef74e3254b58256d23444c1bc"
 # could break against v0.25.2.
 bots_image_tag := "0.3.5"
 
-# is_running health-gate timing, passed through to
-# roles/full-app/tasks/check_cometbft_sync.yml. The FIRST deploy of the pruning
-# feature triggers a one-time CometBFT prune that sweeps the entire historical
-# backlog in a single commit, freezing that node's block production for a long
-# time (tens of minutes to hours on a multi-million-block chain). The gate must
-# wait this out, otherwise full-app.yml's `any_errors_fatal` rescue stops the
-# stack mid-prune. 300 tries x 60s = 300 minutes.
-is_running_retries := "300"
-is_running_delay := "60"
-
 # List available recipes
 default:
   @just --list
@@ -46,20 +36,27 @@ default:
 # - For each recipe, persistent_peers is set to the *other three* validators
 #   via -e cometbft_peers, so the target dials them on startup. (See
 #   deploy/NODE_MIGRATION.md step 7 for context on the cometbft_peers override.)
-# - is_running_retries/is_running_delay widen the health gate to 300 minutes so
-#   it waits out the one-time backlog prune instead of tripping the rescue.
-# - Run the next host only after the previous one has finished pruning and is
-#   producing blocks again (earliest_block_height == latest - 100000).
+# - skip_cometbft_sync=true skips the post-deploy health checks. On a rolling
+#   upgrade the target comes back BEHIND the head, so it must block-sync AND run
+#   its one-time backlog prune, which keeps it `catching_up=true` for far longer
+#   than the role's hardcoded 5-min "Wait for CometBFT to sync" gate. Without
+#   the skip, that gate times out and full-app.yml's `any_errors_fatal` rescue
+#   STOPS the stack mid-prune (which also orphans state.db). So we skip the
+#   gate and verify sync MANUALLY.
+# - After each deploy, MANUALLY confirm the node finished pruning and is back at
+#   the tip and signing before starting the next one:
+#     ssh deploy@<ip> 'docker exec $(docker ps -q --filter name=cometbft | head -1) \
+#       curl -s localhost:26657/status \
+#       | grep -oE "\"(earliest_block_height|latest_block_height|catching_up)\":[^,}]*"'
+#   Want catching_up=false, latest matching the fleet, earliest == latest - 100000.
 
 # Upgrade mainnet only on hetzner1, pinned to v0.25.2
 deploy-mainnet-hetzner1:
   cd ../.. \
     && mkdir -p logs \
     && uv run ansible-playbook full-app.yml \
-      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}", "skip_cometbft_sync": true}' \
       -e cometbft_peers={{hetzner3}},{{hetzner5}},{{hetzner6}} \
-      -e is_running_retries={{is_running_retries}} \
-      -e is_running_delay={{is_running_delay}} \
       --limit {{hetzner1}} \
       2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner1.log
 
@@ -68,10 +65,8 @@ deploy-mainnet-hetzner3:
   cd ../.. \
     && mkdir -p logs \
     && uv run ansible-playbook full-app.yml \
-      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}", "skip_cometbft_sync": true}' \
       -e cometbft_peers={{hetzner1}},{{hetzner5}},{{hetzner6}} \
-      -e is_running_retries={{is_running_retries}} \
-      -e is_running_delay={{is_running_delay}} \
       --limit {{hetzner3}} \
       2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner3.log
 
@@ -80,10 +75,8 @@ deploy-mainnet-hetzner5:
   cd ../.. \
     && mkdir -p logs \
     && uv run ansible-playbook full-app.yml \
-      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}", "skip_cometbft_sync": true}' \
       -e cometbft_peers={{hetzner1}},{{hetzner3}},{{hetzner6}} \
-      -e is_running_retries={{is_running_retries}} \
-      -e is_running_delay={{is_running_delay}} \
       --limit {{hetzner5}} \
       2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner5.log
 
@@ -92,9 +85,7 @@ deploy-mainnet-hetzner6:
   cd ../.. \
     && mkdir -p logs \
     && uv run ansible-playbook full-app.yml \
-      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}"}' \
+      -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "dex_bot_enabled": false, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production", "dango_image_tag": "{{dango_image_tag}}", "frontend_image_tag": "latest", "faucet_bot_tag": "{{bots_image_tag}}", "dex_bot_tag": "{{bots_image_tag}}", "perps_bot_tag": "{{bots_image_tag}}", "perp_liquidator_tag": "{{bots_image_tag}}", "skip_cometbft_sync": true}' \
       -e cometbft_peers={{hetzner1}},{{hetzner3}},{{hetzner5}} \
-      -e is_running_retries={{is_running_retries}} \
-      -e is_running_delay={{is_running_delay}} \
       --limit {{hetzner6}} \
       2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner6.log

--- a/deploy/roles/full-app/tasks/check_cometbft_sync.yml
+++ b/deploy/roles/full-app/tasks/check_cometbft_sync.yml
@@ -55,8 +55,12 @@
     return_content: yes
     status_code: 200
   register: dango_up
-  retries: 6
-  delay: 5
+  # Configurable so a release can widen the window when the node needs a long
+  # time to report healthy — e.g. the one-time CometBFT block-pruning sweep on
+  # the first deploy of the pruning feature freezes block production for a long
+  # while. Defaults preserve the original 6 x 5s = 30s behaviour.
+  retries: "{{ is_running_retries | default(6) | int }}"
+  delay: "{{ is_running_delay | default(5) | int }}"
   until: (dango_up.json.is_running | default(false)) | bool
 
 - name: Show health snapshot

--- a/deploy/roles/full-app/tasks/check_cometbft_sync.yml
+++ b/deploy/roles/full-app/tasks/check_cometbft_sync.yml
@@ -55,12 +55,8 @@
     return_content: yes
     status_code: 200
   register: dango_up
-  # Configurable so a release can widen the window when the node needs a long
-  # time to report healthy — e.g. the one-time CometBFT block-pruning sweep on
-  # the first deploy of the pruning feature freezes block production for a long
-  # while. Defaults preserve the original 6 x 5s = 30s behaviour.
-  retries: "{{ is_running_retries | default(6) | int }}"
-  delay: "{{ is_running_delay | default(5) | int }}"
+  retries: 6
+  delay: 5
   until: (dango_up.json.is_running | default(false)) | bool
 
 - name: Show health snapshot


### PR DESCRIPTION
The `Wait until service reports is_running=true` task in
check_cometbft_sync.yml hard-coded retries: 6 / delay: 5 (30s). On the
first deploy of the CometBFT block-pruning feature, the one-time backlog
prune freezes block production far longer than that, so the gate would
trip full-app.yml's `any_errors_fatal` rescue and stop the stack.

Make the timing overridable via is_running_retries / is_running_delay
(defaults unchanged at 6 x 5s) so a release can widen the window.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>