### PR TITLE
fix(ui): restrict withdraw destinations to wallets

### DIFF
--- a/ui/portal/web/src/components/bridge/Bridge.tsx
+++ b/ui/portal/web/src/components/bridge/Bridge.tsx
@@ -382,7 +382,6 @@ const BridgeWithdraw: React.FC = () => {
                 fullWidth
                 onClick={() =>
                   showModal(Modals.DestinationWallet, {
-                    network,
                     onAddressSet: handleAddressSet,
                   })
                 }

--- a/ui/portal/web/src/components/modals/DestinationWallet.tsx
+++ b/ui/portal/web/src/components/modals/DestinationWallet.tsx
@@ -1,47 +1,30 @@
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { forwardRef, useImperativeHandle } from "react";
 
 import { m } from "@left-curve/foundation/paraglide/messages.js";
-import { isValidAddress } from "@left-curve/sdk";
-import { ethAddressMask } from "@left-curve/applets-kit";
 import { useConnectors } from "@left-curve/store";
 
-import {
-  Button,
-  IconButton,
-  IconClose,
-  IconWarningTriangle,
-  Input,
-  WarningContainer,
-  useApp,
-} from "@left-curve/applets-kit";
+import { Button, IconButton, IconClose, useApp } from "@left-curve/applets-kit";
 
 import type { ModalRef } from "./RootModal";
 import type { EIP1193Provider } from "@left-curve/store/types";
 import { Image } from "~/components/foundation/Image";
 
 type DestinationWalletProps = {
-  network: string;
   onAddressSet: (address: string, walletName?: string, walletIcon?: string) => void;
 };
-
-type Step = "list" | "warning" | "input";
 
 const HIDDEN_CONNECTOR_TYPES = ["passkey", "session", "privy", "debug"];
 
 export const DestinationWallet = forwardRef<ModalRef, DestinationWalletProps>(
-  ({ network, onAddressSet }, ref) => {
+  ({ onAddressSet }, ref) => {
     const { hideModal } = useApp();
     const connectors = useConnectors();
-    const [step, setStep] = useState<Step>("list");
-    const [address, setAddress] = useState("");
 
     useImperativeHandle(ref, () => ({
       triggerOnClose: () => {},
     }));
 
     const filteredConnectors = connectors.filter((c) => !HIDDEN_CONNECTOR_TYPES.includes(c.type));
-
-    const networkName = m["bridge.network"]({ network });
 
     const handleConnectorClick = async (connector: (typeof filteredConnectors)[number]) => {
       try {
@@ -59,86 +42,10 @@ export const DestinationWallet = forwardRef<ModalRef, DestinationWalletProps>(
       }
     };
 
-    const handleConfirm = () => {
-      if (isValidAddress(address)) {
-        onAddressSet(address);
-        hideModal();
-      }
-    };
-
-    if (step === "list") {
-      return (
-        <div className="flex flex-col bg-surface-primary-rice md:border border-outline-secondary-gray pt-4 md:pt-6 rounded-xl relative p-4 md:p-6 gap-5 w-full md:max-w-[25rem]">
-          <p className="text-ink-primary-900 diatype-lg-medium w-full text-center">
-            {m["bridge.destinationWallet"]()}
-          </p>
-          <IconButton
-            className="hidden md:block absolute right-4 top-4"
-            variant="link"
-            onClick={hideModal}
-          >
-            <IconClose className="w-5 h-5 text-ink-tertiary-500" />
-          </IconButton>
-          <div className="flex flex-col gap-3">
-            {filteredConnectors.map((connector) => (
-              <Button
-                key={connector.uid}
-                variant="secondary"
-                fullWidth
-                onClick={() => handleConnectorClick(connector)}
-                className="flex items-center gap-3 justify-center"
-              >
-                {connector.icon && (
-                  <Image src={connector.icon} alt={connector.name} className="w-5 h-5" />
-                )}
-                <span>{connector.name}</span>
-              </Button>
-            ))}
-            <Button
-              variant="secondary"
-              fullWidth
-              onClick={() => setStep("warning")}
-            >
-              {m["bridge.enterAddressManually"]()}
-            </Button>
-          </div>
-        </div>
-      );
-    }
-
-    if (step === "warning") {
-      return (
-        <div className="flex flex-col bg-surface-primary-rice md:border border-outline-secondary-gray pt-4 md:pt-6 rounded-xl relative p-4 md:p-6 gap-5 w-full md:max-w-[25rem]">
-          <div className="w-10 h-10 rounded-full bg-surface-secondary-red flex items-center justify-center">
-            <IconWarningTriangle className="w-5 h-5 text-utility-error-500" />
-          </div>
-          <IconButton
-            className="hidden md:block absolute right-4 top-4"
-            variant="link"
-            onClick={hideModal}
-          >
-            <IconClose className="w-5 h-5 text-ink-tertiary-500" />
-          </IconButton>
-          <div className="flex flex-col gap-2">
-            <p className="diatype-lg-bold text-ink-primary-900">
-              {m["bridge.enterNetworkAddress"]({ network: networkName })}
-            </p>
-            <p className="text-ink-tertiary-500 diatype-m-regular">
-              <strong>{m["bridge.riskOfFundLoss"]()}</strong>{" "}
-              {m["bridge.riskOfFundLossDescription"]()}
-            </p>
-          </div>
-          <Button fullWidth onClick={() => setStep("input")}>
-            {m["bridge.iUnderstandTheRisk"]()}
-          </Button>
-        </div>
-      );
-    }
-
     return (
       <div className="flex flex-col bg-surface-primary-rice md:border border-outline-secondary-gray pt-4 md:pt-6 rounded-xl relative p-4 md:p-6 gap-5 w-full md:max-w-[25rem]">
         <p className="text-ink-primary-900 diatype-lg-medium w-full text-center">
-          {m["bridge.enterNetworkAddress"]({ network: networkName })}
+          {m["bridge.destinationWallet"]()}
         </p>
         <IconButton
           className="hidden md:block absolute right-4 top-4"
@@ -147,20 +54,22 @@ export const DestinationWallet = forwardRef<ModalRef, DestinationWalletProps>(
         >
           <IconClose className="w-5 h-5 text-ink-tertiary-500" />
         </IconButton>
-        <WarningContainer color="error" description={m["bridge.exchangeWarning"]()} />
-        <Input
-          label={m["bridge.withdrawAddress"]()}
-          placeholder={m["bridge.placeholderWithdrawAddress"]({ network: networkName })}
-          value={address}
-          onChange={(e) => setAddress(ethAddressMask(e.target.value, address))}
-        />
-        <Button
-          fullWidth
-          onClick={handleConfirm}
-          isDisabled={!isValidAddress(address)}
-        >
-          {m["bridge.confirm"]()}
-        </Button>
+        <div className="flex flex-col gap-3">
+          {filteredConnectors.map((connector) => (
+            <Button
+              key={connector.uid}
+              variant="secondary"
+              fullWidth
+              onClick={() => handleConnectorClick(connector)}
+              className="flex items-center gap-3 justify-center"
+            >
+              {connector.icon && (
+                <Image src={connector.icon} alt={connector.name} className="w-5 h-5" />
+              )}
+              <span>{connector.name}</span>
+            </Button>
+          ))}
+        </div>
       </div>
     );
   },

--- a/ui/portal/web/tests/bridge-ui.test.tsx
+++ b/ui/portal/web/tests/bridge-ui.test.tsx
@@ -590,7 +590,7 @@ describe("bridge UI", () => {
     expect(bridgeUiMocks.showModal).toHaveBeenCalledWith(
       "DestinationWallet",
       expect.objectContaining({
-        network: "11155111",
+        onAddressSet: expect.any(Function),
       }),
     );
 
@@ -638,7 +638,7 @@ describe("bridge UI", () => {
     const [, destinationProps] = bridgeUiMocks.showModal.mock.calls[0];
 
     await act(async () => {
-      destinationProps.onAddressSet("0x4444444444444444444444444444444444444444");
+      destinationProps.onAddressSet("0x4444444444444444444444444444444444444444", "Browser Wallet");
     });
 
     fireEvent.change(screen.getByRole("textbox", { name: m["bridge.youWithdraw"]() }), {
@@ -661,7 +661,7 @@ describe("bridge UI", () => {
     const [, destinationProps] = bridgeUiMocks.showModal.mock.calls[0];
 
     await act(async () => {
-      destinationProps.onAddressSet("0x4444444444444444444444444444444444444444");
+      destinationProps.onAddressSet("0x4444444444444444444444444444444444444444", "Browser Wallet");
     });
 
     fireEvent.change(screen.getByRole("textbox", { name: m["bridge.youWithdraw"]() }), {
@@ -693,7 +693,7 @@ describe("bridge UI", () => {
     const [, destinationProps] = bridgeUiMocks.showModal.mock.calls[0];
 
     await act(async () => {
-      destinationProps.onAddressSet("0x5555555555555555555555555555555555555555");
+      destinationProps.onAddressSet("0x5555555555555555555555555555555555555555", "Browser Wallet");
     });
 
     expect(screen.getByText("0x5555555555555555555555555555555555555555")).toBeInTheDocument();

--- a/ui/portal/web/tests/destination-wallet.test.tsx
+++ b/ui/portal/web/tests/destination-wallet.test.tsx
@@ -79,10 +79,13 @@ describe("destination wallet modal", () => {
     const onAddressSet = vi.fn();
     const wallet = destinationWalletMocks.connectors[0];
 
-    render(<DestinationWallet network="ethereum" onAddressSet={onAddressSet} />);
+    render(<DestinationWallet onAddressSet={onAddressSet} />);
 
     expect(screen.getByText(m["bridge.destinationWallet"]())).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Browser Wallet/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: m["bridge.enterAddressManually"]() }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Passkey" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Session" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Privy" })).not.toBeInTheDocument();
@@ -114,7 +117,7 @@ describe("destination wallet modal", () => {
     ];
     const onAddressSet = vi.fn();
 
-    render(<DestinationWallet network="ethereum" onAddressSet={onAddressSet} />);
+    render(<DestinationWallet onAddressSet={onAddressSet} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Rejecting Wallet" }));
 
@@ -138,7 +141,7 @@ describe("destination wallet modal", () => {
     ];
     const onAddressSet = vi.fn();
 
-    render(<DestinationWallet network="ethereum" onAddressSet={onAddressSet} />);
+    render(<DestinationWallet onAddressSet={onAddressSet} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Unavailable Wallet" }));
 
@@ -160,7 +163,7 @@ describe("destination wallet modal", () => {
     ];
     const onAddressSet = vi.fn();
 
-    render(<DestinationWallet network="ethereum" onAddressSet={onAddressSet} />);
+    render(<DestinationWallet onAddressSet={onAddressSet} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Empty Wallet" }));
 
@@ -173,59 +176,10 @@ describe("destination wallet modal", () => {
     expect(destinationWalletMocks.hideModal).not.toHaveBeenCalled();
   });
 
-  it("requires risk acknowledgement and a valid manual 0x address", () => {
+  it("closes without setting a recipient", () => {
     const onAddressSet = vi.fn();
 
-    render(<DestinationWallet network="ethereum" onAddressSet={onAddressSet} />);
-
-    fireEvent.click(screen.getByRole("button", { name: m["bridge.enterAddressManually"]() }));
-
-    expect(screen.getByText(m["bridge.riskOfFundLoss"]())).toBeInTheDocument();
-    expect(screen.getByText(m["bridge.riskOfFundLossDescription"]())).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: m["bridge.iUnderstandTheRisk"]() }));
-
-    expect(screen.getByText(m["bridge.withdrawAddress"]())).toBeInTheDocument();
-
-    const input = screen.getByRole("textbox");
-    const confirmButton = screen.getByRole("button", { name: m["bridge.confirm"]() });
-
-    expect(screen.getByText(m["bridge.exchangeWarning"]())).toBeInTheDocument();
-    expect(confirmButton).toBeDisabled();
-
-    fireEvent.change(input, {
-      target: { value: "not-a-wallet" },
-    });
-
-    expect(input).toHaveValue("");
-    expect(confirmButton).toBeDisabled();
-    expect(onAddressSet).not.toHaveBeenCalled();
-
-    fireEvent.change(input, {
-      target: { value: "0x123" },
-    });
-
-    expect(confirmButton).toBeDisabled();
-    expect(onAddressSet).not.toHaveBeenCalled();
-
-    fireEvent.change(input, {
-      target: { value: "0x2222222222222222222222222222222222222222" },
-    });
-    fireEvent.click(confirmButton);
-
-    expect(onAddressSet).toHaveBeenCalledWith("0x2222222222222222222222222222222222222222");
-    expect(destinationWalletMocks.hideModal).toHaveBeenCalledOnce();
-  });
-
-  it("closes the manual address flow without setting a recipient", () => {
-    const onAddressSet = vi.fn();
-
-    const { container } = render(
-      <DestinationWallet network="ethereum" onAddressSet={onAddressSet} />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: m["bridge.enterAddressManually"]() }));
-    fireEvent.click(screen.getByRole("button", { name: m["bridge.iUnderstandTheRisk"]() }));
+    const { container } = render(<DestinationWallet onAddressSet={onAddressSet} />);
 
     const closeButton = container.querySelector("button.absolute");
     if (!closeButton) throw new Error("Expected destination wallet close button");


### PR DESCRIPTION
## Validation
### Completed
- [x] `pnpm exec biome check ui/portal/web/src/components/modals/DestinationWallet.tsx ui/portal/web/src/components/bridge/Bridge.tsx ui/portal/web/tests/destination-wallet.test.tsx ui/portal/web/tests/bridge-ui.test.tsx`
- [x] `pnpm -F @left-curve/portal-web exec vitest run tests/destination-wallet.test.tsx tests/bridge-ui.test.tsx`

### Remaining
- [ ] None

## Manual QA
- Started portal web locally at `http://localhost:5081/`.
- Captured the withdraw destination picker showing wallet options only, with no manual address entry option.
