### PR TITLE
feat(deploy): enable S3 block backup on mainnet hetzner1

### DIFF
--- a/deploy/full-app.yml
+++ b/deploy/full-app.yml
@@ -36,6 +36,11 @@
         commit_author: "{{ lookup('pipe', 'git log -1 --pretty=%an') }}"
       run_once: true
 
+    # s3_bucket here is only the first-deploy default. For system-wide networks
+    # (testnet/mainnet), read_current_deploy.yml later overwrites it with the
+    # bucket name stored in the existing deployment's .env, so the bucket stays
+    # stable across redeploys. Only PR/devnet (non-system-wide) keep this fresh
+    # per-deploy timestamped name.
     - name: Set timestamp and deployment name on all hosts
       set_fact:
         deployment_name: "{{ hostvars[ansible_play_hosts[0]]['timestamp'] }}"

--- a/deploy/host_vars/100.126.8.2.yml
+++ b/deploy/host_vars/100.126.8.2.yml
@@ -7,3 +7,4 @@ dango_networks:
   - mainnet
 cloudflare_lb_enabled: true
 internal_api_enabled: true
+s3_enabled: true

--- a/deploy/roles/full-app/tasks/prep_after_lock.yml
+++ b/deploy/roles/full-app/tasks/prep_after_lock.yml
@@ -1,5 +1,9 @@
 ---
-- name: Set system wide cometbft and dango directories and overwrite s3_bucket
+# These are first-deploy defaults using the fresh timestamp. On a redeploy of an
+# existing system-wide network (testnet/mainnet), read_current_deploy.yml below
+# overwrites dango_directory/cometbft_directory/s3_path/s3_bucket with the values
+# from the live deployment's .env, so they stay stable across deploys.
+- name: Set system wide cometbft and dango directories
   set_fact:
     dango_directory: "{{ ansible_facts['env']['HOME'] }}/{{ dango_network }}/{{ timestamp }}/dango"
     cometbft_directory: "{{ ansible_facts['env']['HOME'] }}/{{ dango_network }}/{{ timestamp }}/cometbft"

--- a/deploy/roles/full-app/tasks/read_current_deploy.yml
+++ b/deploy/roles/full-app/tasks/read_current_deploy.yml
@@ -38,6 +38,10 @@
       loop: "{{ existing_env_variables.stdout_lines }}"
       when: current_deployment is defined and env_file_exists.stat.exists
 
+    # Reuse the existing deployment's data dirs and S3 bucket/path so they stay
+    # stable across redeploys (overrides the fresh-timestamp defaults set in
+    # full-app.yml / prep_after_lock.yml). This is why testnet/mainnet keep a
+    # single persistent S3 bucket instead of a new one per deploy.
     - name: Read .env values for system wide directories
       shell: |
         grep -E '^(DANGO_DIRECTORY|COMETBFT_DIRECTORY|S3_PATH|S3_BUCKET)=' {{ ansible_facts['env']['HOME'] }}/deployments/{{ current_deployment }}/.env | \


### PR DESCRIPTION
## Summary

Enables S3 block backup for **mainnet** by setting `s3_enabled: true` on **hetzner1**, mirroring the existing testnet setup on hetzner2. The credentials (SOPS vault), bucket creation (`create_s3_bucket.yml`), and the every-10-min sync cron (`s3_sync_cron.yml`) are all already wired up and gated on this single flag, so no other config change is needed.

This PR also **clarifies the S3 bucket-naming flow**, which was easy to misread as "a new timestamped bucket per deploy":

- The `dango-<network>-<timestamp>` name set in `full-app.yml` is only a **first-deploy default**.
- For system-wide networks (testnet/mainnet), `read_current_deploy.yml` overwrites it with the bucket name read back from the **live deployment's `.env`**, so the bucket stays **stable across redeploys** — a single persistent bucket, no fragmentation.
- Only PR/devnet (non-system-wide) keep the fresh per-deploy timestamped name.
- The misleading task name `"Set system wide cometbft and dango directories and overwrite s3_bucket"` in `prep_after_lock.yml` is corrected — that task never actually set `s3_bucket`; the real overwrite lives in `read_current_deploy.yml`. Comments now point readers to the source of truth.

### Notes / caveats
- Backfill only covers blocks present in **hetzner1's local block cache** — blocks never cached locally cannot be recovered to S3.
- `just deploy-mainnet` targets all four mainnet hosts, but only hetzner1 has the flag, so only it will create the bucket + cron (matches the testnet single-node pattern).

## Validation

### Completed
- [x] `yamllint -d relaxed` clean on all changed files (no new warnings introduced)
- [x] Verified bucket-stability mechanism by reading `read_current_deploy.yml` (grep-back of `S3_BUCKET` gated on `system_wide_directories and not reset_data`)
- [x] Confirmed the change is a pure superset of testnet's hetzner2 host_vars

### Remaining
- [ ] Run `just deploy-mainnet <dango_tag> <bots_tag>` to apply (production deploy — intentionally not done in this PR)
- [ ] After deploy, confirm bucket creation and that the sync cron is uploading blocks

## Manual QA

None (config-only change; effective on next mainnet deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)