### PR TITLE
fix(cometbft): disable mempool recheck

### DIFF
--- a/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
+++ b/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
@@ -337,7 +337,17 @@ type = "flood"
 # Since a block affects the application state, some transactions in the
 # mempool may become invalid. If this does not apply to your application,
 # you can disable rechecking.
-recheck = true
+#
+# Disabled for Dango. After every committed block, CometBFT reruns CheckTx over
+# EVERY remaining mempool tx, synchronously on the block-apply critical path.
+# With a full mempool (size = 5000) this costs ~1.2s per block -- far above our
+# ~350ms block time -- and on a node catching up via block-sync it throttles
+# apply below the chain's block production rate, so the node can never catch up
+# (observed on mainnet 2026-06-28: a restarted validator stuck at ~47 blk/min vs
+# ~170 produced). The only cost of disabling it is that txs invalidated by a
+# block are no longer evicted from the mempool eagerly; they linger until reaped
+# into a later block (where they execute, fail, and are then removed) or expire.
+recheck = false
 
 # recheck_timeout is the time the application has during the rechecking process
 # to return CheckTx responses, once all requests have been sent. Responses that

--- a/localdango/configs/cometbft/config/config.toml
+++ b/localdango/configs/cometbft/config/config.toml
@@ -335,7 +335,17 @@ type = "flood"
 # Since a block affects the application state, some transactions in the
 # mempool may become invalid. If this does not apply to your application,
 # you can disable rechecking.
-recheck = true
+#
+# Disabled for Dango. After every committed block, CometBFT reruns CheckTx over
+# EVERY remaining mempool tx, synchronously on the block-apply critical path.
+# With a full mempool (size = 5000) this costs ~1.2s per block -- far above our
+# ~350ms block time -- and on a node catching up via block-sync it throttles
+# apply below the chain's block production rate, so the node can never catch up
+# (observed on mainnet 2026-06-28: a restarted validator stuck at ~47 blk/min vs
+# ~170 produced). The only cost of disabling it is that txs invalidated by a
+# block are no longer evicted from the mempool eagerly; they linger until reaped
+# into a later block (where they execute, fail, and are then removed) or expire.
+recheck = false
 
 # recheck_timeout is the time the application has during the rechecking process
 # to return CheckTx responses, once all requests have been sent. Responses that


### PR DESCRIPTION
CometBFT reruns CheckTx over every remaining mempool tx after each committed block, synchronously on the block-apply critical path. With a full mempool (size = 5000) this costs ~1.2s per block -- far above our ~350ms block time. On a node catching up via block-sync it throttles block application below the chain's production rate, so the node can never converge (observed on mainnet: a restarted validator stuck at ~47 blk/min versus ~170 produced, falling further behind).

Disabling recheck is safe for Dango: there is no proposal-time tx validation (ProcessProposal always accepts; the proposal preparer only reorders txs and injects oracle txs), and block execution rejects any now-invalid tx gracefully as a failed outcome -- deterministically, with no panic, halt, or app-hash divergence -- with nonce-replay protection enforced in committed state at execution time. New-tx admission is still gated by CheckTx on arrival. The only cost is some wasted block space on txs that fail once and are then evicted on the next commit.

Applies to both the deploy template (mainnet/testnet/devnet) and the localdango test config.