### PR TITLE
refactor(indexer): co-locate WebSocket subscription errors on their channel

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -2766,15 +2766,18 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 {"channel": "perpsEvents", "id": 1, "data": { ... }}
 {"channel": "fullBlock", "id": 2, "data": { ... }}
 {"channel": "pong", "id": 9}
-{"channel": "error", "id": 1, "data": {"code": "resync", "message": "..."}}
+{"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "..."}}
+{"channel": "error", "error": {"code": "badRequest", "message": "..."}}
 ```
 
 | `channel`                 | Description                                                                                       |
 | ------------------------- | ------------------------------------------------------------------------------------------------- |
 | `subscriptionResponse`    | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                        |
-| `perpsEvents`/`fullBlock` | A data frame, tagged with the originating subscription's `id`                                     |
+| `perpsEvents`/`fullBlock` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§11.3](#113-reconnect-and-errors)) |
 | `pong`                    | Reply to a `ping`, echoing its `id`                                                               |
-| `error`                   | A problem, tagged with the offending `id` when applicable; see [§11.3](#113-reconnect-and-errors) |
+| `error`                   | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§11.3](#113-reconnect-and-errors) |
+
+Each frame on a subscription's channel (`perpsEvents` / `fullBlock`) carries either a `data` payload or an `error`; a client demultiplexes by `id` and branches on which key is present. Errors are co-located this way so a feed's failure arrives on the same channel its data does — see [§11.3](#113-reconnect-and-errors).
 
 **Heartbeat.** The server sends a WebSocket ping every 20 seconds and closes a connection it has heard nothing from for 60 seconds. A client either lets its WebSocket stack answer those pings, or sends `{"method": "ping"}` itself; either keeps an idle subscription alive.
 
@@ -2867,14 +2870,17 @@ Stream every finalized block in full — the same `FullBlock` shape (`block` + `
 
 Both channels are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight`, or `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
 
-Problems are delivered as `error` frames tagged with the offending `id`:
+Problems are delivered as `error`-keyed frames. An error that concerns a specific subscription rides that subscription's own channel and `id` — an `error` sibling of the `data` frames it would otherwise send — so a client handles a feed's failure on the same channel it reads from. An error with no subscription to attribute it to (an unparseable message, or an `unsubscribe` for an unknown `id`) arrives on the dedicated `error` channel instead, carrying the offending `id` when there is one.
 
-| `code`            | Meaning                                                                                                                                                                                                         |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `resync`          | `since` predates the retained window, or the feed lagged past it. Reconnect with a newer `since`; backfill the gap from the `perpsEvents` query ([§5.5](#55-trade-history)) or the `/block/full/*` REST routes. |
-| `tooManyRequests` | The server's subscription limit was reached.                                                                                                                                                                    |
-| `badRequest`      | The message could not be parsed, or the `id` is already in use.                                                                                                                                                 |
+| `code`                | Meaning                                                                                                                                                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resync`              | `since` predates the retained window, or the feed lagged past it. The subscription ends; reconnect with a newer `since` and backfill the gap from the `perpsEvents` query ([§5.5](#55-trade-history)) or the `/block/full/*` REST routes. |
+| `tooManyRequests`     | The server's subscription limit was reached.                                                                                                                                                                                            |
+| `badRequest`          | The message could not be parsed, or the `id` is already in use.                                                                                                                                                                         |
+| `unknownSubscription` | An `unsubscribe` referenced an `id` with no open subscription.                                                                                                                                                                          |
+
+A subscription-scoped error (here, a terminal `resync` on the `perpsEvents` feed opened with `id: 1`):
 
 ```json
-{"channel": "error", "id": 1, "data": {"code": "resync", "message": "resync required: requested from block 100 but the oldest retained block is 900"}}
+{"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "resync required: requested from block 100 but the oldest retained block is 900"}}
 ```

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -2764,18 +2764,18 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 ```json
 {"channel": "subscriptionResponse", "id": 1, "data": {"method": "subscribe", "type": "perpsEvents"}}
 {"channel": "perpsEvents", "id": 1, "data": { ... }}
+{"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "..."}}
 {"channel": "fullBlock", "id": 2, "data": { ... }}
 {"channel": "pong", "id": 9}
-{"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "..."}}
 {"channel": "error", "error": {"code": "badRequest", "message": "..."}}
 ```
 
-| `channel`                 | Description                                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------------------- |
-| `subscriptionResponse`    | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                        |
+| `channel`                 | Description                                                                                                                                             |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `subscriptionResponse`    | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                                                                              |
 | `perpsEvents`/`fullBlock` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§11.3](#113-reconnect-and-errors)) |
-| `pong`                    | Reply to a `ping`, echoing its `id`                                                               |
-| `error`                   | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§11.3](#113-reconnect-and-errors) |
+| `pong`                    | Reply to a `ping`, echoing its `id`                                                                                                                     |
+| `error`                   | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§11.3](#113-reconnect-and-errors)                  |
 
 Each frame on a subscription's channel (`perpsEvents` / `fullBlock`) carries either a `data` payload or an `error`; a client demultiplexes by `id` and branches on which key is present. Errors are co-located this way so a feed's failure arrives on the same channel its data does — see [§11.3](#113-reconnect-and-errors).
 
@@ -2872,12 +2872,12 @@ Both channels are served from an in-memory window of recent blocks. Every data f
 
 Problems are delivered as `error`-keyed frames. An error that concerns a specific subscription rides that subscription's own channel and `id` — an `error` sibling of the `data` frames it would otherwise send — so a client handles a feed's failure on the same channel it reads from. An error with no subscription to attribute it to (an unparseable message, or an `unsubscribe` for an unknown `id`) arrives on the dedicated `error` channel instead, carrying the offending `id` when there is one.
 
-| `code`                | Meaning                                                                                                                                                                                                                                  |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code`                | Meaning                                                                                                                                                                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `resync`              | `since` predates the retained window, or the feed lagged past it. The subscription ends; reconnect with a newer `since` and backfill the gap from the `perpsEvents` query ([§5.5](#55-trade-history)) or the `/block/full/*` REST routes. |
-| `tooManyRequests`     | The server's subscription limit was reached.                                                                                                                                                                                            |
-| `badRequest`          | The message could not be parsed, or the `id` is already in use.                                                                                                                                                                         |
-| `unknownSubscription` | An `unsubscribe` referenced an `id` with no open subscription.                                                                                                                                                                          |
+| `tooManyRequests`     | The server's subscription limit was reached.                                                                                                                                                                                              |
+| `badRequest`          | The message could not be parsed, or the `id` is already in use.                                                                                                                                                                           |
+| `unknownSubscription` | An `unsubscribe` referenced an `id` with no open subscription.                                                                                                                                                                            |
 
 A subscription-scoped error (here, a terminal `resync` on the `perpsEvents` feed opened with `id: 1`):
 

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -3,10 +3,17 @@
 //! One socket carries any number of subscriptions, each identified by a
 //! client-chosen `id`. Client messages are `method`-tagged
 //! (`subscribe` / `unsubscribe` / `ping`); server messages are `channel`-tagged
-//! (`subscriptionResponse` / `<channel>` data / `pong` / `error`). The `id` of a
-//! `subscribe` is echoed on its acknowledgement and on every data frame it
-//! produces, so concurrent subscriptions (e.g. several `perpsEvents` feeds with
-//! different filters) are demultiplexable on the client.
+//! (`subscriptionResponse` / `<channel>` / `pong`). The `id` of a `subscribe` is
+//! echoed on its acknowledgement and on every frame it produces, so concurrent
+//! subscriptions (e.g. several `perpsEvents` feeds with different filters) are
+//! demultiplexable on the client.
+//!
+//! Errors are co-located with the operation they concern: a problem opening or
+//! running a subscription rides that subscription's own channel and `id`, as an
+//! `error`-keyed frame alongside its `data`-keyed frames, so a client handles a
+//! feed's failure on the same channel it reads from. Only errors with no
+//! channel to attribute them to — an unparseable frame, or an `unsubscribe` for
+//! an unknown `id` — use the dedicated `error` channel.
 //!
 //! Two channel types are served, both reusing the in-memory validator stream
 //! that backed the `full_block` / `perps_events` GraphQL subscriptions:
@@ -152,10 +159,14 @@ enum ServerControl<'a> {
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<u64>,
     },
+    /// A connection-level error with no subscription channel to attribute it to
+    /// — an unparseable frame, or an `unsubscribe` for an unknown `id`. Errors
+    /// that concern a specific subscription instead ride its channel; see
+    /// [`ErrorFrame`].
     Error {
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<u64>,
-        data: ErrorData<'a>,
+        error: ErrorData<'a>,
     },
 }
 
@@ -180,6 +191,17 @@ struct DataFrame<'a, T> {
     channel: &'static str,
     id: u64,
     data: &'a T,
+}
+
+/// An error scoped to a subscription, delivered on that subscription's own
+/// channel and `id` — mirroring its data frames — so a client handles a feed's
+/// failure on the same channel it reads from. Connection-level errors that have
+/// no channel to attribute them to use [`ServerControl::Error`] instead.
+#[derive(Debug, Serialize)]
+struct ErrorFrame<'a> {
+    channel: &'static str,
+    id: u64,
+    error: ErrorData<'a>,
 }
 
 // ---- handler ----
@@ -289,10 +311,14 @@ async fn handle_text(
 
     match message {
         ClientMessage::Subscribe { id, subscription } => {
+            // Subscription-scoped errors ride this channel + `id`, mirroring the
+            // data frames the subscription would have produced.
+            let channel = subscription.channel();
+
             if streams.contains_key(&id) {
                 return send(
                     session,
-                    error_frame(Some(id), "badRequest", "id already in use"),
+                    channel_error(channel, id, "badRequest", "id already in use"),
                 )
                 .await;
             }
@@ -305,19 +331,18 @@ async fn handle_text(
                 Err(err) => {
                     return send(
                         session,
-                        error_frame(Some(id), "tooManyRequests", &err.message),
+                        channel_error(channel, id, "tooManyRequests", &err.message),
                     )
                     .await;
                 },
             };
 
-            let channel = subscription.channel();
             match open_stream(id, &subscription, guard, stream_ctx) {
                 Ok(frames) => {
                     streams.insert(id, frames);
                     send(session, ack(id, "subscribe", Some(channel))).await
                 },
-                Err(resync) => send(session, error_frame(Some(id), "resync", &resync)).await,
+                Err(resync) => send(session, channel_error(channel, id, "resync", &resync)).await,
             }
         },
         ClientMessage::Unsubscribe { id } => {
@@ -370,7 +395,7 @@ fn open_stream(
             let frames = guard_subscription_stream(raw, Some(guard))
                 .map(move |block| data_frame("perpsEvents", id, &block));
 
-            Ok(with_terminal(id, frames))
+            Ok(with_terminal("perpsEvents", id, frames))
         },
         Subscription::FullBlock { since } => {
             let raw = stream_ctx
@@ -380,7 +405,7 @@ fn open_stream(
             let frames = guard_subscription_stream(raw, Some(guard))
                 .map(move |block| data_frame("fullBlock", id, &block));
 
-            Ok(with_terminal(id, frames))
+            Ok(with_terminal("fullBlock", id, frames))
         },
     }
 }
@@ -390,13 +415,14 @@ fn open_stream(
 /// feed closed — the client learns to resync instead of seeing the feed go
 /// silent. An explicit `unsubscribe` removes the stream from the map before this
 /// runs, so it never fires spuriously.
-fn with_terminal<S>(id: u64, frames: S) -> FrameStream
+fn with_terminal<S>(channel: &'static str, id: u64, frames: S) -> FrameStream
 where
     S: stream::Stream<Item = String> + Send + 'static,
 {
     let terminal = stream::once(async move {
-        error_frame(
-            Some(id),
+        channel_error(
+            channel,
+            id,
             "resync",
             "subscription ended; reconnect with a newer `since`",
         )
@@ -413,7 +439,7 @@ async fn send(session: &mut Session, text: String) -> bool {
 
 fn control(message: &ServerControl) -> String {
     serde_json::to_string(message).unwrap_or_else(|_| {
-        r#"{"channel":"error","data":{"code":"internal","message":"serialization failed"}}"#
+        r#"{"channel":"error","error":{"code":"internal","message":"serialization failed"}}"#
             .to_string()
     })
 }
@@ -428,8 +454,19 @@ fn ack(id: u64, method: &str, channel: Option<&str>) -> String {
 fn error_frame(id: Option<u64>, code: &str, message: &str) -> String {
     control(&ServerControl::Error {
         id,
-        data: ErrorData { code, message },
+        error: ErrorData { code, message },
     })
+}
+
+/// Serialize an error scoped to a subscription, delivered on that subscription's
+/// own `channel` and `id` — the co-located counterpart to [`data_frame`].
+fn channel_error(channel: &'static str, id: u64, code: &str, message: &str) -> String {
+    serde_json::to_string(&ErrorFrame {
+        channel,
+        id,
+        error: ErrorData { code, message },
+    })
+    .unwrap_or_else(|_| error_frame(Some(id), "internal", "serialization failed"))
 }
 
 fn data_frame<T>(channel: &'static str, id: u64, data: &T) -> String
@@ -562,7 +599,7 @@ mod tests {
 
         assert_eq!(
             parse(&error_frame(Some(3), "resync", "stale")),
-            json!({"channel": "error", "id": 3, "data": {"code": "resync", "message": "stale"}}),
+            json!({"channel": "error", "id": 3, "error": {"code": "resync", "message": "stale"}}),
         );
     }
 
@@ -576,6 +613,22 @@ mod tests {
             ))
             .unwrap(),
             json!({"channel": "perpsEvents", "id": 1, "data": {"blockHeight": 5}}),
+        );
+    }
+
+    #[test]
+    fn serializes_colocated_error_on_its_subscription_channel() {
+        // A subscription-scoped error rides that subscription's own channel and
+        // `id`, as an `error`-keyed sibling of its `data`-keyed frames.
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&channel_error(
+                "perpsEvents",
+                1,
+                "resync",
+                "stale",
+            ))
+            .unwrap(),
+            json!({"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "stale"}}),
         );
     }
 }

--- a/dango/sdk/src/client.rs
+++ b/dango/sdk/src/client.rs
@@ -598,24 +598,31 @@ enum ServerFrame {
 
 fn parse_server_frame(text: &str) -> anyhow::Result<ServerFrame> {
     let value: serde_json::Value = serde_json::from_str(text)?;
+    // An error is co-located on the operation's own channel as an `error`-keyed
+    // frame; a connection-level error uses the dedicated `error` channel. Check
+    // for `error` first, regardless of channel, so a terminal `resync` on the
+    // `perpsEvents` channel is surfaced as an error rather than parsed as data.
+    if let Some(error) = value.get("error") {
+        return Ok(ServerFrame::Error {
+            code: error
+                .get("code")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("error")
+                .to_string(),
+            message: error
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        });
+    }
+
     match value.get("channel").and_then(serde_json::Value::as_str) {
         Some("subscriptionResponse") => Ok(ServerFrame::Ack),
         Some("perpsEvents") => {
             let data = value.get("data").cloned().unwrap_or_default();
             Ok(ServerFrame::Data(serde_json::from_value(data)?))
         },
-        Some("error") => Ok(ServerFrame::Error {
-            code: value
-                .pointer("/data/code")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("error")
-                .to_string(),
-            message: value
-                .pointer("/data/message")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default()
-                .to_string(),
-        }),
         _ => Ok(ServerFrame::Other),
     }
 }

--- a/dango/testing/tests/httpd/ws.rs
+++ b/dango/testing/tests/httpd/ws.rs
@@ -267,8 +267,9 @@ async fn ws_perps_events_stream_absent_filter_matches_all() -> anyhow::Result<()
 }
 
 /// A `since` older than the retained in-memory window does not open a stream; it
-/// replies with an `error` frame tagged `resync` and the offending `id` (the WS
-/// analogue of the SSE `409 Conflict`).
+/// replies with an `error`-keyed frame tagged `resync` (carrying the offending
+/// `id`) on the subscription's own `perpsEvents` channel — the WS analogue of
+/// the SSE `409 Conflict`.
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_perps_events_stream_resync_required_is_error_frame() -> anyhow::Result<()> {
     let (mut suite, mut accounts, _, contracts, _, ctx, _, _, _db_guard) =
@@ -303,9 +304,12 @@ async fn ws_perps_events_stream_resync_required_is_error_frame() -> anyhow::Resu
                 )
                 .await?;
 
-                let error = recv_until(&mut framed, |m| channel(m) == Some("error")).await?;
+                let error = recv_until(&mut framed, |m| {
+                    channel(m) == Some("perpsEvents") && m.get("error").is_some()
+                })
+                .await?;
                 assert_eq!(error["id"].as_u64(), Some(3));
-                assert_eq!(error["data"]["code"].as_str(), Some("resync"));
+                assert_eq!(error["error"]["code"].as_str(), Some("resync"));
 
                 Ok::<(), anyhow::Error>(())
             })

--- a/sdk/python/dango/ws_stream_manager.py
+++ b/sdk/python/dango/ws_stream_manager.py
@@ -139,15 +139,18 @@ class WsStreamManager:
                 return
 
             channel = msg.get("channel")
-            if channel == "perpsEvents":
+            if "error" in msg:
+                # An error is co-located on the operation's own channel as an
+                # `error`-keyed frame (a connection-level error uses the
+                # dedicated `error` channel). Either way it is terminal for this
+                # subscription: notify, then close so the worker thread winds
+                # down.
+                callback({"_error": msg.get("error")})
+                ws.close()
+            elif channel == "perpsEvents":
                 # The data frame's payload is the bare batch (no GraphQL `data`
                 # wrapper), delivered straight to the callback.
                 callback(msg.get("data", {}) or {})
-            elif channel == "error":
-                # Terminal for this subscription (e.g. `resync`): notify, then
-                # close so the worker thread winds down.
-                callback({"_error": msg.get("data")})
-                ws.close()
             # `subscriptionResponse` / `pong` carry no payload for the caller.
 
         def on_error(ws: websocket.WebSocketApp, error: Any) -> None:


### PR DESCRIPTION
Deliver a subscription-scoped error on that subscription's own channel and
`id` — an `error`-keyed frame alongside its `data`-keyed frames — so a
client handles a feed's failure on the same channel it reads from, keyed by
the same `id`. The dedicated `error` channel is now reserved for
connection-level problems that cannot be attributed to a subscription (an
unparseable frame, or an `unsubscribe` for an unknown `id`).

This mirrors the request/response convention Binance and Hyperliquid use on
their WebSocket APIs, and prepares the socket for a forthcoming `broadcast`
write method whose reply co-locates the same way.