### PR TITLE
feat: ws broadcast

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -2994,9 +2994,34 @@ Stream every finalized block in full — the same `FullBlock` shape (`block` + `
 {"channel": "fullBlock", "id": 2, "data": {"block": { ... }, "outcome": { ... }}}
 ```
 
+#### `broadcast`
+
+Submit a signed transaction to the mempool — a **write** request/response (one request, one reply), not a subscription stream. The REST `POST /broadcast` ([§11.3](#113-broadcast)) is the default; this lets a client already holding a `/ws` connection broadcast without opening a separate HTTP request. Like REST, it returns a mempool receipt (`BroadcastTxOutcome`), **not** block inclusion.
+
+```json
+{"method": "broadcast", "id": 1, "tx": { ... signed Tx ... }}
+```
+
+| Field | Type     | Description                                                     |
+| ----- | -------- | --------------------------------------------------------------- |
+| `id`  | `Int`    | Echoed on the reply frame                                       |
+| `tx`  | `Object` | The signed `Tx` (see [§2](#2-authentication-and-transactions))  |
+
+The reply rides the `broadcast` channel. Success — **including a mempool-rejected tx**, whose rejection is carried in `check_tx.result` — is a `data` frame holding the `BroadcastTxOutcome` (same shape as [§11.3](#113-broadcast)):
+
+```json
+{"channel": "broadcast", "id": 1, "data": {"tx_hash": "...", "check_tx": { ... }}}
+```
+
+Only a transport failure to the consensus node is an `error` frame:
+
+```json
+{"channel": "broadcast", "id": 1, "error": {"code": "broadcastFailed", "message": "..."}}
+```
+
 ### 12.3 Reconnect and errors
 
-Both channels are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight`, or `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
+Both subscription channels (`perpsEvents` and `fullBlock`) are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight`, or `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
 
 Problems are delivered as `error`-keyed frames. An error that concerns a specific subscription rides that subscription's own channel and `id` — an `error` sibling of the `data` frames it would otherwise send — so a client handles a feed's failure on the same channel it reads from. An error with no subscription to attribute it to (an unparseable message, or an `unsubscribe` for an unknown `id`) arrives on the dedicated `error` channel instead, carrying the offending `id` when there is one.
 

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -32,11 +32,13 @@
 use {
     crate::{
         context::FullContext,
+        request_ip::RequesterIp,
         subscription_limiter::{ConnectionLimiter, SubscriptionLimiter, guard_subscription_stream},
     },
     actix_web::{HttpRequest, HttpResponse, Resource, guard, web},
     actix_ws::{AggregatedMessage, Session},
     dango_indexer_stream::{Context, make_perps_filter},
+    dango_primitives::{HttpRequestDetails, Tx},
     futures_util::{StreamExt, stream},
     serde::{Deserialize, Serialize},
     std::{collections::HashSet, pin::Pin, sync::Arc, time::Duration},
@@ -94,6 +96,14 @@ enum ClientMessage {
         #[serde(default)]
         id: Option<u64>,
     },
+
+    /// Broadcast a signed transaction to the mempool. Answered on the
+    /// `broadcast` channel: a `BroadcastTxOutcome` (`data`) — including a mempool
+    /// rejection, which rides `check_tx.result` — or an `error` frame only on a
+    /// transport failure to the consensus node. The REST `POST /broadcast` is the
+    /// default; this lets a client already holding a `/ws` connection broadcast
+    /// without a separate HTTP request.
+    Broadcast { id: u64, tx: Tx },
 }
 
 /// The feed a `subscribe` selects, discriminated by `type`.
@@ -216,13 +226,19 @@ pub async fn ws_index(
 ) -> actix_web::Result<HttpResponse> {
     let (response, session, msg_stream) = actix_ws::handle(&req, body)?;
 
-    let stream_ctx = app_ctx.stream_context.clone();
+    // Computed once per connection and reused by every `broadcast` on this
+    // socket, mirroring how the REST/GraphQL broadcast paths capture it per
+    // request.
+    let http_details = RequesterIp::from_request(&req).into_http_request_details();
     let conn_limiter = limiter.new_connection();
 
+    // The connection loop runs on a detached task, so it owns the context (a
+    // cheap `Arc`-cloning `FullContext`) rather than borrowing `web::Data`.
     actix_web::rt::spawn(connection_loop(
         session,
         msg_stream,
-        stream_ctx,
+        app_ctx.as_ref().clone(),
+        http_details,
         conn_limiter,
     ));
 
@@ -234,7 +250,8 @@ pub async fn ws_index(
 async fn connection_loop(
     mut session: Session,
     msg_stream: actix_ws::MessageStream,
-    stream_ctx: Context,
+    app_ctx: FullContext,
+    http_details: HttpRequestDetails,
     conn_limiter: ConnectionLimiter,
 ) {
     let mut msg_stream = msg_stream.aggregate_continuations();
@@ -255,7 +272,7 @@ async fn connection_loop(
 
                 match message {
                     AggregatedMessage::Text(text) => {
-                        if !handle_text(&text, &mut session, &mut streams, &stream_ctx, &conn_limiter).await {
+                        if !handle_text(&text, &mut session, &mut streams, &app_ctx, &http_details, &conn_limiter).await {
                             break;
                         }
                     },
@@ -301,7 +318,8 @@ async fn handle_text(
     text: &str,
     session: &mut Session,
     streams: &mut StreamMap<u64, FrameStream>,
-    stream_ctx: &Context,
+    app_ctx: &FullContext,
+    http_details: &HttpRequestDetails,
     conn_limiter: &ConnectionLimiter,
 ) -> bool {
     let message = match serde_json::from_str::<ClientMessage>(text) {
@@ -337,7 +355,7 @@ async fn handle_text(
                 },
             };
 
-            match open_stream(id, &subscription, guard, stream_ctx) {
+            match open_stream(id, &subscription, guard, &app_ctx.stream_context) {
                 Ok(frames) => {
                     streams.insert(id, frames);
                     send(session, ack(id, "subscribe", Some(channel))).await
@@ -357,6 +375,32 @@ async fn handle_text(
             }
         },
         ClientMessage::Ping { id } => send(session, control(&ServerControl::Pong { id })).await,
+        ClientMessage::Broadcast { id, tx } => {
+            // Reject an `id` already bound to a live subscription on this socket,
+            // so the client can demultiplex the `broadcast` reply unambiguously.
+            if streams.contains_key(&id) {
+                return send(
+                    session,
+                    channel_error("broadcast", id, "badRequest", "id already in use"),
+                )
+                .await;
+            }
+
+            // Awaited inline: `broadcast_tx` is a fast mempool admission, so
+            // briefly pausing this connection's other arms is acceptable. A
+            // mempool rejection comes back as `Ok` (carried in
+            // `check_tx.result`); only a transport failure is an `error` frame.
+            match crate::broadcast::broadcast_tx(app_ctx, http_details, tx).await {
+                Ok(outcome) => send(session, data_frame("broadcast", id, &outcome)).await,
+                Err(err) => {
+                    send(
+                        session,
+                        channel_error("broadcast", id, "broadcastFailed", &err.to_string()),
+                    )
+                    .await
+                },
+            }
+        },
     }
 }
 
@@ -629,6 +673,47 @@ mod tests {
             ))
             .unwrap(),
             json!({"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "stale"}}),
+        );
+    }
+
+    #[test]
+    fn deserializes_broadcast_with_tx() {
+        let message: ClientMessage = serde_json::from_str(
+            r#"{"method":"broadcast","id":5,"tx":{"sender":"0x33361de42571d6aa20c37daa6da4b5ab67bfaad9","gas_limit":1000000,"msgs":[{"transfer":{"0x01bba610cbbfe9df0c99b8862f3ad41b2f646553":{"hyp/all/btc":"100"}}}],"data":{"chain_id":"dev-1","nonce":1,"username":"owner"},"credential":{}}}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(message, ClientMessage::Broadcast { id: 5, .. }));
+    }
+
+    #[test]
+    fn serializes_broadcast_success_frame() {
+        // A successful broadcast rides a `data` frame on the `broadcast`
+        // channel, exactly like a subscription's data frame.
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&data_frame(
+                "broadcast",
+                5,
+                &json!({"tx_hash": "0xabc", "check_tx": {"result": {"Ok": null}}}),
+            ))
+            .unwrap(),
+            json!({"channel": "broadcast", "id": 5, "data": {"tx_hash": "0xabc", "check_tx": {"result": {"Ok": null}}}}),
+        );
+    }
+
+    #[test]
+    fn serializes_broadcast_error_frame() {
+        // A transport failure to the consensus node is an `error` frame on the
+        // `broadcast` channel (a mempool rejection would be a `data` frame).
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&channel_error(
+                "broadcast",
+                5,
+                "broadcastFailed",
+                "connection refused",
+            ))
+            .unwrap(),
+            json!({"channel": "broadcast", "id": 5, "error": {"code": "broadcastFailed", "message": "connection refused"}}),
         );
     }
 }

--- a/dango/sdk/src/client.rs
+++ b/dango/sdk/src/client.rs
@@ -327,6 +327,89 @@ impl HttpClient {
 
         Ok(rx)
     }
+
+    /// Broadcast a signed transaction over the native WebSocket (`GET /ws`,
+    /// `broadcast` channel) rather than REST: open a short-lived connection,
+    /// send one `broadcast` request, and await its reply.
+    ///
+    /// [`HttpClient::broadcast_tx`] (REST `POST /broadcast`) is the default;
+    /// this exists for callers that prefer a single WebSocket round-trip. As
+    /// with REST, a mempool-rejected tx returns `Ok` (the rejection rides
+    /// [`BroadcastTxOutcome::check_tx`]); only a transport failure to the node
+    /// is `Err`.
+    pub async fn broadcast_tx_ws(&self, tx: Tx) -> anyhow::Result<BroadcastTxOutcome> {
+        // Derive the `/ws` URL from the HTTP base (same as
+        // `subscribe_perps_events`).
+        let mut ws_url = self.url.join("ws")?;
+        match ws_url.scheme() {
+            "http" => ws_url
+                .set_scheme("ws")
+                .map_err(|_| anyhow!("failed to set ws scheme"))?,
+            "https" => ws_url
+                .set_scheme("wss")
+                .map_err(|_| anyhow!("failed to set wss scheme"))?,
+            "ws" | "wss" => {},
+            scheme => bail!("invalid URL scheme: {scheme}"),
+        }
+
+        let request = serde_json::json!({
+            "method": "broadcast",
+            "id": 1,
+            "tx": serde_json::to_value(&tx)?,
+        });
+
+        let (ws, _response) = connect_async(ws_url.as_str())
+            .await
+            .map_err(|err| anyhow!("WebSocket connection failed: {err}"))?;
+
+        let (mut sink, mut stream) = ws.split();
+        sink.send(Message::text(request.to_string()))
+            .await
+            .map_err(|err| anyhow!("failed to send broadcast: {err}"))?;
+
+        // Await the single `broadcast` reply, answering control pings meanwhile.
+        loop {
+            match stream.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    let value: serde_json::Value = serde_json::from_str(&text)?;
+
+                    // Co-located error model: an `error` key is a transport
+                    // failure (a mempool rejection arrives as a `data` frame).
+                    if let Some(error) = value.get("error") {
+                        let code = error
+                            .get("code")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("error");
+                        let message = error
+                            .get("message")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or_default();
+                        let _ = sink.close().await;
+                        bail!("{code}: {message}");
+                    }
+
+                    if value.get("channel").and_then(serde_json::Value::as_str) == Some("broadcast")
+                    {
+                        let data = value.get("data").cloned().unwrap_or_default();
+                        let outcome: BroadcastTxOutcome = serde_json::from_value(data)?;
+                        let _ = sink.close().await;
+                        return Ok(outcome);
+                    }
+
+                    // Ignore anything else (e.g. a `pong`).
+                },
+                Some(Ok(Message::Ping(data))) => {
+                    let _ = sink.send(Message::Pong(data)).await;
+                },
+                Some(Ok(Message::Close(frame))) => {
+                    bail!("WebSocket closed before broadcast reply: {frame:?}")
+                },
+                Some(Ok(_)) => {},
+                Some(Err(err)) => bail!("WebSocket error: {err}"),
+                None => bail!("WebSocket closed before broadcast reply"),
+            }
+        }
+    }
 }
 
 /// Macro to generate pagination methods for GraphQL queries.

--- a/dango/sdk/src/client.rs
+++ b/dango/sdk/src/client.rs
@@ -15,9 +15,13 @@ use {
     reqwest::IntoUrl,
     serde::{Deserialize, Serialize},
     std::{fmt::Debug, str::FromStr, time::Duration},
-    tokio_tungstenite::{connect_async, tungstenite::Message},
+    tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message},
     url::Url,
 };
+
+/// The WebSocket connection [`connect_async`] yields for a `ws(s)://` URL.
+/// Aliased so the `/ws` helpers can name it without the full generic spelling.
+type WsConn = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 
 #[derive(Debug, Clone)]
 pub struct HttpClient {
@@ -202,6 +206,24 @@ impl HttpClient {
         Ok(ws_url)
     }
 
+    /// Open a `/ws` connection and send one opening message — a `subscribe` or
+    /// `broadcast` request. Returns the un-split socket; callers read replies
+    /// with [`recv_text`] and split only when they need concurrent reads and
+    /// writes (the long-lived subscription task does; a one-shot does not).
+    async fn ws_connect(&self, message: serde_json::Value) -> anyhow::Result<WsConn> {
+        let ws_url = self.ws_url()?;
+
+        let (mut ws, _response) = connect_async(ws_url.as_str())
+            .await
+            .map_err(|err| anyhow!("WebSocket connection failed: {err}"))?;
+
+        ws.send(Message::text(message.to_string()))
+            .await
+            .map_err(|err| anyhow!("failed to send WebSocket message: {err}"))?;
+
+        Ok(ws)
+    }
+
     /// Subscribe to perps-exchange events over the WebSocket endpoint
     /// (`GET /ws`, `perpsEvents` channel) — the transport replacement for the
     /// `perps_events` GraphQL subscription. Yields one [`PerpsEventsBatch`] per
@@ -222,8 +244,6 @@ impl HttpClient {
         order_ids: Option<Vec<String>>,
         client_order_ids: Option<Vec<String>>,
     ) -> anyhow::Result<impl Stream<Item = anyhow::Result<PerpsEventsBatch>> + Send> {
-        let ws_url = self.ws_url()?;
-
         // Build the subscribe message. Absent filters are omitted (match-all);
         // present ones are sent as JSON arrays.
         let subscribe = {
@@ -253,35 +273,24 @@ impl HttpClient {
             })
         };
 
-        let (ws, _response) = connect_async(ws_url.as_str())
-            .await
-            .map_err(|err| anyhow!("WebSocket connection failed: {err}"))?;
-
-        let (mut sink, mut stream) = ws.split();
-        sink.send(Message::text(subscribe.to_string()))
-            .await
-            .map_err(|err| anyhow!("failed to send subscribe: {err}"))?;
+        let mut ws = self.ws_connect(subscribe).await?;
 
         // Await the acknowledgement, mapping a `resync` / `tooManyRequests`
         // error frame to a connect-time error (no data frame precedes the ack).
         loop {
-            match stream.next().await {
-                Some(Ok(Message::Text(text))) => match parse_server_frame(&text)? {
-                    ServerFrame::Ack => break,
-                    ServerFrame::Error { code, message } => bail!("{code}: {message}"),
-                    ServerFrame::Data(_) | ServerFrame::Other => {},
-                },
-                Some(Ok(Message::Ping(data))) => {
-                    let _ = sink.send(Message::Pong(data)).await;
-                },
-                Some(Ok(Message::Close(frame))) => {
-                    bail!("WebSocket closed before acknowledgement: {frame:?}")
-                },
-                Some(Ok(_)) => {},
-                Some(Err(err)) => bail!("WebSocket error before acknowledgement: {err}"),
-                None => bail!("WebSocket closed before acknowledgement"),
+            let Some(text) = recv_text(&mut ws).await? else {
+                bail!("WebSocket closed before acknowledgement");
+            };
+            match parse_server_frame(&text)? {
+                ServerFrame::Ack => break,
+                ServerFrame::Error { code, message } => bail!("{code}: {message}"),
+                ServerFrame::Data(_) | ServerFrame::Other => {},
             }
         }
+
+        // Hand the socket to the background task split, so its keepalive writes
+        // and its reads can run concurrently.
+        let (mut sink, mut stream) = ws.split();
 
         // Drive the socket on a background task: forward batches to the stream,
         // answer control pings, and send an app-level ping on a fixed schedule
@@ -343,65 +352,47 @@ impl HttpClient {
     /// [`BroadcastTxOutcome::check_tx`]); only a transport failure to the node
     /// is `Err`.
     pub async fn broadcast_tx_ws(&self, tx: Tx) -> anyhow::Result<BroadcastTxOutcome> {
-        let ws_url = self.ws_url()?;
-
         let request = serde_json::json!({
             "method": "broadcast",
             "id": 1,
             "tx": serde_json::to_value(&tx)?,
         });
 
-        let (ws, _response) = connect_async(ws_url.as_str())
-            .await
-            .map_err(|err| anyhow!("WebSocket connection failed: {err}"))?;
+        let mut ws = self.ws_connect(request).await?;
 
-        let (mut sink, mut stream) = ws.split();
-        sink.send(Message::text(request.to_string()))
-            .await
-            .map_err(|err| anyhow!("failed to send broadcast: {err}"))?;
+        // Await the single `broadcast` reply.
+        let outcome = loop {
+            let Some(text) = recv_text(&mut ws).await? else {
+                bail!("WebSocket closed before broadcast reply");
+            };
 
-        // Await the single `broadcast` reply, answering control pings meanwhile.
-        loop {
-            match stream.next().await {
-                Some(Ok(Message::Text(text))) => {
-                    let value: serde_json::Value = serde_json::from_str(&text)?;
+            let value: serde_json::Value = serde_json::from_str(&text)?;
 
-                    // Co-located error model: an `error` key is a transport
-                    // failure (a mempool rejection arrives as a `data` frame).
-                    if let Some(error) = value.get("error") {
-                        let code = error
-                            .get("code")
-                            .and_then(serde_json::Value::as_str)
-                            .unwrap_or("error");
-                        let message = error
-                            .get("message")
-                            .and_then(serde_json::Value::as_str)
-                            .unwrap_or_default();
-                        let _ = sink.close().await;
-                        bail!("{code}: {message}");
-                    }
-
-                    if value.get("channel").and_then(serde_json::Value::as_str) == Some("broadcast")
-                    {
-                        let data = value.get("data").cloned().unwrap_or_default();
-                        let outcome: BroadcastTxOutcome = serde_json::from_value(data)?;
-                        let _ = sink.close().await;
-                        return Ok(outcome);
-                    }
-
-                    // Ignore anything else (e.g. a `pong`).
-                },
-                Some(Ok(Message::Ping(data))) => {
-                    let _ = sink.send(Message::Pong(data)).await;
-                },
-                Some(Ok(Message::Close(frame))) => {
-                    bail!("WebSocket closed before broadcast reply: {frame:?}")
-                },
-                Some(Ok(_)) => {},
-                Some(Err(err)) => bail!("WebSocket error: {err}"),
-                None => bail!("WebSocket closed before broadcast reply"),
+            // Co-located error model: an `error` key is a transport failure (a
+            // mempool rejection arrives as a `data` frame).
+            if let Some(error) = value.get("error") {
+                let code = error
+                    .get("code")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("error");
+                let message = error
+                    .get("message")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                bail!("{code}: {message}");
             }
-        }
+
+            if value.get("channel").and_then(serde_json::Value::as_str) == Some("broadcast") {
+                let data = value.get("data").cloned().unwrap_or_default();
+                break serde_json::from_value::<BroadcastTxOutcome>(data)?;
+            }
+
+            // Ignore anything else (e.g. a `pong`).
+        };
+
+        let _ = ws.close(None).await;
+
+        Ok(outcome)
     }
 }
 
@@ -635,6 +626,26 @@ enum ServerFrame {
 
     /// Anything else (e.g. `pong`).
     Other,
+}
+
+/// Read the next text frame from a `/ws` socket, transparently answering server
+/// pings. `Ok(None)` means the socket closed cleanly; a transport error is
+/// `Err`. The caller parses the returned JSON and decides when it has its
+/// terminal frame. Serves the one-shot read loops (the subscription ack and
+/// `broadcast`); the long-lived subscription task drives its split socket
+/// directly, so its keepalive writes and reads run concurrently.
+async fn recv_text(ws: &mut WsConn) -> anyhow::Result<Option<String>> {
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Text(text))) => return Ok(Some(text.to_string())),
+            Some(Ok(Message::Ping(data))) => {
+                let _ = ws.send(Message::Pong(data)).await;
+            },
+            Some(Ok(Message::Close(_))) | None => return Ok(None),
+            Some(Ok(_)) => {},
+            Some(Err(err)) => bail!("WebSocket error: {err}"),
+        }
+    }
 }
 
 fn parse_server_frame(text: &str) -> anyhow::Result<ServerFrame> {

--- a/dango/sdk/src/client.rs
+++ b/dango/sdk/src/client.rs
@@ -186,6 +186,22 @@ impl HttpClient {
         Ok(all_items)
     }
 
+    /// Derive the `ws(s)://…/ws` endpoint URL from this client's HTTP base.
+    fn ws_url(&self) -> anyhow::Result<Url> {
+        let mut ws_url = self.url.join("ws")?;
+        match ws_url.scheme() {
+            "http" => ws_url
+                .set_scheme("ws")
+                .map_err(|_| anyhow!("failed to set ws scheme"))?,
+            "https" => ws_url
+                .set_scheme("wss")
+                .map_err(|_| anyhow!("failed to set wss scheme"))?,
+            "ws" | "wss" => {},
+            scheme => bail!("invalid URL scheme: {scheme}"),
+        }
+        Ok(ws_url)
+    }
+
     /// Subscribe to perps-exchange events over the WebSocket endpoint
     /// (`GET /ws`, `perpsEvents` channel) — the transport replacement for the
     /// `perps_events` GraphQL subscription. Yields one [`PerpsEventsBatch`] per
@@ -206,18 +222,7 @@ impl HttpClient {
         order_ids: Option<Vec<String>>,
         client_order_ids: Option<Vec<String>>,
     ) -> anyhow::Result<impl Stream<Item = anyhow::Result<PerpsEventsBatch>> + Send> {
-        // Derive the `/ws` URL from the HTTP base.
-        let mut ws_url = self.url.join("ws")?;
-        match ws_url.scheme() {
-            "http" => ws_url
-                .set_scheme("ws")
-                .map_err(|_| anyhow!("failed to set ws scheme"))?,
-            "https" => ws_url
-                .set_scheme("wss")
-                .map_err(|_| anyhow!("failed to set wss scheme"))?,
-            "ws" | "wss" => {},
-            scheme => bail!("invalid URL scheme: {scheme}"),
-        }
+        let ws_url = self.ws_url()?;
 
         // Build the subscribe message. Absent filters are omitted (match-all);
         // present ones are sent as JSON arrays.
@@ -338,19 +343,7 @@ impl HttpClient {
     /// [`BroadcastTxOutcome::check_tx`]); only a transport failure to the node
     /// is `Err`.
     pub async fn broadcast_tx_ws(&self, tx: Tx) -> anyhow::Result<BroadcastTxOutcome> {
-        // Derive the `/ws` URL from the HTTP base (same as
-        // `subscribe_perps_events`).
-        let mut ws_url = self.url.join("ws")?;
-        match ws_url.scheme() {
-            "http" => ws_url
-                .set_scheme("ws")
-                .map_err(|_| anyhow!("failed to set ws scheme"))?,
-            "https" => ws_url
-                .set_scheme("wss")
-                .map_err(|_| anyhow!("failed to set wss scheme"))?,
-            "ws" | "wss" => {},
-            scheme => bail!("invalid URL scheme: {scheme}"),
-        }
+        let ws_url = self.ws_url()?;
 
         let request = serde_json::json!({
             "method": "broadcast",

--- a/dango/testing/tests/sdk/client.rs
+++ b/dango/testing/tests/sdk/client.rs
@@ -34,6 +34,32 @@ async fn broadcast() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The same broadcast, but over the native WebSocket `broadcast` channel
+/// instead of REST `POST /broadcast`.
+#[tokio::test(flavor = "multi_thread")]
+async fn broadcast_ws() -> anyhow::Result<()> {
+    let (client, mut accounts) = setup_client_test().await?;
+
+    let tx = accounts.user1.sign_transaction(
+        NonEmpty::new_unchecked(vec![Message::transfer(
+            accounts.user2.address.into_inner(),
+            Coins::one(usdc::DENOM.clone(), 100)?,
+        )?]),
+        MOCK_CHAIN_ID,
+        1000000,
+    )?;
+
+    let res = client.broadcast_tx_ws(tx).await?;
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let tx_hash = res.tx_hash;
+
+    client.search_tx(tx_hash).await?.outcome.should_succeed();
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn simulate() -> anyhow::Result<()> {
     let (client, accounts) = setup_client_test().await?;

--- a/sdk/python/dango/info.py
+++ b/sdk/python/dango/info.py
@@ -281,6 +281,17 @@ class Info(API):
 
         return cast("dict[str, Any]", self.post("/broadcast", tx))
 
+    def broadcast_tx_ws(self, tx: Tx) -> dict[str, Any]:
+        """Submit a signed Tx over the native WebSocket `broadcast` channel.
+
+        An alternative to `broadcast_tx_sync` (REST `POST /broadcast`, the
+        default) for clients already holding a `/ws` connection. Returns the
+        same BroadcastTxOutcome; a mempool-rejected tx returns normally (the
+        rejection rides `check_tx.result`).
+        """
+
+        return self._ws_stream.broadcast(cast("dict[str, Any]", tx))
+
     # --- Perps queries -------------------------------------------------------
     #
     # Each method below is a typed wrapper around `query_app_smart` against

--- a/sdk/python/dango/ws_stream_manager.py
+++ b/sdk/python/dango/ws_stream_manager.py
@@ -19,9 +19,11 @@ import contextlib
 import json
 import threading
 from collections.abc import Callable
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import websocket  # from websocket-client
+
+from dango.utils.error import ServerError
 
 # Frame-level keepalive interval. The server closes a connection it has not
 # heard from for 60s; a 20s ping (and the automatic pong to the server's own
@@ -105,6 +107,60 @@ class WsStreamManager:
 
         for thread in threads:
             thread.join(timeout=timeout)
+
+    def broadcast(self, tx: dict[str, Any], *, timeout: float = 10.0) -> dict[str, Any]:
+        """Broadcast a signed tx over the `broadcast` channel; return the `BroadcastTxOutcome`.
+
+        A one-shot request/response on a dedicated short-lived connection
+        (unlike `subscribe`, which is a long-lived stream on its own thread).
+        `Info.broadcast_tx_sync` (REST `POST /broadcast`) is the default; this
+        avoids a second HTTP connection for callers already on `/ws`. A
+        mempool-rejected tx returns normally (the rejection rides
+        `check_tx.result`); only a transport failure raises `ServerError`.
+        """
+
+        try:
+            ws = websocket.create_connection(self._ws_url, timeout=timeout)
+        except Exception as exc:
+            raise ServerError(f"WebSocket connection to {self._ws_url} failed: {exc}") from exc
+
+        try:
+            ws.send(json.dumps({"method": "broadcast", "id": 1, "tx": tx}))
+
+            while True:
+                try:
+                    raw = ws.recv()
+                except Exception as exc:
+                    raise ServerError(f"WebSocket broadcast failed: {exc}") from exc
+
+                if not raw:
+                    raise ServerError("WebSocket closed before broadcast reply")
+
+                try:
+                    msg = json.loads(raw)
+                except Exception as exc:
+                    raise ServerError(f"non-JSON WebSocket frame: {raw!r}") from exc
+
+                if not isinstance(msg, dict):
+                    continue
+
+                # A transport failure to the consensus node is an `error` frame;
+                # a mempool rejection arrives as a `data` frame instead.
+                if "error" in msg:
+                    error = msg.get("error")
+                    if isinstance(error, dict):
+                        detail = f"{error.get('code', 'error')}: {error.get('message', '')}"
+                    else:
+                        detail = str(error)
+                    raise ServerError(f"broadcast failed: {detail}")
+
+                if msg.get("channel") == "broadcast":
+                    return cast("dict[str, Any]", msg.get("data", {}) or {})
+
+                # Ignore anything else (e.g. a `pong`).
+        finally:
+            with contextlib.suppress(Exception):
+                ws.close()
 
     # --- internals -----------------------------------------------------------
 

--- a/sdk/python/tests/test_info_subscriptions.py
+++ b/sdk/python/tests/test_info_subscriptions.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from dango.info import Info
-from dango.utils.types import Addr, CandleInterval, PairId
+from dango.utils.types import Addr, CandleInterval, PairId, Tx
 
 
 class _FakeWebsocketManager:
@@ -70,6 +70,12 @@ class _FakeWsStreamManager:
         self.unsubscribed: list[int] = []
         self.stopped: bool = False
         self._next_id: int = 0
+        # One-shot broadcasts: the txs sent, and the canned outcome returned.
+        self.broadcasts: list[dict[str, Any]] = []
+        self.broadcast_result: dict[str, Any] = {
+            "tx_hash": "0xabc",
+            "check_tx": {"result": {"Ok": None}},
+        }
 
     def subscribe(self, subscription: dict[str, Any], callback: Any) -> int:
         self._next_id += 1
@@ -86,6 +92,10 @@ class _FakeWsStreamManager:
     def join(self, timeout: float | None = None) -> None:
         pass
 
+    def broadcast(self, tx: dict[str, Any]) -> dict[str, Any]:
+        self.broadcasts.append(tx)
+        return self.broadcast_result
+
 
 def _make_info_with_fake_ws_stream() -> tuple[Info, _FakeWsStreamManager]:
     """Build an Info and inject a fake WsStreamManager into its slot."""
@@ -94,6 +104,28 @@ def _make_info_with_fake_ws_stream() -> tuple[Info, _FakeWsStreamManager]:
     fake = _FakeWsStreamManager()
     info._ws_stream_manager = fake  # type: ignore[assignment]
     return info, fake
+
+
+class TestBroadcastWs:
+    def test_delegates_to_ws_stream(self) -> None:
+        """`broadcast_tx_ws` forwards the tx to the manager and returns its outcome."""
+
+        info, fake = _make_info_with_fake_ws_stream()
+        tx = cast(
+            Tx,
+            {
+                "sender": "0x000000000000000000000000000000000000beef",
+                "gas_limit": 1000000,
+                "msgs": [],
+                "data": {},
+                "credential": {},
+            },
+        )
+
+        result = info.broadcast_tx_ws(tx)
+
+        assert fake.broadcasts == [tx]
+        assert result == fake.broadcast_result
 
 
 class TestLazyWsConstruction:


### PR DESCRIPTION
Add a request/response `broadcast` operation to the native `/ws` endpoint, so a
client already holding a WebSocket connection can submit a signed transaction
without a separate HTTP request. REST `POST /broadcast` remains the default.

- Thread the per-connection `HttpRequestDetails` (from the requester IP) and an
  owned `FullContext` through `connection_loop` / `handle_text`.
- Add `ClientMessage::Broadcast { id, tx }` (method `"broadcast"`); reply on the
  `broadcast` channel — a `data` frame with the `BroadcastTxOutcome` (a mempool
  rejection included, carried in `check_tx.result`), or an `error` frame only on
  a transport failure to the consensus node. Reuse the shared
  `crate::broadcast::broadcast_tx` helper; await inline.
- Add DB-free serde unit tests for the new message and frames.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>