### PR TITLE
fix(ui): use shared applets-kit mock in swapper tests

### DIFF
--- a/ui/portal/web/tests/swapper-deposit.test.tsx
+++ b/ui/portal/web/tests/swapper-deposit.test.tsx
@@ -1,10 +1,10 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { resetAppletsKitMocks } from "./mocks/applets-kit";
 import { SwapperDeposit } from "../src/components/bridge/SwapperDeposit";
 
 import type { Connector } from "@left-curve/store/types";
-import type React from "react";
 
 type MockConnector = {
   getProvider?: () => Promise<unknown>;
@@ -46,19 +46,6 @@ const swapperDepositMocks = vi.hoisted(() => ({
 
 vi.mock("../src/components/bridge/DepositOptions", () => ({
   DepositFeeBadge: () => <span data-testid="deposit-fee" />,
-}));
-
-vi.mock("@left-curve/applets-kit", () => ({
-  Button: ({ children, onClick }: React.PropsWithChildren<{ onClick?: () => void }>) => (
-    <button type="button" onClick={onClick}>
-      {children}
-    </button>
-  ),
-  IconChevronRight: () => <span aria-hidden="true" />,
-  WarningContainer: ({ description }: { description: string }) => (
-    <div role="alert">{description}</div>
-  ),
-  useTheme: () => ({ theme: "light" }),
 }));
 
 vi.mock("@left-curve/store", () => ({
@@ -139,6 +126,7 @@ function renderSwapperDeposit(signerConnector?: MockConnector) {
 
 describe("swapper deposit signer", () => {
   beforeEach(() => {
+    resetAppletsKitMocks();
     swapperDepositMocks.dangoConnector = undefined;
     swapperDepositMocks.isConnected = true;
     swapperDepositMocks.signerClients = new Map();


### PR DESCRIPTION
## Summary

- Remove the bespoke local `@left-curve/applets-kit` mock from `swapper-deposit.test.tsx`.
- Use the shared `tests/mocks/applets-kit.ts` helper so the portal quality guard keeps passing.
- Preserve the existing swapper signer assertions without adding a reviewed local mock exception.

## Validation

### Completed

- [x] `corepack pnpm exec biome check ui/portal/web/tests/swapper-deposit.test.tsx`
- [x] `corepack pnpm --filter @left-curve/portal-web exec vitest run tests/test-quality-guards.test.tsx tests/swapper-deposit.test.tsx`

### Remaining

- [ ] Full CI / Portal Deployment

## Manual QA

None