### PR TITLE
feat(perps): report post-event position and order sizes on fill events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,6 +4689,7 @@ dependencies = [
  "dango-storage",
  "sea-orm",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
 ]
 

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -1622,7 +1622,9 @@ The `data` field contains the event-specific payload as JSON. For example, an `o
   "fee": "6.500000",
   "client_order_id": "42",
   "fill_id": "17",
-  "is_maker": false
+  "is_maker": false,
+  "remaining_order_size": "0.000000",
+  "remaining_position_size": "0.100000"
 }
 ```
 
@@ -2381,12 +2383,12 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 ### Order events
 
-| Event             | Fields                                                                                                                                                                            | Description                     |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `realized_funding?`, `fee`, `client_order_id?`, `fill_id?`, `is_maker?` | Order partially or fully filled |
-| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                                                                          | Limit order placed on book      |
-| `order_resized`   | `order_id`, `pair_id`, `user`, `old_size`, `new_size`, `client_order_id?`                                                                                                         | Reduce-only order shrunk        |
-| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                                                                       | Order removed from book         |
+| Event             | Fields                                                                                                                                                                                                                                 | Description                     |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `realized_funding?`, `fee`, `client_order_id?`, `fill_id?`, `is_maker?`, `remaining_order_size?`, `remaining_position_size?` | Order partially or fully filled |
+| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                                                                                                                               | Limit order placed on book      |
+| `order_resized`   | `order_id`, `pair_id`, `user`, `old_size`, `new_size`, `client_order_id?`                                                                                                                                                              | Reduce-only order shrunk        |
+| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                                                                                                                            | Order removed from book         |
 
 `client_order_id` is `null` if the order was submitted without one. Off-chain consumers can use it to correlate fills, persistence, resizes, and removal with the originally-submitted client id.
 
@@ -2402,6 +2404,10 @@ The perps contract emits the following events. These can be queried via `perpsEv
 
 Trading fees are reported separately in the `fee` field on `order_filled`; ADL and deleverage fills incur no trading fees.
 
+`remaining_position_size` reports the size of the affected position **after** the event is applied — positive for a long, negative for a short, and zero when the position was closed entirely. It lets consumers track a position's live size directly instead of accumulating the per-event `closing_size` / `opening_size` (or `adl_size`) deltas. It refers to the fill's user (taker or maker) on `order_filled`, the counter-party on `deleveraged`, and the liquidated user on `liquidated`. A liquidation closes each pair with its own `liquidated` event, so each event reports the resulting size for its own pair. The field is `null` for events emitted before v0.26.0 — the resulting size was not recorded prior to that release.
+
+`remaining_order_size` (on `order_filled` only) reports the order's remaining unfilled size **after** this fill, carrying the same sign as the order's side. It is non-zero when the order is only partially filled and zero once it is fully filled; for the taker side it is the incoming order's remainder (which may then rest on the book or be discarded), and for the maker side the resting order's remainder. The field is `null` for trades executed before v0.26.0 — the remaining order size was not recorded prior to that release.
+
 ### Conditional order events
 
 | Event                         | Fields                                                                          | Description                   |
@@ -2412,11 +2418,11 @@ Trading fees are reported separately in the `fee` field on `order_filled`; ADL a
 
 ### Liquidation events
 
-| Event              | Fields                                                                                  | Description                      |
-| ------------------ | --------------------------------------------------------------------------------------- | -------------------------------- |
-| `liquidated`       | `user`, `pair_id`, `adl_size`, `adl_price`, `adl_realized_pnl`, `adl_realized_funding?` | Position liquidated in a pair    |
-| `deleveraged`      | `user`, `pair_id`, `closing_size`, `fill_price`, `realized_pnl`, `realized_funding?`    | Counter-party hit by ADL         |
-| `bad_debt_covered` | `liquidated_user`, `amount`, `insurance_fund_remaining`                                 | Insurance fund absorbed bad debt |
+| Event              | Fields                                                                                                              | Description                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `liquidated`       | `user`, `pair_id`, `adl_size`, `adl_price`, `adl_realized_pnl`, `adl_realized_funding?`, `remaining_position_size?` | Position liquidated in a pair    |
+| `deleveraged`      | `user`, `pair_id`, `closing_size`, `fill_price`, `realized_pnl`, `realized_funding?`, `remaining_position_size?`    | Counter-party hit by ADL         |
+| `bad_debt_covered` | `liquidated_user`, `amount`, `insurance_fund_remaining`                                                             | Insurance fund absorbed bad debt |
 
 ### ReasonForOrderRemoval
 
@@ -3005,10 +3011,10 @@ Submit a signed transaction to the mempool — a **write** request/response (one
 {"method": "broadcast", "id": 1, "tx": { ... signed Tx ... }}
 ```
 
-| Field | Type     | Description                                                     |
-| ----- | -------- | --------------------------------------------------------------- |
-| `id`  | `Int`    | Echoed on the reply frame                                       |
-| `tx`  | `Object` | The signed `Tx` (see [§2](#2-authentication-and-transactions))  |
+| Field | Type     | Description                                                    |
+| ----- | -------- | -------------------------------------------------------------- |
+| `id`  | `Int`    | Echoed on the reply frame                                      |
+| `tx`  | `Object` | The signed `Tx` (see [§2](#2-authentication-and-transactions)) |
 
 The reply rides the `broadcast` channel. Success — **including a mempool-rejected tx**, whose rejection is carried in `check_tx.result` — is a `data` frame holding the `BroadcastTxOutcome` (same shape as [§11.3](#113-broadcast)):
 

--- a/dango/exchange/perps/src/maintain/liquidate.rs
+++ b/dango/exchange/perps/src/maintain/liquidate.rs
@@ -710,6 +710,13 @@ fn execute_close_schedule(
                 adl_price: Some(adl_price),
                 adl_realized_pnl,
                 adl_realized_funding: Some(adl_funding),
+                remaining_position_size: Some(
+                    user_state
+                        .positions
+                        .get(pair_id)
+                        .map(|p| p.size)
+                        .unwrap_or_default(),
+                ),
             })?;
 
             #[cfg(feature = "metrics")]
@@ -728,6 +735,13 @@ fn execute_close_schedule(
                 adl_price: None,
                 adl_realized_pnl: UsdValue::ZERO,
                 adl_realized_funding: Some(UsdValue::ZERO),
+                remaining_position_size: Some(
+                    user_state
+                        .positions
+                        .get(pair_id)
+                        .map(|p| p.size)
+                        .unwrap_or_default(),
+                ),
             })?;
         }
     }
@@ -931,6 +945,13 @@ fn execute_adl(
             fill_price: bankruptcy_price,
             realized_pnl: counter_settlement.pnl.closing,
             realized_funding: Some(counter_settlement.pnl.funding),
+            remaining_position_size: Some(
+                counter_state
+                    .positions
+                    .get(pair_id)
+                    .map(|p| p.size)
+                    .unwrap_or_default(),
+            ),
         })?;
 
         remaining = remaining.checked_sub(user_close)?;

--- a/dango/exchange/perps/src/trade/submit_order.rs
+++ b/dango/exchange/perps/src/trade/submit_order.rs
@@ -806,6 +806,13 @@ pub fn match_order(
         }
     };
 
+    // Running remainder of the taker's order, decremented on each fill below
+    // so every taker-side `OrderFilled` can report the order's post-fill size.
+    // Mirrors `walk_book`'s own `remaining_size` decrement using the same
+    // per-fill sizes, so the two stay exactly in sync. Captured here before
+    // the `remaining_size` binding is shadowed by the walk's leftover.
+    let mut taker_remaining_size = remaining_size;
+
     let WalkBookOutcome {
         steps,
         remaining_size,
@@ -896,6 +903,14 @@ pub fn match_order(
             }) => {
                 let maker_fill_size = taker_fill_size.checked_neg()?;
 
+                // Post-fill order remainders reported on the two `OrderFilled`
+                // events below. Decrement the taker's running remainder (the
+                // same trajectory `walk_book` computed); the maker's signed
+                // remainder is its pre-fill size less what it just filled, and
+                // is zero on a full fill.
+                taker_remaining_size.checked_sub_assign(taker_fill_size)?;
+                let maker_remaining_size = maker_order.size.checked_sub(maker_fill_size)?;
+
                 // ---------------- Allocate a shared fill id ------------------
                 //
                 // Both `OrderFilled` events below carry this `fill_id`, so
@@ -922,6 +937,7 @@ pub fn match_order(
                         taker_client_order_id,
                         fill_id,
                         false,
+                        taker_remaining_size,
                     )),
                 )?;
 
@@ -982,7 +998,14 @@ pub fn match_order(
                     maker_fill_size,
                     fill_price,
                     maker_fee_rate,
-                    Some((events, maker_order_id, maker_client_order_id, fill_id, true)),
+                    Some((
+                        events,
+                        maker_order_id,
+                        maker_client_order_id,
+                        fill_id,
+                        true,
+                        maker_remaining_size,
+                    )),
                 )?;
 
                 volumes
@@ -1196,6 +1219,9 @@ pub fn settle_fill(
         Option<ClientOrderId>,
         FillId,
         bool,
+        // The order's remaining unfilled size after this fill, forwarded to
+        // `OrderFilled.remaining_order_size`.
+        Quantity,
     )>,
 ) -> StdResult<FillSettlement> {
     let (closing, opening) = {
@@ -1220,7 +1246,18 @@ pub fn settle_fill(
 
     let volume = compute_notional(fill_size, fill_price)?;
 
-    if let Some((events, order_id, client_order_id, fill_id, is_maker)) = events {
+    if let Some((events, order_id, client_order_id, fill_id, is_maker, remaining_order_size)) =
+        events
+    {
+        // `execute_fill` just mutated the position; read its resulting size.
+        // An absent entry means the fill closed the position entirely, which
+        // `unwrap_or_default` reports as zero.
+        let remaining_position_size = user_state
+            .positions
+            .get(pair_id)
+            .map(|p| p.size)
+            .unwrap_or_default();
+
         events.push(OrderFilled {
             order_id,
             pair_id: pair_id.clone(),
@@ -1235,6 +1272,8 @@ pub fn settle_fill(
             client_order_id,
             fill_id: Some(fill_id),
             is_maker: Some(is_maker),
+            remaining_order_size: Some(remaining_order_size),
+            remaining_position_size: Some(remaining_position_size),
         })?;
     }
 

--- a/dango/exchange/types/Cargo.toml
+++ b/dango/exchange/types/Cargo.toml
@@ -28,3 +28,6 @@ dango-storage         = { workspace = true }
 sea-orm               = { workspace = true, optional = true }
 serde                 = { workspace = true }
 sha2                  = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/dango/exchange/types/src/perps.rs
+++ b/dango/exchange/types/src/perps.rs
@@ -1333,6 +1333,27 @@ pub struct OrderFilled {
     /// `None` for trades executed before v0.16.0 — the maker/taker flag was not
     /// recorded prior to that release.
     pub is_maker: Option<bool>,
+
+    /// The filled order's remaining unfilled size after this fill, carrying
+    /// the same sign as the order's side. Non-zero when the order is only
+    /// partially filled, zero when it is fully filled. For the taker side
+    /// this is the incoming order's remainder (which may then rest on the
+    /// book or be discarded); for the maker side, the resting order's
+    /// remainder.
+    ///
+    /// `None` for trades executed before v0.26.0 — the remaining order size
+    /// was not recorded prior to that release.
+    pub remaining_order_size: Option<Quantity>,
+
+    /// The user's resulting position size in this pair after this fill is
+    /// applied — positive for long, negative for short, zero if the fill
+    /// closed the position entirely. Lets consumers track live position
+    /// size without accumulating the `closing_size` / `opening_size` deltas
+    /// themselves.
+    ///
+    /// `None` for trades executed before v0.26.0 — the resulting position
+    /// size was not recorded prior to that release.
+    pub remaining_position_size: Option<Quantity>,
 }
 
 /// Event indicating a user has been liquidated in a specific pair.
@@ -1372,6 +1393,15 @@ pub struct Liquidated {
     /// `None` for liquidations executed before v0.17.0 — funding was
     /// reported as part of `adl_realized_pnl` prior to that release.
     pub adl_realized_funding: Option<UsdValue>,
+
+    /// The liquidated user's resulting position size in this pair after this
+    /// pair's liquidation — zero if the position was fully closed, non-zero
+    /// if it was only partially closed. One `Liquidated` event is emitted
+    /// per pair closed, so each event reports its own pair's resulting size.
+    ///
+    /// `None` for liquidations executed before v0.26.0 — the resulting
+    /// position size was not recorded prior to that release.
+    pub remaining_position_size: Option<Quantity>,
 }
 
 /// Event indicating a counter-party's position was reduced during ADL.
@@ -1406,6 +1436,14 @@ pub struct Deleveraged {
     /// `None` for ADL fills executed before v0.17.0 — funding was
     /// reported as part of `realized_pnl` prior to that release.
     pub realized_funding: Option<UsdValue>,
+
+    /// The counter-party's resulting position size in this pair after this
+    /// ADL fill — zero if the position was fully closed, non-zero if it was
+    /// only partially reduced.
+    ///
+    /// `None` for ADL fills executed before v0.26.0 — the resulting position
+    /// size was not recorded prior to that release.
+    pub remaining_position_size: Option<Quantity>,
 }
 
 /// Event indicating the insurance fund absorbed bad debt from a liquidation.
@@ -1452,7 +1490,11 @@ pub struct ReferralSet {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::collections::BTreeMap};
+    use {
+        super::*,
+        dango_primitives::Denom,
+        std::{collections::BTreeMap, str::FromStr},
+    };
 
     #[test]
     fn resolve_empty_tiers() {
@@ -1533,5 +1575,87 @@ mod tests {
         assert_eq!(schedule.resolve(UsdValue::new_int(50_000)), base);
         assert_eq!(schedule.resolve(UsdValue::new_int(500_000)), tier1_rate);
         assert_eq!(schedule.resolve(UsdValue::new_int(5_000_000)), tier2_rate);
+    }
+
+    // The post-v0.26.0 position/order-size fields are `Option`s so that events
+    // emitted (and stored/indexed) before those fields existed still
+    // deserialize — the missing keys must decode as `None`, not error. These
+    // tests strip the new keys from a current event's JSON to mimic a legacy
+    // payload.
+
+    #[test]
+    fn order_filled_deserializes_without_new_fields_as_none() {
+        let event = OrderFilled {
+            order_id: OrderId::new(1),
+            pair_id: Denom::from_str("perp/btcusd").unwrap(),
+            user: Addr::mock(1),
+            fill_price: UsdPrice::new_int(2_000),
+            fill_size: Quantity::new_int(3),
+            closing_size: Quantity::ZERO,
+            opening_size: Quantity::new_int(3),
+            realized_pnl: UsdValue::ZERO,
+            realized_funding: Some(UsdValue::ZERO),
+            fee: UsdValue::ZERO,
+            client_order_id: None,
+            fill_id: Some(FillId::new(7)),
+            is_maker: Some(false),
+            remaining_position_size: Some(Quantity::new_int(3)),
+            remaining_order_size: Some(Quantity::ZERO),
+        };
+
+        let mut json = serde_json::to_value(&event).unwrap();
+        let obj = json.as_object_mut().unwrap();
+        obj.remove("remaining_position_size");
+        obj.remove("remaining_order_size");
+
+        let parsed: OrderFilled = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.remaining_position_size, None);
+        assert_eq!(parsed.remaining_order_size, None);
+        // A pre-existing field still decodes correctly.
+        assert_eq!(parsed.fill_size, Quantity::new_int(3));
+    }
+
+    #[test]
+    fn liquidated_deserializes_without_new_field_as_none() {
+        let event = Liquidated {
+            user: Addr::mock(1),
+            pair_id: Denom::from_str("perp/btcusd").unwrap(),
+            adl_size: Quantity::new_int(-5),
+            adl_price: Some(UsdPrice::new_int(1_782)),
+            adl_realized_pnl: UsdValue::ZERO,
+            adl_realized_funding: Some(UsdValue::ZERO),
+            remaining_position_size: Some(Quantity::ZERO),
+        };
+
+        let mut json = serde_json::to_value(&event).unwrap();
+        json.as_object_mut()
+            .unwrap()
+            .remove("remaining_position_size");
+
+        let parsed: Liquidated = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.remaining_position_size, None);
+        assert_eq!(parsed.adl_size, Quantity::new_int(-5));
+    }
+
+    #[test]
+    fn deleveraged_deserializes_without_new_field_as_none() {
+        let event = Deleveraged {
+            user: Addr::mock(1),
+            pair_id: Denom::from_str("perp/btcusd").unwrap(),
+            closing_size: Quantity::new_int(5),
+            fill_price: UsdPrice::new_int(1_782),
+            realized_pnl: UsdValue::ZERO,
+            realized_funding: Some(UsdValue::ZERO),
+            remaining_position_size: Some(Quantity::ZERO),
+        };
+
+        let mut json = serde_json::to_value(&event).unwrap();
+        json.as_object_mut()
+            .unwrap()
+            .remove("remaining_position_size");
+
+        let parsed: Deleveraged = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.remaining_position_size, None);
+        assert_eq!(parsed.closing_size, Quantity::new_int(5));
     }
 }

--- a/dango/indexer/clickhouse/src/indexer/perps_fees.rs
+++ b/dango/indexer/clickhouse/src/indexer/perps_fees.rs
@@ -489,6 +489,8 @@ mod tests {
             client_order_id: None,
             fill_id: Some(Uint64::new(42)),
             is_maker: Some(false),
+            remaining_order_size: None,
+            remaining_position_size: None,
         }
     }
 
@@ -500,6 +502,7 @@ mod tests {
             fill_price: UsdPrice::new_int(fill_price_int),
             realized_pnl: UsdValue::new_int(0),
             realized_funding: Some(UsdValue::new_int(0)),
+            remaining_position_size: None,
         }
     }
 

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -858,6 +858,12 @@ async fn liquidation_with_adl() {
         "v0.17.0+ Liquidated events always carry Some(adl_realized_funding); \
          with no funding accrued it must be Some(ZERO)"
     );
+    assert_eq!(
+        liq.remaining_position_size,
+        Some(Quantity::ZERO),
+        "liquidation fully closed Trader A's 5-long in this pair, so the \
+         resulting position size must be Some(ZERO)"
+    );
 
     // The Deleveraged event for the counter-party (Trader B) should
     // mirror the split: closing-only `realized_pnl = +$1,090` (Trader B
@@ -886,6 +892,12 @@ async fn liquidation_with_adl() {
         Some(UsdValue::ZERO),
         "v0.17.0+ Deleveraged events always carry Some(realized_funding); \
          with no funding accrued it must be Some(ZERO)"
+    );
+    assert_eq!(
+        dlv.remaining_position_size,
+        Some(Quantity::ZERO),
+        "ADL closed Trader B's entire 5-short in this pair, so the resulting \
+         position size must be Some(ZERO)"
     );
 
     // Trader A should have no positions and $0 margin.

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -250,7 +250,7 @@ async fn liquidation_on_order_book() {
     let vault_margin_before = vault_state_before.unwrap().margin;
 
     // Anyone can call Liquidate.
-    suite
+    let liq_events = suite
         .execute(
             &mut accounts.owner,
             contracts.perps,
@@ -260,7 +260,37 @@ async fn liquidation_on_order_book() {
             Coins::new(),
         )
         .await
-        .should_succeed();
+        .should_succeed()
+        .events;
+
+    // The book absorbed the whole close, so the single Liquidated event takes
+    // the no-ADL shape — and must report the position size left after the
+    // partial close: 5 - 1.689656 = 3.310344 ETH, the same value the state
+    // query asserts below.
+    let liquidated_events = liq_events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "liquidated")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Liquidated>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        liquidated_events.len(),
+        1,
+        "one Liquidated event for the single scheduled pair"
+    );
+    let liq = &liquidated_events[0];
+    assert_eq!(liq.user, accounts.user1.address());
+    assert_eq!(liq.adl_size, Quantity::ZERO, "book absorbed the close");
+    assert_eq!(liq.adl_price, None, "no ADL, no ADL price");
+    assert_eq!(liq.adl_realized_pnl, UsdValue::ZERO);
+    assert_eq!(
+        liq.remaining_position_size,
+        Some(Quantity::new_raw(3_310_344)),
+        "Liquidated must report the post-close position size on a partial close"
+    );
 
     // Trader position should be reduced from 5 to ~3.310345 ETH (partial close).
     let state = suite
@@ -1767,6 +1797,7 @@ async fn liquidation_book_fills_have_fill_id_adl_does_not() {
     // deserialize fine (extra fields ignored) but this assertion
     // documents the intended shape.
     let deleveraged_events = events
+        .clone()
         .search_event::<CheckedContractEvent>()
         .with_predicate(|e| e.ty == "deleveraged")
         .take()
@@ -1778,5 +1809,33 @@ async fn liquidation_book_fills_have_fill_id_adl_does_not() {
     assert!(
         !deleveraged_events.is_empty(),
         "liquidation should have ADL'd the remainder against a counter-party"
+    );
+
+    // The 3-ETH ADL leg only partially consumes Trader B's 5-ETH short: the
+    // Deleveraged event must report the -2 ETH that survives.
+    assert_eq!(deleveraged_events.len(), 1, "single ADL counter-party");
+    assert_eq!(deleveraged_events[0].user, accounts.user3.address());
+    assert_eq!(
+        deleveraged_events[0].remaining_position_size,
+        Some(Quantity::new_int(-2)),
+        "Deleveraged must report the counter-party's post-ADL position size"
+    );
+
+    // Trader A's full 5-ETH long is closed across the book leg (2) and the
+    // ADL leg (3), so the pair's Liquidated event reports a zero remainder.
+    let liquidated_events = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "liquidated")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<Liquidated>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(liquidated_events.len(), 1);
+    assert_eq!(
+        liquidated_events[0].remaining_position_size,
+        Some(Quantity::ZERO),
+        "the mixed book+ADL close wipes the whole position"
     );
 }

--- a/dango/testing/tests/perps/liquidation_spec.rs
+++ b/dango/testing/tests/perps/liquidation_spec.rs
@@ -407,6 +407,14 @@ async fn run_single(case: SingleCase) {
     assert_eq!(liquidated.len(), 1, "exactly one Liquidated event");
     assert_eq!(liquidated[0].user, accounts.user1.address());
 
+    // The event reports Alice's position size after this pair's liquidation —
+    // the same value the state query asserts below, whether the close was
+    // partial (book and/or ADL) or full.
+    assert_eq!(
+        liquidated[0].remaining_position_size,
+        Some(Quantity::new_int(case.alice_pos))
+    );
+
     match &case.adl {
         Some(adl) => {
             // Alice's ADL closes against her position: negative for a long.
@@ -437,6 +445,14 @@ async fn run_single(case: SingleCase) {
             assert_eq!(
                 deleveraged[0].realized_pnl,
                 UsdValue::new_raw(-alice_adl_pnl)
+            );
+
+            // The event reports Bob's position size after the ADL fill —
+            // non-zero when his position was only partially consumed, and
+            // the same value the state query asserts below.
+            assert_eq!(
+                deleveraged[0].remaining_position_size,
+                Some(Quantity::new_int(case.bob_pos))
             );
         },
         None => {
@@ -647,6 +663,15 @@ async fn run_double(case: DoubleCase) {
         UsdValue::new_raw(alice_btc_pnl)
     );
 
+    // Each per-pair Liquidated event reports its own pair's resulting size:
+    // Alice's 1-BTC position less the BTC ADL leg.
+    assert_eq!(
+        liquidated[0].remaining_position_size,
+        Some(Quantity::new_raw(
+            (1_000_000 - case.btc_adl.size_raw) * sign
+        ))
+    );
+
     if let Some(eth_adl) = &case.eth_adl {
         assert_eq!(liquidated[1].pair_id, eth);
         assert_eq!(
@@ -656,6 +681,11 @@ async fn run_double(case: DoubleCase) {
         assert_eq!(
             liquidated[1].adl_price,
             Some(UsdPrice::new_int(eth_adl.price))
+        );
+        // Alice's 10-ETH position less the ETH ADL leg.
+        assert_eq!(
+            liquidated[1].remaining_position_size,
+            Some(Quantity::new_raw((10_000_000 - eth_adl.size_raw) * sign))
         );
     }
 
@@ -678,6 +708,14 @@ async fn run_double(case: DoubleCase) {
         UsdValue::new_raw(-alice_btc_pnl)
     );
 
+    // Bob's post-ADL BTC size mirrors Alice's remainder on the short side.
+    assert_eq!(
+        deleveraged[0].remaining_position_size,
+        Some(Quantity::new_raw(
+            -(1_000_000 - case.btc_adl.size_raw) * sign
+        ))
+    );
+
     if let Some(eth_adl) = &case.eth_adl {
         let alice_eth_pnl = eth_adl.size_raw * (eth_adl.price - ENTRY_ETH) * sign;
         assert_eq!(deleveraged[1].user, accounts.user2.address());
@@ -686,6 +724,11 @@ async fn run_double(case: DoubleCase) {
         assert_eq!(
             deleveraged[1].realized_pnl,
             UsdValue::new_raw(-alice_eth_pnl)
+        );
+        // Bob's post-ADL ETH size mirrors Alice's remainder on the short side.
+        assert_eq!(
+            deleveraged[1].remaining_position_size,
+            Some(Quantity::new_raw(-(10_000_000 - eth_adl.size_raw) * sign))
         );
     }
 

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -2,8 +2,8 @@ use {
     crate::{default_pair_param, default_param, register_oracle_prices},
     dango_math::Uint128,
     dango_order_book::{
-        ChildOrder, Dimensionless, LiquidityDepthResponse, OrderId, OrderKind, Quantity,
-        QueryOrdersByUserResponseItem, TimeInForce, UsdPrice, UsdValue,
+        ChildOrder, Dimensionless, LiquidityDepthResponse, OrderId, OrderKind, OrderPersisted,
+        Quantity, QueryOrdersByUserResponseItem, TimeInForce, UsdPrice, UsdValue,
     },
     dango_primitives::{
         Addressable, CheckedContractEvent, Coins, Inner, JsonDeExt, QuerierExt, ResultExt,
@@ -1624,6 +1624,304 @@ async fn order_filled_reports_resulting_position_size_on_flip() {
         taker_fill.remaining_order_size,
         Some(Quantity::ZERO),
         "a fully-filled order must report zero remaining size"
+    );
+}
+
+/// A partially-filled maker's `OrderFilled` must report the resting order's
+/// post-fill remainder, and that remainder must equal the order left on the
+/// book. Every prior fill test consumes its makers in full, so the non-zero
+/// maker-side `remaining_order_size` was never exercised.
+///
+/// user1 rests a 10-lot ask; user3 market-buys 4. By intent: the taker is
+/// fully filled (remainder 0, position long 4), the maker keeps a 6-lot ask
+/// on the book (remainder -6, position short 4).
+#[tokio::test]
+async fn order_filled_reports_maker_remainder_on_partial_fill() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let pair = pair_id();
+
+    for user in [&mut accounts.user1, &mut accounts.user3] {
+        suite
+            .execute(
+                user,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+                Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+            )
+            .await
+            .should_succeed();
+    }
+
+    // user1 rests a 10-lot ask at $2,000.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // user3 market-buys 4, partially consuming the resting ask.
+    let events = suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(4),
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    let fills = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_filled")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderFilled>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(fills.len(), 2, "one match → taker and maker OrderFilled");
+
+    let taker_fill = fills
+        .iter()
+        .find(|f| f.user == accounts.user3.address())
+        .expect("a taker fill for user3");
+    assert_eq!(taker_fill.is_maker, Some(false));
+    assert_eq!(
+        taker_fill.remaining_order_size,
+        Some(Quantity::ZERO),
+        "the 4-lot buy is fully filled"
+    );
+    assert_eq!(
+        taker_fill.remaining_position_size,
+        Some(Quantity::new_int(4))
+    );
+
+    let maker_fill = fills
+        .iter()
+        .find(|f| f.user == accounts.user1.address())
+        .expect("a maker fill for user1");
+    assert_eq!(maker_fill.is_maker, Some(true));
+    assert_eq!(
+        maker_fill.remaining_order_size,
+        Some(Quantity::new_int(-6)),
+        "the 10-lot ask keeps 6 lots after filling 4"
+    );
+    assert_eq!(
+        maker_fill.remaining_position_size,
+        Some(Quantity::new_int(-4))
+    );
+
+    // The event's remainder must equal the order actually left on the book.
+    let maker_orders = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+    assert_eq!(
+        maker_orders.len(),
+        1,
+        "the partially-filled ask still rests"
+    );
+    let resting = maker_orders.values().next().unwrap();
+    assert_eq!(
+        Some(resting.size),
+        maker_fill.remaining_order_size,
+        "event remainder must match the resized resting order"
+    );
+
+    // And the events' position sizes must equal the durable user states.
+    for (user, expected) in [
+        (accounts.user1.address(), Quantity::new_int(-4)),
+        (accounts.user3.address(), Quantity::new_int(4)),
+    ] {
+        let state = suite
+            .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest { user })
+            .should_succeed()
+            .unwrap();
+        assert_eq!(state.positions[&pair].size, expected);
+    }
+}
+
+/// A GTC taker whose remainder rests on the book must report that remainder
+/// on its last fill, and the value must equal both the `OrderPersisted`
+/// event's size and the durable resting order. No prior test asserts
+/// `OrderPersisted` at all.
+///
+/// user1 rests a 5-lot ask; user3 submits a GTC limit buy for 10 at the same
+/// price. By intent: 5 fill (position long 5), 5 rest as a bid.
+#[tokio::test]
+async fn order_filled_taker_remainder_matches_persisted_order() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let pair = pair_id();
+
+    for user in [&mut accounts.user1, &mut accounts.user3] {
+        suite
+            .execute(
+                user,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+                Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+            )
+            .await
+            .should_succeed();
+    }
+
+    // user1 rests a 5-lot ask at $2,000.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-5),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // user3 GTC-buys 10 at $2,000: 5 fill, 5 rest.
+    let events = suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    let fills = events
+        .clone()
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_filled")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderFilled>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(fills.len(), 2, "one match → taker and maker OrderFilled");
+
+    let taker_fill = fills
+        .iter()
+        .find(|f| f.user == accounts.user3.address())
+        .expect("a taker fill for user3");
+    assert_eq!(
+        taker_fill.remaining_order_size,
+        Some(Quantity::new_int(5)),
+        "the 10-lot buy has 5 left after consuming the 5-lot ask"
+    );
+    assert_eq!(
+        taker_fill.remaining_position_size,
+        Some(Quantity::new_int(5))
+    );
+
+    let maker_fill = fills
+        .iter()
+        .find(|f| f.user == accounts.user1.address())
+        .expect("a maker fill for user1");
+    assert_eq!(
+        maker_fill.remaining_order_size,
+        Some(Quantity::ZERO),
+        "the 5-lot ask is fully consumed"
+    );
+
+    // The remainder rests: OrderPersisted must carry the same size the
+    // taker's fill reported as remaining.
+    let persisted = events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_persisted")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderPersisted>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        persisted.len(),
+        1,
+        "the unfilled remainder rests on the book"
+    );
+    assert_eq!(persisted[0].user, accounts.user3.address());
+    assert_eq!(persisted[0].limit_price, UsdPrice::new_int(2_000));
+    assert_eq!(
+        Some(persisted[0].size),
+        taker_fill.remaining_order_size,
+        "OrderPersisted size must equal the taker fill's remaining_order_size"
+    );
+
+    // Durable cross-check: the resting bid on the book carries the same size,
+    // and the maker's book is empty.
+    let taker_orders = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user3.address(),
+        })
+        .should_succeed();
+    assert_eq!(taker_orders.len(), 1);
+    let resting = taker_orders.values().next().unwrap();
+    assert_eq!(resting.size, Quantity::new_int(5));
+    assert_eq!(resting.limit_price, UsdPrice::new_int(2_000));
+
+    let maker_orders = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+    assert!(
+        maker_orders.is_empty(),
+        "the maker's ask was fully consumed"
     );
 }
 

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -1445,6 +1445,186 @@ async fn fill_id_is_shared_across_match_sides_and_increments_per_match() {
              with no prior position it must be Some(ZERO)"
         );
     }
+
+    // The two post-fill fields. Event order per match is (taker, maker), so
+    // fills are [taker@1, maker1, taker@2, maker2]. Values derived from the
+    // trade intent (taker buys 4 across two 2-lot makers), not the code:
+    //
+    // - resulting position: the taker ends long 2 after match 1 and long 4
+    //   after match 2; each maker starts flat and ends short 2.
+    // - order remainder: the taker's buy-4 has 2 left after match 1 and 0
+    //   after match 2; each maker's 2-lot ask is fully consumed (0 left).
+    assert_eq!(
+        fills
+            .iter()
+            .map(|f| f.remaining_position_size)
+            .collect::<Vec<_>>(),
+        vec![
+            Some(Quantity::new_int(2)),
+            Some(Quantity::new_int(-2)),
+            Some(Quantity::new_int(4)),
+            Some(Quantity::new_int(-2)),
+        ],
+        "each OrderFilled must report the position size resulting from that fill"
+    );
+    assert_eq!(
+        fills
+            .iter()
+            .map(|f| f.remaining_order_size)
+            .collect::<Vec<_>>(),
+        vec![
+            Some(Quantity::new_int(2)),
+            Some(Quantity::ZERO),
+            Some(Quantity::ZERO),
+            Some(Quantity::ZERO),
+        ],
+        "each OrderFilled must report the order's remaining size after that fill"
+    );
+}
+
+/// A fill that closes and then flips a position reports the resulting *signed*
+/// position size and the order's post-fill remainder. Complements
+/// `fill_id_is_shared_across_match_sides_and_increments_per_match`, which only
+/// exercises position-opening fills.
+///
+/// Trader (user3) opens long 10, then sells 15 in a single match: this closes
+/// the 10 long and opens a 5 short — the `decompose_fill` flip example
+/// documented on `OrderFilled`. The taker fill must report
+/// `remaining_position_size = Some(-5)` and, since the sell fully fills against
+/// a 15-lot bid, `remaining_order_size = Some(0)`.
+#[tokio::test]
+async fn order_filled_reports_resulting_position_size_on_flip() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let pair = pair_id();
+
+    for user in [
+        &mut accounts.user1,
+        &mut accounts.user2,
+        &mut accounts.user3,
+    ] {
+        suite
+            .execute(
+                user,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+                Coins::one(usdc::DENOM.clone(), Uint128::new(100_000_000_000)).unwrap(),
+            )
+            .await
+            .should_succeed();
+    }
+
+    // Open: user1 rests a 10-lot ask; user3 market-buys 10 → long 10.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-10),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+    suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(10),
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // Flip: user2 rests a 15-lot bid; user3 market-sells 15 → closes the 10
+    // long and opens a 5 short.
+    suite
+        .execute(
+            &mut accounts.user2,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(15),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(2_000),
+                    time_in_force: TimeInForce::PostOnly,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+    let flip_events = suite
+        .execute(
+            &mut accounts.user3,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(-15),
+                kind: OrderKind::Market {
+                    max_slippage: Dimensionless::new_percent(50),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed()
+        .events;
+
+    let taker_fill = flip_events
+        .search_event::<CheckedContractEvent>()
+        .with_predicate(|e| e.ty == "order_filled")
+        .take()
+        .all()
+        .into_iter()
+        .map(|e| e.event.data.deserialize_json::<OrderFilled>().unwrap())
+        .find(|f| f.user == accounts.user3.address())
+        .expect("a taker order_filled event for user3");
+
+    // The documented `decompose_fill` flip: long 10 selling 15 closes 10 and
+    // opens 5 on the short side.
+    assert_eq!(taker_fill.fill_size, Quantity::new_int(-15));
+    assert_eq!(taker_fill.closing_size, Quantity::new_int(-10));
+    assert_eq!(taker_fill.opening_size, Quantity::new_int(-5));
+    // Resulting position: flipped from long 10 to short 5.
+    assert_eq!(
+        taker_fill.remaining_position_size,
+        Some(Quantity::new_int(-5)),
+        "selling 15 while long 10 must leave the position short 5"
+    );
+    // The 15-lot sell fully fills against the 15-lot bid → nothing left.
+    assert_eq!(
+        taker_fill.remaining_order_size,
+        Some(Quantity::ZERO),
+        "a fully-filled order must report zero remaining size"
+    );
 }
 
 /// Bug reproduction: sell-side market order with partial fill is incorrectly


### PR DESCRIPTION
Add `remaining_position_size` to the `order_filled`, `liquidated`, and `deleveraged` events, giving the affected position's resulting size after the change so consumers can track live size without accumulating the per-event deltas themselves. Add `remaining_order_size` to `order_filled`, giving the order's remaining unfilled size after the fill (zero once fully filled).

All new fields are `Option`s so events emitted before they shipped still deserialize — a missing key decodes as `None` — matching the existing `fill_id` / `is_maker` convention. Populated at each emission site, documented in book/perps/8-api.md, and covered by spec-based e2e assertions plus backward-compat deserialization tests.