### PR TITLE
fix(indexer): serve pre-0.26.0 Configure blocks via frozen legacy wire schema

### DIFF
--- a/dango/archive/block-source/src/httpd_client.rs
+++ b/dango/archive/block-source/src/httpd_client.rs
@@ -84,8 +84,8 @@ impl HttpdClient {
     /// Open a WebSocket subscription to the node's `fullBlock` channel and return
     /// a stream of fully-assembled [`BlockData`], **always starting at the live
     /// tip** (only blocks newer than the current tip). Each data frame's `data`
-    /// is the node's `{block, outcome}` — a `FullBlock`, which `BlockData` (an
-    /// alias of it) deserializes directly.
+    /// is the node's `{block, outcome}` — which `BlockData` (the untagged
+    /// compat enum) deserializes directly, legacy pre-0.26.0 blocks included.
     ///
     /// There is deliberately **no `since`**. The node serves this feed from a
     /// small in-memory ring, so a `since` below that window fails the

--- a/dango/archive/block-source/src/local/mod.rs
+++ b/dango/archive/block-source/src/local/mod.rs
@@ -180,12 +180,12 @@ impl BlockSource for LocalBlockSource {
             return Ok(None);
         }
 
-        let cache_file = CacheFile::load_from_disk_async(path).await?;
+        // Compat load: the co-located node's cache files have the same seven
+        // legacy pre-0.26.0 blocks as everyone else's.
+        let compat =
+            tokio::task::spawn_blocking(move || CacheFile::load_from_disk_compat(path)).await??;
 
-        Ok(Some(BlockData {
-            block: cache_file.data.block,
-            outcome: cache_file.data.block_outcome,
-        }))
+        Ok(Some(compat.into_full_block()))
     }
 
     fn subscribe(&self) -> broadcast::Receiver<Arc<BlockData>> {

--- a/dango/archive/block-source/src/remote/fetcher/sentinel.rs
+++ b/dango/archive/block-source/src/remote/fetcher/sentinel.rs
@@ -194,11 +194,11 @@ async fn fetch_range<C>(
 mod tests {
     use {
         super::*,
-        dango_primitives::{Block, BlockInfo, BlockOutcome, Hash256, Timestamp},
+        dango_primitives::{Block, BlockInfo, BlockOutcome, FullBlock, Hash256, Timestamp},
     };
 
     fn block(height: u64) -> BlockData {
-        BlockData {
+        BlockData::Current(FullBlock {
             block: Block {
                 info: BlockInfo {
                     height,
@@ -213,7 +213,7 @@ mod tests {
                 cron_outcomes: vec![],
                 tx_outcomes: vec![],
             },
-        }
+        })
     }
 
     /// A range client that serves `[from, to]` but caps each response at

--- a/dango/archive/block-source/src/remote/mod.rs
+++ b/dango/archive/block-source/src/remote/mod.rs
@@ -512,14 +512,14 @@ impl BlockSource for RemoteBlockSource {
 mod tests {
     use {
         super::*,
-        dango_primitives::{Block, BlockInfo, BlockOutcome, Hash256, Timestamp},
+        dango_primitives::{Block, BlockInfo, BlockOutcome, FullBlock, Hash256, Timestamp},
         tokio::time::timeout,
     };
 
     /// A minimal `BlockData` carrying only the height the coordinator/healer
     /// logic reads — empty txs/outcomes, zero hashes.
     fn block(height: u64) -> BlockData {
-        BlockData {
+        BlockData::Current(FullBlock {
             block: Block {
                 info: BlockInfo {
                     height,
@@ -534,7 +534,7 @@ mod tests {
                 cron_outcomes: vec![],
                 tx_outcomes: vec![],
             },
-        }
+        })
     }
 
     /// A fetcher for which every requested height "exists": `spawn(from, to)`

--- a/dango/archive/block-source/src/remote/store/disk.rs
+++ b/dango/archive/block-source/src/remote/store/disk.rs
@@ -18,7 +18,10 @@ use {
 const CF_DEFAULT: &str = "default";
 
 /// Column family for the raw blocks: key = `height` big-endian (so RocksDB's
-/// lexicographic order *is* height order), value = borsh-encoded [`BlockData`].
+/// lexicographic order *is* height order), value = borsh-encoded [`BlockData`]
+/// — the compat enum with its one-byte version tag for values written since
+/// the tag existed, a bare (untagged) payload for older ones (see
+/// [`decode_stored_block`]).
 const CF_BLOCKS: &str = "blocks";
 
 /// Key in the default CF holding the topology checkpoint — the [`StoredRanges`]
@@ -150,6 +153,10 @@ impl BlockStore for RocksdbBlockStore {
         let put_start = std::time::Instant::now();
 
         let db = self.db.clone();
+        // `BlockData` is the compat enum, so this writes its one-byte version
+        // tag ahead of the payload — every new value is explicitly versioned.
+        // Values persisted before the tag existed are bare payloads; `get`
+        // falls back to the bare decoder for those.
         let block_bytes = borsh::to_vec(data)?;
         let topology_bytes = borsh::to_vec(&next.to_ranges())?;
         tokio::task::spawn_blocking(move || -> AnyResult<()> {
@@ -186,7 +193,7 @@ impl BlockStore for RocksdbBlockStore {
         let db = self.db.clone();
         let block = tokio::task::spawn_blocking(move || -> AnyResult<Option<BlockData>> {
             match db.get_cf(blocks_cf(&db), height.to_be_bytes())? {
-                Some(bytes) => Ok(Some(borsh::from_slice(&bytes)?)),
+                Some(bytes) => Ok(Some(decode_stored_block(&bytes)?)),
                 None => Ok(None),
             }
         })
@@ -315,6 +322,18 @@ const ROCKSDB_GAUGES: &[(&str, &[(&str, &str)])] = &[
 ];
 
 /// Handle to the blocks CF — a cheap lookup; the CF always exists once opened.
+/// Decode a stored block value. New writes carry the compat enum's one-byte
+/// version tag; values persisted before the tag existed are bare (untagged)
+/// current-schema payloads — fall back to the bare decoder for those. Borsh's
+/// `from_slice` must consume every byte, which makes an accidental
+/// cross-format parse practically impossible.
+fn decode_stored_block(bytes: &[u8]) -> AnyResult<BlockData> {
+    match borsh::from_slice::<BlockData>(bytes) {
+        Ok(block) => Ok(block),
+        Err(_tagged) => Ok(BlockData::decode_borsh(bytes)?),
+    }
+}
+
 fn blocks_cf(db: &DB) -> &ColumnFamily {
     db.cf_handle(CF_BLOCKS)
         .expect("blocks column family must exist")
@@ -390,8 +409,8 @@ mod tests {
     use {super::*, dango_archive_types::BlockDataExt, dango_temp_rocksdb::TempDataDir};
 
     fn block(height: u64) -> BlockData {
-        use dango_primitives::{Block, BlockInfo, BlockOutcome, Hash256, Timestamp};
-        BlockData {
+        use dango_primitives::{Block, BlockInfo, BlockOutcome, FullBlock, Hash256, Timestamp};
+        BlockData::Current(FullBlock {
             block: Block {
                 info: BlockInfo {
                     height,
@@ -406,7 +425,7 @@ mod tests {
                 cron_outcomes: vec![],
                 tx_outcomes: vec![],
             },
-        }
+        })
     }
 
     #[tokio::test]
@@ -417,6 +436,29 @@ mod tests {
         store.put(5, &block(5)).await.unwrap();
         assert_eq!(store.get(5).await.unwrap().unwrap().height(), 5);
         assert_eq!(store.get(6).await.unwrap(), None);
+    }
+
+    /// Values persisted before the compat enum's version tag existed are bare
+    /// (untagged) current-schema payloads: `get` reads them through the
+    /// bare-decoder fallback.
+    #[tokio::test]
+    async fn reads_pre_tag_bare_values() {
+        let dir = TempDataDir::new("_blockstore_bare_compat");
+        let store = RocksdbBlockStore::open(&dir).unwrap();
+
+        // Simulate an old row: bare bytes of the inner block, no version tag,
+        // written straight into the blocks CF.
+        let data = block(7);
+        let BlockData::Current(inner) = &data else {
+            unreachable!()
+        };
+        let bare = borsh::to_vec(inner).unwrap();
+        store
+            .db
+            .put_cf(blocks_cf(&store.db), 7u64.to_be_bytes(), bare)
+            .unwrap();
+
+        assert_eq!(store.get(7).await.unwrap().unwrap(), data);
     }
 
     #[tokio::test]

--- a/dango/archive/projection/src/activity/http/hydrate.rs
+++ b/dango/archive/projection/src/activity/http/hydrate.rs
@@ -46,22 +46,24 @@ pub(crate) async fn hydrate_transactions(
 
         let outcome = match item.kind {
             UnitKind::Transaction => {
+                // `TxRefCompat` serializes untagged: a pre-0.26.0 transaction
+                // hydrates as the exact JSON of its era.
                 let (tx, _hash) = block
-                    .block
-                    .txs
-                    .get(idx)
+                    .tx(idx)
                     .ok_or_else(|| missing("transaction", item.idx, item.block_height))?;
                 item.tx = Some(serde_json::to_value(tx)?);
 
-                let out =
-                    block.outcome.tx_outcomes.get(idx).cloned().ok_or_else(|| {
-                        missing("transaction outcome", item.idx, item.block_height)
-                    })?;
+                let out = block
+                    .outcome()
+                    .tx_outcomes
+                    .get(idx)
+                    .cloned()
+                    .ok_or_else(|| missing("transaction outcome", item.idx, item.block_height))?;
                 UnitOutcome::Transaction(Box::new(out))
             },
             UnitKind::Cron => {
                 let out = block
-                    .outcome
+                    .outcome()
                     .cron_outcomes
                     .get(idx)
                     .cloned()

--- a/dango/archive/projection/src/activity/mod.rs
+++ b/dango/archive/projection/src/activity/mod.rs
@@ -135,11 +135,11 @@ impl Projection for ActivityProjection {
         http::scopes()
     }
 
-    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(height = block.block.info.height)))]
+    #[cfg_attr(feature = "tracing", instrument(skip_all, fields(height = block.info().height)))]
     async fn process(&self, ctx: &mut Ctx, block: &BlockData) -> AnyResult<()> {
-        let block_height = block.block.info.height;
+        let block_height = block.info().height;
         let height = block_height as i64;
-        let timestamp = block.block.info.timestamp.into_nanos() as i64;
+        let timestamp = block.info().timestamp.into_nanos() as i64;
 
         let mut rows = Rows::default();
 
@@ -149,7 +149,7 @@ impl Projection for ActivityProjection {
         // `category_index` separates the units.
 
         // ---- cron units ----
-        for (cron_idx, cron_outcome) in block.outcome.cron_outcomes.iter().enumerate() {
+        for (cron_idx, cron_outcome) in block.outcome().cron_outcomes.iter().enumerate() {
             rows.transactions.push(transactions::ActiveModel {
                 block_height: Set(height),
                 idx: Set(cron_idx as i32),
@@ -170,10 +170,8 @@ impl Projection for ActivityProjection {
 
         // ---- tx units ----
         for (tx_idx, ((tx, tx_hash), tx_outcome)) in block
-            .block
-            .txs
-            .iter()
-            .zip(block.outcome.tx_outcomes.iter())
+            .txs()
+            .zip(block.outcome().tx_outcomes.iter())
             .enumerate()
         {
             rows.transactions.push(transactions::ActiveModel {
@@ -181,7 +179,7 @@ impl Projection for ActivityProjection {
                 idx: Set(tx_idx as i32),
                 kind: Set(FlatCategory::Tx as i16),
                 hash: Set(Some(tx_hash.as_ref().to_vec())),
-                sender: Set(Some(tx.sender.as_ref().to_vec())),
+                sender: Set(Some(tx.sender().as_ref().to_vec())),
                 success: Set(tx_outcome.result.is_ok()),
                 timestamp: Set(timestamp),
             });
@@ -404,15 +402,15 @@ pub(crate) fn flatten_unit(
     category: i16,
     category_index: usize,
 ) -> Vec<FlatEventInfo> {
-    let block_height = block.block.info.height;
+    let block_height = block.info().height;
     if category == FlatCategory::Cron as i16 {
-        let Some(cron) = block.outcome.cron_outcomes.get(category_index) else {
+        let Some(cron) = block.outcome().cron_outcomes.get(category_index) else {
             return Vec::new();
         };
         let mut event_id = EventId::new(block_height, FlatCategory::Cron, category_index as u32, 0);
         flatten_commitment_status(&mut event_id, cron.cron_event.clone())
     } else if category == FlatCategory::Tx as i16 {
-        let Some(tx) = block.outcome.tx_outcomes.get(category_index) else {
+        let Some(tx) = block.outcome().tx_outcomes.get(category_index) else {
             return Vec::new();
         };
         flatten_tx_events(tx.events.clone(), block_height, category_index as u32)

--- a/dango/archive/testing/tests/live_ws.rs
+++ b/dango/archive/testing/tests/live_ws.rs
@@ -68,16 +68,16 @@ async fn live_subscriber_receives_blocks_over_ws() {
         .expect("the frame decodes into a FullBlock");
 
     assert!(
-        block.block.info.height >= 1,
+        block.info().height >= 1,
         "the live block sits at a real height",
     );
     assert_eq!(
-        block.block.txs.len(),
+        block.tx_count(),
         1,
         "the live block carries exactly the one broadcast tx",
     );
     assert_eq!(
-        block.block.txs[0].1.to_string(),
+        block.tx(0).expect("one tx").1.to_string(),
         tx_hash,
         "the tx in the live block is the one we broadcast",
     );

--- a/dango/archive/types/src/block_data.rs
+++ b/dango/archive/types/src/block_data.rs
@@ -1,30 +1,34 @@
-use dango_primitives::FullBlock;
+use dango_primitives::FullBlockCompat;
 
 /// The block payload that flows through the [`BlockSource`] and is consumed by
-/// projections: the full `Block` together with its `BlockOutcome`.
+/// projections: the full `Block` together with its `BlockOutcome`, in
+/// whichever wire schema the block was written.
 ///
-/// This is the node's own [`dango_primitives::FullBlock`], reused directly
-/// rather than duplicated. Two properties fall out of that for free:
+/// This is the node's own [`dango_primitives::FullBlockCompat`], reused
+/// directly rather than duplicated. Two properties fall out of that for free:
 ///
 /// - **Wire compatibility by construction.** The `full_block` subscription and
-///   the `/block/full/*` REST routes serialize `FullBlock` (`{ block, outcome }`),
-///   so what we deserialize is *exactly* what the node serializes — no chance of
-///   a field-name drift between a private wire struct and the node's type.
-/// - **On-disk format.** `FullBlock` derives borsh, the same format the dango
-///   node uses for its block cache files, so the detached `RemoteBlockSource` can
-///   persist it to its raw store unchanged.
+///   the `/block/full/*` REST routes serialize the same compat shape
+///   (`{ block, outcome }`, untagged), so what we deserialize is *exactly*
+///   what the node serializes — including the seven historical blocks whose
+///   `Message::Configure` predates the 0.26.0 taxman removal and only exists
+///   in the legacy layout (see [`dango_primitives::legacy`]).
+/// - **On-disk format.** The compat enum derives borsh; the detached
+///   `RemoteBlockSource` persists it to its raw store with the enum's
+///   one-byte version tag, and falls back to the bare (untagged) layout for
+///   values written before the tag existed.
 ///
 /// `BlockData` is kept as the indexer's domain name for the payload (the alias
 /// the `BlockSource` trait and the projections speak in).
 ///
 /// [`BlockSource`]: dango_archive_block_source::BlockSource
-pub type BlockData = FullBlock;
+pub type BlockData = FullBlockCompat;
 
 /// `height()` ergonomics for [`BlockData`].
 ///
-/// `FullBlock` carries no inherent methods, so the height accessor the source
-/// and projections lean on lives here as an extension trait — in scope wherever
-/// it is called.
+/// The compat enum's inherent accessors live in `dango-primitives`; the height
+/// shorthand the source and projections lean on lives here as an extension
+/// trait — in scope wherever it is called.
 pub trait BlockDataExt {
     /// The block height, taken from `block.info`.
     fn height(&self) -> u64;
@@ -32,6 +36,6 @@ pub trait BlockDataExt {
 
 impl BlockDataExt for BlockData {
     fn height(&self) -> u64 {
-        self.block.info.height
+        self.info().height
     }
 }

--- a/dango/core/types/src/legacy.rs
+++ b/dango/core/types/src/legacy.rs
@@ -1,0 +1,435 @@
+//! Frozen pre-0.26.0 ("wire v1") shapes of the transaction path, kept solely
+//! for **reading** historical Borsh-serialized blocks.
+//!
+//! 0.26.0 (#2192) removed the taxman contract and changed [`Config`] in place
+//! (dropped `taxman`, added `gas_token` / `gas_fee_rate` / `gas_exemptions`).
+//! Borsh is positional — no field names, no tags — so any persisted block that
+//! *contains* a [`Message::Configure`] embeds the old `Config` layout and no
+//! longer deserializes with the current types. Exactly seven blocks do:
+//!
+//! | network | height   | date (2026) |
+//! |---------|----------|-------------|
+//! | mainnet | 16847666 | Apr 8       |
+//! | mainnet | 18782883 | Apr 20      |
+//! | mainnet | 18786698 | Apr 20      |
+//! | mainnet | 18787415 | Apr 20      |
+//! | testnet | 18563232 | Apr 1       |
+//! | testnet | 23062422 | Apr 20      |
+//! | testnet | 23063329 | Apr 20      |
+//!
+//! The event/outcome side needs no shadow: 0.26.0 deliberately retained the
+//! affected outcome types ("retained so that historical, Borsh-serialized
+//! cached blocks still deserialize" — see `EvtFinalize`, `EvtWithhold`). This
+//! module extends the same policy to the one type that could not be retained,
+//! because its new fields migrated out of the deleted taxman's storage.
+//!
+//! Rules for this module:
+//!
+//! - **Never modify these types.** They mirror the exact wire layout the seven
+//!   blocks above were written with. Field order is Borsh layout.
+//! - Variants of [`MessageV1`] must keep the **same order** as the era's
+//!   `Message` (Borsh enums serialize the variant index).
+//! - Serde derives mirror the era's attributes so a V1 block serializes to
+//!   **exactly the JSON it always had** (`taxman` present, no gas fields) —
+//!   history is served faithfully, hashes and signatures stay valid.
+//! - Going forward, types embedded in persisted data are **append-only**: add
+//!   a new message variant instead of changing an existing struct in place.
+
+use {
+    crate::{
+        Addr, BlockInfo, BlockOutcome, Duration, FullBlock, Hash256, HttpRequestDetails, Json,
+        MsgExecute, MsgInstantiate, MsgMigrate, MsgTransfer, MsgUpgrade, MsgUpload, NonEmpty,
+        Permissions, Tx,
+    },
+    borsh::{BorshDeserialize, BorshSerialize},
+    serde::{Deserialize, Serialize},
+    serde_with::skip_serializing_none,
+    std::collections::{BTreeMap, HashMap},
+};
+
+/// Chain-level configurations as they existed before 0.26.0: `taxman` still
+/// present, no `gas_token` / `gas_fee_rate` / `gas_exemptions`.
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConfigV1 {
+    /// The account that can update this config.
+    pub owner: Addr,
+    /// The contract the manages fungible token transfers.
+    pub bank: Addr,
+    /// The contract that handles transaction fees.
+    pub taxman: Addr,
+    /// A list of contracts that are to be called at regular time intervals.
+    pub cronjobs: BTreeMap<Addr, Duration>,
+    /// Permissions for certain gated actions.
+    pub permissions: Permissions,
+    /// Maximum age allowed for orphaned codes.
+    pub max_orphan_age: Duration,
+}
+
+/// [`crate::MsgConfigure`] carrying the pre-0.26.0 [`ConfigV1`].
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+pub struct MsgConfigureV1 {
+    pub new_cfg: Option<ConfigV1>,
+    pub new_app_cfg: Option<Json>,
+}
+
+/// [`crate::Message`] with the pre-0.26.0 `Configure` payload. Every other
+/// variant reuses the current type — none of them changed wire layout. The
+/// variant **order** mirrors the era's enum: Borsh serializes the index.
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageV1 {
+    Configure(MsgConfigureV1),
+    Upgrade(MsgUpgrade),
+    Transfer(MsgTransfer),
+    Upload(MsgUpload),
+    Instantiate(MsgInstantiate),
+    Execute(MsgExecute),
+    Migrate(MsgMigrate),
+}
+
+/// [`crate::Tx`] whose messages may carry the pre-0.26.0 `Configure`.
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+pub struct TxV1 {
+    pub sender: Addr,
+    pub gas_limit: u64,
+    pub msgs: NonEmpty<Vec<MessageV1>>,
+    pub data: Json,
+    pub credential: Json,
+}
+
+/// [`crate::Block`] in the pre-0.26.0 wire layout.
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct BlockV1 {
+    pub info: BlockInfo,
+    pub txs: Vec<(TxV1, Hash256)>,
+}
+
+/// [`FullBlock`] in the pre-0.26.0 wire layout.
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct FullBlockV1 {
+    pub block: BlockV1,
+    pub outcome: BlockOutcome,
+}
+
+/// [`crate::BlockAndBlockOutcomeWithHttpDetails`] — the block-cache file
+/// payload — in the pre-0.26.0 wire layout.
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+pub struct BlockAndBlockOutcomeWithHttpDetailsV1 {
+    pub block: BlockV1,
+    pub block_outcome: BlockOutcome,
+    pub http_request_details: HashMap<Hash256, HttpRequestDetails>,
+}
+
+// ------------------------------- compat views --------------------------------
+
+/// Raw block bytes decode as neither the current schema nor legacy v1.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "block bytes decode as neither the current schema ({current}) nor the pre-0.26.0 v1 schema ({v1})"
+)]
+pub struct LegacyDecodeError {
+    pub current: std::io::Error,
+    pub v1: std::io::Error,
+}
+
+/// A block in whichever wire schema it was written. Serializes untagged, so a
+/// V1 block renders **exactly the JSON it always had**.
+///
+/// Borsh derives give the compat enum a one-byte variant tag — use it for
+/// *new* writes (e.g. the archive's block store); historical bare payloads are
+/// handled by [`Self::decode_borsh`]'s fallback.
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum FullBlockCompat {
+    Current(FullBlock),
+    V1(FullBlockV1),
+}
+
+/// A borrowed transaction from either schema. Serializes untagged — faithful
+/// to its own era's JSON.
+#[derive(Serialize, Debug, Clone, Copy)]
+#[serde(untagged)]
+pub enum TxRefCompat<'a> {
+    Current(&'a Tx),
+    V1(&'a TxV1),
+}
+
+impl TxRefCompat<'_> {
+    pub fn sender(&self) -> &Addr {
+        match self {
+            Self::Current(tx) => &tx.sender,
+            Self::V1(tx) => &tx.sender,
+        }
+    }
+}
+
+impl FullBlockCompat {
+    /// Decode a **bare** (untagged) borsh payload: try the current schema
+    /// first — the overwhelming majority — then fall back to legacy v1.
+    ///
+    /// The whole-payload retry is deliberate: borsh is positional and streams
+    /// don't rewind, so version detection cannot happen locally inside
+    /// `Config`. `from_slice` requires consuming every byte, which makes an
+    /// accidental cross-schema parse practically impossible.
+    pub fn decode_borsh(bytes: &[u8]) -> Result<Self, LegacyDecodeError> {
+        match borsh::from_slice::<FullBlock>(bytes) {
+            Ok(block) => Ok(Self::Current(block)),
+            Err(current) => match borsh::from_slice::<FullBlockV1>(bytes) {
+                Ok(block) => Ok(Self::V1(block)),
+                Err(v1) => Err(LegacyDecodeError { current, v1 }),
+            },
+        }
+    }
+
+    pub fn info(&self) -> &BlockInfo {
+        match self {
+            Self::Current(b) => &b.block.info,
+            Self::V1(b) => &b.block.info,
+        }
+    }
+
+    pub fn outcome(&self) -> &BlockOutcome {
+        match self {
+            Self::Current(b) => &b.outcome,
+            Self::V1(b) => &b.outcome,
+        }
+    }
+
+    pub fn tx_count(&self) -> usize {
+        match self {
+            Self::Current(b) => b.block.txs.len(),
+            Self::V1(b) => b.block.txs.len(),
+        }
+    }
+
+    pub fn tx(&self, idx: usize) -> Option<(TxRefCompat<'_>, &Hash256)> {
+        match self {
+            Self::Current(b) => b
+                .block
+                .txs
+                .get(idx)
+                .map(|(tx, hash)| (TxRefCompat::Current(tx), hash)),
+            Self::V1(b) => b
+                .block
+                .txs
+                .get(idx)
+                .map(|(tx, hash)| (TxRefCompat::V1(tx), hash)),
+        }
+    }
+
+    pub fn txs(&self) -> impl Iterator<Item = (TxRefCompat<'_>, &Hash256)> {
+        (0..self.tx_count()).map(move |idx| self.tx(idx).expect("index within tx_count"))
+    }
+}
+
+/// A block-cache file payload in whichever wire schema it was written.
+/// Serializes untagged — a V1 file renders its era's exact JSON.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum CachedBlockCompat {
+    Current(crate::BlockAndBlockOutcomeWithHttpDetails),
+    V1(BlockAndBlockOutcomeWithHttpDetailsV1),
+}
+
+impl CachedBlockCompat {
+    /// Decode a cache-file payload: current schema first, then legacy v1. See
+    /// [`FullBlockCompat::decode_borsh`] for why the retry spans the whole
+    /// payload.
+    pub fn decode(bytes: &[u8]) -> Result<Self, LegacyDecodeError> {
+        match borsh::from_slice::<crate::BlockAndBlockOutcomeWithHttpDetails>(bytes) {
+            Ok(data) => Ok(Self::Current(data)),
+            Err(current) => match borsh::from_slice::<BlockAndBlockOutcomeWithHttpDetailsV1>(bytes)
+            {
+                Ok(data) => Ok(Self::V1(data)),
+                Err(v1) => Err(LegacyDecodeError { current, v1 }),
+            },
+        }
+    }
+
+    /// Project to the `{block, outcome}` shape the httpd serves, dropping the
+    /// `http_request_details` (client IPs) exactly like the current routes do.
+    pub fn into_full_block(self) -> FullBlockCompat {
+        match self {
+            Self::Current(data) => FullBlockCompat::Current(FullBlock {
+                block: data.block,
+                outcome: data.block_outcome,
+            }),
+            Self::V1(data) => FullBlockCompat::V1(FullBlockV1 {
+                block: data.block,
+                outcome: data.block_outcome,
+            }),
+        }
+    }
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{Block, BlockAndBlockOutcomeWithHttpDetails, Permission, Timestamp},
+    };
+
+    fn config_v1() -> ConfigV1 {
+        ConfigV1 {
+            owner: Addr::mock(1),
+            bank: Addr::mock(2),
+            taxman: Addr::mock(3),
+            cronjobs: BTreeMap::new(),
+            permissions: Permissions {
+                upload: Permission::Everybody,
+                instantiate: Permission::Everybody,
+            },
+            max_orphan_age: Duration::from_hours(1),
+        }
+    }
+
+    /// A block shaped like the seven legacy ones: a single transaction whose
+    /// only message is a pre-0.26.0 `Configure`.
+    fn full_block_v1() -> FullBlockV1 {
+        FullBlockV1 {
+            block: BlockV1 {
+                info: BlockInfo {
+                    height: 16847666,
+                    timestamp: Timestamp::from_nanos(0),
+                    hash: Hash256::ZERO,
+                },
+                txs: vec![(
+                    TxV1 {
+                        sender: Addr::mock(9),
+                        gas_limit: 1_000_000,
+                        msgs: NonEmpty::new_unchecked(vec![MessageV1::Configure(MsgConfigureV1 {
+                            new_cfg: Some(config_v1()),
+                            new_app_cfg: None,
+                        })]),
+                        data: Json::from_inner(serde_json::Value::Null),
+                        credential: Json::from_inner(serde_json::Value::Null),
+                    },
+                    Hash256::ZERO,
+                )],
+            },
+            outcome: BlockOutcome {
+                height: 16847666,
+                app_hash: Hash256::ZERO,
+                cron_outcomes: vec![],
+                tx_outcomes: vec![],
+            },
+        }
+    }
+
+    fn full_block_current() -> FullBlock {
+        FullBlock {
+            block: Block {
+                info: BlockInfo {
+                    height: 42,
+                    timestamp: Timestamp::from_nanos(0),
+                    hash: Hash256::ZERO,
+                },
+                txs: vec![],
+            },
+            outcome: BlockOutcome {
+                height: 42,
+                app_hash: Hash256::ZERO,
+                cron_outcomes: vec![],
+                tx_outcomes: vec![],
+            },
+        }
+    }
+
+    /// Bare V1 borsh — the exact shape of the node's seven legacy cache
+    /// blocks — is rejected by the current schema, picked up by the fallback,
+    /// and rendered as its era's exact JSON (taxman present, no gas fields).
+    #[test]
+    fn bare_v1_bytes_decode_via_fallback_and_render_faithfully() {
+        let bytes = borsh::to_vec(&full_block_v1()).unwrap();
+
+        // The current schema must NOT accidentally accept these bytes — this
+        // is the exact failure mode of the seven historical blocks.
+        assert!(borsh::from_slice::<FullBlock>(&bytes).is_err());
+
+        let compat = FullBlockCompat::decode_borsh(&bytes).unwrap();
+        assert!(matches!(compat, FullBlockCompat::V1(_)));
+
+        let json = serde_json::to_string(&compat).unwrap();
+        assert!(json.contains(r#""taxman""#));
+        assert!(!json.contains("gas_token"));
+    }
+
+    #[test]
+    fn bare_current_bytes_decode_as_current() {
+        let bytes = borsh::to_vec(&full_block_current()).unwrap();
+        let compat = FullBlockCompat::decode_borsh(&bytes).unwrap();
+        assert!(matches!(compat, FullBlockCompat::Current(_)));
+    }
+
+    /// The tagged compat enum — the archive store's on-disk format for new
+    /// writes — roundtrips both variants.
+    #[test]
+    fn tagged_compat_roundtrips() {
+        for compat in [
+            FullBlockCompat::V1(full_block_v1()),
+            FullBlockCompat::Current(full_block_current()),
+        ] {
+            let bytes = borsh::to_vec(&compat).unwrap();
+            assert_eq!(
+                borsh::from_slice::<FullBlockCompat>(&bytes).unwrap(),
+                compat
+            );
+        }
+    }
+
+    /// The JSON wire — the archive's ingest path — deserializes untagged into
+    /// the right variant for both eras.
+    #[test]
+    fn untagged_json_picks_the_right_variant() {
+        let v1 = FullBlockCompat::V1(full_block_v1());
+        let json = serde_json::to_string(&v1).unwrap();
+        assert!(matches!(
+            serde_json::from_str::<FullBlockCompat>(&json).unwrap(),
+            FullBlockCompat::V1(_)
+        ));
+
+        let current = FullBlockCompat::Current(full_block_current());
+        let json = serde_json::to_string(&current).unwrap();
+        assert!(matches!(
+            serde_json::from_str::<FullBlockCompat>(&json).unwrap(),
+            FullBlockCompat::Current(_)
+        ));
+    }
+
+    /// Cache-file payloads (block + outcome + http_request_details) go through
+    /// the same fallback, and project to the served `{block, outcome}` shape.
+    #[test]
+    fn cached_block_decode_v1_and_project() {
+        let v1 = full_block_v1();
+        let cached = BlockAndBlockOutcomeWithHttpDetailsV1 {
+            block: v1.block.clone(),
+            block_outcome: v1.outcome.clone(),
+            http_request_details: HashMap::new(),
+        };
+        let bytes = borsh::to_vec(&cached).unwrap();
+
+        let compat = CachedBlockCompat::decode(&bytes).unwrap();
+        assert!(matches!(compat, CachedBlockCompat::V1(_)));
+        assert_eq!(compat.into_full_block(), FullBlockCompat::V1(v1));
+
+        let current = full_block_current();
+        let cached = BlockAndBlockOutcomeWithHttpDetails {
+            block: current.block.clone(),
+            block_outcome: current.outcome.clone(),
+            http_request_details: HashMap::new(),
+        };
+        let bytes = borsh::to_vec(&cached).unwrap();
+        assert!(matches!(
+            CachedBlockCompat::decode(&bytes).unwrap(),
+            CachedBlockCompat::Current(_)
+        ));
+    }
+}

--- a/dango/core/types/src/lib.rs
+++ b/dango/core/types/src/lib.rs
@@ -30,6 +30,7 @@ mod indexer;
 mod inner;
 mod jellyfish_merkle;
 mod json;
+mod legacy;
 mod length_bounded;
 mod lengthy;
 mod macros;
@@ -55,10 +56,10 @@ pub use {
     address::*, app::*, bank::*, binary::*, bound::*, buffer::*, builder::*, bytes::*, cache::*,
     code::*, coin::*, coin_pair::*, coins::*, context::*, db::*, dec_coin::*, denom::*, empty::*,
     encoded_bytes::*, encoders::*, error::*, events::*, ffi::*, git_info::*, hash::*, hashers::*,
-    httpd::*, imports::*, indexer::*, inner::*, jellyfish_merkle::*, json::*, length_bounded::*,
-    lengthy::*, metrics::*, non_zero::*, outcome::*, predicate::*, query::*, response::*,
-    result::*, serializers::*, shared::*, signer::*, status::*, time::*, transfer::*, tx::*,
-    unique_vec::*, upgrade::*, utils::*,
+    httpd::*, imports::*, indexer::*, inner::*, jellyfish_merkle::*, json::*, legacy::*,
+    length_bounded::*, lengthy::*, metrics::*, non_zero::*, outcome::*, predicate::*, query::*,
+    response::*, result::*, serializers::*, shared::*, signer::*, status::*, time::*, transfer::*,
+    tx::*, unique_vec::*, upgrade::*, utils::*,
 };
 
 // ---------------------------------- testing ----------------------------------

--- a/dango/indexer/cache/src/cache_file.rs
+++ b/dango/indexer/cache/src/cache_file.rs
@@ -2,7 +2,9 @@ use {
     super::error,
     borsh::{BorshDeserialize, BorshSerialize},
     dango_disk_saver::persistence::DiskPersistence,
-    dango_primitives::{Block, BlockAndBlockOutcomeWithHttpDetails, BlockOutcome},
+    dango_primitives::{
+        Block, BlockAndBlockOutcomeWithHttpDetails, BlockOutcome, CachedBlockCompat,
+    },
     serde::{Deserialize, Serialize},
     std::{
         collections::HashMap,
@@ -76,6 +78,20 @@ impl CacheFile {
         let mut block_to_index: Self = DiskPersistence::new(file_path.clone(), false).load()?;
         block_to_index.filename = file_path;
         Ok(block_to_index)
+    }
+
+    /// Load a block file in whichever wire schema it was written: the current
+    /// one first, then the pre-0.26.0 legacy layout — blocks containing a
+    /// `Message::Configure` from before the taxman removal only deserialize
+    /// with the latter (see [`dango_primitives::legacy`]).
+    ///
+    /// `CacheFile`'s only extra field (`filename`) is `borsh(skip)`, so the
+    /// file bytes are exactly a [`BlockAndBlockOutcomeWithHttpDetails`]
+    /// payload, which is what the compat decoder parses.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    pub fn load_from_disk_compat(file_path: PathBuf) -> error::Result<CachedBlockCompat> {
+        let bytes = DiskPersistence::new(file_path, false).load_bytes()?;
+        Ok(CachedBlockCompat::decode(&bytes)?)
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]

--- a/dango/indexer/cache/src/error.rs
+++ b/dango/indexer/cache/src/error.rs
@@ -41,6 +41,10 @@ pub enum IndexerError {
 
     #[error(transparent)]
     #[backtrace(new)]
+    LegacyDecode(dango_primitives::LegacyDecodeError),
+
+    #[error(transparent)]
+    #[backtrace(new)]
     SerdeJson(serde_json::Error),
 
     #[error("parse error: {0}")]
@@ -97,6 +101,7 @@ impl From<IndexerError> for dango_app::IndexerError {
             IndexerError::Io(e) => parse_error!(Io, e),
             IndexerError::Persist(e) => parse_error!(Io, e),
             IndexerError::Persistence(e) => parse_error!(Storage, e),
+            IndexerError::LegacyDecode(e) => parse_error!(Serialization, e),
             IndexerError::SerdeJson(e) => parse_error!(Serialization, e),
             IndexerError::Parse(e) => parse_error!(Generic, e),
             IndexerError::S3 { error, backtrace } => parse_error!(Generic, error, backtrace),

--- a/dango/indexer/httpd/src/routes/blocks.rs
+++ b/dango/indexer/httpd/src/routes/blocks.rs
@@ -6,7 +6,7 @@ use {
         get, web,
     },
     dango_indexer_cache::cache_file::CacheFile,
-    dango_primitives::FullBlock,
+    dango_primitives::{CachedBlockCompat, FullBlockCompat},
     serde::Deserialize,
     std::path::PathBuf,
 };
@@ -57,8 +57,12 @@ fn _block_by_height(block_height: u64, app_ctx: &FullContext) -> Result<HttpResp
 
     check_block_exists(block_filename.clone(), block_height)?;
 
-    match CacheFile::load_from_disk(block_filename) {
-        Ok(cache_file) => Ok(HttpResponse::Ok().json(cache_file.data.block)),
+    // Compat load: blocks containing a pre-0.26.0 `Message::Configure` only
+    // deserialize with the legacy schema; either way the JSON out is the exact
+    // shape the block was written with.
+    match CacheFile::load_from_disk_compat(block_filename) {
+        Ok(CachedBlockCompat::Current(data)) => Ok(HttpResponse::Ok().json(data.block)),
+        Ok(CachedBlockCompat::V1(data)) => Ok(HttpResponse::Ok().json(data.block)),
         Err(err) => {
             Ok(HttpResponse::InternalServerError()
                 .body(format!("failed to load block file: {err}")))
@@ -99,8 +103,11 @@ fn _block_results_by_height(
 
     check_block_exists(block_filename.clone(), block_height)?;
 
-    match CacheFile::load_from_disk(block_filename) {
-        Ok(cache_file) => Ok(HttpResponse::Ok().json(cache_file.data.block_outcome)),
+    // The outcome types were kept wire-compatible by 0.26.0, so both schema
+    // variants carry the same `BlockOutcome`.
+    match CacheFile::load_from_disk_compat(block_filename) {
+        Ok(CachedBlockCompat::Current(data)) => Ok(HttpResponse::Ok().json(data.block_outcome)),
+        Ok(CachedBlockCompat::V1(data)) => Ok(HttpResponse::Ok().json(data.block_outcome)),
         Err(err) => {
             Ok(HttpResponse::InternalServerError()
                 .body(format!("failed to load block file: {err}")))
@@ -186,15 +193,13 @@ fn _full_block_by_height(block_height: u64, app_ctx: &FullContext) -> Result<Htt
 /// Load a block file from disk and project it to `block` + `block_outcome`,
 /// dropping the `http_request_details` (client IPs) the file also holds — the
 /// same projection the `/info` and `/result` routes use. Returns the same
-/// `FullBlock` shape as the `/ws` `fullBlock` channel.
-fn load_full_block(block_filename: PathBuf) -> Result<FullBlock, Error> {
-    let cache_file = CacheFile::load_from_disk(block_filename)
+/// `FullBlock` shape as the `/ws` `fullBlock` channel; a pre-0.26.0 block
+/// serializes untagged as the exact JSON of its era.
+fn load_full_block(block_filename: PathBuf) -> Result<FullBlockCompat, Error> {
+    let compat = CacheFile::load_from_disk_compat(block_filename)
         .map_err(|err| ErrorInternalServerError(format!("failed to load block file: {err}")))?;
 
-    Ok(FullBlock {
-        block: cache_file.data.block,
-        outcome: cache_file.data.block_outcome,
-    })
+    Ok(compat.into_full_block())
 }
 
 #[derive(Deserialize)]

--- a/dango/utils/disk-saver/src/persistence.rs
+++ b/dango/utils/disk-saver/src/persistence.rs
@@ -256,6 +256,13 @@ impl DiskPersistence {
 
     /// Load and decompress the data from disk and deserialize it.
     pub fn load<T: BorshDeserialize>(&mut self) -> Result<T, Error> {
+        Ok(borsh::from_slice(&self.load_bytes()?)?)
+    }
+
+    /// Load and decompress the data from disk, returning the raw Borsh payload
+    /// without deserializing it — for callers that need to attempt more than
+    /// one schema on the same bytes (e.g. legacy block formats).
+    pub fn load_bytes(&mut self) -> Result<Vec<u8>, Error> {
         let disk_data = match fs::read(&self.file_path) {
             Ok(data) => data,
             Err(_e) => {
@@ -271,16 +278,14 @@ impl DiskPersistence {
             },
         };
 
-        let data = if self.compressed {
+        if self.compressed {
             let mut decompressed = Vec::new();
             lzma_decompress(&mut disk_data.as_slice(), &mut decompressed)?;
 
-            borsh::from_slice(&decompressed)?
+            Ok(decompressed)
         } else {
-            borsh::from_slice(&disk_data)?
-        };
-
-        Ok(data)
+            Ok(disk_data)
+        }
     }
 
     pub fn exists(&self) -> bool {


### PR DESCRIPTION
## Summary

0.26.0 (#2192) removed the taxman contract and changed `Config` in place (dropped `taxman`, added the gas fields that migrated out of taxman's storage). Borsh is positional, so the seven historical blocks that contain a `Message::Configure` no longer deserialize with the current types:

| network | height | date |
|---|---|---|
| mainnet | 16847666 | Apr 8 |
| mainnet | 18782883 | Apr 20 |
| mainnet | 18786698 | Apr 20 |
| mainnet | 18787415 | Apr 20 |
| testnet | 18563232 | Apr 1 |
| testnet | 23062422 | Apr 20 |
| testnet | 23063329 | Apr 20 |

The indexer-httpd answers `500 — failed to load block file: invalid utf-8 sequence` for them (all mainnet nodes; cometbft has pruned far past these heights, so no live source can serve them), and the archive's backfill is currently stalled at 16,847,660 on mainnet.

This is "Option 1" from the team discussion, implemented **once, at the type level**, so every consumer inherits it from the shared crate — the same policy #2192 itself applied to the outcome types ("retained so that historical, Borsh-serialized cached blocks still deserialize"), extended to the one type that could not be retained:

- **dango-primitives**: new `legacy` module — the frozen v1 shadow of the tx path (`ConfigV1 → MsgConfigureV1 → MessageV1 → TxV1 → BlockV1 → FullBlockV1` + the cache payload), read-only by design, with untagged compat views (`FullBlockCompat`, `CachedBlockCompat`, `TxRefCompat`) and whole-payload try-current-then-v1 borsh decoding (borsh can't version-detect mid-stream). **Bytes on disk are untouched — hashes and signatures stay valid** — and a V1 block serializes to exactly the JSON of its era (`taxman` present, no gas fields): no invented values.
- **disk-saver**: `load_bytes()` splits read+decompress off `load()` so one payload can be attempted against multiple schemas.
- **indexer-cache / indexer-httpd**: `CacheFile::load_from_disk_compat` + the `/block` routes (`info`, `result`, `full`, `full/range`) serve the compat shape.
- **archive**: `BlockData` becomes the compat enum — ingest (WS + range fetch) accepts V1 JSON untagged; the RocksDB store writes the enum's one-byte version tag for new values and falls back to the bare decoder for rows persisted before the tag existed; projection + read-API hydration go through schema-agnostic accessors; the co-located `LocalBlockSource` reads node cache files through the same fallback.

Going forward, the module documents the policy that prevents a recurrence: types embedded in persisted data are **append-only** — add a message variant, never change an existing struct in place.

## Validation

### Completed
- [x] `legacy` golden-bytes tests: bare V1 bytes are **rejected by the current schema** (reproduces the exact production failure) and decoded by the fallback; JSON output contains `taxman` and no `gas_token`
- [x] tagged (store) and untagged (JSON) roundtrips for both eras
- [x] cache-payload decode + projection to the served `{block, outcome}` shape
- [x] archive store: pre-tag bare values read through the fallback (new test), `put`/`get` roundtrip with the tagged format
- [x] full test suites of the touched crates green (`dango-primitives`, `dango-archive-block-source` 25, `dango-archive-projection` 10, `dango-indexer-cache`, `dango-disk-saver`)
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets --all-features` zero warnings
- [x] `just fmt`

### Remaining
- [ ] Deploy to one mainnet node and verify `/block/full/range?from=16847661&to=16847680` answers 200 with the real block 16847666
- [ ] Verify the archive backfill resumes past 16,847,660 (mainnet) and through the testnet heights when it reaches them
- [ ] Optional: capture one real legacy block file as a fixture for a golden-file regression test

## Manual QA

1. Deploy the dango image on one mainnet full-app host.
2. `curl 'http://<host>/block/full/range?from=16847661&to=16847680' -H 'Host: api-mainnet.dango.zone'` → 200, 20 blocks; block 16847666's configure message shows the era's config (with `taxman`).
3. Deploy the archive image on hetzner7: the healer resumes automatically (frontier passes 16,847,660 within minutes; `archive_block_fetcher_requests_total{outcome="error"}` stops growing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)