### PR TITLE
fix(core): make MsgConfigure.new_cfg a raw JSON value

### DIFF
--- a/dango/core/app/src/execute/configure.rs
+++ b/dango/core/app/src/execute/configure.rs
@@ -5,7 +5,7 @@ use {
         APP_CONFIG, AppError, AppResult, CONFIG, EventResult, NEXT_CRONJOBS, TraceOption,
         schedule_cronjob,
     },
-    dango_primitives::{Addr, BlockInfo, EvtConfigure, MsgConfigure, Storage},
+    dango_primitives::{Addr, BlockInfo, Config, EvtConfigure, JsonDeExt, MsgConfigure, Storage},
 };
 
 pub fn do_configure(
@@ -51,6 +51,11 @@ fn _do_configure(
     }
 
     if let Some(new_cfg) = msg.new_cfg {
+        // `MsgConfigure.new_cfg` is a raw JSON value rather than a typed
+        // `Config`, so that historical blocks containing config updates keep
+        // deserializing across `Config` schema changes. Parse it here instead.
+        let new_cfg: Config = new_cfg.deserialize_json()?;
+
         // If the list of cronjobs has been changed, we have to delete the
         // existing scheduled ones and reschedule.
         if new_cfg.cronjobs != cfg.cronjobs {

--- a/dango/core/types/src/tx.rs
+++ b/dango/core/types/src/tx.rs
@@ -136,7 +136,7 @@ impl Message {
         T: Serialize,
     {
         Ok(MsgConfigure {
-            new_cfg,
+            new_cfg: new_cfg.map(|cfg| cfg.to_json_value()).transpose()?,
             new_app_cfg: new_app_cfg.map(|t| t.to_json_value()).transpose()?,
         }
         .into())
@@ -249,7 +249,20 @@ impl Message {
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct MsgConfigure {
-    pub new_cfg: Option<Config>,
+    /// The new chain-level config, as a raw JSON value. Parsed into a
+    /// [`Config`] at execution time.
+    ///
+    /// This field is deliberately _not_ typed as `Config`. The `Config` schema
+    /// evolves over time (e.g. commit `c5cdf66c9` replaced the `taxman` field
+    /// with the gas fields), while `MsgConfigure`s live forever inside
+    /// serialized historical blocks — in the indexer's cached block files and
+    /// in tx JSONs. If this field were typed, every `Config` schema change
+    /// would make each historical block that contains a config update
+    /// impossible to deserialize. As a raw JSON value, such blocks survive
+    /// schema changes, and additionally preserve the config update's original
+    /// content faithfully.
+    pub new_cfg: Option<Json>,
+
     pub new_app_cfg: Option<Json>,
 }
 


### PR DESCRIPTION
MsgConfigure messages live forever inside serialized historical blocks -- in the indexer's cached block files and in tx JSONs -- so typing new_cfg as Config makes every historical block containing a config update impossible to deserialize whenever the Config schema changes. Concretely, the taxman removal (c5cdf66c9) broke Borsh deserialization of seven cached block files across mainnet and testnet, surfacing as "invalid utf-8 sequence of 1 bytes from index 0" on the /block REST routes.

Store the field as a raw JSON value instead, and parse it into a Config at execution time in do_configure. The Message::configure helper keeps its typed Option<Config> signature and converts internally, so callers are unchanged. The GraphQL schema is unaffected (Tx is a scalar).

The seven affected block files still need a one-off rewrite (their bytes predate this change); with this schema, the rewrite can preserve the original config content verbatim instead of fabricating values for fields that did not exist at the time.