### PR TITLE
feat(archive): parallelize the sentinel backfill fetcher

### DIFF
--- a/dango/archive/block-source/src/remote/fetcher/sentinel.rs
+++ b/dango/archive/block-source/src/remote/fetcher/sentinel.rs
@@ -4,6 +4,7 @@ use {
     super::{BlockFetcher, FetchStream},
     async_trait::async_trait,
     dango_archive_types::{AnyResult, BlockData, BlockDataExt},
+    futures::future::join_all,
     std::{cmp::min, time::Duration},
     tokio::{sync::mpsc, time::sleep},
 };
@@ -35,17 +36,27 @@ pub struct SentinelFetcherConfig {
     /// Blocks requested per `/block/full/range` call, clamped to the blocks left
     /// in the gap and capped at [`MAX_BLOCK_RANGE`] (the endpoint's own limit).
     pub range_size: u64,
+    /// Concurrent `/block/full/range` calls per batch. The fetcher issues this
+    /// many contiguous strides at once and commits the responses in height
+    /// order, so the stream stays strictly ascending; `1` restores the serial
+    /// one-call-at-a-time pull. In block-dense height regions a call is
+    /// payload-bound (hundreds of KB per block, most of it the sentinel's disk
+    /// read + JSON serialization), so this is as much an upstream-load knob as
+    /// a throughput one: a handful of concurrent calls is enough to keep the
+    /// pipeline fed, and more mostly costs the sentinel CPU.
+    pub parallelism: usize,
     /// Per-request timeout before retrying.
     pub timeout: Duration,
     /// Upper bound on blocks fetched-ahead but not yet consumed. The fetcher can
-    /// be far faster than the store writer during a backfill; a bounded channel
-    /// makes a full buffer block the fetcher (backpressure) instead of letting it
-    /// race ahead and balloon RAM. No throughput cost — the consumer is the
-    /// bottleneck and the fetcher only needs a small lead. This is a **RAM** knob:
-    /// at the measured payloads (median ~20 KB, p90 ~150 KB borsh) 2_000 is
-    /// ~40 MB typical / ~300 MB peak.
+    /// outpace the store writer during a backfill; a bounded channel makes a
+    /// full buffer block the fetcher (backpressure) instead of letting it race
+    /// ahead and balloon RAM. No throughput cost — the consumer only needs a
+    /// small lead. This is a **RAM** knob sized for the *dense* eras a backfill
+    /// crosses (hundreds of KB per block, not the ~20 KB median): 256 is ~5 MB
+    /// typical / ~75 MB at the heavy tail.
     pub channel_capacity: usize,
-    /// Backoff after a failed, timed-out, or empty response before retrying.
+    /// Backoff after a failed, timed-out, empty, or contiguity-breaking batch
+    /// before re-issuing.
     pub retry_backoff: Duration,
 }
 
@@ -53,8 +64,9 @@ impl Default for SentinelFetcherConfig {
     fn default() -> Self {
         Self {
             range_size: MAX_BLOCK_RANGE,
+            parallelism: 4,
             timeout: Duration::from_secs(30),
-            channel_capacity: 2_000,
+            channel_capacity: 256,
             retry_backoff: Duration::from_millis(500),
         }
     }
@@ -62,12 +74,15 @@ impl Default for SentinelFetcherConfig {
 
 /// [`BlockFetcher`] backed by a sentinel's `/block/full/range` endpoint.
 ///
-/// Fills a bounded gap `[from, to]` by pulling contiguous runs of up to
-/// `range_size` full blocks per request and streaming the assembled
-/// [`BlockData`] in ascending order. Each request starts one past the **last
-/// block actually received**, so a short run (the sentinel not yet holding the
-/// next height) simply re-requests from there instead of assuming a fixed
-/// stride.
+/// Fills a bounded gap `[from, to]` by issuing up to `parallelism` range calls
+/// (contiguous strides of up to `range_size` blocks each) concurrently, and
+/// committing the responses **in height order** into the stream — so the
+/// output stays strictly ascending and contiguous while the requests overlap.
+/// The batch shape is borrowed from the bots `BlockFetcher` (see
+/// `design/remote-block-source.md`): `join_all` preserves submission order, so
+/// no reorder buffer is needed, and the bounded output channel is the only
+/// backpressure — a full channel stalls the commit walk, which stalls the next
+/// batch.
 ///
 /// Generic over the client so the crate depends only on the [`BlockRangeClient`]
 /// trait, not a concrete HTTP client — and so it can be driven by a mock in
@@ -100,12 +115,22 @@ where
     }
 }
 
-/// Fetch `[from, to]` inclusive in contiguous runs, sending each [`BlockData`] in
-/// ascending order through `tx`. Returns when the range is done or the consumer
-/// drops the receiver. Transient failures (request error, timeout, or a
-/// not-yet-available height) back off and retry — every block in the range
-/// exists below the live tip, so a failure is always transient and never
-/// surfaced to the consumer.
+/// Fetch `[from, to]` inclusive, sending each [`BlockData`] in ascending order
+/// through `tx`. Returns when the range is done or the consumer drops the
+/// receiver.
+///
+/// Each round issues one **batch**: up to `parallelism` concurrent range calls
+/// on fixed contiguous strides of `range_size` blocks. `join_all` preserves
+/// submission order, so the responses come back height-ordered and are
+/// forwarded block by block while they stay contiguous with `next_from` — the
+/// first height not yet delivered. The first anomaly — a request error or
+/// timeout, an empty response, or a run that breaks contiguity (which is also
+/// how a **short** run surfaces: the next fixed stride no longer aligns) —
+/// stops the walk, discards the rest of the batch, and the next round
+/// re-issues from `next_from` after a backoff. Refetching a discarded tail
+/// trades a little bandwidth for never buffering out-of-order blocks; every
+/// height in a gap exists below the live tip, so anomalies are transient and
+/// rare, and are never surfaced to the consumer.
 #[cfg_attr(
     feature = "tracing",
     instrument(skip_all, name = "bsource.fetcher", fields(from, to))
@@ -120,71 +145,109 @@ async fn fetch_range<C>(
     C: BlockRangeClient + Clone + 'static,
 {
     let range_size = config.range_size.clamp(1, MAX_BLOCK_RANGE);
+    let parallelism = config.parallelism.max(1) as u64;
     let mut next_from = from;
 
     while next_from <= to {
-        // Up to `range_size` blocks, clamped to the blocks left in the gap.
-        let batch_to = min(next_from + range_size - 1, to);
+        // One batch: up to `parallelism` contiguous strides, requested
+        // concurrently. Each call is timed and its outcome labeled (ok / error
+        // / timeout / empty) — the four mutually-exclusive ends of one request
+        // — exactly as when the calls were serial.
+        let batch = (0..parallelism)
+            .map(|i| next_from + i * range_size)
+            .take_while(|&chunk_from| chunk_from <= to)
+            .map(|chunk_from| {
+                let chunk_to = min(chunk_from + range_size - 1, to);
+                let client = client.clone();
+                let timeout = config.timeout;
 
-        // Time each range call and label its outcome (ok / error / timeout /
-        // empty) — the four mutually-exclusive ends of one request.
-        #[cfg(feature = "metrics")]
-        let request_start = std::time::Instant::now();
+                async move {
+                    #[cfg(feature = "metrics")]
+                    let request_start = std::time::Instant::now();
 
-        let response = tokio::time::timeout(
-            config.timeout,
-            client.fetch_block_range(next_from, batch_to),
-        )
-        .await;
+                    let response = tokio::time::timeout(
+                        timeout,
+                        client.fetch_block_range(chunk_from, chunk_to),
+                    )
+                    .await;
 
-        #[cfg(feature = "metrics")]
-        metrics::histogram!(crate::metrics::FETCHER_REQUEST_DURATION)
-            .record(request_start.elapsed().as_secs_f64());
+                    #[cfg(feature = "metrics")]
+                    {
+                        metrics::histogram!(crate::metrics::FETCHER_REQUEST_DURATION)
+                            .record(request_start.elapsed().as_secs_f64());
 
-        let blocks = match response {
-            Ok(Ok(blocks)) => blocks,
-            Ok(Err(_error)) => {
-                #[cfg(feature = "metrics")]
-                metrics::counter!(crate::metrics::FETCHER_REQUESTS, "outcome" => "error")
-                    .increment(1);
-                #[cfg(feature = "tracing")]
-                tracing::warn!(error = %_error, next_from, "sentinel range fetch failed, retrying");
-                sleep(config.retry_backoff).await;
-                continue;
-            },
-            Err(_timeout) => {
-                #[cfg(feature = "metrics")]
-                metrics::counter!(crate::metrics::FETCHER_REQUESTS, "outcome" => "timeout")
-                    .increment(1);
-                #[cfg(feature = "tracing")]
-                tracing::warn!(next_from, "sentinel range fetch timed out, retrying");
-                sleep(config.retry_backoff).await;
-                continue;
-            },
-        };
+                        let outcome = match &response {
+                            Ok(Ok(blocks)) if blocks.is_empty() => "empty",
+                            Ok(Ok(_)) => "ok",
+                            Ok(Err(_)) => "error",
+                            Err(_) => "timeout",
+                        };
+                        metrics::counter!(crate::metrics::FETCHER_REQUESTS, "outcome" => outcome)
+                            .increment(1);
+                    }
 
-        // An empty response means `next_from` is not yet on the sentinel — retry
-        // from the same height after a backoff.
-        let Some(last) = blocks.last().map(|block| block.height()) else {
-            #[cfg(feature = "metrics")]
-            metrics::counter!(crate::metrics::FETCHER_REQUESTS, "outcome" => "empty").increment(1);
-            sleep(config.retry_backoff).await;
-            continue;
-        };
+                    response
+                }
+            })
+            .collect::<Vec<_>>();
 
-        #[cfg(feature = "metrics")]
-        metrics::counter!(crate::metrics::FETCHER_REQUESTS, "outcome" => "ok").increment(1);
+        // Commit in submission (= height) order; stop at the first anomaly.
+        let mut clean = true;
 
-        for block in blocks {
-            if tx.send(block).await.is_err() {
-                // The consumer dropped the `FetchStream`; stop.
-                return;
+        'walk: for response in join_all(batch).await {
+            let blocks = match response {
+                Ok(Ok(blocks)) => blocks,
+                Ok(Err(_error)) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(error = %_error, next_from, "sentinel range fetch failed, retrying");
+                    clean = false;
+                    break 'walk;
+                },
+                Err(_timeout) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(next_from, "sentinel range fetch timed out, retrying");
+                    clean = false;
+                    break 'walk;
+                },
+            };
+
+            // An empty response means the stride's first height is not on the
+            // sentinel — retry from `next_from` after a backoff.
+            if blocks.is_empty() {
+                clean = false;
+                break 'walk;
+            }
+
+            for block in blocks {
+                let height = block.height();
+
+                // The endpoint serves runs contiguous from the requested
+                // `from`, so a mismatch means an *earlier* stride came back
+                // short (this stride's fixed start no longer aligns) — or a
+                // misbehaving backend. Either way: discard and refetch.
+                if height != next_from {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        height,
+                        expected = next_from,
+                        "sentinel run broke contiguity, refetching"
+                    );
+                    clean = false;
+                    break 'walk;
+                }
+
+                if tx.send(block).await.is_err() {
+                    // The consumer dropped the `FetchStream`; stop.
+                    return;
+                }
+
+                next_from += 1;
             }
         }
 
-        // Resume one past the last block actually received — a short run just
-        // re-requests from the next height.
-        next_from = last + 1;
+        if !clean {
+            sleep(config.retry_backoff).await;
+        }
     }
 }
 
@@ -195,6 +258,10 @@ mod tests {
     use {
         super::*,
         dango_primitives::{Block, BlockInfo, BlockOutcome, Hash256, Timestamp},
+        std::sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
     };
 
     fn block(height: u64) -> BlockData {
@@ -262,7 +329,9 @@ mod tests {
     #[tokio::test]
     async fn resumes_from_last_received_on_short_runs() {
         // The client returns at most 3 blocks per call, well under `range_size`,
-        // so the loop must keep advancing via `last + 1`.
+        // so the loop must keep advancing via the committed frontier. With a
+        // 10-block gap and `range_size` 20 every batch is a single stride, so a
+        // short run resumes immediately (no misaligned follow-up stride).
         let fetcher =
             SentinelBlockFetcher::new(MockRangeClient { max_per_call: 3 }, SentinelFetcherConfig {
                 range_size: 20,
@@ -271,6 +340,145 @@ mod tests {
 
         let mut stream = fetcher.spawn(1, 10);
         assert_eq!(collect(&mut stream, 10).await, (1..=10).collect::<Vec<_>>());
+        assert!(stream.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn serial_mode_is_the_degenerate_batch() {
+        // `parallelism: 1` = one stride per batch: the pre-parallelism loop.
+        let fetcher =
+            SentinelBlockFetcher::new(MockRangeClient { max_per_call: 3 }, SentinelFetcherConfig {
+                range_size: 20,
+                parallelism: 1,
+                ..SentinelFetcherConfig::default()
+            });
+
+        let mut stream = fetcher.spawn(1, 10);
+        assert_eq!(collect(&mut stream, 10).await, (1..=10).collect::<Vec<_>>());
+        assert!(stream.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn short_run_mid_batch_discards_the_tail_and_refetches() {
+        // Strides of 5, three per batch, but the client caps every response at
+        // 3 blocks: the first stride comes back short, so the second stride's
+        // fixed start no longer aligns with the committed frontier and the
+        // walk must discard the batch tail and re-issue — never skipping or
+        // reordering a height. Zero backoff keeps the test instant.
+        let fetcher =
+            SentinelBlockFetcher::new(MockRangeClient { max_per_call: 3 }, SentinelFetcherConfig {
+                range_size: 5,
+                parallelism: 3,
+                retry_backoff: Duration::ZERO,
+                ..SentinelFetcherConfig::default()
+            });
+
+        let mut stream = fetcher.spawn(1, 30);
+        assert_eq!(collect(&mut stream, 30).await, (1..=30).collect::<Vec<_>>());
+        assert!(stream.recv().await.is_none());
+    }
+
+    /// Serves correct runs, except the *first* call for `from == 6`, which
+    /// returns a run starting two heights high — a misbehaving backend.
+    #[derive(Clone)]
+    struct SkewedOnceClient {
+        skewed: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl BlockRangeClient for SkewedOnceClient {
+        async fn fetch_block_range(&self, from: u64, to: u64) -> AnyResult<Vec<BlockData>> {
+            if from == 6 && !self.skewed.swap(true, Ordering::SeqCst) {
+                return Ok((from + 2..=to + 2).map(block).collect());
+            }
+            Ok((from..=to).map(block).collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn non_contiguous_response_is_discarded_and_refetched() {
+        // Batch of two strides [1, 5] and [6, 10]; the second comes back
+        // skewed (8..=12). The consumer must never see the skewed run — the
+        // walk discards it and refetches from 6.
+        let fetcher = SentinelBlockFetcher::new(
+            SkewedOnceClient {
+                skewed: Arc::new(AtomicBool::new(false)),
+            },
+            SentinelFetcherConfig {
+                range_size: 5,
+                parallelism: 2,
+                retry_backoff: Duration::ZERO,
+                ..SentinelFetcherConfig::default()
+            },
+        );
+
+        let mut stream = fetcher.spawn(1, 10);
+        assert_eq!(collect(&mut stream, 10).await, (1..=10).collect::<Vec<_>>());
+        assert!(stream.recv().await.is_none());
+    }
+
+    /// Counts in-flight calls and records the high-water mark, holding each
+    /// call open briefly so a batch's calls demonstrably overlap.
+    #[derive(Clone)]
+    struct GaugedClient {
+        inflight: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl BlockRangeClient for GaugedClient {
+        async fn fetch_block_range(&self, from: u64, to: u64) -> AnyResult<Vec<BlockData>> {
+            let now = self.inflight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(now, Ordering::SeqCst);
+            sleep(Duration::from_millis(10)).await;
+            self.inflight.fetch_sub(1, Ordering::SeqCst);
+            Ok((from..=to).map(block).collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_calls_run_concurrently_and_stay_bounded() {
+        let peak = Arc::new(AtomicUsize::new(0));
+        let fetcher = SentinelBlockFetcher::new(
+            GaugedClient {
+                inflight: Arc::new(AtomicUsize::new(0)),
+                peak: peak.clone(),
+            },
+            SentinelFetcherConfig {
+                range_size: 5,
+                parallelism: 4,
+                ..SentinelFetcherConfig::default()
+            },
+        );
+
+        // 40 blocks = 8 strides = 2 batches of 4.
+        let mut stream = fetcher.spawn(1, 40);
+        assert_eq!(collect(&mut stream, 40).await, (1..=40).collect::<Vec<_>>());
+        assert!(stream.recv().await.is_none());
+
+        // Every call of a batch parks on the mock's sleep before any
+        // completes, so the high-water mark is exactly the batch size — proof
+        // the calls overlap and never exceed `parallelism`.
+        assert_eq!(peak.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn saturated_channel_stalls_the_fetcher_then_resumes() {
+        // A 1-slot channel forces the commit walk to block on nearly every
+        // send while a whole batch of responses is in hand; draining the
+        // stream must still yield every height exactly once, in order.
+        let fetcher = SentinelBlockFetcher::new(
+            MockRangeClient { max_per_call: 20 },
+            SentinelFetcherConfig {
+                range_size: 5,
+                parallelism: 4,
+                channel_capacity: 1,
+                ..SentinelFetcherConfig::default()
+            },
+        );
+
+        let mut stream = fetcher.spawn(1, 40);
+        assert_eq!(collect(&mut stream, 40).await, (1..=40).collect::<Vec<_>>());
         assert!(stream.recv().await.is_none());
     }
 }

--- a/dango/archive/cli/config.example.toml
+++ b/dango/archive/cli/config.example.toml
@@ -19,7 +19,8 @@ live_url   = "http://node:8080"     # node httpd: live full_block tail + sentine
 # Which backfill fetcher to use (only `sentinel` for now; `s3` planned).
 # Defaults to sentinel if this section is omitted.
 [block_source.fetcher]
-type = "sentinel"                   # reuses live_url — no URL of its own
+type        = "sentinel"            # reuses live_url — no URL of its own
+parallelism = 4                     # concurrent range calls per backfill batch
 
 [httpd]
 enabled = true

--- a/dango/archive/cli/src/config.rs
+++ b/dango/archive/cli/src/config.rs
@@ -13,7 +13,7 @@
 
 use {
     dango_archive_projection::{EventType, WhiteOrBlackList},
-    serde::Deserialize,
+    serde::{Deserialize, Deserializer, de},
     std::path::PathBuf,
 };
 
@@ -141,23 +141,57 @@ pub struct RemoteSourceConfig {
 
 /// Backfill fetcher for a remote source, selected by `type`. Only `sentinel`
 /// exists today; an S3 archive fetcher is planned, hence the tagged enum.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum FetcherConfig {
     /// Bounded backfill from a sentinel node's `/block/full/range`. Reuses the
     /// source's `live_url` (same node as the live tail), so it has no URL field.
-    #[default]
-    Sentinel,
+    Sentinel {
+        /// Concurrent range calls per backfill batch; omitted → the
+        /// block-source crate's default. Overridable per instance as
+        /// `BLOCK_SOURCE__FETCHER__PARALLELISM`.
+        #[serde(default, deserialize_with = "de_opt_usize")]
+        parallelism: Option<usize>,
+    },
     // Future: `S3(S3FetcherConfig)` — backfill from an archive bucket with its
     // own bucket / region / prefix; the live tail still uses `live_url`.
+}
+
+impl Default for FetcherConfig {
+    fn default() -> Self {
+        Self::Sentinel { parallelism: None }
+    }
 }
 
 impl FetcherConfig {
     /// A short label for logs.
     pub fn kind(&self) -> &'static str {
         match self {
-            Self::Sentinel => "sentinel",
+            Self::Sentinel { .. } => "sentinel",
         }
+    }
+}
+
+/// Deserialize an optional integer that may arrive as a **string** — the shape
+/// an environment override takes: the `config` crate merges env values as
+/// strings, and inside the internally-tagged `block_source` table serde's
+/// content buffering performs no string→int coercion (which is why the plain
+/// TOML integer also has to be accepted here).
+fn de_opt_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IntOrString {
+        Int(usize),
+        String(String),
+    }
+
+    match Option::<IntOrString>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(IntOrString::Int(value)) => Ok(Some(value)),
+        Some(IntOrString::String(raw)) => raw.parse().map(Some).map_err(de::Error::custom),
     }
 }
 
@@ -275,7 +309,10 @@ mod tests {
             BlockSourceConfig::Remote(remote) => {
                 assert_eq!(remote.store_path, PathBuf::from("data/blocks"));
                 assert_eq!(remote.live_url, "http://node:8080");
-                assert!(matches!(remote.fetcher, FetcherConfig::Sentinel));
+                // The TOML-integer path through `de_opt_usize`.
+                assert!(matches!(remote.fetcher, FetcherConfig::Sentinel {
+                    parallelism: Some(4)
+                }));
             },
             other => panic!("expected a remote source, got {other:?}"),
         }
@@ -299,27 +336,32 @@ mod tests {
         );
         assert!(cfg.activity.event_type_filter.is_none());
 
-        // Environment overrides — the two the deploy role injects (env.j2):
-        // `POSTGRES__URL` wins over the TOML value, and `BLOCK_SOURCE__LIVE_URL`
-        // reaches *inside* the internally-tagged `block_source` table (the
-        // fragile path: the env value must merge into the table without
-        // clobbering its `type` tag).
+        // Environment overrides — the ones the deploy role can inject (env.j2):
+        // `POSTGRES__URL` wins over the TOML value, while `BLOCK_SOURCE__LIVE_URL`
+        // and `BLOCK_SOURCE__FETCHER__PARALLELISM` reach *inside* the
+        // internally-tagged `block_source` table (the fragile paths: the env
+        // value must merge into the table without clobbering its `type` tag,
+        // and a numeric field arrives as a string — the `de_opt_usize` path).
         // SAFETY: single-threaded within this test; set then immediately
         // cleared, and no other test reads these keys.
         unsafe {
             std::env::set_var("POSTGRES__URL", "postgres://override@host/db");
             std::env::set_var("BLOCK_SOURCE__LIVE_URL", "http://sentinel:9999");
+            std::env::set_var("BLOCK_SOURCE__FETCHER__PARALLELISM", "6");
         }
         let overridden: Config = parse_config(&path).unwrap();
         unsafe {
             std::env::remove_var("POSTGRES__URL");
             std::env::remove_var("BLOCK_SOURCE__LIVE_URL");
+            std::env::remove_var("BLOCK_SOURCE__FETCHER__PARALLELISM");
         }
         assert_eq!(overridden.postgres.url, "postgres://override@host/db");
         match &overridden.block_source {
             BlockSourceConfig::Remote(remote) => {
                 assert_eq!(remote.live_url, "http://sentinel:9999");
-                assert!(matches!(remote.fetcher, FetcherConfig::Sentinel));
+                assert!(matches!(remote.fetcher, FetcherConfig::Sentinel {
+                    parallelism: Some(6)
+                }));
             },
             other => panic!("expected a remote source, got {other:?}"),
         }

--- a/dango/archive/cli/src/source.rs
+++ b/dango/archive/cli/src/source.rs
@@ -54,10 +54,16 @@ fn build_remote(
         .with_context(|| format!("invalid live_url `{}`", cfg.live_url))?;
 
     let fetcher: Arc<dyn BlockFetcher> = match &cfg.fetcher {
-        FetcherConfig::Sentinel => Arc::new(SentinelBlockFetcher::new(
-            live.clone(),
-            SentinelFetcherConfig::default(),
-        )),
+        FetcherConfig::Sentinel { parallelism } => {
+            // The block-source crate owns the tuning defaults; the config only
+            // overrides what the deployment sets explicitly.
+            let mut fetcher_config = SentinelFetcherConfig::default();
+            if let Some(parallelism) = parallelism {
+                fetcher_config.parallelism = *parallelism;
+            }
+
+            Arc::new(SentinelBlockFetcher::new(live.clone(), fetcher_config))
+        },
     };
 
     Ok(Arc::new(RemoteBlockSource::new(

--- a/dango/archive/design/remote-block-source.md
+++ b/dango/archive/design/remote-block-source.md
@@ -363,15 +363,27 @@ Design notes:
 ### `SentinelBlockFetcher` (built now)
 
 A background task that pulls blocks from a sentinel's `GET /block/full/range`
-endpoint in **contiguous runs** of up to `range_size` heights per call (the
-endpoint caps a response at `MAX_BLOCK_RANGE` = 20). Each request starts one past
-the **last block actually received**, so a short run — the sentinel not yet
-holding the next height — simply re-requests from there rather than assuming a
-fixed stride. It sends the assembled `BlockData` through the bounded channel
-ascending and stops after `to`. No adaptive ramp: every height in a gap is below
-the live tip and therefore exists, so a plain sequential pull suffices. The
-endpoint returns the **full `Block`** (not just `block.info`), since projections
-need txs and events.
+endpoint (which caps a response at `MAX_BLOCK_RANGE` = 20 heights). Each round
+issues one **batch**: up to `parallelism` concurrent calls on fixed contiguous
+strides of `range_size` heights. `join_all` preserves submission order, so the
+responses come back height-ordered and are committed block by block while they
+stay contiguous with the next expected height — the stream stays strictly
+ascending with no reorder buffer. The first anomaly (a request error or
+timeout, an empty response, or a run that breaks contiguity — which is also how
+a **short** run surfaces, since the next fixed stride then no longer aligns)
+discards the rest of the batch, and the next round re-issues from the first
+height not yet delivered, after a backoff. Refetching a discarded tail trades a
+little bandwidth for never buffering out-of-order blocks; anomalies are
+transient and rare, so the cost is nil in steady state.
+
+Why parallel at all: in block-dense height regions a call is **payload-bound**
+(hundreds of KB per block — the sentinel's disk read + JSON serialization
+dominate), so a serial pull caps at one response-time per `range_size` blocks
+however fast the store writes. A handful of overlapping calls is enough to keep
+the pipeline fed; `parallelism = 1` restores the serial pull. No adaptive ramp:
+every height in a gap is below the live tip and therefore exists, so there is
+no tip to probe for. The endpoint returns the **full `Block`** (not just
+`block.info`), since projections need txs and events.
 
 ## The coordinator: forward the advance to the broadcast
 
@@ -478,13 +490,17 @@ store on restart : {1..50, 200..210}   live subscribe resumes at L = 250
 ## Borrowed pattern: bots `BlockFetcher`
 
 `bots/types/src/block_fetcher.rs` already solves the hard part and we lift it:
-the background task + `AbortOnDrop` + bounded channel + `recv()` interface, and
-the ordered-output discipline (send `block, block+1, …` in sequence, resume from
-the last height actually received). We drop the adaptive ramp (it exists to
-follow the tip, which a bounded gap never reaches) and the per-height concurrent
-fetch (the `/block/full/range` endpoint returns a whole run in one call, so the
-loop is a sequential walk of ranges), emit the full `Block` (not `block.info`),
-and add the `from/to` bound so the task terminates.
+the background task + `AbortOnDrop` + bounded channel + `recv()` interface, the
+ordered-output discipline (send `block, block+1, …` in sequence, resume from
+the last height actually received), and the **concurrent-batch shape** — issue
+N fetches at once, commit the results in submission order via `join_all`,
+discard from the first anomaly and re-issue from the last committed height.
+Adapted: the unit of a fetch is a `/block/full/range` stride (up to 20 blocks)
+rather than a single height, we emit the full `Block` (not `block.info`), and
+we add the `from/to` bound so the task terminates. We drop the adaptive ramp
+(`loops = min(i+1, max_loops)`): it exists to follow the tip, where most probed
+heights don't exist yet — a bounded gap sits entirely below the live tip, so a
+fixed `parallelism` suffices.
 
 ## Configuration
 
@@ -500,9 +516,12 @@ signal, to absorb an out-of-order delivery before fetching), `reconnect_backoff`
 (between live re-subscribes).
 
 `SentinelFetcherConfig` — `range_size` (heights requested per `/block/full/range`
-call, clamped to the gap and capped at `MAX_BLOCK_RANGE` = 20), `timeout`
-(per-request RPC timeout), `channel_capacity` (fetch-ahead backlog — the dominant
-backfill-RAM knob), `retry_backoff`.
+call, clamped to the gap and capped at `MAX_BLOCK_RANGE` = 20), `parallelism`
+(concurrent range calls per batch — the only tuning knob also wired through the
+TOML, as `[block_source.fetcher] parallelism`, env-overridable as
+`BLOCK_SOURCE__FETCHER__PARALLELISM`), `timeout` (per-request RPC timeout),
+`channel_capacity` (fetch-ahead backlog — the dominant backfill-RAM knob),
+`retry_backoff`.
 
 Already wired through `remote.*`: `live_url` (the sentinel's base `httpd` URL,
 from which `HttpdClient::new` derives both the `full_block` subscription and the

--- a/deploy/roles/archive/files/app.toml
+++ b/deploy/roles/archive/files/app.toml
@@ -14,8 +14,15 @@ type       = "remote"
 store_path = "data/blocks"          # under --home (/root/.archive)
 # live_url is injected from BLOCK_SOURCE__LIVE_URL (see header)
 
+# Concurrent /block/full/range calls per backfill batch; responses are
+# committed in height order, so the stream the projections see stays
+# ascending. Sized against the sentinel node's spare CPU (each in-flight call
+# costs it a range read + JSON serialization) and the activity projection's
+# own throughput ceiling — higher values buy nothing until the projection
+# keeps up. Overridable per instance as BLOCK_SOURCE__FETCHER__PARALLELISM.
 [block_source.fetcher]
-type = "sentinel"
+type        = "sentinel"
+parallelism = 4
 
 [httpd]
 enabled = true

--- a/deploy/roles/archive/files/app.toml
+++ b/deploy/roles/archive/files/app.toml
@@ -16,13 +16,17 @@ store_path = "data/blocks"          # under --home (/root/.archive)
 
 # Concurrent /block/full/range calls per backfill batch; responses are
 # committed in height order, so the stream the projections see stays
-# ascending. Sized against the sentinel node's spare CPU (each in-flight call
-# costs it a range read + JSON serialization) and the activity projection's
-# own throughput ceiling — higher values buy nothing until the projection
-# keeps up. Overridable per instance as BLOCK_SOURCE__FETCHER__PARALLELISM.
+# ascending. 8 lands the dense-era fetch (~500 blocks/s theoretical) just
+# under the store writer's ~780 blocks/s ceiling — the stage that actually
+# backpressures the fetcher (projections don't: they pull-catch-up behind
+# the frontier at their own pace). Higher values buy nothing downstream and
+# only load the sentinel node, which pays a disk read + JSON serialization
+# per in-flight call on the NIC it shares with consensus p2p — watch its
+# dango CPU / network on deploy. Overridable per instance as
+# BLOCK_SOURCE__FETCHER__PARALLELISM (1 = serial rollback, no rebuild).
 [block_source.fetcher]
 type        = "sentinel"
-parallelism = 4
+parallelism = 8
 
 [httpd]
 enabled = true


### PR DESCRIPTION
## Summary

The mainnet archive backfill entered a block-dense height region (~19M+, roughly May 2026 onward) where the serial `/block/full/range` pull is **payload-bound**: a 20-block call grew from ~60 KB / ~30 ms (early chain) to ~5 MB / ~300 ms, collapsing backfill throughput from ~640 to ~50–260 blocks/s — while the store and projections sat idle (`archive_channel_depth{channel="fetcher"}` pinned at 0).

This PR parallelizes the fetch, borrowing the **bots `BlockFetcher` batch shape** (`bots/types/src/block_fetcher.rs`), adapted from per-height calls to range strides:

- Each round issues up to `parallelism` (default 4) concurrent range calls on fixed contiguous strides of `range_size` blocks. `join_all` preserves submission order, so responses come back height-ordered and are committed block by block — **no reorder buffer**, the stream stays strictly ascending.
- The first anomaly (request error, timeout, empty response, or a contiguity break — which is also how a *short* run surfaces, since the next fixed stride no longer aligns) discards the rest of the batch and re-issues from the first height not yet delivered, after the existing backoff. Anomalies are transient by construction (every height in a gap sits below the live tip), so refetching a discarded tail trades a little bandwidth for simplicity.
- The bots adaptive ramp (`loops = min(i+1, max_loops)`) is deliberately dropped: it exists to chase the live tip, where probed heights may not exist yet — the archive's healer only fills bounded gaps below the tip.
- **Untouched**: the `BlockFetcher` contract, `backfill_gap`'s contiguity validation, the coordinator, the store. Backpressure is unchanged — the bounded output channel stalls the commit walk, which stalls the next batch (`parallelism = 1` restores the exact serial behaviour).
- `channel_capacity` default shrinks 2000 → 256: it is a RAM knob, and in dense eras (hundreds of KB per block) 2000 buffered blocks would be ~500 MB — a buffer the fetcher could never fill while serial, but can now that it outruns the store writer.
- Config: `[block_source.fetcher] parallelism` in the TOML, overridable per instance as `BLOCK_SOURCE__FETCHER__PARALLELISM`. Env values arrive as strings inside the internally-tagged `block_source` table where serde performs no coercion, hence the string-tolerant `de_opt_usize` deserializer (covered by the config unit test).
- Deploy `app.toml` sets `parallelism = 8` (the crate default stays 4); `design/remote-block-source.md` updated (fetcher section, borrowed-pattern section, configuration section).

Expected effect: with the deploy's `parallelism = 8`, dense-era fetch lands just under the **store writer's** ~780 b/s ceiling — the stage that actually backpressures the fetcher (projections never throttle it: the broadcast is a ring and they pull-catch-up behind the frontier at their own pace, ~250 b/s in dense eras). The cost that matters is upstream: each in-flight call costs the sentinel node a disk read + JSON serialization, on the NIC it shares with consensus p2p — its dango CPU / network are the post-deploy watch items.

## Validation

### Completed

- [x] `cargo test -p dango-archive-block-source --all-features` — 29 passed; 7 fetcher tests cover: full-range ordering under overlapping calls, short-run resume (single stride), short run **mid-batch** (discard tail + refetch, no skip/reorder), a non-contiguous (misbehaving) response never reaching the consumer, in-flight calls demonstrably concurrent and bounded exactly at `parallelism`, saturated 1-slot channel stalling then resuming in order, and `parallelism = 1` as the serial degenerate case
- [x] `cargo test -p dango-archive-cli --all-features` — example config parses (`parallelism = 4` via the TOML-integer path); `BLOCK_SOURCE__FETCHER__PARALLELISM=6` env override reaches inside the tagged `block_source` table (string path)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` on both touched crates
- [x] `cargo clippy -p dango-archive-block-source --no-default-features` (metrics/tracing `cfg` paths)
- [x] `cargo +nightly fmt --all`

### Remaining

- [ ] Canary deploy on testnet (hetzner8) — projection-bound there, so expect correctness signal more than throughput
- [ ] Mainnet deploy (hetzner7) while the current heal gap (~23M → 34.5M) is still open, to observe the gain on real dense-era blocks
- [ ] Post-deploy watch: `rate(archive_block_fetcher_blocks_total)`, `archive_block_fetcher_request_duration` (upstream strain shows here first), sentinel dango CPU on the source node, `archive_channel_depth{channel="fetcher"}` (a rising depth = bottleneck handed off to the projection, as predicted)

## Manual QA

1. `just deploy-archive testnet` (then mainnet) from `deploy/`.
2. Grafana "Dango Archive Indexer" dashboard: blocks/s should rise ~3–4× in dense regions; fetcher channel depth may now sit above 0 (expected — it means the fetcher is no longer the bottleneck).
3. Emergency rollback without a rebuild: set `BLOCK_SOURCE__FETCHER__PARALLELISM=1` in the instance `.env` and restart the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
