### PR TITLE
feat(archive): spawn sentinel strides as tasks and gzip the range fetches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ pyth-lazer-protocol         = "0.40.0"
 quote                       = "1"
 rand                        = "0.8" # FIXME: can't bump to 0.10 because RustCrypto requires 0.8
 rangemap                    = "1"
-reqwest                     = { version = "0.13", features = ["stream"] }
+reqwest                     = { version = "0.13", features = ["gzip", "stream"] }
 ripemd                      = "0.1"
 roaring                     = "0.11"
 rocksdb                     = "0.24"

--- a/dango/archive/block-source/src/httpd_client.rs
+++ b/dango/archive/block-source/src/httpd_client.rs
@@ -279,6 +279,16 @@ impl BlockRangeClient for HttpdClient {
         // `url` crate (this reqwest build has no RequestBuilder::query) and the
         // body decoded with serde_json (no `json` feature). `BlockData` decodes
         // the `{ block, outcome }` items directly.
+        //
+        // With reqwest's `gzip` feature the call advertises
+        // `Accept-Encoding: gzip`, the node's actix `Compress` middleware
+        // obliges (~4x smaller for block JSON), and reqwest inflates
+        // transparently — `bytes()` below always sees the raw JSON. Asking
+        // ourselves also keeps an intermediary from doing it for us: a Go
+        // proxy in front of the node (traefik) otherwise injects its own
+        // `Accept-Encoding: gzip` and re-inflates the response before
+        // forwarding, shipping the payload uncompressed on our leg of the
+        // wire.
         let mut url = self.range_url.clone();
         url.query_pairs_mut()
             .append_pair("from", &from.to_string())

--- a/dango/archive/block-source/src/remote/fetcher/mod.rs
+++ b/dango/archive/block-source/src/remote/fetcher/mod.rs
@@ -13,10 +13,12 @@ pub use sentinel::{
 ///
 /// [`FetchStream`] holds one of these so the background fetch task's lifetime
 /// is tied to the stream: drop the stream and the task stops, rather than
-/// leaking and racing ahead of a consumer that is no longer reading.
-pub(crate) struct AbortOnDrop(pub(crate) JoinHandle<()>);
+/// leaking and racing ahead of a consumer that is no longer reading. The
+/// sentinel fetcher wraps its per-stride range-call tasks in the same guard,
+/// so aborting the fetch task in turn aborts the strides it has in flight.
+pub(crate) struct AbortOnDrop<T = ()>(pub(crate) JoinHandle<T>);
 
-impl Drop for AbortOnDrop {
+impl<T> Drop for AbortOnDrop<T> {
     fn drop(&mut self) {
         self.0.abort();
     }

--- a/dango/archive/block-source/src/remote/fetcher/sentinel.rs
+++ b/dango/archive/block-source/src/remote/fetcher/sentinel.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 use {
-    super::{BlockFetcher, FetchStream},
+    super::{AbortOnDrop, BlockFetcher, FetchStream},
     async_trait::async_trait,
     dango_archive_types::{AnyResult, BlockData, BlockDataExt},
     futures::future::join_all,
@@ -37,13 +37,14 @@ pub struct SentinelFetcherConfig {
     /// in the gap and capped at [`MAX_BLOCK_RANGE`] (the endpoint's own limit).
     pub range_size: u64,
     /// Concurrent `/block/full/range` calls per batch. The fetcher issues this
-    /// many contiguous strides at once and commits the responses in height
-    /// order, so the stream stays strictly ascending; `1` restores the serial
-    /// one-call-at-a-time pull. In block-dense height regions a call is
-    /// payload-bound (hundreds of KB per block, most of it the sentinel's disk
-    /// read + JSON serialization), so this is as much an upstream-load knob as
-    /// a throughput one: a handful of concurrent calls is enough to keep the
-    /// pipeline fed, and more mostly costs the sentinel CPU.
+    /// many contiguous strides at once — each as its own runtime task — and
+    /// commits the responses in height order, so the stream stays strictly
+    /// ascending; `1` restores the serial one-call-at-a-time pull. In
+    /// block-dense height regions a call is payload-bound (hundreds of KB per
+    /// block: the sentinel's disk read + JSON serialization on one end, this
+    /// side's body assembly + JSON parse on the other), so this knob scales
+    /// both the overlap of the HTTP waits and the CPU the parses can use —
+    /// and, symmetrically, the load on the sentinel.
     pub parallelism: usize,
     /// Per-request timeout before retrying.
     pub timeout: Duration,
@@ -75,14 +76,19 @@ impl Default for SentinelFetcherConfig {
 /// [`BlockFetcher`] backed by a sentinel's `/block/full/range` endpoint.
 ///
 /// Fills a bounded gap `[from, to]` by issuing up to `parallelism` range calls
-/// (contiguous strides of up to `range_size` blocks each) concurrently, and
-/// committing the responses **in height order** into the stream — so the
-/// output stays strictly ascending and contiguous while the requests overlap.
-/// The batch shape is borrowed from the bots `BlockFetcher` (see
-/// `design/remote-block-source.md`): `join_all` preserves submission order, so
-/// no reorder buffer is needed, and the bounded output channel is the only
-/// backpressure — a full channel stalls the commit walk, which stalls the next
-/// batch.
+/// (contiguous strides of up to `range_size` blocks each) concurrently — each
+/// spawned as its own runtime task — and committing the responses **in height
+/// order** into the stream, so the output stays strictly ascending and
+/// contiguous while the requests overlap. Spawning (rather than polling the
+/// call futures inside this task) is what lets the CPU half of a call — body
+/// assembly and the serde_json parse, the dominant cost in dense eras — run on
+/// the runtime's worker threads in parallel; polled in-task, the parses
+/// serialize on one thread and cap the whole backfill near one core of JSON
+/// throughput regardless of `parallelism`. The batch shape is borrowed from
+/// the bots `BlockFetcher` (see `design/remote-block-source.md`): `join_all`
+/// preserves submission order, so no reorder buffer is needed, and the bounded
+/// output channel is the only backpressure — a full channel stalls the commit
+/// walk, which stalls the next batch.
 ///
 /// Generic over the client so the crate depends only on the [`BlockRangeClient`]
 /// trait, not a concrete HTTP client — and so it can be driven by a mock in
@@ -119,18 +125,23 @@ where
 /// through `tx`. Returns when the range is done or the consumer drops the
 /// receiver.
 ///
-/// Each round issues one **batch**: up to `parallelism` concurrent range calls
-/// on fixed contiguous strides of `range_size` blocks. `join_all` preserves
-/// submission order, so the responses come back height-ordered and are
-/// forwarded block by block while they stay contiguous with `next_from` — the
-/// first height not yet delivered. The first anomaly — a request error or
-/// timeout, an empty response, or a run that breaks contiguity (which is also
-/// how a **short** run surfaces: the next fixed stride no longer aligns) —
-/// stops the walk, discards the rest of the batch, and the next round
-/// re-issues from `next_from` after a backoff. Refetching a discarded tail
-/// trades a little bandwidth for never buffering out-of-order blocks; every
-/// height in a gap exists below the live tip, so anomalies are transient and
-/// rare, and are never surfaced to the consumer.
+/// Each round issues one **batch**: up to `parallelism` range calls on fixed
+/// contiguous strides of `range_size` blocks, each spawned as its own runtime
+/// task so the response parses run on the worker threads, not serialized on
+/// this task (see [`SentinelBlockFetcher`]). The tasks are guarded by
+/// [`AbortOnDrop`], so when this task is itself aborted (the consumer dropped
+/// the [`FetchStream`]) the in-flight strides die with it. `join_all` over the
+/// handles preserves submission order, so the responses come back
+/// height-ordered and are forwarded block by block while they stay contiguous
+/// with `next_from` — the first height not yet delivered. The first anomaly —
+/// a request error or timeout, a panicked stride task, an empty response, or
+/// a run that breaks contiguity (which is also how a **short** run surfaces:
+/// the next fixed stride no longer aligns) — stops the walk, discards the
+/// rest of the batch, and the next round re-issues from `next_from` after a
+/// backoff. Refetching a discarded tail trades a little bandwidth for never
+/// buffering out-of-order blocks; every height in a gap exists below the live
+/// tip, so anomalies are transient and rare, and are never surfaced to the
+/// consumer.
 #[cfg_attr(
     feature = "tracing",
     instrument(skip_all, name = "bsource.fetcher", fields(from, to))
@@ -149,11 +160,13 @@ async fn fetch_range<C>(
     let mut next_from = from;
 
     while next_from <= to {
-        // One batch: up to `parallelism` contiguous strides, requested
-        // concurrently. Each call is timed and its outcome labeled (ok / error
-        // / timeout / empty) — the four mutually-exclusive ends of one request
-        // — exactly as when the calls were serial.
-        let batch = (0..parallelism)
+        // One batch: up to `parallelism` contiguous strides, each spawned as
+        // its own task so the CPU half of a call (body assembly + JSON parse)
+        // lands on the runtime's workers instead of serializing here. Each
+        // call is timed and its outcome labeled (ok / error / timeout / empty)
+        // — the four mutually-exclusive ends of one request — exactly as when
+        // the calls were serial.
+        let mut strides = (0..parallelism)
             .map(|i| next_from + i * range_size)
             .take_while(|&chunk_from| chunk_from <= to)
             .map(|chunk_from| {
@@ -161,7 +174,7 @@ async fn fetch_range<C>(
                 let client = client.clone();
                 let timeout = config.timeout;
 
-                async move {
+                AbortOnDrop(tokio::spawn(async move {
                     #[cfg(feature = "metrics")]
                     let request_start = std::time::Instant::now();
 
@@ -187,25 +200,33 @@ async fn fetch_range<C>(
                     }
 
                     response
-                }
+                }))
             })
             .collect::<Vec<_>>();
 
         // Commit in submission (= height) order; stop at the first anomaly.
+        // Awaiting `&mut handle` leaves the guards owning the tasks, so an
+        // abort of this task mid-await still tears the strides down.
         let mut clean = true;
 
-        'walk: for response in join_all(batch).await {
-            let blocks = match response {
-                Ok(Ok(blocks)) => blocks,
-                Ok(Err(_error)) => {
+        'walk: for joined in join_all(strides.iter_mut().map(|stride| &mut stride.0)).await {
+            let blocks = match joined {
+                Ok(Ok(Ok(blocks))) => blocks,
+                Ok(Ok(Err(_error))) => {
                     #[cfg(feature = "tracing")]
                     tracing::warn!(error = %_error, next_from, "sentinel range fetch failed, retrying");
                     clean = false;
                     break 'walk;
                 },
-                Err(_timeout) => {
+                Ok(Err(_timeout)) => {
                     #[cfg(feature = "tracing")]
                     tracing::warn!(next_from, "sentinel range fetch timed out, retrying");
+                    clean = false;
+                    break 'walk;
+                },
+                Err(_join_error) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(error = %_join_error, next_from, "sentinel stride task failed, retrying");
                     clean = false;
                     break 'walk;
                 },

--- a/dango/archive/design/remote-block-source.md
+++ b/dango/archive/design/remote-block-source.md
@@ -364,11 +364,17 @@ Design notes:
 
 A background task that pulls blocks from a sentinel's `GET /block/full/range`
 endpoint (which caps a response at `MAX_BLOCK_RANGE` = 20 heights). Each round
-issues one **batch**: up to `parallelism` concurrent calls on fixed contiguous
-strides of `range_size` heights. `join_all` preserves submission order, so the
-responses come back height-ordered and are committed block by block while they
-stay contiguous with the next expected height — the stream stays strictly
-ascending with no reorder buffer. The first anomaly (a request error or
+issues one **batch**: up to `parallelism` calls on fixed contiguous strides of
+`range_size` heights, each spawned as its own runtime task (guarded by
+`AbortOnDrop`, so dropping the fetch task tears down its in-flight strides).
+Spawning is what parallelizes the CPU half of a call — body assembly and the
+serde_json parse, the dominant per-call cost in dense eras — across the
+runtime's workers; polled as plain futures inside the fetch task they would
+serialize on one thread, capping the backfill near one core of JSON throughput
+(~40 MB/s) regardless of `parallelism`. `join_all` over the handles preserves
+submission order, so the responses come back height-ordered and are committed
+block by block while they stay contiguous with the next expected height — the
+stream stays strictly ascending with no reorder buffer. The first anomaly (a request error or
 timeout, an empty response, or a run that breaks contiguity — which is also how
 a **short** run surfaces, since the next fixed stride then no longer aligns)
 discards the rest of the batch, and the next round re-issues from the first
@@ -377,10 +383,11 @@ little bandwidth for never buffering out-of-order blocks; anomalies are
 transient and rare, so the cost is nil in steady state.
 
 Why parallel at all: in block-dense height regions a call is **payload-bound**
-(hundreds of KB per block — the sentinel's disk read + JSON serialization
-dominate), so a serial pull caps at one response-time per `range_size` blocks
-however fast the store writes. A handful of overlapping calls is enough to keep
-the pipeline fed; `parallelism = 1` restores the serial pull. No adaptive ramp:
+(hundreds of KB per block — the sentinel's disk read + JSON serialization on
+one end, our body assembly + JSON parse on the other), so a serial pull caps
+at one response-time per `range_size` blocks however fast the store writes.
+`parallelism` overlaps the HTTP waits *and* spreads the parses over that many
+workers; `parallelism = 1` restores the serial pull. No adaptive ramp:
 every height in a gap is below the live tip and therefore exists, so there is
 no tip to probe for. The endpoint returns the **full `Block`** (not just
 `block.info`), since projections need txs and events.

--- a/deploy/host_vars/100.126.43.113.yml
+++ b/deploy/host_vars/100.126.43.113.yml
@@ -11,11 +11,14 @@ cloudflare_lb_enabled: true
 # live_host_override resolves the live_url hostname to the source node's
 # wireguard IP inside the container (compose extra_hosts): traffic reaches the
 # node's traefik :80 directly over the VPN, bypassing Cloudflare and its rate
-# limits. 10.99.0.8 = hetzner1; on node migration point it at another mainnet
-# full-app host (its tailscale IP works too).
+# limits. 10.99.0.10 = hetzner3 (FSN1, same campus as this host — picked over
+# hetzner1/HEL1 for latency, and it clocked the fastest /block/full/range
+# among the mainnet nodes; hetzner6 is unusable as a source: no blocks below
+# ~23.2M). On node migration point it at another mainnet full-app host with
+# full history (its tailscale IP works too).
 archive_instances:
   - name: mainnet
     live_url: "http://api-mainnet.dango.zone"
-    live_host_override: "10.99.0.8"
+    live_host_override: "10.99.0.10"
     metrics_host_port: 9192
     httpd_host_port: 9082


### PR DESCRIPTION
## Summary

Follow-up to #2219 — the parallelized backfill fetcher didn't deliver the expected speedup. Metrics showed why: both archive instances pinned at **~40 MB/s of JSON ingest on ~1 core** (mainnet ~250 blocks/s in the dense era at ~191 KB/block, testnet ~1370 blocks/s at ~29 KB/block — same byte ceiling), while the store writer idled (0.67 ms/block, fetcher→writer channel depth 0) on a 96-core box.

Root cause: `join_all` polled the stride futures **inside the single `fetch_range` task**, so the HTTP waits overlapped but the CPU half of every call — body assembly + `serde_json::from_slice` of ~3.8 MB — serialized on one thread, capping the whole backfill near one core of JSON throughput regardless of `parallelism`.

Two changes:

1. **Spawn each stride as its own runtime task** (`AbortOnDrop<T>`-guarded `tokio::spawn`): parses now run on the runtime's worker threads in parallel. Ordered commit is unchanged — `join_all` over the handles preserves submission order; a panicked stride surfaces as one more batch anomaly (discard tail, backoff, refetch). Dropping the `FetchStream` still cancels everything: aborting the fetch task drops the guards, which abort the in-flight strides.
2. **Enable reqwest's `gzip` feature** (workspace): the client advertises `Accept-Encoding: gzip` itself, so the sentinel's actix `Compress` responds compressed **end-to-end** (~4x for block JSON). Today traefik's Go transport injects its own `Accept-Encoding: gzip` toward the node and re-inflates before forwarding, so the archive leg ships uncompressed (observed on mainnet: dango tx ~10 MB/s vs traefik tx ~42 MB/s for the same stream).
3. **Deploy config**: point the mainnet archive's `live_host_override` at hetzner3 (`10.99.0.10`, FSN1 — same campus as hetzner7) instead of hetzner1 (HEL1, ~25 ms away). hetzner3 clocked the fastest `/block/full/range` among the mainnet nodes and has full history from block 1; hetzner6 is documented as unusable as a source (no blocks below ~23.2M). Already applied to the live instance — committed so the next `deploy-archive` run doesn't revert it.

Expected next ceilings after this: the sentinel's serve rate (~200–260 ms server-side per dense-era range call) and/or the store writer (~1.5k blocks/s at current put latency).

## Validation

### Completed

- [x] `cargo test -p dango-archive-block-source` — 29/29 (ordering, short runs, contiguity breaks, bounded concurrency, saturated-channel backpressure, serial degenerate mode)
- [x] `cargo clippy -p dango-archive-block-source --all-targets` — zero warnings
- [x] `cargo fetch --locked` — lockfile already satisfies the `gzip` feature (no new crates)
- [x] `just fmt`

### Remaining

- [ ] Redeploy the mainnet archive and confirm `rate(archive_block_fetcher_blocks_total[10m])` climbs well past ~250 b/s in the dense era, with `archive_block_fetcher_request_duration_seconds` p50 dropping toward the sentinel's server-side time
- [ ] Confirm wire compression on the archive leg (archive container rx should drop ~4x per block at equal block rate)
- [ ] Watch the sentinel node's dango CPU / traefik after the deploy (it now serves more concurrent parses' worth of requests)

## Manual QA

1. `just deploy-archive mainnet` (hetzner7), then watch the metrics above in Prometheus/Grafana for ~15 min of dense-era backfill.
2. Rollback lever unchanged: `BLOCK_SOURCE__FETCHER__PARALLELISM=1` restores the serial pull without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
