### PR TITLE
feat(deploy): expose archive indexer through cloudflare lb

### DIFF
--- a/deploy/host_vars/100.126.43.113.yml
+++ b/deploy/host_vars/100.126.43.113.yml
@@ -22,3 +22,6 @@ archive_instances:
     live_host_override: "10.99.0.10"
     metrics_host_port: 9192
     httpd_host_port: 9082
+    cloudflare:
+      enabled: true
+      load_balancer: true

--- a/deploy/host_vars/100.126.43.113.yml
+++ b/deploy/host_vars/100.126.43.113.yml
@@ -3,9 +3,8 @@ tailscale_ip: "100.126.43.113"
 hostname: "hetzner7"
 wireguard_ip: "10.99.0.12"
 reboot_time: "15:30"
-dango_networks:
-  - mainnet
-cloudflare_lb_enabled: true
+dango_networks: []
+cloudflare_lb_enabled: false
 
 # Archive indexer instance — `just deploy-archive mainnet` (roles/archive).
 # live_host_override resolves the live_url hostname to the source node's

--- a/deploy/host_vars/100.99.36.21.yml
+++ b/deploy/host_vars/100.99.36.21.yml
@@ -3,9 +3,8 @@ tailscale_ip: "100.99.36.21"
 hostname: "hetzner8"
 wireguard_ip: "10.99.0.13"
 reboot_time: "16:00"
-dango_networks:
-  - testnet
-cloudflare_lb_enabled: true
+dango_networks: []
+cloudflare_lb_enabled: false
 
 # Archive indexer instance — `just deploy-archive testnet` (roles/archive).
 # See host_vars/100.126.43.113.yml (hetzner7) for the live_host_override

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -258,6 +258,31 @@ deploy-archive network tag="latest":
       --limit archive-{{network}} \
       2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-archive.log
 
+# Bootstrap public exposure for an archive network. Run this the first time a
+# host is exposed publicly, or after changing Traefik/Cloudflare routing. Normal
+# image deploys should use `deploy-archive`.
+setup-archive-public network tag="latest":
+  mkdir -p {{justfile_directory()}}/logs \
+    && { \
+      uv run ansible-playbook traefik.yml --limit archive-{{network}} \
+      && uv run ansible-playbook archive.yml -e archive_tag={{tag}} --limit archive-{{network}} \
+      && uv run ansible-playbook cloudflared.yml --limit archive-{{network}}; \
+    } 2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-setup-archive-public.log
+
+# Reconcile the shared Traefik stack/static config for archive hosts.
+update-archive-traefik network:
+  mkdir -p {{justfile_directory()}}/logs \
+    && uv run ansible-playbook traefik.yml \
+      --limit archive-{{network}} \
+      2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-update-archive-traefik.log
+
+# Reconcile Cloudflared, archive DNS records, and archive Cloudflare LB state.
+update-archive-cloudflare network:
+  mkdir -p {{justfile_directory()}}/logs \
+    && uv run ansible-playbook cloudflared.yml \
+      --limit archive-{{network}} \
+      2>&1 | tee {{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-update-archive-cloudflare.log
+
 stop-archive network:
   mkdir -p {{justfile_directory()}}/logs \
     && uv run ansible-playbook stop-archive.yml \

--- a/deploy/roles/archive/defaults/main.yml
+++ b/deploy/roles/archive/defaults/main.yml
@@ -5,12 +5,16 @@ archive_tag: "latest"
 
 # Instances to run on this host. Each runs as its own docker compose project
 # (own directory, container, RocksDB data dir, and Postgres database). The
-# read API is published VPN-only on httpd_host_port (wireguard+tailscale);
-# public exposure through Traefik (archive-<name>.<dango_domain>) is commented
-# out until the DNS/cloudflared work lands. Multiple instances coexist on one
-# host as long as each has a unique name and unique host ports. Populated from
-# the host's host_vars/<ip>.yml (the [archive-<network>] inventory groups only
-# drive `--limit` targeting).
+# read API is published VPN-only on httpd_host_port (wireguard+tailscale) by
+# default. Public exposure is opt-in per instance with:
+#
+#   cloudflare:
+#     enabled: true        # cloudflared -> traefik -> archive
+#     load_balancer: true  # api-archive-<name>.<dango_domain>
+#
+# Multiple instances coexist on one host as long as each has a unique name and
+# unique host ports. Populated from the host's host_vars/<ip>.yml (the
+# [archive-<network>] inventory groups only drive `--limit` targeting).
 #
 # Example (live_host_override makes the container resolve the live_url
 # hostname to that IP — direct VPN path to the node's traefik, no Cloudflare;
@@ -22,6 +26,9 @@ archive_tag: "latest"
 #       live_host_override: "10.99.0.9"
 #       metrics_host_port: 9191
 #       httpd_host_port: 9081
+#       cloudflare:
+#         enabled: true
+#         load_balancer: true
 archive_instances: []
 
 # Postgres connection — the shared host postgres, reached by the container over

--- a/deploy/roles/archive/tasks/deploy-instance.yml
+++ b/deploy/roles/archive/tasks/deploy-instance.yml
@@ -6,6 +6,12 @@
       - instance.live_url is defined
       - instance.metrics_host_port is defined
       - instance.httpd_host_port is defined
+      - instance.name is match('^[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
+      - instance.cloudflare is not defined or instance.cloudflare.enabled is defined
+      - instance.cloudflare is not defined or instance.cloudflare.load_balancer is defined
+      - instance.cloudflare is not defined or instance.cloudflare.load_balancer is not defined or not instance.cloudflare.load_balancer or instance.cloudflare.enabled
+      - inventory_hostname in (groups['traefik'] | default([]))
+      - instance.cloudflare is not defined or not instance.cloudflare.enabled or inventory_hostname in (groups['cloudflared'] | default([]))
       - archive_db_password is defined
       - archive_db_password | length > 0
       - postgres_user is defined
@@ -13,9 +19,12 @@
       - ghcr_user is defined
       - ghcr_token is defined
     fail_msg: >-
-      archive instance needs name/live_url/metrics_host_port/httpd_host_port,
-      plus archive_db_password, postgres_user, postgres_password,
-      ghcr_user, ghcr_token
+      archive instance needs a DNS-safe name, live_url, metrics_host_port,
+      httpd_host_port, plus archive_db_password, postgres_user,
+      postgres_password, ghcr_user, ghcr_token. If cloudflare is present it
+      must include enabled and load_balancer. If cloudflare.enabled is true, the
+      host must be in [cloudflared]; all archive hosts must be in [traefik]
+      because the compose stack joins the external traefik network.
 
 - name: "{{ instance.name }} - Derive instance facts"
   set_fact:
@@ -36,6 +45,11 @@
 - name: "{{ instance.name }} - Ensure postgres docker network exists"
   community.docker.docker_network:
     name: postgres
+    state: present
+
+- name: "{{ instance.name }} - Ensure traefik docker network exists"
+  community.docker.docker_network:
+    name: traefik
     state: present
 
 - name: "{{ instance.name }} - Create postgres user"
@@ -108,11 +122,16 @@
     registry: ghcr.io
     state: absent
 
-# Public exposure via Traefik is parked until the DNS/cloudflared work lands
-# (traefik is not deployed on the archive hosts). Re-enable together with the
-# `traefik` network in templates/docker-compose.yml.j2.
-# - name: "{{ instance.name }} - Configure Traefik route"
-#   template:
-#     src: traefik-archive.yml.j2
-#     dest: "{{ traefik_dir }}/config/archive-{{ instance.name }}.yml"
-#     mode: "0644"
+- name: "{{ instance.name }} - Ensure Traefik config directory exists"
+  file:
+    path: "{{ traefik_dir }}/config"
+    state: directory
+    mode: "0755"
+  when: instance.cloudflare is defined and instance.cloudflare.enabled
+
+- name: "{{ instance.name }} - Configure Traefik route"
+  template:
+    src: traefik-archive.yml.j2
+    dest: "{{ traefik_dir }}/config/archive-{{ instance.name }}.yml"
+    mode: "0644"
+  when: instance.cloudflare is defined and instance.cloudflare.enabled

--- a/deploy/roles/archive/templates/docker-compose.yml.j2
+++ b/deploy/roles/archive/templates/docker-compose.yml.j2
@@ -35,19 +35,17 @@ services:
       # same dual binding as promtail/node-exporter.
       - "{{ wireguard_ip }}:{{ instance.metrics_host_port }}:9191"
       - "{{ tailscale_ip }}:{{ instance.metrics_host_port }}:9191"
-      # Read API (GraphQL httpd), VPN-only — the only way in until the
-      # Traefik/Cloudflare exposure lands (see commented traefik bits below).
+      # Read API (GraphQL httpd), VPN-only host bindings. Public traffic enters
+      # through cloudflared -> Traefik -> Docker network instead of these host
+      # ports when a Traefik route is enabled.
       - "{{ wireguard_ip }}:{{ instance.httpd_host_port }}:8080"
       - "{{ tailscale_ip }}:{{ instance.httpd_host_port }}:8080"
     networks:
-      # Re-enable together with the "Configure Traefik route" task in
-      # deploy-instance.yml when the public exposure (traefik + DNS) lands —
-      # traefik is not deployed on the archive hosts yet.
-      # - traefik
+      - traefik
       - postgres
 
 networks:
-  # traefik:
-  #   external: true
+  traefik:
+    external: true
   postgres:
     external: true

--- a/deploy/roles/archive/templates/traefik-archive.yml.j2
+++ b/deploy/roles/archive/templates/traefik-archive.yml.j2
@@ -7,14 +7,14 @@ http:
 
   routers:
     archive-{{ instance.name }}-ssl:
-      rule: "Host(`archive-{{ instance.name }}.{{ dango_domain }}`)"
+      rule: "Host(`api-archive-{{ instance.name }}-{{ hostname }}.{{ dango_domain }}`) || Host(`api-archive-{{ instance.name }}.{{ dango_domain }}`)"
       entryPoints:
         - "websecure"
       tls: {}
       service: "archive-{{ instance.name }}"
 
     archive-{{ instance.name }}:
-      rule: "Host(`archive-{{ instance.name }}.{{ dango_domain }}`)"
+      rule: "Host(`api-archive-{{ instance.name }}-{{ hostname }}.{{ dango_domain }}`) || Host(`api-archive-{{ instance.name }}.{{ dango_domain }}`)"
       entryPoints:
         - "web"
       service: "archive-{{ instance.name }}"

--- a/deploy/roles/cloudflared/tasks/archive_instances.yml
+++ b/deploy/roles/cloudflared/tasks/archive_instances.yml
@@ -1,0 +1,39 @@
+---
+- name: Initialize normalized archive instance lists
+  set_fact:
+    archive_public_instances: []
+    archive_lb_instances: []
+
+- name: Validate archive instance Cloudflare fields
+  assert:
+    that:
+      - archive_instance.name is defined
+      - archive_instance.cloudflare is not defined or archive_instance.cloudflare.enabled is defined
+      - archive_instance.cloudflare is not defined or archive_instance.cloudflare.load_balancer is defined
+      - archive_instance.cloudflare is not defined or archive_instance.cloudflare.load_balancer is not defined or not archive_instance.cloudflare.load_balancer or archive_instance.cloudflare.enabled
+    fail_msg: >-
+      archive_instances need name; if cloudflare is present it must include
+      enabled and load_balancer. load_balancer requires cloudflare.enabled.
+  loop: "{{ archive_instances | default([]) }}"
+  loop_control:
+    loop_var: archive_instance
+
+- name: Collect public archive instances
+  set_fact:
+    archive_public_instances: "{{ archive_public_instances + [archive_instance] }}"
+  loop: "{{ archive_instances | default([]) }}"
+  loop_control:
+    loop_var: archive_instance
+    label: "{{ archive_instance.name }}"
+  when:
+    - archive_instance.cloudflare is defined
+    - archive_instance.cloudflare.enabled
+
+- name: Collect load-balanced archive instances
+  set_fact:
+    archive_lb_instances: "{{ archive_lb_instances + [archive_instance] }}"
+  loop: "{{ archive_public_instances }}"
+  loop_control:
+    loop_var: archive_instance
+    label: "{{ archive_instance.name }}"
+  when: archive_instance.cloudflare.load_balancer

--- a/deploy/roles/cloudflared/tasks/cloudflare_archive_collect_networks.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_archive_collect_networks.yml
@@ -1,0 +1,11 @@
+---
+- name: Collect archive Cloudflare LB networks for host
+  become: false
+  delegate_to: localhost
+  set_fact:
+    archive_cf_lb_networks: "{{ archive_cf_lb_networks + [archive_instance.name] }}"
+  loop: "{{ hostvars[archive_host].archive_lb_instances | default([]) }}"
+  loop_control:
+    loop_var: archive_instance
+    label: "{{ archive_instance.name }}"
+  when: archive_instance.name not in archive_cf_lb_networks

--- a/deploy/roles/cloudflared/tasks/cloudflare_archive_lb.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_archive_lb.yml
@@ -1,0 +1,123 @@
+---
+- name: Initialize archive Cloudflare LB networks
+  run_once: true
+  become: false
+  delegate_to: localhost
+  set_fact:
+    archive_cf_lb_hosts: "{{ ansible_play_hosts_all }}"
+    archive_cf_lb_networks: []
+
+- name: Collect archive Cloudflare LB networks
+  include_tasks: cloudflare_archive_collect_networks.yml
+  loop: "{{ archive_cf_lb_hosts }}"
+  loop_control:
+    loop_var: archive_host
+    label: "{{ archive_host }}"
+
+- name: Get all monitors for archive LBs
+  run_once: true
+  become: false
+  delegate_to: localhost
+  uri:
+    url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/monitors"
+    method: GET
+    headers: { Authorization: "Bearer {{ cloudflare_api_token }}" }
+  register: cf_monitors
+  when: archive_cf_lb_networks | length > 0
+
+- name: Ensure archive Cloudflare monitor
+  include_tasks: cloudflare_monitor.yml
+  vars:
+    mon: { name: "api-archive", path: "/up", expect: "200" }
+  when: archive_cf_lb_networks | length > 0
+
+- name: Refresh monitors after archive monitor creation
+  run_once: true
+  become: false
+  delegate_to: localhost
+  uri:
+    url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/monitors"
+    method: GET
+    headers: { Authorization: "Bearer {{ cloudflare_api_token }}" }
+  register: cf_monitors
+  when: archive_cf_lb_networks | length > 0
+
+- name: Build archive monitor id map by name
+  run_once: true
+  become: false
+  delegate_to: localhost
+  set_fact:
+    monitor_id_map: "{{ dict(cf_monitors.json.result | map(attribute='description') | zip(cf_monitors.json.result | map(attribute='id'))) }}"
+  when: archive_cf_lb_networks | length > 0
+
+- name: Get all pools for archive LBs
+  run_once: true
+  become: false
+  delegate_to: localhost
+  uri:
+    url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/pools"
+    method: GET
+    headers: { Authorization: "Bearer {{ cloudflare_api_token }}" }
+  register: cf_pools
+  when: archive_cf_lb_networks | length > 0
+
+- name: Create archive pools
+  include_tasks: cloudflare_archive_pool.yml
+  loop: "{{ archive_cf_lb_networks }}"
+  loop_control:
+    loop_var: archive_network
+  when: archive_cf_lb_networks | length > 0
+
+- name: Refresh pools after archive pool creation
+  run_once: true
+  become: false
+  delegate_to: localhost
+  uri:
+    url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/pools"
+    method: GET
+    headers: { Authorization: "Bearer {{ cloudflare_api_token }}" }
+  register: cf_pools
+  when: archive_cf_lb_networks | length > 0
+
+- name: Ensure Cloudflare zone id for archive LBs
+  run_once: true
+  become: false
+  delegate_to: localhost
+  when:
+    - archive_cf_lb_networks | length > 0
+    - cloudflare_zone_id is not defined
+  block:
+    - name: Lookup Cloudflare zone by name
+      uri:
+        url: "https://api.cloudflare.com/client/v4/zones?name={{ dango_domain }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ cloudflare_api_token }}"
+          Content-Type: "application/json"
+      register: zone_info
+
+    - name: Set Cloudflare zone id
+      set_fact:
+        cloudflare_zone_id: "{{ zone_info.json.result[0].id }}"
+
+- name: Get all load balancers for archive LBs
+  run_once: true
+  become: false
+  delegate_to: localhost
+  uri:
+    url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/load_balancers"
+    method: GET
+    headers: { Authorization: "Bearer {{ cloudflare_api_token }}" }
+  register: cf_load_balancers
+  when: archive_cf_lb_networks | length > 0
+
+- name: Create archive LBs
+  vars:
+    svcnet:
+      - api-archive
+      - "{{ archive_network }}"
+  include_tasks: cloudflare_zone_lb.yml
+  loop: "{{ archive_cf_lb_networks }}"
+  loop_control:
+    loop_var: archive_network
+  when: archive_cf_lb_networks | length > 0

--- a/deploy/roles/cloudflared/tasks/cloudflare_archive_pool.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_archive_pool.yml
@@ -1,0 +1,30 @@
+# expects: archive_network, cf_pools, monitor_id_map, cloudflare_account_id, cloudflare_api_token
+
+- name: Initialize archive pool origins
+  set_fact:
+    archive_pool_origins: []
+
+- name: Append origin for each archive host
+  vars:
+    archive_instance: >-
+      {{
+        (hostvars[item].archive_lb_instances | default([])
+         | selectattr('name','equalto', archive_network)
+         | list | first) | default(None)
+      }}
+    hn: "{{ hostvars[item].hostname }}"
+    addr: "api-archive-{{ archive_network }}-{{ hn }}.{{ dango_domain }}"
+    origin_name: "api-archive-{{ archive_network }}-{{ hn }}"
+  set_fact:
+    archive_pool_origins: "{{ archive_pool_origins + [ { 'name': origin_name, 'address': addr, 'enabled': true, 'header': { 'Host': [ addr ] } } ] }}"
+  loop: "{{ archive_cf_lb_hosts }}"
+  when:
+    - archive_instance is mapping
+
+- name: Ensure Cloudflare pool for archive service
+  vars:
+    dango_network: "{{ archive_network }}"
+    pool: { name: "api-archive" }
+    pool_origins_override: "{{ archive_pool_origins }}"
+  include_tasks: cloudflare_pool.yml
+  when: archive_pool_origins | length > 0

--- a/deploy/roles/cloudflared/tasks/cloudflare_lb_cleanup.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_lb_cleanup.yml
@@ -48,7 +48,7 @@
       {{ (cf_load_balancers.json.result
           | selectattr('name', 'equalto', excl_lb_name)
           | map(attribute='id')
-          | list | first) | default('') }}
+          | list | first) | default(None) }}
   uri:
     url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/load_balancers/{{ excl_lb_id }}"
     method: DELETE
@@ -58,7 +58,9 @@
   loop_control:
     loop_var: item
     label: "{{ item.1 }}-{{ item.0.key }}"
-  when: excl_lb_id | length > 0
+  when:
+    - excl_lb_id is string
+    - excl_lb_id | length > 0
   run_once: true
   become: false
   delegate_to: localhost
@@ -70,7 +72,7 @@
       {{ (cf_pools.json.result
           | selectattr('name', 'equalto', excl_pool_name)
           | map(attribute='id')
-          | list | first) | default('') }}
+          | list | first) | default(None) }}
   uri:
     url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/pools/{{ excl_pool_id }}"
     method: DELETE
@@ -80,7 +82,9 @@
   loop_control:
     loop_var: item
     label: "pool-{{ item.1 }}-{{ item.0.key }}"
-  when: excl_pool_id | length > 0
+  when:
+    - excl_pool_id is string
+    - excl_pool_id | length > 0
   run_once: true
   become: false
   delegate_to: localhost

--- a/deploy/roles/cloudflared/tasks/cloudflare_monitor.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_monitor.yml
@@ -2,6 +2,11 @@
 
 - name: Ensure Cloudflare monitor
   block:
+    - name: Initialize monitor vars
+      set_fact:
+        existing_id: null
+        created_id: null
+
     - name: Build desired monitor spec (typed)
       set_fact:
         desired_monitor: >-
@@ -34,7 +39,7 @@
         existing_id: "{{ existing_mon.id }}"
 
     - name: Create monitor if missing
-      when: existing_id is not defined
+      when: existing_id is not string
       uri:
         url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/monitors"
         method: POST
@@ -47,10 +52,11 @@
 
     - name: Expose monitor id fact per service
       set_fact:
-        "monitor_id_{{ mon.name }}": "{{ existing_id | default(create_mon.json.result.id) }}"
+        "monitor_id_{{ mon.name | regex_replace('[^A-Za-z0-9_]', '_') }}": >-
+          {{ existing_id if existing_id is string else create_mon.json.result.id }}
 
     - name: Update monitor to desired state (always)
-      when: existing_id is defined
+      when: existing_id is string
       uri:
         url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/monitors/{{ existing_id }}"
         method: PUT
@@ -72,8 +78,8 @@
         msg:
           name: "{{ mon.name }}"
           path: "{{ mon.path }}"
-          existing_id: "{{ existing_id | default('none') }}"
-          created_id: "{{ created_id | default('n/a') }}"
+          existing_id: "{{ existing_id }}"
+          created_id: "{{ created_id }}"
           update_status: "{{ (update_mon.status if (update_mon is defined and update_mon.status is defined) else 'n/a') }}"
   delegate_to: localhost
   become: false

--- a/deploy/roles/cloudflared/tasks/cloudflare_pool.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_pool.yml
@@ -6,12 +6,12 @@
       set_fact:
         pool_name: "pool-{{ pool.name }}-{{ dango_network }}"
         pool_monitor_id: "{{ (monitor_id_map[pool.name] if monitor_id_map is defined and monitor_id_map.get(pool.name) is defined else omit) }}"
-        pool_origins: []
+        pool_origins: "{{ pool_origins_override | default([]) }}"
 
     - name: Initialize per-iteration vars
       set_fact:
-        existing_pool_id: ""
-        created_pool_id: ""
+        existing_pool_id: null
+        created_pool_id: null
 
     - name: Append origin for each cloudflared host
       vars:
@@ -21,7 +21,9 @@
       set_fact:
         pool_origins: "{{ pool_origins + [ { 'name': origin_name, 'address': addr, 'enabled': true, 'header': { 'Host': [ addr ] } } ] }}"
       loop: "{{ groups['cloudflared'] | default([]) }}"
-      when: dango_network in (hostvars[item].dango_networks | default([]))
+      when:
+        - pool_origins_override is not defined
+        - dango_network in (hostvars[item].dango_networks | default([]))
 
     - name: Find existing pool by name
       set_fact:
@@ -38,7 +40,7 @@
         existing_pool_id: "{{ existing_pool.id }}"
 
     - name: Create pool if missing
-      when: (existing_pool_id | default('') | length) == 0
+      when: existing_pool_id is not string
       uri:
         url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/pools"
         method: POST
@@ -72,7 +74,7 @@
         created_pool_id: "{{ create_pool.json.result.id }}"
 
     - name: Update pool to desired state (always)
-      when: (existing_pool_id | default('') | length) > 0
+      when: existing_pool_id is string
       uri:
         url: "https://api.cloudflare.com/client/v4/accounts/{{ cloudflare_account_id }}/load_balancers/pools/{{ existing_pool_id }}"
         method: PUT
@@ -105,8 +107,8 @@
     - debug:
         msg:
           pool_name: "{{ pool_name }}"
-          existing_pool_id: "{{ existing_pool_id | default('none') }}"
-          created_pool_id: "{{ created_pool_id | default('n/a') }}"
+          existing_pool_id: "{{ existing_pool_id }}"
+          created_pool_id: "{{ created_pool_id }}"
           origins: "{{ pool_origins | map(attribute='address') | list }}"
           update_status: "{{ (update_pool.status if (update_pool is defined and update_pool.status is defined) else 'n/a') }}"
   delegate_to: localhost

--- a/deploy/roles/cloudflared/tasks/cloudflare_pool.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_pool.yml
@@ -20,7 +20,7 @@
         origin_name: "{{ pool.name }}-{{ dango_network }}-{{ hn }}"
       set_fact:
         pool_origins: "{{ pool_origins + [ { 'name': origin_name, 'address': addr, 'enabled': true, 'header': { 'Host': [ addr ] } } ] }}"
-      loop: "{{ groups['cloudflared'] | default([]) }}"
+      loop: "{{ (groups['cloudflared'] | default([])) | intersect(groups['full-app'] | default([])) }}"
       when:
         - pool_origins_override is not defined
         - dango_network in (hostvars[item].dango_networks | default([]))

--- a/deploy/roles/cloudflared/tasks/cloudflare_tunnel.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_tunnel.yml
@@ -67,6 +67,9 @@
     tunnel_id: "{{ (cloudflare_tunnel_token | b64decode | from_json).t }}"
   when: tunnel_id is not defined
 
+- name: Normalize archive instances
+  include_tasks: archive_instances.yml
+
 - name: Create cloudflared directory
   file:
     path: "{{ cloudflared_dir }}"
@@ -154,6 +157,21 @@
     proxied: true
     state: present
     api_token: "{{ cloudflare_api_token }}"
+  retries: 3
+  delay: 5
+
+- name: Ensure per-host archive CNAME → tunnel
+  community.general.cloudflare_dns:
+    zone: "{{ dango_domain }}"
+    record: "api-archive-{{ item.name }}-{{ hostname }}"
+    type: CNAME
+    value: "{{ tunnel_id }}.cfargotunnel.com"
+    proxied: true
+    state: present
+    api_token: "{{ cloudflare_api_token }}"
+  loop: "{{ archive_public_instances }}"
+  loop_control:
+    label: "api-archive-{{ item.name }}-{{ hostname }}"
   retries: 3
   delay: 5
 

--- a/deploy/roles/cloudflared/tasks/cloudflare_zone_lb.yml
+++ b/deploy/roles/cloudflared/tasks/cloudflare_zone_lb.yml
@@ -9,6 +9,7 @@
         lb_name: "{{ svcnet.0 }}-{{ svcnet.1 }}.{{ dango_domain }}"
         pool_name: "pool-{{ svcnet.0 }}-{{ svcnet.1 }}"
         desired_lb_description: "Auto-managed by Ansible: service={{ svcnet.0 }}, network={{ svcnet.1 }}"
+        existing_lb_id: null
 
     - name: Lookup pool id for service/network
       set_fact:
@@ -17,7 +18,7 @@
             (cf_pools.json.result
              | selectattr('name','equalto', pool_name)
              | map(attribute='id')
-             | list | first) | default(omit)
+             | list | first) | default(None)
           }}
 
     - name: Find existing LB by name
@@ -34,8 +35,15 @@
       set_fact:
         existing_lb_id: "{{ existing_lb.id }}"
 
+    - name: Validate Cloudflare pool exists for LB
+      assert:
+        that:
+          - pool_id is string
+          - pool_id | length > 0
+        fail_msg: "Cloudflare pool {{ pool_name }} must exist before creating/updating LB {{ lb_name }}."
+
     - name: Create LB if missing
-      when: (existing_lb_id | default('') | length) == 0 and (pool_id is defined)
+      when: existing_lb_id is not string
       uri:
         url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/load_balancers"
         method: POST
@@ -56,13 +64,8 @@
       failed_when: create_lb.status not in [200,409]
       changed_when: create_lb.status == 200
 
-    - name: Skip LB creation when pool_id missing
-      when: (existing_lb_id | default('') | length) == 0 and (pool_id is not defined)
-      debug:
-        msg: "Skipping LB {{ lb_name }} because pool {{ pool_name }} was not found."
-
     - name: Update LB to desired state (always)
-      when: (existing_lb_id | default('') | length) > 0 and (pool_id is defined)
+      when: existing_lb_id is string
       uri:
         url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/load_balancers/{{ existing_lb_id }}"
         method: PUT
@@ -89,8 +92,8 @@
           lb: "{{ lb_name }}"
           description: "{{ desired_lb_description }}"
           pool_name: "{{ pool_name }}"
-          pool_id: "{{ pool_id | default('missing') }}"
-          existing_lb_id: "{{ existing_lb_id | default('none') }}"
+          pool_id: "{{ pool_id }}"
+          existing_lb_id: "{{ existing_lb_id }}"
           created_status: "{{ (create_lb.status if (create_lb is defined and create_lb.status is defined) else 'n/a') }}"
           update_status: "{{ (update_lb.status if (update_lb is defined and update_lb.status is defined) else 'n/a') }}"
   delegate_to: localhost

--- a/deploy/roles/cloudflared/tasks/main.yml
+++ b/deploy/roles/cloudflared/tasks/main.yml
@@ -9,3 +9,6 @@
   loop_control:
     loop_var: dango_network
   when: cloudflare_lb_enabled
+
+- include_tasks: cloudflare_archive_lb.yml
+  run_once: true

--- a/deploy/roles/cloudflared/templates/config.yml
+++ b/deploy/roles/cloudflared/templates/config.yml
@@ -26,4 +26,8 @@ ingress:
   - hostname: points-{{ dango_network }}.{{ dango_domain }}
     service: http://traefik
 {% endfor %}
+{% for instance in archive_public_instances | default([]) %}
+  - hostname: api-archive-{{ instance.name }}-{{ hostname }}.{{ dango_domain }}
+    service: http://traefik
+{% endfor %}
   - service: http_status:404

--- a/deploy/roles/traefik/templates/docker-compose-hetzner7.yml
+++ b/deploy/roles/traefik/templates/docker-compose-hetzner7.yml
@@ -1,0 +1,60 @@
+services:
+  traefik:
+    ports:
+      - "80:80"
+      - "443:443"
+      # traefik dashboard
+      - "{{ tailscale_ip }}:8888:8888"
+      - "{{ wireguard_ip }}:8888:8888"
+      # devnet
+      - "8080:8080"
+      - "8082:8082"
+      - "{{ wireguard_ip }}:26657:26657"
+      - "{{ wireguard_ip }}:26660:26660"
+      - "{{ wireguard_ip }}:8083:8083"
+      - "{{ wireguard_ip }}:8084:8084"
+      - "{{ wireguard_ip }}:8085:8085"
+      - "{{ tailscale_ip }}:26657:26657"
+      - "{{ tailscale_ip }}:26660:26660"
+      - "{{ tailscale_ip }}:8083:8083"
+      - "{{ tailscale_ip }}:8084:8084"
+      - "{{ tailscale_ip }}:8085:8085"
+      # testnet
+      - "8050:8050"
+      - "8052:8052"
+      - "{{ wireguard_ip }}:36657:36657"
+      - "{{ wireguard_ip }}:36660:36660"
+      - "{{ wireguard_ip }}:8053:8053"
+      - "{{ wireguard_ip }}:8054:8054"
+      - "{{ wireguard_ip }}:8055:8055"
+      - "{{ tailscale_ip }}:36657:36657"
+      - "{{ tailscale_ip }}:36660:36660"
+      - "{{ tailscale_ip }}:8053:8053"
+      - "{{ tailscale_ip }}:8054:8054"
+      - "{{ tailscale_ip }}:8055:8055"
+      # mainnet
+      - "8030:8030"
+      - "8032:8032"
+      - "{{ wireguard_ip }}:46657:46657"
+      - "{{ wireguard_ip }}:46660:46660"
+      - "{{ wireguard_ip }}:8033:8033"
+      - "{{ wireguard_ip }}:8034:8034"
+      - "{{ wireguard_ip }}:8035:8035"
+      - "{{ tailscale_ip }}:46657:46657"
+      - "{{ tailscale_ip }}:46660:46660"
+      - "{{ tailscale_ip }}:8033:8033"
+      - "{{ tailscale_ip }}:8034:8034"
+      - "{{ tailscale_ip }}:8035:8035"
+    networks:
+      - traefik
+      - monitoring
+      - cloudflare
+
+networks:
+  traefik:
+    driver: bridge
+    name: traefik
+  monitoring:
+    external: true
+  cloudflare:
+    external: true

--- a/deploy/roles/traefik/templates/docker-compose-hetzner8.yml
+++ b/deploy/roles/traefik/templates/docker-compose-hetzner8.yml
@@ -1,0 +1,60 @@
+services:
+  traefik:
+    ports:
+      - "80:80"
+      - "443:443"
+      # traefik dashboard
+      - "{{ tailscale_ip }}:8888:8888"
+      - "{{ wireguard_ip }}:8888:8888"
+      # devnet
+      - "8080:8080"
+      - "8082:8082"
+      - "{{ wireguard_ip }}:26657:26657"
+      - "{{ wireguard_ip }}:26660:26660"
+      - "{{ wireguard_ip }}:8083:8083"
+      - "{{ wireguard_ip }}:8084:8084"
+      - "{{ wireguard_ip }}:8085:8085"
+      - "{{ tailscale_ip }}:26657:26657"
+      - "{{ tailscale_ip }}:26660:26660"
+      - "{{ tailscale_ip }}:8083:8083"
+      - "{{ tailscale_ip }}:8084:8084"
+      - "{{ tailscale_ip }}:8085:8085"
+      # testnet
+      - "8050:8050"
+      - "8052:8052"
+      - "{{ wireguard_ip }}:36657:36657"
+      - "{{ wireguard_ip }}:36660:36660"
+      - "{{ wireguard_ip }}:8053:8053"
+      - "{{ wireguard_ip }}:8054:8054"
+      - "{{ wireguard_ip }}:8055:8055"
+      - "{{ tailscale_ip }}:36657:36657"
+      - "{{ tailscale_ip }}:36660:36660"
+      - "{{ tailscale_ip }}:8053:8053"
+      - "{{ tailscale_ip }}:8054:8054"
+      - "{{ tailscale_ip }}:8055:8055"
+      # mainnet
+      - "8030:8030"
+      - "8032:8032"
+      - "{{ wireguard_ip }}:46657:46657"
+      - "{{ wireguard_ip }}:46660:46660"
+      - "{{ wireguard_ip }}:8033:8033"
+      - "{{ wireguard_ip }}:8034:8034"
+      - "{{ wireguard_ip }}:8035:8035"
+      - "{{ tailscale_ip }}:46657:46657"
+      - "{{ tailscale_ip }}:46660:46660"
+      - "{{ tailscale_ip }}:8033:8033"
+      - "{{ tailscale_ip }}:8034:8034"
+      - "{{ tailscale_ip }}:8035:8035"
+    networks:
+      - traefik
+      - monitoring
+      - cloudflare
+
+networks:
+  traefik:
+    driver: bridge
+    name: traefik
+  monitoring:
+    external: true
+  cloudflare:
+    external: true

--- a/deploy/roles/traefik/templates/traefik-hetzner7.yml
+++ b/deploy/roles/traefik/templates/traefik-hetzner7.yml
@@ -1,0 +1,141 @@
+api:
+  dashboard: true
+  insecure: true
+
+# using static certs
+# certificatesResolvers:
+#   letsencrypt:
+#     acme:
+#       email: letsencrypt-dango@pen.so
+#       storage: /letsencrypt/acme.json
+#       httpChallenge:
+#         entryPoint: web
+
+ping: true
+
+providers:
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /config
+    watch: true
+
+serversTransport:
+  maxIdleConnsPerHost: 4096
+  forwardingTimeouts:
+    dialTimeout: 10s
+    responseHeaderTimeout: 60s
+
+entryPoints:
+  # Public (all interfaces)
+  web:
+    address: :80
+    reusePort: true
+    transport:
+      lifeCycle:
+        requestAcceptGraceTimeout: 0s
+      respondingTimeouts:
+        readTimeout: 60s
+    forwardedHeaders:
+      trustedIPs:
+{% for cidr in cloudflare_ips %}
+        - {{ cidr }}
+{% endfor %}
+        - 127.0.0.1/32
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - fc00::/7
+  websecure:
+    address: :443
+    reusePort: true
+    transport:
+      lifeCycle:
+        requestAcceptGraceTimeout: 0s
+      respondingTimeouts:
+        readTimeout: 60s
+    forwardedHeaders:
+      trustedIPs:
+{% for cidr in cloudflare_ips %}
+        - {{ cidr }}
+{% endfor %}
+        - 127.0.0.1/32
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - fc00::/7
+  devnet-dango:
+    address: ":{{ traefik.devnet.ports.dango_port }}"
+  devnet-faucet_bot:
+    address: ":{{ traefik.devnet.ports.faucet_port }}"
+  devnet-graphiql:
+    address: ":{{ traefik.devnet.ports.graphiql_port }}"
+  testnet-dango:
+    address: ":{{ traefik.testnet.ports.dango_port }}"
+  testnet-faucet_bot:
+    address: ":{{ traefik.testnet.ports.faucet_port }}"
+  testnet-graphiql:
+    address: ":{{ traefik.testnet.ports.graphiql_port }}"
+  mainnet-dango:
+    address: ":{{ traefik.mainnet.ports.dango_port }}"
+  mainnet-faucet_bot:
+    address: ":{{ traefik.mainnet.ports.faucet_port }}"
+  mainnet-graphiql:
+    address: ":{{ traefik.mainnet.ports.graphiql_port }}"
+
+  # Tailscale/VPN only
+  traefik:
+    address: :8888
+  devnet-dango-metrics:
+    address: :8083
+  devnet-db-metrics:
+    address: :8084
+  devnet-clickhouse-metrics:
+    address: :8085
+  devnet-cometbft_rpc:
+    address: :26657
+  devnet-cometbft_metrics:
+    address: :26660
+  testnet-dango-metrics:
+    address: :8053
+  testnet-db-metrics:
+    address: :8054
+  testnet-clickhouse-metrics:
+    address: :8055
+  testnet-cometbft_rpc:
+    address: :36657
+  testnet-cometbft_metrics:
+    address: :36660
+  mainnet-dango-metrics:
+    address: :8033
+  mainnet-db-metrics:
+    address: :8034
+  mainnet-clickhouse-metrics:
+    address: :8035
+  mainnet-cometbft_rpc:
+    address: :46657
+  mainnet-cometbft_metrics:
+    address: :46660
+
+metrics:
+  prometheus: {}
+
+log:
+  level: INFO
+  format: json
+
+accessLog:
+  format: json
+  fields:
+    names:
+      RouterName: keep
+      ServiceName: keep
+    headers:
+      defaultMode: drop
+      names:
+        CF-Connecting-IP: keep
+        X-Forwarded-For: keep
+        Forwarded: keep
+        True-Client-IP: keep
+        X-Real-IP: keep
+        Cf-Ray: keep

--- a/deploy/roles/traefik/templates/traefik-hetzner8.yml
+++ b/deploy/roles/traefik/templates/traefik-hetzner8.yml
@@ -1,0 +1,141 @@
+api:
+  dashboard: true
+  insecure: true
+
+# using static certs
+# certificatesResolvers:
+#   letsencrypt:
+#     acme:
+#       email: letsencrypt-dango@pen.so
+#       storage: /letsencrypt/acme.json
+#       httpChallenge:
+#         entryPoint: web
+
+ping: true
+
+providers:
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /config
+    watch: true
+
+serversTransport:
+  maxIdleConnsPerHost: 4096
+  forwardingTimeouts:
+    dialTimeout: 10s
+    responseHeaderTimeout: 60s
+
+entryPoints:
+  # Public (all interfaces)
+  web:
+    address: :80
+    reusePort: true
+    transport:
+      lifeCycle:
+        requestAcceptGraceTimeout: 0s
+      respondingTimeouts:
+        readTimeout: 60s
+    forwardedHeaders:
+      trustedIPs:
+{% for cidr in cloudflare_ips %}
+        - {{ cidr }}
+{% endfor %}
+        - 127.0.0.1/32
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - fc00::/7
+  websecure:
+    address: :443
+    reusePort: true
+    transport:
+      lifeCycle:
+        requestAcceptGraceTimeout: 0s
+      respondingTimeouts:
+        readTimeout: 60s
+    forwardedHeaders:
+      trustedIPs:
+{% for cidr in cloudflare_ips %}
+        - {{ cidr }}
+{% endfor %}
+        - 127.0.0.1/32
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - fc00::/7
+  devnet-dango:
+    address: ":{{ traefik.devnet.ports.dango_port }}"
+  devnet-faucet_bot:
+    address: ":{{ traefik.devnet.ports.faucet_port }}"
+  devnet-graphiql:
+    address: ":{{ traefik.devnet.ports.graphiql_port }}"
+  testnet-dango:
+    address: ":{{ traefik.testnet.ports.dango_port }}"
+  testnet-faucet_bot:
+    address: ":{{ traefik.testnet.ports.faucet_port }}"
+  testnet-graphiql:
+    address: ":{{ traefik.testnet.ports.graphiql_port }}"
+  mainnet-dango:
+    address: ":{{ traefik.mainnet.ports.dango_port }}"
+  mainnet-faucet_bot:
+    address: ":{{ traefik.mainnet.ports.faucet_port }}"
+  mainnet-graphiql:
+    address: ":{{ traefik.mainnet.ports.graphiql_port }}"
+
+  # Tailscale/VPN only
+  traefik:
+    address: :8888
+  devnet-dango-metrics:
+    address: :8083
+  devnet-db-metrics:
+    address: :8084
+  devnet-clickhouse-metrics:
+    address: :8085
+  devnet-cometbft_rpc:
+    address: :26657
+  devnet-cometbft_metrics:
+    address: :26660
+  testnet-dango-metrics:
+    address: :8053
+  testnet-db-metrics:
+    address: :8054
+  testnet-clickhouse-metrics:
+    address: :8055
+  testnet-cometbft_rpc:
+    address: :36657
+  testnet-cometbft_metrics:
+    address: :36660
+  mainnet-dango-metrics:
+    address: :8033
+  mainnet-db-metrics:
+    address: :8034
+  mainnet-clickhouse-metrics:
+    address: :8035
+  mainnet-cometbft_rpc:
+    address: :46657
+  mainnet-cometbft_metrics:
+    address: :46660
+
+metrics:
+  prometheus: {}
+
+log:
+  level: INFO
+  format: json
+
+accessLog:
+  format: json
+  fields:
+    names:
+      RouterName: keep
+      ServiceName: keep
+    headers:
+      defaultMode: drop
+      names:
+        CF-Connecting-IP: keep
+        X-Forwarded-For: keep
+        Forwarded: keep
+        True-Client-IP: keep
+        X-Real-IP: keep
+        Cf-Ray: keep

--- a/deploy/tasks/load-debian-root-secrets.yml
+++ b/deploy/tasks/load-debian-root-secrets.yml
@@ -1,6 +1,16 @@
 - name: Load debian root secrets
   community.sops.load_vars:
     file: vaults/debian/root_vault.sops.json
+    return_method: facts-only
+  when: not (debian_root_secrets_loaded | default(false))
+  register: debian_root_secrets_load
+  no_log: true
+  become: false
+
+- name: Mark debian root secrets as loaded
+  ansible.builtin.set_fact:
+    debian_root_secrets_loaded: true
+  when: debian_root_secrets_load is not skipped
   no_log: true
   become: false
 


### PR DESCRIPTION
## Summary

- Expose archive indexer instances through the same `cloudflared -> Traefik -> archive` path used by the Dango services.
- Add Cloudflare DNS, monitor, pool, and load balancer automation for `api-archive-<network>.dango.zone`.
- Enable the mainnet archive on hetzner7 and add explicit Traefik templates for hetzner7/hetzner8.
- Keep archive hosts out of normal Dango LB pools by limiting Dango origins to `[cloudflared] ∩ [full-app]` hosts.
- Mark hetzner7/hetzner8 as archive-only for Dango LB purposes while keeping `archive_instances` as their archive source of truth.
- Cache debian root SOPS secrets as host facts during a playbook run so `traefik.yml` does not prompt/decrypt the same YubiKey-backed vault twice.
- Keep normal archive image deploys on `deploy-archive`; add `setup-archive-public` for first-time public exposure or routing changes.
- Add separate archive maintenance actions for Traefik (`update-archive-traefik`) and Cloudflare/Cloudflared (`update-archive-cloudflare`).
- Normalize archive Cloudflare config once per host, scope archive LB discovery to the current play hosts, and fail early when archive or Cloudflare LB config is partial.
- Model missing Cloudflare IDs as `null`/absent instead of empty-string sentinels.

## Validation

### Completed

- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check archive.yml`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check archive.yml --limit archive-mainnet`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check cloudflared.yml`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check cloudflared.yml --limit archive-mainnet`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check cloudflared.yml --limit archive-testnet`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check cloudflared.yml --limit 100.76.197.30`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check traefik.yml`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-playbook --syntax-check traefik.yml --limit archive-mainnet`
- [x] `ANSIBLE_VARS_ENABLED=host_group_vars uv run ansible-inventory --list` confirms normal Dango LB origins exclude hetzner7/hetzner8.
- [x] SSH read-only checks on hetzner7/hetzner8 show archive containers and no normal Dango deployment containers/directories.
- [x] `just --dry-run deploy-archive-mainnet latest`
- [x] `just --dry-run setup-archive-public mainnet latest`
- [x] `just --dry-run update-archive-traefik mainnet`
- [x] `just --dry-run update-archive-cloudflare mainnet`
- [x] `rg -n "default\\(\\\"\\\"\\)|default\\(''\\)|default\\('unknown'\\)|default\\(\\\"unknown\\\"\\)|unknown" deploy/roles/cloudflared deploy/roles/archive` returns no matches.
- [x] `rg -n "groups\\['cloudflared'\\]" deploy/roles/cloudflared/tasks/cloudflare_archive_* deploy/roles/cloudflared/tasks/archive_instances.yml deploy/roles/cloudflared/templates/config.yml` returns no matches.
- [x] `shasum deploy/roles/traefik/templates/docker-compose-dango.yml deploy/roles/traefik/templates/docker-compose-hetzner7.yml deploy/roles/traefik/templates/docker-compose-hetzner8.yml deploy/roles/traefik/templates/traefik-dango.yml deploy/roles/traefik/templates/traefik-hetzner7.yml deploy/roles/traefik/templates/traefik-hetzner8.yml`
- [x] Rendered the archive compose, Cloudflared config, and Traefik archive route templates with hetzner7/mainnet values.

### Remaining

- [ ] Run the normal SOPS-backed Ansible checks/deploy from an environment with the required YubiKey access.
- [ ] Deploy `setup-archive-public mainnet` once for the initial public exposure, then use normal `deploy-archive-mainnet` image deploys.
- [ ] Verify `api-archive-mainnet-hetzner7.dango.zone` plus `api-archive-mainnet.dango.zone`.

## Manual QA

Not run locally; requires Cloudflare credentials, SOPS/YubiKey access, and target infrastructure.