### PR TITLE
feat(archive): perps-events shortcut, /block/latest, and OpenAPI docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -3772,6 +3775,7 @@ dependencies = [
  "dango-indexer-metrics",
  "dango-primitives",
  "dango-sdk",
+ "dango-types",
  "futures",
  "home",
  "metrics",
@@ -3790,8 +3794,10 @@ dependencies = [
  "actix-cors",
  "actix-web",
  "anyhow",
+ "async-trait",
  "dango-archive-block-source",
  "dango-archive-types",
+ "dango-primitives",
  "futures",
  "hex",
  "metrics",
@@ -3800,6 +3806,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "utoipa",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -3823,6 +3831,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "utoipa",
  "uuid",
  "zstd",
 ]
@@ -4961,6 +4970,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +5591,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -9510,6 +9531,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12148,6 +12203,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "actix-web",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "utoipa-swagger-ui-vendored",
+ "zip",
+]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
+
+[[package]]
 name = "uuid"
 version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13320,10 +13423,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,8 @@ tracing-opentelemetry       = "0.33"
 tracing-subscriber          = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 typenum                     = "1"
 url                         = "2.5.4"
+utoipa                      = "5"
+utoipa-swagger-ui           = { version = "9", features = ["actix-web", "vendored"] }
 uuid                        = { version = "1", features = ["serde", "v4"] }
 wasmer                      = "7"
 wasmer-middlewares          = "7"

--- a/dango/archive/DESIGN.md
+++ b/dango/archive/DESIGN.md
@@ -608,8 +608,23 @@ actix `Scope`s of `#[get]`-routed handlers, one per resource, just like the
 in-process indexer's `routes::blocks::services()`. The app gathers them in
 `run` into one configurator, and the httpd injects the shared read handles
 (the Postgres pool, the block source) as actix app data and applies it. The
-httpd never names a projection; its only built-in route is the generic
-`GET /block/{height}`, read straight from the `BlockSource`.
+httpd never names a projection; its only built-in routes are the generic
+`GET /block/{height}`, read straight from the `BlockSource`, and
+`GET /block/latest` — the block at the source's **contiguous frontier** (the
+highest `H` with every height in `[1, H]` stored, i.e. the newest block
+servable together with all the history below it; the frontier is the O(1)
+in-memory topology the block store already owns, so the route adds no state).
+During a backfill the frontier trails the chain tip the live tail is already
+storing above the gap; once gap-free, it is the tip.
+
+The surface is self-describing: each projection contributes an OpenAPI
+fragment through `Projection::api_doc()` — derived from the same
+`#[utoipa::path]` annotations sitting on its handlers, so conditionally-mounted
+routes are documented exactly when they exist — and the httpd merges the
+fragments into its own base document (the core routes above) and serves the
+result at `GET /openapi.json`, with Swagger UI on `GET /docs/`; the base
+`GET /` redirects there. The docs derivation mirrors the route derivation, so
+the served spec can never enumerate a surface different from the one mounted.
 
 Each feed is a `GET` whose path + query string carry the same arguments the
 queries always took (address, contract, type, role, kind, names, plus

--- a/dango/archive/app/src/app.rs
+++ b/dango/archive/app/src/app.rs
@@ -80,8 +80,15 @@ impl App {
         // configurator that mounts every projection's `services()` scopes, run
         // the httpd over the shared pool + source, and supervise it as one more
         // task — so a server error stops the app too. The read surface is
-        // derived from the registered projections, never enumerated twice.
+        // derived from the registered projections, never enumerated twice; the
+        // OpenAPI docs come from the same projections (`api_doc()`), so the
+        // served spec always matches the mounted routes.
         if let Some(cfg) = self.read_cfg {
+            let api_docs = self
+                .projections
+                .iter()
+                .filter_map(|projection| projection.api_doc())
+                .collect();
             let projections = self.projections.clone();
             let configure: Configurator = Arc::new(move |service_config| {
                 for projection in &projections {
@@ -95,6 +102,7 @@ impl App {
                 self.db.clone(),
                 self.source.clone(),
                 configure,
+                api_docs,
             )));
         }
 

--- a/dango/archive/cli/Cargo.toml
+++ b/dango/archive/cli/Cargo.toml
@@ -25,6 +25,7 @@ dango-indexer-cache         = { workspace = true, features = ["metrics", "tracin
 dango-indexer-metrics       = { workspace = true, features = ["tracing"] }
 dango-primitives            = { workspace = true }
 dango-sdk                   = { workspace = true, features = ["tracing"] }
+dango-types                 = { workspace = true }
 futures                     = { workspace = true }
 home                        = { workspace = true }
 metrics                     = { workspace = true }

--- a/dango/archive/cli/src/activity.rs
+++ b/dango/archive/cli/src/activity.rs
@@ -4,14 +4,17 @@
 //! built-in default), and `involvement_blacklist` is the config addresses
 //! merged with the deployment's **system contracts** — read from the node's
 //! `app_config` and harvested with `Extractable`, so the per-network addresses
-//! never have to be listed by hand.
+//! never have to be listed by hand. The same `app_config` also names the
+//! deployment's **perps contract** (`addresses.perps`), injected as the anchor
+//! of the read API's `/perps-events` shortcut.
 
 use {
     crate::config::ActivitySettings,
     anyhow::{Context, bail},
     dango_archive_projection::ActivityConfig,
-    dango_primitives::{Addr, Extractable, Json, QueryClientExt},
+    dango_primitives::{Addr, Extractable, Json, JsonDeExt, QueryClientExt},
     dango_sdk::HttpClient,
+    dango_types::config::AppConfig,
     std::{collections::HashSet, str::FromStr, time::Duration},
 };
 
@@ -21,8 +24,9 @@ const APP_CONFIG_ATTEMPTS: usize = 10;
 const APP_CONFIG_BACKOFF: Duration = Duration::from_secs(3);
 
 /// Resolve the activity projection's [`ActivityConfig`]: the event-type filters
-/// (config override, else the built-in default), and `involvement_blacklist` =
-/// the config addresses ∪ the node's system contracts (from `app_config`).
+/// (config override, else the built-in default), `involvement_blacklist` = the
+/// config addresses ∪ the node's system contracts (from `app_config`), and
+/// `perps_contract` = the typed `addresses.perps` of the same `app_config`.
 pub async fn config(settings: &ActivitySettings, node_url: &str) -> anyhow::Result<ActivityConfig> {
     let mut config = ActivityConfig::default();
 
@@ -36,43 +40,63 @@ pub async fn config(settings: &ActivitySettings, node_url: &str) -> anyhow::Resu
         config.involvement_filter = filter;
     }
 
-    // involvement_blacklist = config addresses ∪ the node's system contracts.
+    let app_config = app_config(node_url).await?;
+
+    // involvement_blacklist = config addresses ∪ the node's system contracts —
+    // the latter harvested generically with `Extractable`, so the per-network
+    // addresses never have to be listed by hand.
     let mut blacklist = HashSet::new();
     for raw in &settings.involvement_blacklist {
         let addr = Addr::from_str(raw)
             .with_context(|| format!("invalid involvement_blacklist address `{raw}`"))?;
         blacklist.insert(addr);
     }
-    blacklist.extend(system_contracts(node_url).await?);
+    let mut system_contracts = HashSet::new();
+    app_config.extract_addresses(&mut system_contracts);
+    tracing::info!(
+        count = system_contracts.len(),
+        "extracted system contracts from app_config"
+    );
+    blacklist.extend(system_contracts);
     tracing::info!(
         addresses = blacklist.len(),
         "activity involvement blacklist assembled"
     );
     config.involvement_blacklist = blacklist;
 
+    // The perps contract anchors the read API's `/perps-events` shortcut. The
+    // typed parse is best-effort: a deployment whose `app_config` no longer
+    // matches [`AppConfig`] only loses the shortcut route (warn), never ingest
+    // — the blacklist harvest above is shape-agnostic.
+    match app_config.deserialize_json::<AppConfig>() {
+        Ok(app_config) => {
+            tracing::info!(
+                perps = %app_config.addresses.perps,
+                "resolved the perps contract from app_config"
+            );
+            config.perps_contract = Some(app_config.addresses.perps);
+        },
+        Err(err) => tracing::warn!(
+            error = %err,
+            "app_config does not deserialize as AppConfig; \
+             the /perps-events shortcut will not be mounted"
+        ),
+    }
+
     Ok(config)
 }
 
-/// Query the node's `app_config` and extract every address in it — the
-/// deployment's system contracts. The block source needs the same node, so one
+/// Query the node's `app_config`. The block source needs the same node, so one
 /// that never answers is fatal: retry [`APP_CONFIG_ATTEMPTS`] times with a
 /// backoff, then give up and let the caller abort.
-async fn system_contracts(node_url: &str) -> anyhow::Result<HashSet<Addr>> {
+async fn app_config(node_url: &str) -> anyhow::Result<Json> {
     let client =
         HttpClient::new(node_url).with_context(|| format!("invalid node url `{node_url}`"))?;
 
     let mut last_err = None;
     for attempt in 1..=APP_CONFIG_ATTEMPTS {
         match client.query_app_config::<Json>().await {
-            Ok(app_config) => {
-                let mut addresses = HashSet::new();
-                app_config.extract_addresses(&mut addresses);
-                tracing::info!(
-                    count = addresses.len(),
-                    "extracted system contracts from app_config"
-                );
-                return Ok(addresses);
-            },
+            Ok(app_config) => return Ok(app_config),
             Err(err) => {
                 tracing::warn!(attempt, error = %err, "app_config query failed; retrying");
                 last_err = Some(err);

--- a/dango/archive/httpd/Cargo.toml
+++ b/dango/archive/httpd/Cargo.toml
@@ -31,3 +31,9 @@ serde                      = { workspace = true, features = ["derive"] }
 serde_json                 = { workspace = true }
 tokio                      = { workspace = true }
 tracing                    = { workspace = true, optional = true }
+utoipa                     = { workspace = true }
+utoipa-swagger-ui          = { workspace = true }
+
+[dev-dependencies]
+async-trait      = { workspace = true }
+dango-primitives = { workspace = true }

--- a/dango/archive/httpd/src/lib.rs
+++ b/dango/archive/httpd/src/lib.rs
@@ -3,8 +3,12 @@
 //! A deliberately small actix-web service: given the shared read handles (the
 //! Postgres pool and the [`BlockSource`](dango_archive_block_source::BlockSource))
 //! plus the projections' route registrars, it injects the handles as actix app
-//! data, mounts the core `GET /block/{height}` and `GET /up` routes, applies each
-//! projection's feeds, and serves.
+//! data, mounts the core `GET /block/{height}`, `GET /block/latest` (the block
+//! at the source's contiguous frontier), and `GET /up` routes, applies each
+//! projection's feeds, and serves. The merged OpenAPI document (its own core
+//! paths + every projection's `api_doc()` fragment) is served at
+//! `GET /openapi.json`, with Swagger UI on `GET /docs/` and the base `GET /`
+//! redirecting there.
 //!
 //! - [`serve`] returns the boxed, supervised server task.
 //! - [`Configurator`] is the route-mounting closure the app builds from its

--- a/dango/archive/httpd/src/read.rs
+++ b/dango/archive/httpd/src/read.rs
@@ -17,6 +17,7 @@ use {
     crate::error::ApiError,
     sea_orm::Value,
     serde::{Serialize, de::DeserializeOwned},
+    utoipa::ToSchema,
 };
 
 /// Page size when a feed is queried without an explicit `first`.
@@ -98,7 +99,7 @@ impl Binder {
 // ---- page assembly ----
 
 /// A page of a feed's results: the items plus the cursor of the last one.
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Page<N> {
     pub items: Vec<N>,
@@ -108,7 +109,7 @@ pub struct Page<N> {
 /// Forward-pagination metadata. `hasNextPage` comes from the surplus
 /// `limit + 1`-th row; `endCursor` is the cursor of the last returned item (the
 /// `after` for the next page), `null` when the page is empty.
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PageInfo {
     pub has_next_page: bool,

--- a/dango/archive/httpd/src/server.rs
+++ b/dango/archive/httpd/src/server.rs
@@ -9,6 +9,8 @@ use {
     sea_orm::DatabaseConnection,
     std::sync::Arc,
     tokio::sync::oneshot,
+    utoipa::OpenApi as _,
+    utoipa_swagger_ui::SwaggerUi,
 };
 
 /// Mounts the projections' read routes onto an actix
@@ -23,13 +25,36 @@ use {
 /// gives it. Mirrors the in-process indexer's `config_app`.
 pub type Configurator = Arc<dyn Fn(&mut web::ServiceConfig) + Send + Sync>;
 
+/// The OpenAPI document of the httpd's own built-in routes — the base every
+/// projection's [`api_doc`](dango_archive_projection) fragment is merged into.
+/// Derived from the same `#[utoipa::path]` annotations that sit on the
+/// handlers, so the spec lives next to the code it describes.
+#[derive(utoipa::OpenApi)]
+#[openapi(
+    info(
+        title = "Dango Archive API",
+        description = "REST read surface of the Dango archive: raw blocks from \
+                       the block store, plus each projection's feeds. All feeds \
+                       are newest-first and keyset-paginated (`first` / `after`, \
+                       the page's `endCursor` rolls back in as the next `after`).",
+    ),
+    paths(block, latest_block, up)
+)]
+struct ApiDoc;
+
 /// Serve the read API until the process stops, as a boxed task.
 ///
 /// Builds an actix-web server from the shared read handles and the app's route
 /// configurator: the Postgres pool and the block source are injected as app data
-/// (handlers pull them with `web::Data`), the core `GET /block/{height}` and
-/// `GET /up` routes are mounted directly, and `configure` adds the projections'
-/// feed scopes.
+/// (handlers pull them with `web::Data`), the core `GET /block/{height}`,
+/// `GET /block/latest`, and `GET /up` routes are mounted directly, and
+/// `configure` adds the projections' feed scopes.
+///
+/// `api_docs` are the projections' OpenAPI fragments (gathered by the app the
+/// same way the route configurator is); they are merged into the httpd's own
+/// [`ApiDoc`] and the result is served as `GET /openapi.json`, with Swagger UI
+/// on `GET /docs/` and a redirect from the base `GET /` — so the httpd stays
+/// projection-agnostic for the docs exactly as it is for the routes.
 ///
 /// Returned type-erased (`BoxFuture`) so the app supervises it like any other
 /// task. actix-web's server future is `!Send`, so it runs on a dedicated thread
@@ -41,6 +66,7 @@ pub fn serve(
     db: DatabaseConnection,
     source: Arc<dyn BlockSource>,
     configure: Configurator,
+    api_docs: Vec<utoipa::openapi::OpenApi>,
 ) -> BoxFuture<'static, AnyResult<()>> {
     Box::pin(async move {
         let (tx, rx) = oneshot::channel();
@@ -48,7 +74,8 @@ pub fn serve(
         std::thread::Builder::new()
             .name("archive-httpd".to_string())
             .spawn(move || {
-                let outcome = System::new().block_on(serve_actix(config, db, source, configure));
+                let outcome =
+                    System::new().block_on(serve_actix(config, db, source, configure, api_docs));
                 // A gone receiver just means the app is already tearing down.
                 let _ = tx.send(outcome);
             })
@@ -61,6 +88,16 @@ pub fn serve(
     })
 }
 
+/// The full OpenAPI document: the httpd's own [`ApiDoc`] with every
+/// projection's fragment merged in.
+fn merged_api_doc(api_docs: Vec<utoipa::openapi::OpenApi>) -> utoipa::openapi::OpenApi {
+    let mut doc = ApiDoc::openapi();
+    for fragment in api_docs {
+        doc.merge(fragment);
+    }
+    doc
+}
+
 /// Mount the routes and drive the actix server. Runs on the dedicated httpd
 /// thread, inside its actix `System`.
 async fn serve_actix(
@@ -68,8 +105,10 @@ async fn serve_actix(
     db: DatabaseConnection,
     source: Arc<dyn BlockSource>,
     configure: Configurator,
+    api_docs: Vec<utoipa::openapi::OpenApi>,
 ) -> AnyResult<()> {
     let bind = config.bind.clone();
+    let api_doc = merged_api_doc(api_docs);
 
     #[cfg(feature = "tracing")]
     tracing::info!(%bind, "archive httpd listening");
@@ -112,12 +151,24 @@ async fn serve_actix(
                     res
                 }
             })
-            // Core routes: the block-by-height read (not a projection) and the
-            // liveness probe.
+            // Core routes: the block reads (not a projection) and the liveness
+            // probe. `/block/latest` must be registered before
+            // `/block/{height}` so the literal segment wins the match (actix
+            // matches in registration order; after `{height}`, "latest" would
+            // be a failed u64 parse → 400).
+            .route("/block/latest", web::get().to(latest_block))
             .route("/block/{height}", web::get().to(block))
             .route("/up", web::get().to(up))
             // The projections' feed scopes, mounted by the app's configurator.
             .configure(move |cfg| (*configure)(cfg))
+            // The API docs: Swagger UI on `/docs/` over the merged OpenAPI
+            // document (also served plain at `/openapi.json`), with the base
+            // path redirecting there — hitting the service root in a browser
+            // lands on the docs.
+            .service(
+                SwaggerUi::new("/docs/{_:.*}").url("/openapi.json", api_doc.clone()),
+            )
+            .route("/", web::get().to(docs_redirect))
     })
     // The app owns process signals; the server simply stops with the process.
     .disable_signals()
@@ -137,6 +188,21 @@ async fn serve_actix(
 /// [`BlockSource`]. `404` when the source does not hold that height (below its
 /// backfill floor, or not yet ingested); the body is the canonical block JSON,
 /// the same shape the node's `/block/full/{height}` route returns.
+#[utoipa::path(
+    get,
+    path = "/block/{height}",
+    tag = "block",
+    summary = "Block by height",
+    description = "The full block at `height` — `{ block, outcome }`, the same \
+                   JSON the node's `/block/full/{height}` route serves.",
+    params(
+        ("height" = u64, Path, description = "Block height"),
+    ),
+    responses(
+        (status = 200, description = "The block at that height, as `{ block, outcome }`"),
+        (status = 404, description = "The source does not hold that height"),
+    ),
+)]
 async fn block(
     source: web::Data<Arc<dyn BlockSource>>,
     height: web::Path<u64>,
@@ -151,7 +217,233 @@ async fn block(
     }
 }
 
+/// The latest indexed block — the block at the source's **contiguous
+/// frontier**: the highest `H` with every height in `[1, H]` stored, i.e. the
+/// newest block that can be served *together with all the history below it*
+/// (`GET /block/{height}` answers for every height up to this one). During a
+/// backfill this climbs from the bottom and can trail the chain tip the live
+/// tail is already storing above a gap; once the store is gap-free it **is**
+/// the tip. The frontier is O(1) in-memory state owned by the block store — no
+/// scan, no extra cache. `404` while the store holds no contiguous prefix yet
+/// (a cold, still-empty archive); the body is the same `{ block, outcome }`
+/// JSON as `/block/{height}`.
+#[utoipa::path(
+    get,
+    path = "/block/latest",
+    tag = "block",
+    summary = "Latest indexed block",
+    description = "The block at the source's contiguous frontier — the highest \
+                   `H` with every height in `[1, H]` stored, i.e. the newest \
+                   block servable together with all the history below it. \
+                   During a backfill this trails the chain tip; once the store \
+                   is gap-free it is the tip. Same `{ block, outcome }` shape \
+                   as `/block/{height}`.",
+    responses(
+        (status = 200, description = "The block at the contiguous frontier"),
+        (status = 404, description = "The store holds no contiguous prefix yet (cold, still-empty archive)"),
+    ),
+)]
+async fn latest_block(source: web::Data<Arc<dyn BlockSource>>) -> actix_web::Result<HttpResponse> {
+    let frontier = source
+        .contiguous_frontier()
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let Some(height) = frontier else {
+        return Ok(HttpResponse::NotFound().finish());
+    };
+    // `h <= frontier ⟹ get(h) = Some` (the source persists before it
+    // broadcasts, and the frontier only grows) — a miss here is a broken
+    // invariant, not an absent resource, so it surfaces as a 500.
+    let block = source
+        .get(height)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?
+        .ok_or_else(|| {
+            actix_web::error::ErrorInternalServerError(format!(
+                "frontier {height} missing from the store"
+            ))
+        })?;
+    Ok(HttpResponse::Ok().json(block))
+}
+
 /// Liveness probe.
+#[utoipa::path(
+    get,
+    path = "/up",
+    tag = "meta",
+    summary = "Liveness probe",
+    responses(
+        (status = 200, description = "The service is up", body = serde_json::Value,
+         example = json!({ "status": "ok" })),
+    ),
+)]
 async fn up() -> impl Responder {
     HttpResponse::Ok().json(serde_json::json!({ "status": "ok" }))
+}
+
+/// `GET /` — the base path lands on the API docs.
+async fn docs_redirect() -> HttpResponse {
+    HttpResponse::Found()
+        .insert_header(("location", "/docs/"))
+        .finish()
+}
+
+// ---- tests ----
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        actix_web::{App, test},
+        dango_archive_types::BlockData,
+        dango_primitives::{Block, BlockInfo, BlockOutcome, Hash256, Timestamp},
+        tokio::sync::broadcast,
+    };
+
+    /// A `BlockSource` with a scripted frontier: `get` serves any height iff
+    /// `holds_blocks` — cleared to fake the impossible "frontier names a height
+    /// the store lost" state, so the 500 path is pinned too.
+    struct StubSource {
+        frontier: Option<u64>,
+        holds_blocks: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl BlockSource for StubSource {
+        async fn run(self: Arc<Self>) -> AnyResult<()> {
+            Ok(())
+        }
+
+        async fn get(&self, height: u64) -> AnyResult<Option<BlockData>> {
+            Ok(self.holds_blocks.then(|| BlockData {
+                block: Block {
+                    info: BlockInfo {
+                        height,
+                        timestamp: Timestamp::from_nanos(0),
+                        hash: Hash256::ZERO,
+                    },
+                    txs: vec![],
+                },
+                outcome: BlockOutcome {
+                    height,
+                    app_hash: Hash256::ZERO,
+                    cron_outcomes: vec![],
+                    tx_outcomes: vec![],
+                },
+            }))
+        }
+
+        fn subscribe(&self) -> broadcast::Receiver<Arc<BlockData>> {
+            broadcast::channel(1).1
+        }
+
+        async fn contiguous_frontier(&self) -> AnyResult<Option<u64>> {
+            Ok(self.frontier)
+        }
+    }
+
+    /// The two block routes over a stub source, mounted in the same order as
+    /// [`serve_actix`] — `/block/latest` before `/block/{height}`, so the
+    /// literal wins the match.
+    fn block_routes(stub: StubSource) -> impl FnOnce(&mut web::ServiceConfig) {
+        let source: Arc<dyn BlockSource> = Arc::new(stub);
+        move |cfg| {
+            cfg.app_data(web::Data::new(source))
+                .route("/block/latest", web::get().to(latest_block))
+                .route("/block/{height}", web::get().to(block));
+        }
+    }
+
+    /// The happy path: `latest` resolves the frontier, serves that block (the
+    /// literal route wins over `{height}`), and the by-height route still works.
+    #[actix_web::test]
+    async fn latest_block_serves_the_frontier() {
+        let app = test::init_service(App::new().configure(block_routes(StubSource {
+            frontier: Some(7),
+            holds_blocks: true,
+        })))
+        .await;
+
+        let req = test::TestRequest::get().uri("/block/latest").to_request();
+        let body: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+        assert_eq!(body["block"]["info"]["height"].as_u64(), Some(7));
+
+        let req = test::TestRequest::get().uri("/block/3").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(
+            resp.status().is_success(),
+            "the by-height route still works"
+        );
+    }
+
+    /// A cold, still-empty archive has no contiguous prefix: `latest` is a 404,
+    /// like any absent resource.
+    #[actix_web::test]
+    async fn latest_block_404_when_the_store_is_empty() {
+        let app = test::init_service(App::new().configure(block_routes(StubSource {
+            frontier: None,
+            holds_blocks: true,
+        })))
+        .await;
+
+        let req = test::TestRequest::get().uri("/block/latest").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 404);
+    }
+
+    /// A frontier pointing at a height the store cannot serve violates
+    /// `h <= frontier ⟹ get(h) = Some` — an internal error (500), never a 404
+    /// that would read as "no latest block".
+    #[actix_web::test]
+    async fn latest_block_500_when_the_frontier_block_is_missing() {
+        let app = test::init_service(App::new().configure(block_routes(StubSource {
+            frontier: Some(7),
+            holds_blocks: false,
+        })))
+        .await;
+
+        let req = test::TestRequest::get().uri("/block/latest").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 500);
+    }
+
+    /// The docs surface, mounted as [`serve_actix`] mounts it: the merged spec
+    /// is served at `/openapi.json` (here with no projection fragments — just
+    /// the core paths), Swagger UI answers on `/docs/`, and the base path
+    /// redirects there.
+    #[actix_web::test]
+    async fn docs_are_served_from_the_base_path() {
+        let app = test::init_service(
+            App::new()
+                .service(
+                    SwaggerUi::new("/docs/{_:.*}").url("/openapi.json", merged_api_doc(vec![])),
+                )
+                .route("/", web::get().to(docs_redirect)),
+        )
+        .await;
+
+        // The base path lands on the docs.
+        let req = test::TestRequest::get().uri("/").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status().as_u16(), 302);
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/docs/"
+        );
+
+        // The UI itself.
+        let req = test::TestRequest::get().uri("/docs/").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success(), "swagger ui should be served");
+
+        // The spec carries the httpd's own routes.
+        let req = test::TestRequest::get().uri("/openapi.json").to_request();
+        let spec: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+        for path in ["/block/{height}", "/block/latest", "/up"] {
+            assert!(
+                spec["paths"].get(path).is_some(),
+                "the spec should document {path}",
+            );
+        }
+    }
 }

--- a/dango/archive/projection/Cargo.toml
+++ b/dango/archive/projection/Cargo.toml
@@ -34,6 +34,7 @@ sea-orm-migration          = { workspace = true }
 serde                      = { workspace = true, features = ["derive"] }
 serde_json                 = { workspace = true }
 tracing                    = { workspace = true, optional = true }
+utoipa                     = { workspace = true }
 zstd                       = { workspace = true }
 
 [dev-dependencies]

--- a/dango/archive/projection/src/activity/DESIGN.md
+++ b/dango/archive/projection/src/activity/DESIGN.md
@@ -534,7 +534,7 @@ join.
 
 The eight access paths are served by `#[get]`-routed handlers in
 `http/services/` (one module per resource), over the database feeds in
-`http/feeds.rs`, folded into **four routes** — two on `transactions`, two on
+`http/feeds.rs`, folded into **five routes** — two on `transactions`, three on
 `events`:
 
 | route | access paths | arguments |
@@ -543,6 +543,7 @@ The eight access paths are served by `#[get]`-routed handlers in
 | `GET /transactions/involving/{address}` | 1 | + optional `role`, `kind` |
 | `GET /events` | 2, 5, 6 | `type` (a list) and/or `involved` — **at least one required** |
 | `GET /contract-events/{contract}` | 3 / 4 / 7 / 8 | + optional `user`, `names` (a list) |
+| `GET /perps-events` | 3 / 4 / 7 / 8, `contract` pre-bound to the perps address | + optional `user`, `names` (a list) |
 
 `/events` folds the by-type feed (Q2) and the involving feeds (Q5/Q6):
 `involved` anchors on the address (the type list is then a residual filter),
@@ -553,6 +554,18 @@ it is a **400**. `/contract-events` makes `contract` mandatory, which keeps ever
 reachable combination index-anchored and makes the unsupported shapes (a name
 filter without a contract, a type filter with a contract) structurally
 impossible.
+
+`/perps-events` is a **shortcut**, not a new access path: the same
+contract-events feeds with the `contract` argument pre-bound to the
+deployment's perps address, so the dominant consumer (perps activity) never has
+to carry the address around. The address is injected at construction — the cli
+resolves it from the node's `app_config` (the typed `addresses.perps`, next to
+the shape-agnostic `Extractable` harvest that seeds the involvement blacklist)
+and hands it to the projection through `ActivityConfig::perps_contract`, which
+the events scope carries as scope-local app data. The pre-bound contract is the
+index anchor, so the route needs no mandatory argument; when no address was
+injected (`None`), the route is simply not mounted. Read-time only — the field
+affects no written row, so changing it needs no re-backfill.
 
 Each runs the access path above verbatim: hand-written, `Binder`-parameterized
 SQL (`DISTINCT ON`, the involved ∪ sender union, the in-index `IN (…)` name
@@ -597,10 +610,15 @@ per distinct block in the page.
 
 The routes are served by the projection-agnostic `httpd` crate, which injects
 the Postgres pool and the block source as actix app data; the projection
-contributes them through `Projection::services()` — three `web::scope`s
-(`/transactions`, `/events`, `/contract-events`) of `#[get]`-routed handlers,
-grouped in `http/services/` one module per resource — and the app gathers every
-projection's scopes when it builds the server.
+contributes them through `Projection::services()` — four `web::scope`s
+(`/transactions`, `/events`, `/contract-events`, `/perps-events`) of
+`#[get]`-routed handlers, grouped in `http/services/` one module per resource —
+and the app gathers every projection's scopes when it builds the server. The
+docs follow the same path: `Projection::api_doc()` returns the OpenAPI fragment
+derived from the `#[utoipa::path]` annotations on those same handlers (each
+resource module owns its fragment, `/perps-events` included exactly when
+mounted), and the httpd merges it into the document it serves at
+`/openapi.json` / `/docs/`.
 
 ## Out of scope
 

--- a/dango/archive/projection/src/activity/event_type.rs
+++ b/dango/archive/projection/src/activity/event_type.rs
@@ -14,7 +14,7 @@ use {
 /// Serialized snake_case (`transfer`, `contract_event`, …): the spelling the
 /// read API accepts to filter the activity feeds by type and surfaces as an
 /// event's `type`.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[repr(i16)]
 pub enum EventType {

--- a/dango/archive/projection/src/activity/http/feeds.rs
+++ b/dango/archive/projection/src/activity/http/feeds.rs
@@ -276,7 +276,9 @@ fn single_type_scan(binder: &mut Binder, ty: EventType, keyset: &str, fetch: u64
 }
 
 /// Queries 3 / 4 — contract events emitted by a contract, optionally narrowed to
-/// a set of event names (a single value or a list).
+/// a set of event names (a single value or a list). Serves both
+/// `/contract-events/{contract}` and the `/perps-events` shortcut (the same
+/// call with the injected perps address).
 pub(crate) async fn contract_events(
     db: &DatabaseConnection,
     contract: Addr,
@@ -338,7 +340,8 @@ pub(crate) async fn events_involving(
 }
 
 /// Queries 7 / 8 — contract events of a contract **involving** an address,
-/// optionally narrowed to a set of event names.
+/// optionally narrowed to a set of event names. Like [`contract_events`], also
+/// serves the `/perps-events` shortcut.
 pub(crate) async fn contract_events_involving(
     db: &DatabaseConnection,
     address: Addr,

--- a/dango/archive/projection/src/activity/http/mod.rs
+++ b/dango/archive/projection/src/activity/http/mod.rs
@@ -16,7 +16,8 @@
 //! lives in the `httpd` crate, shared across projections; this module only adds
 //! the activity's own SQL, types, and cursor shapes.
 //!
-//! Only [`scopes`](services::scopes) escapes the module; everything else is
+//! Only [`scopes`](services::scopes) and its docs counterpart
+//! [`api_doc`](services::api_doc) escape the module; everything else is
 //! plumbing the app and the httpd never name. The handlers reach the shared
 //! Postgres pool and block source through actix app data, injected when the
 //! httpd builds the server.
@@ -26,4 +27,4 @@ mod hydrate;
 mod services;
 mod types;
 
-pub(crate) use services::scopes;
+pub(crate) use services::{api_doc, scopes};

--- a/dango/archive/projection/src/activity/http/services/events.rs
+++ b/dango/archive/projection/src/activity/http/services/events.rs
@@ -1,5 +1,5 @@
-//! The `/events` and `/contract-events` read scopes, routed by `#[get]`
-//! attribute macros.
+//! The `/events`, `/contract-events`, and `/perps-events` read scopes, routed
+//! by `#[get]` attribute macros.
 //!
 //! - `GET /events` — events filtered by `type` (a comma-separated list) and/or
 //!   `involved` (an address); **at least one** is required, since an unfiltered
@@ -8,53 +8,129 @@
 //!   narrowed by `user` (a participant address) and `names` (a comma-separated
 //!   list). The mandatory `contract` keeps every reachable combination
 //!   index-anchored.
+//! - `GET /perps-events` — the perps shortcut: exactly
+//!   `/contract-events/{contract}` with the contract pre-bound to the
+//!   deployment's perps address (injected at construction, resolved by the cli
+//!   from the node's `app_config`), so the dominant consumer never has to carry
+//!   the address around. Same optional `user` / `names`, same feeds. Mounted
+//!   only when an address was injected.
 //!
 //! Each handler parses its arguments (a malformed address / type / cursor is a
 //! 400), runs the matching feed in [`feeds`](super::super::feeds), hydrates the
 //! page's `data` from the shared block source ([`hydrate`](super::super::hydrate)),
 //! and answers with the JSON page. The shared read handles come from actix app
-//! data (`web::Data`), injected by the httpd.
+//! data (`web::Data`), injected by the httpd; the perps anchor rides as
+//! scope-local app data instead, since only its own scope needs it.
 
 use {
-    super::super::{feeds, hydrate},
+    super::super::{feeds, hydrate, types::Event},
     crate::activity::event_type::EventType,
     actix_web::{HttpResponse, Scope, get, web},
     dango_archive_block_source::BlockSource,
-    dango_archive_httpd::ApiError,
+    dango_archive_httpd::{ApiError, Page},
     dango_primitives::Addr,
     sea_orm::DatabaseConnection,
     serde::Deserialize,
     std::sync::Arc,
+    utoipa::{IntoParams, OpenApi},
 };
 
-/// The `/events` and `/contract-events` scopes.
-pub(crate) fn services() -> Vec<Scope> {
-    vec![
+/// The injected perps contract's address — the pre-bound anchor of the
+/// `/perps-events` shortcut, carried as scope-local app data.
+#[derive(Clone, Copy)]
+struct PerpsContract(Addr);
+
+/// The `/events`, `/contract-events`, and (when a perps address was injected)
+/// `/perps-events` scopes.
+pub(crate) fn services(perps_contract: Option<Addr>) -> Vec<Scope> {
+    let mut scopes = vec![
         web::scope("/events").service(events),
         web::scope("/contract-events").service(contract_events),
-    ]
+    ];
+    // Without an injected address the shortcut has no anchor, so the route is
+    // simply not mounted (404) — the explicit `/contract-events/{contract}`
+    // form still serves everything.
+    if let Some(contract) = perps_contract {
+        scopes.push(
+            web::scope("/perps-events")
+                .app_data(web::Data::new(PerpsContract(contract)))
+                .service(perps_events),
+        );
+    }
+    scopes
+}
+
+/// The scopes' OpenAPI fragment — the docs counterpart of [`services`], with
+/// the same conditional: `/perps-events` is documented exactly when it is
+/// mounted.
+pub(crate) fn api_doc(perps_mounted: bool) -> utoipa::openapi::OpenApi {
+    #[derive(OpenApi)]
+    #[openapi(paths(events, contract_events))]
+    struct Doc;
+
+    #[derive(OpenApi)]
+    #[openapi(paths(perps_events))]
+    struct PerpsDoc;
+
+    let mut doc = Doc::openapi();
+    if perps_mounted {
+        doc.merge(PerpsDoc::openapi());
+    }
+    doc
 }
 
 /// `/events` arguments — `type` (comma-separated list) and/or `involved`.
-#[derive(Deserialize)]
+#[derive(Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 struct EventsQuery {
+    /// Comma-separated list of event types (`transfer`, `contract_event`, …).
+    /// Required when `involved` is absent.
     #[serde(rename = "type")]
+    #[param(value_type = Option<String>)]
     ty: Option<String>,
+    /// Participant address (`0x` hex): only events the address is a party to.
+    #[param(value_type = Option<String>)]
     involved: Option<Addr>,
+    /// Page size (max 50; default 50).
     first: Option<i32>,
+    /// Opaque cursor of the previous page (`pageInfo.endCursor`).
     after: Option<String>,
 }
 
-/// `/contract-events/{contract}` arguments — optional `user` and `names`
-/// (comma-separated list).
-#[derive(Deserialize)]
+/// `/contract-events/{contract}` and `/perps-events` arguments — optional
+/// `user` and `names` (comma-separated list). The two routes differ only in
+/// where the contract address comes from (path vs injected), so they share the
+/// argument surface.
+#[derive(Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 struct ContractEventsQuery {
+    /// Participant address (`0x` hex): only the contract's events this address
+    /// is a party to.
+    #[param(value_type = Option<String>)]
     user: Option<Addr>,
+    /// Comma-separated list of contract-event names (`order_filled`, …).
     names: Option<String>,
+    /// Page size (max 50; default 50).
     first: Option<i32>,
+    /// Opaque cursor of the previous page (`pageInfo.endCursor`).
     after: Option<String>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/events",
+    tag = "events",
+    summary = "Events by type and/or involved address",
+    description = "Events filtered by `type` (a comma-separated list) and/or \
+                   `involved` (a participant address). **At least one is \
+                   required** — an unfiltered feed has no index anchor. \
+                   Newest-first, keyset-paginated.",
+    params(EventsQuery),
+    responses(
+        (status = 200, description = "One page of events, newest-first", body = Page<Event>),
+        (status = 400, description = "Neither `type` nor `involved` given, or a malformed argument / cursor"),
+    ),
+)]
 #[get("")]
 async fn events(
     db: web::Data<DatabaseConnection>,
@@ -82,6 +158,23 @@ async fn events(
     Ok(HttpResponse::Ok().json(page))
 }
 
+#[utoipa::path(
+    get,
+    path = "/contract-events/{contract}",
+    tag = "events",
+    summary = "Events emitted by a contract",
+    description = "The contract-events of one emitting contract, optionally \
+                   narrowed to a participant (`user`) and/or a set of event \
+                   names (`names`). Newest-first, keyset-paginated.",
+    params(
+        ("contract" = String, Path, description = "Emitting contract address (`0x` hex)"),
+        ContractEventsQuery,
+    ),
+    responses(
+        (status = 200, description = "One page of events, newest-first", body = Page<Event>),
+        (status = 400, description = "Malformed address, argument, or cursor"),
+    ),
+)]
 #[get("/{contract}")]
 async fn contract_events(
     db: web::Data<DatabaseConnection>,
@@ -89,18 +182,61 @@ async fn contract_events(
     contract: web::Path<Addr>,
     query: web::Query<ContractEventsQuery>,
 ) -> Result<HttpResponse, ApiError> {
-    let contract = contract.into_inner();
-    let q = query.into_inner();
+    serve_contract_events(
+        &db,
+        source.get_ref(),
+        contract.into_inner(),
+        query.into_inner(),
+    )
+    .await
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps-events",
+    tag = "events",
+    summary = "Events emitted by the perps contract",
+    description = "Shortcut: exactly `/contract-events/{contract}` with the \
+                   contract pre-bound to the deployment's perps address \
+                   (resolved from the node's `app_config` at startup). Same \
+                   optional `user` / `names` filters, same feeds. Mounted only \
+                   when the deployment resolved a perps address.",
+    params(ContractEventsQuery),
+    responses(
+        (status = 200, description = "One page of the perps contract's events, newest-first",
+         body = Page<Event>),
+        (status = 400, description = "Malformed argument or cursor"),
+    ),
+)]
+#[get("")]
+async fn perps_events(
+    db: web::Data<DatabaseConnection>,
+    source: web::Data<Arc<dyn BlockSource>>,
+    perps: web::Data<PerpsContract>,
+    query: web::Query<ContractEventsQuery>,
+) -> Result<HttpResponse, ApiError> {
+    serve_contract_events(&db, source.get_ref(), perps.0, query.into_inner()).await
+}
+
+/// Run the contract-events feeds for `contract` and answer with the hydrated
+/// page — the shared body of `/contract-events/{contract}` and the
+/// `/perps-events` shortcut, which only differ in where the contract address
+/// comes from.
+async fn serve_contract_events(
+    db: &DatabaseConnection,
+    source: &Arc<dyn BlockSource>,
+    contract: Addr,
+    q: ContractEventsQuery,
+) -> Result<HttpResponse, ApiError> {
     let names = parse_names(q.names);
 
     let mut page = match q.user {
         Some(address) => {
-            feeds::contract_events_involving(&db, address, contract, names, q.first, q.after)
-                .await?
+            feeds::contract_events_involving(db, address, contract, names, q.first, q.after).await?
         },
-        None => feeds::contract_events(&db, contract, names, q.first, q.after).await?,
+        None => feeds::contract_events(db, contract, names, q.first, q.after).await?,
     };
-    hydrate::hydrate_events(source.get_ref(), &mut page.items).await?;
+    hydrate::hydrate_events(source, &mut page.items).await?;
     Ok(HttpResponse::Ok().json(page))
 }
 

--- a/dango/archive/projection/src/activity/http/services/mod.rs
+++ b/dango/archive/projection/src/activity/http/services/mod.rs
@@ -3,33 +3,50 @@
 //! grouped in a `web::scope`).
 //!
 //! - [`transaction`] — the `/transactions` scope;
-//! - [`events`] — the `/events` and `/contract-events` scopes.
+//! - [`events`] — the `/events`, `/contract-events`, and `/perps-events`
+//!   scopes.
 //!
 //! [`scopes`] gathers them into the list the app mounts on the shared httpd. The
 //! handlers reach the shared Postgres pool and block source through actix app
-//! data, so a scope carries no state and is cheap to rebuild per worker.
+//! data, so a scope carries no per-request state and is cheap to rebuild per
+//! worker; the one projection-specific input — the perps address anchoring the
+//! `/perps-events` shortcut — rides as scope-local app data.
 
 mod events;
 mod transaction;
 
-use actix_web::Scope;
+use {actix_web::Scope, dango_primitives::Addr};
 
 /// Every read scope the activity projection exposes — `/transactions`,
-/// `/events`, and `/contract-events`.
-pub(crate) fn scopes() -> Vec<Scope> {
+/// `/events`, `/contract-events`, and (when a perps address was injected)
+/// `/perps-events`.
+pub(crate) fn scopes(perps_contract: Option<Addr>) -> Vec<Scope> {
     let mut scopes = vec![transaction::services()];
-    scopes.extend(events::services());
+    scopes.extend(events::services(perps_contract));
     scopes
+}
+
+/// The projection's OpenAPI fragment — the same resources [`scopes`] mounts
+/// (including the conditional `/perps-events`), merged from each module's own
+/// doc so the two derivations can't drift apart.
+pub(crate) fn api_doc(perps_mounted: bool) -> utoipa::openapi::OpenApi {
+    let mut doc = transaction::api_doc();
+    doc.merge(events::api_doc(perps_mounted));
+    doc
 }
 
 #[cfg(test)]
 mod tests {
     use {
         super::scopes,
-        actix_web::{App, test, web},
+        actix_web::{
+            App, test,
+            web::{self, ServiceConfig},
+        },
         dango_archive_block_source::BlockSource,
         dango_archive_httpd::ApiError,
         dango_archive_types::{AnyResult, BlockData},
+        dango_primitives::Addr,
         sea_orm::Database,
         std::sync::Arc,
     };
@@ -58,6 +75,30 @@ mod tests {
         }
     }
 
+    /// Mirror the read-API app the httpd assembles: the shared read handles
+    /// plus the path / query error handlers that make a malformed argument a
+    /// uniform 400 (without `PathConfig`, actix would 404 a bad path param).
+    /// The SQLite handle is throwaway — the rejection paths never query it.
+    async fn test_config(perps_contract: Option<Addr>) -> impl FnOnce(&mut ServiceConfig) {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("connect the throwaway db");
+        let source: Arc<dyn BlockSource> = Arc::new(StubSource);
+        move |cfg: &mut ServiceConfig| {
+            cfg.app_data(web::Data::new(db))
+                .app_data(web::Data::new(source))
+                .app_data(web::PathConfig::default().error_handler(|err, _req| {
+                    ApiError::bad_request(format!("invalid path parameter: {err}")).into()
+                }))
+                .app_data(web::QueryConfig::default().error_handler(|err, _req| {
+                    ApiError::bad_request(format!("invalid query parameter: {err}")).into()
+                }));
+            for scope in scopes(perps_contract) {
+                cfg.service(scope);
+            }
+        }
+    }
+
     /// Every malformed or unanchored request is rejected with a **400** before
     /// any database query — exercising actix's path / query extraction and our
     /// own guardrails (the unknown-type / unanchored-`/events` / bad-cursor 400s
@@ -66,31 +107,8 @@ mod tests {
     /// Postgres, are covered by the `backfill` integration test.
     #[actix_web::test]
     async fn rejects_malformed_or_unanchored_requests() {
-        let db = Database::connect("sqlite::memory:")
-            .await
-            .expect("connect the throwaway db");
-        let source: Arc<dyn BlockSource> = Arc::new(StubSource);
-
-        // Mirror the read-API app the httpd assembles: the shared read handles
-        // plus the path / query error handlers that make a malformed argument a
-        // uniform 400 (without `PathConfig`, actix would 404 a bad path param).
-        let app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(db))
-                .app_data(web::Data::new(source))
-                .app_data(web::PathConfig::default().error_handler(|err, _req| {
-                    ApiError::bad_request(format!("invalid path parameter: {err}")).into()
-                }))
-                .app_data(web::QueryConfig::default().error_handler(|err, _req| {
-                    ApiError::bad_request(format!("invalid query parameter: {err}")).into()
-                }))
-                .configure(|cfg| {
-                    for scope in scopes() {
-                        cfg.service(scope);
-                    }
-                }),
-        )
-        .await;
+        let app =
+            test::init_service(App::new().configure(test_config(Some(Addr::mock(1))).await)).await;
 
         for path in [
             "/events",                                // no anchor: neither type nor involved
@@ -98,6 +116,8 @@ mod tests {
             "/events?type=transfer&after=zz",         // malformed cursor (not hex)
             "/events?involved=not_an_address",        // malformed address (query)
             "/contract-events/not_an_address",        // malformed address (path)
+            "/perps-events?user=not_an_address",      // malformed address (query)
+            "/perps-events?after=zz",                 // malformed cursor (not hex)
             "/transactions/by-hash/not_a_hash",       // malformed hash (path)
             "/transactions/involving/not_an_address", // malformed address (path)
         ] {
@@ -109,6 +129,62 @@ mod tests {
                 "GET {path} should be a 400, got {}",
                 resp.status()
             );
+        }
+    }
+
+    /// `/perps-events` exists only when an anchor address was injected: without
+    /// one the scope is not mounted at all (404), never a half-configured
+    /// handler. The mounted case is pinned by the same path answering 400 (a
+    /// parse rejection — proof the handler ran) in the test above.
+    #[actix_web::test]
+    async fn perps_shortcut_unmounted_without_an_injected_address() {
+        let app = test::init_service(App::new().configure(test_config(None).await)).await;
+
+        let req = test::TestRequest::get()
+            .uri("/perps-events?after=zz")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status().as_u16(),
+            404,
+            "without an injected perps address the shortcut route must not exist",
+        );
+    }
+
+    /// The OpenAPI fragment mirrors the mounted routes: the four always-on
+    /// paths are documented unconditionally, `/perps-events` exactly when the
+    /// shortcut is mounted. (`actix_web::test`, not the bare `#[test]`: the
+    /// module's `use actix_web::{test, ...}` shadows the built-in attribute.)
+    #[actix_web::test]
+    async fn api_doc_mirrors_the_mounted_routes() {
+        for (perps_mounted, expects_perps) in [(false, false), (true, true)] {
+            let doc = super::api_doc(perps_mounted);
+            for path in [
+                "/transactions/by-hash/{hash}",
+                "/transactions/involving/{address}",
+                "/events",
+                "/contract-events/{contract}",
+            ] {
+                assert!(
+                    doc.paths.paths.contains_key(path),
+                    "the fragment should document {path}",
+                );
+            }
+            assert_eq!(
+                doc.paths.paths.contains_key("/perps-events"),
+                expects_perps,
+                "/perps-events must be documented iff mounted (perps_mounted = {perps_mounted})",
+            );
+
+            // The response schemas referenced by the paths are auto-collected
+            // into the components, so the spec is self-contained.
+            let components = doc.components.as_ref().expect("components");
+            for schema in ["Event", "Transaction", "EventType", "UnitKind"] {
+                assert!(
+                    components.schemas.contains_key(schema),
+                    "the fragment should carry the `{schema}` schema",
+                );
+            }
         }
     }
 }

--- a/dango/archive/projection/src/activity/http/services/transaction.rs
+++ b/dango/archive/projection/src/activity/http/services/transaction.rs
@@ -11,15 +11,16 @@
 use {
     super::super::{
         feeds, hydrate,
-        types::{AddressRole, UnitKind},
+        types::{AddressRole, Transaction, UnitKind},
     },
     actix_web::{HttpResponse, Scope, get, web},
     dango_archive_block_source::BlockSource,
-    dango_archive_httpd::ApiError,
+    dango_archive_httpd::{ApiError, Page},
     dango_primitives::{Addr, Hash256},
     sea_orm::DatabaseConnection,
     serde::Deserialize,
     std::sync::Arc,
+    utoipa::{IntoParams, OpenApi},
 };
 
 /// The `/transactions` scope: the by-hash lookup and the "involving" feed.
@@ -29,15 +30,47 @@ pub(crate) fn services() -> Scope {
         .service(involving)
 }
 
+/// The scope's OpenAPI fragment — the docs counterpart of [`services`].
+pub(crate) fn api_doc() -> utoipa::openapi::OpenApi {
+    #[derive(OpenApi)]
+    #[openapi(paths(by_hash, involving))]
+    struct Doc;
+    Doc::openapi()
+}
+
 /// `transactionsInvolving` arguments.
-#[derive(Deserialize)]
+#[derive(Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 struct InvolvingQuery {
+    /// How the address must relate to the unit: `sender` or `participant`.
+    /// Omitted ⇒ either.
     role: Option<AddressRole>,
+    /// Restrict to one kind of unit: `transaction` or `cron`. Omitted ⇒ both.
     kind: Option<UnitKind>,
+    /// Page size (max 50; default 50).
     first: Option<i32>,
+    /// Opaque cursor of the previous page (`pageInfo.endCursor`).
     after: Option<String>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/transactions/by-hash/{hash}",
+    tag = "transactions",
+    summary = "Transactions by content hash",
+    description = "Every unit whose transaction bytes hash to `hash`, \
+                   newest-first, un-paginated: the hash is **not** unique — \
+                   byte-identical re-submissions can land in later blocks. Cron \
+                   units carry no hash, so this only ever resolves transactions.",
+    params(
+        ("hash" = String, Path, description = "Transaction content hash (64 hex chars)"),
+    ),
+    responses(
+        (status = 200, description = "Every matching unit, newest-first (empty if none)",
+         body = Vec<Transaction>),
+        (status = 400, description = "Malformed hash"),
+    ),
+)]
 #[get("/by-hash/{hash}")]
 async fn by_hash(
     db: web::Data<DatabaseConnection>,
@@ -49,6 +82,24 @@ async fn by_hash(
     Ok(HttpResponse::Ok().json(items))
 }
 
+#[utoipa::path(
+    get,
+    path = "/transactions/involving/{address}",
+    tag = "transactions",
+    summary = "Transactions involving an address",
+    description = "Units the address **sent** or **participated in** (a party \
+                   to one of the unit's events) — the union by default, \
+                   narrowed with `role` / `kind`. Newest-first, keyset-paginated.",
+    params(
+        ("address" = String, Path, description = "Account address (`0x` hex)"),
+        InvolvingQuery,
+    ),
+    responses(
+        (status = 200, description = "One page of units, newest-first",
+         body = Page<Transaction>),
+        (status = 400, description = "Malformed address, argument, or cursor"),
+    ),
+)]
 #[get("/involving/{address}")]
 async fn involving(
     db: web::Data<DatabaseConnection>,

--- a/dango/archive/projection/src/activity/http/types.rs
+++ b/dango/archive/projection/src/activity/http/types.rs
@@ -43,7 +43,7 @@ fn hash_from_bytes(bytes: Vec<u8>) -> Result<Hash256, ApiError> {
 /// How an `address` argument must relate to a unit in the
 /// `transactionsInvolving` feed. Omitted ⇒ **either** — the address sent the
 /// unit *or* was a party to one of its events (their union).
-#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum AddressRole {
     /// The address sent the unit (`transactions.sender`). Cron units have no
@@ -56,7 +56,7 @@ pub(crate) enum AddressRole {
 
 /// The kind of an executed unit — mirrors [`dango_primitives::FlatCategory`].
 /// Serialized / parsed as `"cron"` / `"transaction"`.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum UnitKind {
     Cron,
@@ -106,7 +106,7 @@ pub(crate) struct EventRow {
 /// for contract events; `data` is the decoded payload, hydrated eagerly (from
 /// the `event_data` blob for priority types, otherwise from the unit's block),
 /// `null` only if the source no longer holds the block.
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Event {
     /// Height of the block the event was emitted in.
@@ -121,6 +121,7 @@ pub(crate) struct Event {
     #[serde(rename = "type")]
     pub ty: EventType,
     /// Emitting contract — present only for contract events.
+    #[schema(value_type = Option<String>)]
     pub contract: Option<Addr>,
     /// The contract-event name (`order_filled`, …) — present only for contract
     /// events.
@@ -129,6 +130,7 @@ pub(crate) struct Event {
     /// for priority types (decompressed from the joined blob) and by
     /// [`super::hydrate`] from the block for the rest; `null` when the block is
     /// unavailable.
+    #[schema(value_type = Option<Object>)]
     pub data: Option<serde_json::Value>,
 }
 
@@ -158,7 +160,7 @@ pub(crate) fn event_from_row(row: EventRow) -> Result<Event, ApiError> {
 /// columns are cheap; the full submitted `tx` and the execution `outcome` are
 /// hydrated eagerly from the unit's block (see [`super::hydrate`]) — `tx` is
 /// `null` for cron units, both are `null` if the block is unavailable.
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Transaction {
     /// Height of the block the unit executed in.
@@ -168,8 +170,10 @@ pub(crate) struct Transaction {
     /// Whether this is a transaction or a cronjob.
     pub kind: UnitKind,
     /// Content hash — absent for cron units.
+    #[schema(value_type = Option<String>)]
     pub hash: Option<Hash256>,
     /// Account or contract that sent the unit — absent for cron units.
+    #[schema(value_type = Option<String>)]
     pub sender: Option<Addr>,
     /// Whether the unit's outcome was `Ok`.
     pub success: bool,
@@ -178,10 +182,12 @@ pub(crate) struct Transaction {
     pub timestamp: String,
     /// The full transaction as submitted on-chain (the `Tx` JSON the node
     /// serializes) — `null` for cron units. Hydrated from the block.
+    #[schema(value_type = Option<Object>)]
     pub tx: Option<serde_json::Value>,
     /// The unit's execution outcome as JSON — externally tagged
     /// `{"transaction": …}` / `{"cron": …}` (see [`UnitOutcome`]). Hydrated from
     /// the block.
+    #[schema(value_type = Option<Object>)]
     pub outcome: Option<serde_json::Value>,
 }
 

--- a/dango/archive/projection/src/activity/mod.rs
+++ b/dango/archive/projection/src/activity/mod.rs
@@ -83,6 +83,12 @@ pub struct ActivityConfig {
     /// Addresses excluded from participation at write time — the deployment's
     /// system contracts, merged in by the cli from the node's `app_config`.
     pub involvement_blacklist: HashSet<Addr>,
+    /// The perps contract's address — the anchor of the `/perps-events`
+    /// shortcut route (the contract-events feeds with the contract argument
+    /// pre-bound). Injected by the cli from the node's `app_config`
+    /// (`addresses.perps`); `None` (the default) leaves the route unmounted.
+    /// Read-time only — it affects no written row.
+    pub perps_contract: Option<Addr>,
 }
 
 impl Default for ActivityConfig {
@@ -102,6 +108,7 @@ impl Default for ActivityConfig {
             event_data_filter: WhiteOrBlackList::Whitelist(priority.clone()),
             involvement_filter: WhiteOrBlackList::Whitelist(priority),
             involvement_blacklist: HashSet::new(),
+            perps_contract: None,
         }
     }
 }
@@ -132,7 +139,11 @@ impl Projection for ActivityProjection {
     }
 
     fn services(&self) -> Vec<Scope> {
-        http::scopes()
+        http::scopes(self.config.perps_contract)
+    }
+
+    fn api_doc(&self) -> Option<utoipa::openapi::OpenApi> {
+        Some(http::api_doc(self.config.perps_contract.is_some()))
     }
 
     #[cfg_attr(feature = "tracing", instrument(skip_all, fields(height = block.block.info.height)))]

--- a/dango/archive/projection/src/projection.rs
+++ b/dango/archive/projection/src/projection.rs
@@ -85,10 +85,24 @@ pub trait Projection: Send + Sync {
     /// A projection owns both its tables and the read surface over them, so the
     /// queries that expose its data live here, next to the schema that backs
     /// them. The handlers a scope mounts read the shared Postgres pool and block
-    /// source from actix app data; they never need the projection instance, so a
-    /// scope carries no state and is cheap to rebuild per worker. The default is
-    /// none — a write-only (or not-yet-served) projection contributes no routes.
+    /// source from actix app data; they never need the projection instance —
+    /// anything projection-specific a handler does need (e.g. the activity
+    /// projection's injected perps address) rides as scope-local app data, so a
+    /// scope stays self-contained and cheap to rebuild per worker. The default
+    /// is none — a write-only (or not-yet-served) projection contributes no
+    /// routes.
     fn services(&self) -> Vec<Scope> {
         vec![]
+    }
+
+    /// The OpenAPI fragment documenting this projection's read surface — the
+    /// docs counterpart of [`services`](Self::services), gathered by the app the
+    /// same way and merged by the httpd into the base document it serves at
+    /// `/openapi.json` (Swagger UI on `/docs/`). Built from the projection
+    /// instance, so conditionally-mounted routes (e.g. the activity projection's
+    /// `/perps-events` shortcut) appear in the docs exactly when they exist. The
+    /// default is none — a projection with no routes documents nothing.
+    fn api_doc(&self) -> Option<utoipa::openapi::OpenApi> {
+        None
     }
 }

--- a/dango/archive/testing/src/lib.rs
+++ b/dango/archive/testing/src/lib.rs
@@ -20,7 +20,7 @@ use {
         RemoteBlockSourceConfig, RocksdbBlockStore, SentinelBlockFetcher, SentinelFetcherConfig,
     },
     dango_archive_httpd::HttpdConfig,
-    dango_archive_projection::{ActivityProjection, Committer, Projection},
+    dango_archive_projection::{ActivityConfig, ActivityProjection, Committer, Projection},
     dango_genesis::{Contracts, GenesisOption},
     dango_primitives::{
         Addr, BroadcastClient, Coins, Hash256, MOCK_CHAIN_ID, Message, NonEmpty, Signer,
@@ -258,7 +258,16 @@ impl PendingEnv {
 
         // The committer + projections — ClickHouse deferred (`None`).
         let committer: Arc<dyn Committer> = Arc::new(PgChCommitter::new(db.conn.clone(), None));
-        let projections: Vec<Arc<dyn Projection>> = vec![Arc::new(ActivityProjection::default())];
+        // The `/perps-events` shortcut anchors on whatever address is injected.
+        // The tests' window produces no perps activity (it stays below the
+        // first perps cron), so anchor the shortcut on the **bank** instead:
+        // every `/contract-events/{bank}` assertion can then be replayed on
+        // `/perps-events` verbatim — same code path, real fixtures.
+        let projections: Vec<Arc<dyn Projection>> =
+            vec![Arc::new(ActivityProjection::new(ActivityConfig {
+                perps_contract: Some(contracts.bank),
+                ..Default::default()
+            }))];
 
         // Migrate up front so the tables are queryable immediately; `App::run`
         // re-migrates idempotently at boot. Doing it here also surfaces a
@@ -381,6 +390,23 @@ impl Env {
         self.get_opt(path)
             .await?
             .with_context(|| format!("GET {path} returned 404"))
+    }
+
+    /// GET `path` returning the raw body as text (redirects followed),
+    /// requiring a `2xx` — for non-JSON resources like the Swagger UI page.
+    pub async fn get_text(&self, path: &str) -> anyhow::Result<String> {
+        let response = self
+            .http
+            .get(format!("{}{path}", self.read_url))
+            .send()
+            .await
+            .with_context(|| format!("GET {path}"))?;
+        let status = response.status();
+        let body = response.text().await.context("reading the response body")?;
+        if !status.is_success() {
+            anyhow::bail!("GET {path} -> {status}");
+        }
+        Ok(body)
     }
 
     /// Poll `GET /transactions/by-hash/{hash}` until that tx is indexed or

--- a/dango/archive/testing/tests/backfill.rs
+++ b/dango/archive/testing/tests/backfill.rs
@@ -381,6 +381,43 @@ async fn backfill_then_live_then_query_coverage() {
         .unwrap();
     assert_eq!(ci4_sent, vec![marker_height]);
 
+    // ---- perpsEvents (the injected-anchor shortcut) ----
+    // The harness anchors the shortcut on the bank (see
+    // `PendingEnv::start_indexer`), so every `/contract-events/{bank}` read
+    // above must be reproducible on `/perps-events` verbatim — same feeds,
+    // the contract argument pre-bound instead of path-supplied.
+    let pe_all = env.collect_heights("/perps-events").await.unwrap();
+    assert_eq!(
+        pe_all.len(),
+        2 * total,
+        "the unfiltered shortcut serves the anchor's whole feed (sent + received)",
+    );
+    assert!(non_increasing(&pe_all));
+    let pe_sent = env
+        .collect_heights("/perps-events?names=sent")
+        .await
+        .unwrap();
+    assert_eq!(
+        pe_sent, sent_events,
+        "the shortcut's `names` filter matches the explicit route's",
+    );
+    let pe4 = env
+        .collect_heights(&format!("/perps-events?user={user4}"))
+        .await
+        .unwrap();
+    assert_eq!(
+        pe4, ci4,
+        "the shortcut's `user` filter matches the explicit route's",
+    );
+    let pe4_received = env
+        .collect_heights(&format!("/perps-events?user={user4}&names=received"))
+        .await
+        .unwrap();
+    assert_eq!(
+        pe4_received, ci4_received,
+        "the shortcut's combined `user` + `names` matches the explicit route's",
+    );
+
     // ===== eager payload hydration — the read paths back to the store =====
 
     // GET /block/{height}: the full `{ block, outcome }` read straight from the
@@ -401,6 +438,55 @@ async fn backfill_then_live_then_query_coverage() {
         .await
         .unwrap();
     assert!(absent.is_none(), "an un-ingested height is a 404");
+
+    // GET /block/latest: the block at the contiguous frontier. The projection
+    // has caught up to the last live block and the mock chain only produces on
+    // broadcast, so the frontier — which always leads the projection — must sit
+    // exactly at the tip: the marker (the lowest block) plus the `total`
+    // contiguous blocks asserted above.
+    let latest = env.get("/block/latest").await.unwrap();
+    let latest_height = latest["block"]["info"]["height"]
+        .as_u64()
+        .expect("latest height");
+    assert_eq!(
+        latest_height,
+        marker_height + total as u64 - 1,
+        "GET /block/latest is the contiguous frontier (== the tip once caught up)",
+    );
+    assert!(
+        latest["outcome"].is_object(),
+        "...with the same {{ block, outcome }} shape as /block/{{height}}"
+    );
+
+    // ===== the API docs =====
+
+    // The merged OpenAPI spec documents the core block routes and every
+    // activity feed — including /perps-events, since this harness injects an
+    // anchor (see `PendingEnv::start_indexer`).
+    let spec = env.get("/openapi.json").await.unwrap();
+    for path in [
+        "/block/{height}",
+        "/block/latest",
+        "/up",
+        "/transactions/by-hash/{hash}",
+        "/transactions/involving/{address}",
+        "/events",
+        "/contract-events/{contract}",
+        "/perps-events",
+    ] {
+        assert!(
+            spec["paths"].get(path).is_some(),
+            "the OpenAPI spec should document {path}",
+        );
+    }
+
+    // The base path lands on Swagger UI (via the /docs/ redirect, which the
+    // client follows).
+    let docs = env.get_text("/").await.unwrap();
+    assert!(
+        docs.contains("swagger-ui"),
+        "GET / should land on the Swagger UI page",
+    );
 
     // Transaction.tx / Transaction.outcome: hydrated eagerly from the unit's
     // block (→ source.get → RocksDB).


### PR DESCRIPTION
## Summary

Three additions to the archive's read API:

**`GET /perps-events`** — shortcut for the dominant consumer: exactly `/contract-events/{contract}` with the contract pre-bound to the deployment's perps address, so clients never have to carry it around. Same optional `user` / `names` filters, dispatching to the same two feeds (`contract_events` / `contract_events_involving`). The cli resolves the address from the node's `app_config` (typed `addresses.perps`, reusing the query that already seeds the involvement blacklist — the typed parse is best-effort: on a shape mismatch the archive warns and skips the route, ingest is never at risk) and injects it via the new `ActivityConfig::perps_contract`; the events scope carries it as scope-local app data, and without one the route is simply not mounted.

**`GET /block/latest`** — the block at the source's **contiguous frontier**: the highest `H` with every height in `[1, H]` stored, i.e. the newest block servable together with all the history below it (`h ≤ frontier ⟹ get(h) = Some`, so paging `1..=latest` never finds a hole — during a backfill this is deliberately *not* the tip the live tail is already storing above the gap). The frontier is the O(1) in-memory topology the block store already owns, so the route adds no state, no cache, no new plumbing. Registered before `/block/{height}` so the literal wins the match.

**OpenAPI docs, served from the base path** — each projection contributes a fragment through the new `Projection::api_doc()` (derived from `#[utoipa::path]` annotations sitting on the same handlers; `/perps-events` documented exactly when mounted), the httpd merges the fragments into its own base document (core block routes) and serves the result at `GET /openapi.json`, with Swagger UI on `GET /docs/` and `GET /` redirecting there. The docs derivation mirrors the route derivation, so the served spec can't drift from the mounted surface. New workspace deps: `utoipa` 5, `utoipa-swagger-ui` 9 (vendored — no build-time downloads).

## Validation

### Completed
- [x] `cargo clippy --all-targets` clean (zero warnings) on all archive crates
- [x] Unit: perps shortcut 400s on malformed args, 404 when unmounted; `/block/latest` 200/404/500 paths over a stub source; docs served from `/` (302 → `/docs/`), spec carries the core paths
- [x] Unit: `api_doc` mirrors mounted routes (perps iff configured) and auto-collects the `Event` / `Transaction` / `EventType` / `UnitKind` schemas
- [x] Postgres feeds integration test (hand-written SQL against a real engine)
- [x] E2E backfill: `/perps-events` replays every `/contract-events/{bank}` assertion verbatim (harness injects the bank as anchor — the window has no perps activity), `/block/latest` equals the tip once caught up, `/openapi.json` documents all 8 paths, `GET /` lands on Swagger UI
- [x] `cargo fetch --locked`

### Remaining
- [ ] Deploy on the testnet archive (h8) and smoke-test against live data

## Manual QA

On a running archive (e.g. testnet h8 over VPN):
1. `curl :9081/block/latest | jq .block.info.height` — matches the frontier gauge.
2. `curl ':9081/perps-events?names=order_filled&first=5'` — perps fills without passing the contract address; cross-check against `/contract-events/{perps}` with the same filters.
3. Open `http://<host>:9081/` in a browser — lands on Swagger UI with all routes documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PBRud6KHYdhYGwqPWVKG5