### PR TITLE
feat(deploy): add per-network reupload_heights to batch-block-backup

### DIFF
--- a/deploy/justfile
+++ b/deploy/justfile
@@ -290,13 +290,16 @@ stop-perps-bot:
 
 # Deploy the batch-block-backup bot for a network. testnet runs on hetzner2,
 # mainnet on hetzner1 (the full-app node hosts, so the blocks/ dir is on local
-# disk).
+# disk). Pass comma-separated heights as the third argument to rebuild and
+# re-upload their batches once at startup (redeploy without it afterwards, or
+# the rebuild re-runs on every container restart).
 # Usage: just deploy-batch-block-backup testnet
 #        just deploy-batch-block-backup mainnet v1.2.3
-deploy-batch-block-backup network tag="latest":
+#        just deploy-batch-block-backup testnet latest 200,300
+deploy-batch-block-backup network tag="latest" reupload_heights="":
   mkdir -p "{{justfile_directory()}}/logs" \
     && uv run ansible-playbook batch-block-backup.yml \
-      -e '{"batch_block_backup_networks": ["{{network}}"], "batch_block_backup_tag": "{{tag}}"}' \
+      -e '{"batch_block_backup_networks": ["{{network}}"], "batch_block_backup_tag": "{{tag}}", "batch_block_backup_reupload_heights": {"{{network}}": "{{reupload_heights}}"}}' \
       --limit batch-block-backup-{{network}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-batch-block-backup.log"
 

--- a/deploy/roles/batch-block-backup/defaults/main.yml
+++ b/deploy/roles/batch-block-backup/defaults/main.yml
@@ -14,3 +14,8 @@ batch_block_backup_http_port: 9320
 batch_block_backup_blocks_dir: {}
 # Lowest height that should be archived (see the image .env.example).
 batch_block_backup_start_height: 1
+# Comma-separated block heights whose batches should be rebuilt and re-uploaded
+# once at startup, keyed by network (e.g. {testnet: "200,300"}). One-shot: the
+# rebuild re-runs on every container restart while set, so redeploy without it
+# once the re-upload has completed.
+batch_block_backup_reupload_heights: {}

--- a/deploy/roles/batch-block-backup/templates/env.j2
+++ b/deploy/roles/batch-block-backup/templates/env.j2
@@ -1,12 +1,15 @@
 # Managed by Ansible (roles/batch-block-backup) — do not edit by hand.
 
 # -------- SOURCE (local node disk) --------
-# The node's blocks/ dir is bind-mounted read-only at /data/blocks (see
-# docker-compose.yml).
+# The node's blocks/ dir — the one containing the reverse-digit shard tree
+# (block files live at <blocks_dir>/<r>/<r>/<r>/<height>.borsh.xz). It is
+# bind-mounted read-only at /data/blocks (see docker-compose.yml).
 blocks_dir=/data/blocks
 
-# HTTP endpoint of the local Dango node, resolved over the shared `traefik`
-# docker network (the dango service is reachable there by name).
+# HTTP/REST endpoint of the local Dango node, queried for the latest block
+# height to decide which ranges are fully produced (the node is assumed to have
+# stored every block <= tip on the local disk above). Resolved over the shared
+# `traefik` docker network (the dango service is reachable there by name).
 dango_url=http://dango:8080
 
 # Network label, also used to derive the default destination bucket
@@ -14,18 +17,59 @@ dango_url=http://dango:8080
 network={{ network }}
 
 # -------- BATCHING --------
-# Lowest height that should be archived (height 0 never exists).
+# Blocks per archive (default: 10000). Ranges are fixed modulo windows.
+# batch_size=10000
+
+# Lowest height that exists / should be archived (default: 1 — the chain's
+# first block is height 1; height 0 never exists). Only picks the first range
+# scanned; window keys are fixed modulo ranges, e.g. 1-9999.tar.xz.
 start_height={{ batch_block_backup_start_height }}
 
+# xz compression level 0-9 (default: 9).
+# xz_level=9
+
+# S3 key for the JSON resume cursor (last sealed range index), stored in the
+# destination bucket so restarts resume without any local state / volume.
+# Default: state/progress.json (outside the v1/ archive namespace). If absent,
+# the bot self-heals by rescanning.
+# state_key=state/progress.json
+
+# Seconds between rechecks when caught up to the chain tip (default: 60).
+# scan_interval=60
+
+# Comma-separated block heights whose batches should be rebuilt and re-uploaded
+# once at startup (default: disabled). Each height maps to its containing batch
+# window — e.g. 200 and 300 both live in 1-9999 and yield a single archive —
+# and the existing object is overwritten. Runs in a background task alongside
+# the normal sealing loop.
+{% if batch_block_backup_reupload_heights[network] is defined
+      and batch_block_backup_reupload_heights[network] %}
+reupload_heights={{ batch_block_backup_reupload_heights[network] }}
+{% else %}
+# reupload_heights=200,300,20005
+{% endif %}
+
 # -------- DESTINATION (S3 / Backblaze B2) --------
+# Defaults to dango-<network>-batches. Set to override.
+# dest_bucket=dango-{{ network }}-batches
+
+# Key prefix inside the bucket (default: v1/). The only format versioning.
+# dest_prefix=v1/
+
+# Create the destination bucket if it doesn't exist (default: true).
+# create_bucket=true
+
 # Credentials read from the Ansible vault. batch-block-backup uses Larry's
 # dedicated read/write Backblaze application key (a separate S3 account from
 # the node's s3_* keys, hence its own endpoint — B2 S3 endpoints are
-# per-account clusters).
+# per-account clusters). REGION=auto is normalized to the cluster implied by
+# the endpoint (e.g. eu-central-003).
 INDEXER__S3__ENDPOINT={{ backblaze_larry_endpoint }}
 INDEXER__S3__ACCESS_KEY={{ backblaze_larry_read_write_access_key }}
 INDEXER__S3__SECRET_KEY={{ backblaze_larry_read_write_secret_key }}
+# INDEXER__S3__REGION=auto
 
 # -------- HTTP HEALTH/METRICS SERVER --------
-# Endpoints: /health, /status, /metrics. Published on the tailscale IP.
+# Endpoints: /health, /status, /metrics. Container port 8083, published on the
+# host's tailscale IP (see docker-compose.yml).
 http_port=8083


### PR DESCRIPTION
## Summary

- Sync `roles/batch-block-backup/templates/env.j2` with the bot image's new `.env.example`: richer comments plus the new optional settings (`batch_size`, `xz_level`, `state_key`, `scan_interval`, `reupload_heights`, `dest_bucket`, `dest_prefix`, `create_bucket`, `INDEXER__S3__REGION`), all commented out with their defaults.
- Expose `reupload_heights` as a per-network Ansible dict (`batch_block_backup_reupload_heights`, same pattern as the `blocks_dir` override) so specific batch windows can be rebuilt and re-uploaded once at startup.
- Add an optional third argument to `just deploy-batch-block-backup <network> [tag] [reupload_heights]` that passes the heights through for that network only, e.g. `just deploy-batch-block-backup testnet latest 200,300`.

The rebuild is one-shot per container start but the setting persists in the host `.env` until the next deploy, so the recipe comment and role defaults both note to redeploy without the argument once the re-upload completes.

## Validation

### Completed

- [x] Rendered `env.j2` with Ansible's Jinja settings (`trim_blocks=True`) for all three cases — dict unset, empty string, and heights set — and verified the emitted `reupload_heights` line.
- [x] `just lint` in `deploy/`: no warnings on the touched files (pre-existing line-length warnings in unrelated playbooks remain).

### Remaining

- [ ] Deploy to testnet with a real height list and confirm the batch archive is rebuilt and overwritten in the bucket.

## Manual QA

1. `just deploy-batch-block-backup testnet latest <heights>`
2. Check `~deploy/batch-block-backup/testnet/.env` on hetzner2 contains `reupload_heights=<heights>`.
3. Watch the bot's `/status` endpoint / logs for the one-shot rebuild, then redeploy without the third argument and confirm the line is commented out again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)