### PR TITLE
refactor(archive): plural route collections; contract filter as query param

### DIFF
--- a/dango/archive/DESIGN.md
+++ b/dango/archive/DESIGN.md
@@ -609,8 +609,8 @@ in-process indexer's `routes::blocks::services()`. The app gathers them in
 `run` into one configurator, and the httpd injects the shared read handles
 (the Postgres pool, the block source) as actix app data and applies it. The
 httpd never names a projection; its only built-in routes are the generic
-`GET /block/by-height/{height}`, read straight from the `BlockSource`, and
-`GET /block/latest` — the block at the source's **contiguous frontier** (the
+`GET /blocks/{height}`, read straight from the `BlockSource`, and
+`GET /blocks/latest` — the block at the source's **contiguous frontier** (the
 highest `H` with every height in `[1, H]` stored, i.e. the newest block
 servable together with all the history below it; the frontier is the O(1)
 in-memory topology the block store already owns, so the route adds no state).

--- a/dango/archive/design/observability.md
+++ b/dango/archive/design/observability.md
@@ -171,8 +171,8 @@ derived in Grafana. Catch-up speed = `rate(projection_blocks_total)`.
 `query` values: `events_by_type`, `contract_events`, `events_involving`,
 `contract_events_involving`, `transactions_involving`, `transactions_by_hash`.
 A feed slow relative to the others points straight at an index miss. (The core
-`GET /block/by-height/{height}` route is not a feed; its latency rides the
-end-to-end HTTP histogram below.)
+`GET /blocks/{height}` route is not a feed; its latency rides the end-to-end
+HTTP histogram below.)
 
 ### Misc
 

--- a/dango/archive/httpd/src/lib.rs
+++ b/dango/archive/httpd/src/lib.rs
@@ -3,10 +3,10 @@
 //! A deliberately small actix-web service: given the shared read handles (the
 //! Postgres pool and the [`BlockSource`](dango_archive_block_source::BlockSource))
 //! plus the projections' route registrars, it injects the handles as actix app
-//! data, mounts the core `GET /block/by-height/{height}`, `GET /block/latest`
-//! (the block at the source's contiguous frontier), and `GET /up` routes,
-//! applies each projection's feeds, and serves. The merged OpenAPI document
-//! (its own core paths + every projection's `api_doc()` fragment) is served at
+//! data, mounts the core `GET /blocks/{height}`, `GET /blocks/latest` (the
+//! block at the source's contiguous frontier), and `GET /up` routes, applies
+//! each projection's feeds, and serves. The merged OpenAPI document (its own
+//! core paths + every projection's `api_doc()` fragment) is served at
 //! `GET /openapi.json`, with Swagger UI on `GET /docs/` and the base `GET /`
 //! redirecting there.
 //!

--- a/dango/archive/httpd/src/server.rs
+++ b/dango/archive/httpd/src/server.rs
@@ -46,9 +46,9 @@ struct ApiDoc;
 ///
 /// Builds an actix-web server from the shared read handles and the app's route
 /// configurator: the Postgres pool and the block source are injected as app data
-/// (handlers pull them with `web::Data`), the core
-/// `GET /block/by-height/{height}`, `GET /block/latest`, and `GET /up` routes
-/// are mounted directly, and `configure` adds the projections' feed scopes.
+/// (handlers pull them with `web::Data`), the core `GET /blocks/{height}`,
+/// `GET /blocks/latest`, and `GET /up` routes are mounted directly, and
+/// `configure` adds the projections' feed scopes.
 ///
 /// `api_docs` are the projections' OpenAPI fragments (gathered by the app the
 /// same way the route configurator is); they are merged into the httpd's own
@@ -152,9 +152,12 @@ async fn serve_actix(
                 }
             })
             // Core routes: the block reads (not a projection) and the liveness
-            // probe.
-            .route("/block/latest", web::get().to(latest_block))
-            .route("/block/by-height/{height}", web::get().to(block))
+            // probe. `/blocks/latest` must be registered before
+            // `/blocks/{height}` so the literal segment wins the match (actix
+            // matches in registration order; after `{height}`, "latest" would
+            // be a failed u64 parse → 400).
+            .route("/blocks/latest", web::get().to(latest_block))
+            .route("/blocks/{height}", web::get().to(block))
             .route("/up", web::get().to(up))
             // The projections' feed scopes, mounted by the app's configurator.
             .configure(move |cfg| (*configure)(cfg))
@@ -187,7 +190,7 @@ async fn serve_actix(
 /// the same shape the node's `/block/full/{height}` route returns.
 #[utoipa::path(
     get,
-    path = "/block/by-height/{height}",
+    path = "/blocks/{height}",
     tag = "block",
     summary = "Block by height",
     description = "The full block at `height` — `{ block, outcome }`, the same \
@@ -217,16 +220,16 @@ async fn block(
 /// The latest indexed block — the block at the source's **contiguous
 /// frontier**: the highest `H` with every height in `[1, H]` stored, i.e. the
 /// newest block that can be served *together with all the history below it*
-/// (`GET /block/by-height/{height}` answers for every height up to this one).
-/// During a backfill this climbs from the bottom and can trail the chain tip
+/// (`GET /blocks/{height}` answers for every height up to this one). During a
+/// backfill this climbs from the bottom and can trail the chain tip
 /// the live tail is already storing above a gap; once the store is gap-free it
 /// **is** the tip. The frontier is O(1) in-memory state owned by the block
 /// store — no scan, no extra cache. `404` while the store holds no contiguous
 /// prefix yet (a cold, still-empty archive); the body is the same
-/// `{ block, outcome }` JSON as `/block/by-height/{height}`.
+/// `{ block, outcome }` JSON as `/blocks/{height}`.
 #[utoipa::path(
     get,
-    path = "/block/latest",
+    path = "/blocks/latest",
     tag = "block",
     summary = "Latest indexed block",
     description = "The block at the source's contiguous frontier — the highest \
@@ -234,7 +237,7 @@ async fn block(
                    block servable together with all the history below it. \
                    During a backfill this trails the chain tip; once the store \
                    is gap-free it is the tip. Same `{ block, outcome }` shape \
-                   as `/block/by-height/{height}`.",
+                   as `/blocks/{height}`.",
     responses(
         (status = 200, description = "The block at the contiguous frontier"),
         (status = 404, description = "The store holds no contiguous prefix yet (cold, still-empty archive)"),
@@ -339,19 +342,21 @@ mod tests {
         }
     }
 
-    /// The two block routes over a stub source, mounted as [`serve_actix`]
-    /// mounts them.
+    /// The two block routes over a stub source, mounted in the same order as
+    /// [`serve_actix`] — `/blocks/latest` before `/blocks/{height}`, so the
+    /// literal wins the match.
     fn block_routes(stub: StubSource) -> impl FnOnce(&mut web::ServiceConfig) {
         let source: Arc<dyn BlockSource> = Arc::new(stub);
         move |cfg| {
             cfg.app_data(web::Data::new(source))
-                .route("/block/latest", web::get().to(latest_block))
-                .route("/block/by-height/{height}", web::get().to(block));
+                .route("/blocks/latest", web::get().to(latest_block))
+                .route("/blocks/{height}", web::get().to(block));
         }
     }
 
-    /// The happy path: `latest` resolves the frontier and serves that block,
-    /// and the by-height route still works.
+    /// The happy path: `latest` resolves the frontier, serves that block (the
+    /// literal route wins over `{height}`), and the by-height route still
+    /// works.
     #[actix_web::test]
     async fn latest_block_serves_the_frontier() {
         let app = test::init_service(App::new().configure(block_routes(StubSource {
@@ -360,13 +365,11 @@ mod tests {
         })))
         .await;
 
-        let req = test::TestRequest::get().uri("/block/latest").to_request();
+        let req = test::TestRequest::get().uri("/blocks/latest").to_request();
         let body: serde_json::Value = test::call_and_read_body_json(&app, req).await;
         assert_eq!(body["block"]["info"]["height"].as_u64(), Some(7));
 
-        let req = test::TestRequest::get()
-            .uri("/block/by-height/3")
-            .to_request();
+        let req = test::TestRequest::get().uri("/blocks/3").to_request();
         let resp = test::call_service(&app, req).await;
         assert!(
             resp.status().is_success(),
@@ -384,7 +387,7 @@ mod tests {
         })))
         .await;
 
-        let req = test::TestRequest::get().uri("/block/latest").to_request();
+        let req = test::TestRequest::get().uri("/blocks/latest").to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status().as_u16(), 404);
     }
@@ -400,7 +403,7 @@ mod tests {
         })))
         .await;
 
-        let req = test::TestRequest::get().uri("/block/latest").to_request();
+        let req = test::TestRequest::get().uri("/blocks/latest").to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status().as_u16(), 500);
     }
@@ -437,7 +440,7 @@ mod tests {
         // The spec carries the httpd's own routes.
         let req = test::TestRequest::get().uri("/openapi.json").to_request();
         let spec: serde_json::Value = test::call_and_read_body_json(&app, req).await;
-        for path in ["/block/by-height/{height}", "/block/latest", "/up"] {
+        for path in ["/blocks/{height}", "/blocks/latest", "/up"] {
             assert!(
                 spec["paths"].get(path).is_some(),
                 "the spec should document {path}",

--- a/dango/archive/projection/src/activity/DESIGN.md
+++ b/dango/archive/projection/src/activity/DESIGN.md
@@ -539,10 +539,10 @@ The eight access paths are served by `#[get]`-routed handlers in
 
 | route | access paths | arguments |
 |-------|--------------|-----------|
-| `GET /transactions/by-hash/{hash}` | — | un-paginated; the hash is non-unique, so a **list**, newest-first |
+| `GET /transactions/{hash}` | — | un-paginated; the hash is non-unique, so a **list**, newest-first |
 | `GET /transactions/involving/{address}` | 1 | + optional `role`, `kind` |
 | `GET /events` | 2, 5, 6 | `type` (a list) and/or `involved` — **at least one required** |
-| `GET /events/by-contract/{contract}` | 3 / 4 / 7 / 8 | + optional `user`, `names` (a list) |
+| `GET /events/contract` | 3 / 4 / 7 / 8 | mandatory `contract`, + optional `user`, `names` (a list) |
 | `GET /events/perps` | 3 / 4 / 7 / 8, `contract` pre-bound to the perps address | + optional `user`, `names` (a list) |
 
 `/events` folds the by-type feed (Q2) and the involving feeds (Q5/Q6):
@@ -550,7 +550,7 @@ The eight access paths are served by `#[get]`-routed handlers in
 `type` alone anchors on `event_type` (a single type is the clean `idx_type`
 scan, several a bounded `UNION ALL` per type — never a full-type sort). Neither
 argument present has no index anchor — it would be a full-table scan + sort — so
-it is a **400**. `/events/by-contract` makes `contract` mandatory, which keeps every
+it is a **400**. `/events/contract` makes `contract` mandatory, which keeps every
 reachable combination index-anchored and makes the unsupported shapes (a name
 filter without a contract, a type filter with a contract) structurally
 impossible.

--- a/dango/archive/projection/src/activity/http/feeds.rs
+++ b/dango/archive/projection/src/activity/http/feeds.rs
@@ -277,8 +277,8 @@ fn single_type_scan(binder: &mut Binder, ty: EventType, keyset: &str, fetch: u64
 
 /// Queries 3 / 4 — contract events emitted by a contract, optionally narrowed to
 /// a set of event names (a single value or a list). Serves both
-/// `/events/by-contract/{contract}` and the `/events/perps` shortcut (the same
-/// call with the injected perps address).
+/// `/events/contract` and the `/events/perps` shortcut (the same call with the
+/// injected perps address).
 pub(crate) async fn contract_events(
     db: &DatabaseConnection,
     contract: Addr,

--- a/dango/archive/projection/src/activity/http/services.rs
+++ b/dango/archive/projection/src/activity/http/services.rs
@@ -110,15 +110,16 @@ mod tests {
             test::init_service(App::new().configure(test_config(Some(Addr::mock(1))).await)).await;
 
         for path in [
-            "/events",                                // no anchor: neither type nor involved
-            "/events?type=not_a_type",                // unknown event type
-            "/events?type=transfer&after=zz",         // malformed cursor (not hex)
-            "/events?involved=not_an_address",        // malformed address (query)
-            "/events/by-contract/not_an_address",     // malformed address (path)
-            "/events/perps?user=not_an_address",      // malformed address (query)
-            "/events/perps?after=zz",                 // malformed cursor (not hex)
-            "/transactions/by-hash/not_a_hash",       // malformed hash (path)
-            "/transactions/involving/not_an_address", // malformed address (path)
+            "/events",                                  // no anchor: neither type nor involved
+            "/events?type=not_a_type",                  // unknown event type
+            "/events?type=transfer&after=zz",           // malformed cursor (not hex)
+            "/events?involved=not_an_address",          // malformed address (query)
+            "/events/contract",                         // missing required contract
+            "/events/contract?contract=not_an_address", // malformed address (query)
+            "/events/perps?user=not_an_address",        // malformed address (query)
+            "/events/perps?after=zz",                   // malformed cursor (not hex)
+            "/transactions/not_a_hash",                 // malformed hash (path)
+            "/transactions/involving/not_an_address",   // malformed address (path)
         ] {
             let req = test::TestRequest::get().uri(path).to_request();
             let resp = test::call_service(&app, req).await;
@@ -159,10 +160,10 @@ mod tests {
         for (perps_mounted, expects_perps) in [(false, false), (true, true)] {
             let doc = super::api_doc(perps_mounted);
             for path in [
-                "/transactions/by-hash/{hash}",
+                "/transactions/{hash}",
                 "/transactions/involving/{address}",
                 "/events",
-                "/events/by-contract/{contract}",
+                "/events/contract",
             ] {
                 assert!(
                     doc.paths.paths.contains_key(path),

--- a/dango/archive/projection/src/activity/http/services/events.rs
+++ b/dango/archive/projection/src/activity/http/services/events.rs
@@ -4,16 +4,17 @@
 //! - `GET /events` — events filtered by `type` (a comma-separated list) and/or
 //!   `involved` (an address); **at least one** is required, since an unfiltered
 //!   feed has no index anchor (it would be a full-table scan + sort → 400).
-//! - `GET /events/by-contract/{contract}` — a contract's events, optionally
-//!   narrowed by `user` (a participant address) and `names` (a comma-separated
-//!   list). The mandatory `contract` keeps every reachable combination
-//!   index-anchored.
-//! - `GET /events/perps` — the perps shortcut: exactly
-//!   `/events/by-contract/{contract}` with the contract pre-bound to the
-//!   deployment's perps address (injected at construction, resolved by the cli
-//!   from the node's `app_config`), so the dominant consumer never has to carry
-//!   the address around. Same optional `user` / `names`, same feeds. Mounted
-//!   only when an address was injected.
+//! - `GET /events/contract` — the contract events (the event sub-type
+//!   contracts emit) of one emitting contract, named by the mandatory
+//!   `contract` query argument and optionally narrowed by `user` (a
+//!   participant address) and `names` (a comma-separated list). The mandatory
+//!   `contract` keeps every reachable combination index-anchored.
+//! - `GET /events/perps` — the perps shortcut: exactly `/events/contract`
+//!   with the contract pre-bound to the deployment's perps address (injected
+//!   at construction, resolved by the cli from the node's `app_config`), so
+//!   the dominant consumer never has to carry the address around. Same
+//!   optional `user` / `names`, same feeds. Mounted only when an address was
+//!   injected.
 //!
 //! Each handler parses its arguments (a malformed address / type / cursor is a
 //! 400), runs the matching feed in [`feeds`](super::super::feeds), hydrates the
@@ -40,15 +41,15 @@ use {
 #[derive(Clone, Copy)]
 struct PerpsContract(Addr);
 
-/// The `/events` scope: the by-type / involved feed, the by-contract feed,
-/// and (when a perps address was injected) the `/events/perps` shortcut.
+/// The `/events` scope: the by-type / involved feed, the contract-events
+/// feed, and (when a perps address was injected) the `/events/perps` shortcut.
 pub(crate) fn services(perps_contract: Option<Addr>) -> Vec<Scope> {
     let mut scope = web::scope("/events")
         .service(events)
         .service(contract_events);
     // Without an injected address the shortcut has no anchor, so the route is
-    // simply not mounted (404) — the explicit `/events/by-contract/{contract}`
-    // form still serves everything.
+    // simply not mounted (404) — the explicit `/events/contract` form still
+    // serves everything.
     if let Some(contract) = perps_contract {
         scope = scope
             .app_data(web::Data::new(PerpsContract(contract)))
@@ -94,21 +95,47 @@ struct EventsQuery {
     after: Option<String>,
 }
 
-/// `/events/by-contract/{contract}` and `/events/perps` arguments — optional
-/// `user` and `names` (comma-separated list). The two routes differ only in
-/// where the contract address comes from (path vs injected), so they share the
-/// argument surface.
+/// `/events/contract` arguments — the mandatory emitting `contract`, plus the
+/// same optional narrowing `/events/perps` takes.
 #[derive(Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
 struct ContractEventsQuery {
+    /// Emitting contract address (`0x` hex). Required — the feed's index
+    /// anchor.
+    #[param(value_type = String)]
+    contract: Addr,
+
     /// Participant address (`0x` hex): only the contract's events this address
     /// is a party to.
     #[param(value_type = Option<String>)]
     user: Option<Addr>,
+
     /// Comma-separated list of contract-event names (`order_filled`, …).
     names: Option<String>,
+
     /// Page size (max 50; default 50).
     first: Option<i32>,
+
+    /// Opaque cursor of the previous page (`pageInfo.endCursor`).
+    after: Option<String>,
+}
+
+/// `/events/perps` arguments — the same narrowing as `/events/contract`,
+/// minus `contract` itself (pre-bound to the injected perps address).
+#[derive(Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+struct PerpsEventsQuery {
+    /// Participant address (`0x` hex): only the perps contract's events this
+    /// address is a party to.
+    #[param(value_type = Option<String>)]
+    user: Option<Addr>,
+
+    /// Comma-separated list of contract-event names (`order_filled`, …).
+    names: Option<String>,
+
+    /// Page size (max 50; default 50).
+    first: Option<i32>,
+
     /// Opaque cursor of the previous page (`pageInfo.endCursor`).
     after: Option<String>,
 }
@@ -157,33 +184,34 @@ async fn events(
 
 #[utoipa::path(
     get,
-    path = "/events/by-contract/{contract}",
+    path = "/events/contract",
     tag = "events",
-    summary = "Events emitted by a contract",
-    description = "The contract-events of one emitting contract, optionally \
-                   narrowed to a participant (`user`) and/or a set of event \
-                   names (`names`). Newest-first, keyset-paginated.",
-    params(
-        ("contract" = String, Path, description = "Emitting contract address (`0x` hex)"),
-        ContractEventsQuery,
-    ),
+    summary = "Contract events of an emitting contract",
+    description = "The contract events — the event sub-type contracts emit — \
+                   of one emitting contract (the mandatory `contract`), \
+                   optionally narrowed to a participant (`user`) and/or a set \
+                   of event names (`names`). Newest-first, keyset-paginated.",
+    params(ContractEventsQuery),
     responses(
         (status = 200, description = "One page of events, newest-first", body = Page<Event>),
-        (status = 400, description = "Malformed address, argument, or cursor"),
+        (status = 400, description = "Missing or malformed `contract`, or a malformed argument / cursor"),
     ),
 )]
-#[get("/by-contract/{contract}")]
+#[get("/contract")]
 async fn contract_events(
     db: web::Data<DatabaseConnection>,
     source: web::Data<Arc<dyn BlockSource>>,
-    contract: web::Path<Addr>,
     query: web::Query<ContractEventsQuery>,
 ) -> Result<HttpResponse, ApiError> {
+    let q = query.into_inner();
     serve_contract_events(
         &db,
         source.get_ref(),
-        contract.into_inner(),
-        query.into_inner(),
+        q.contract,
+        q.user,
+        q.names,
+        q.first,
+        q.after,
     )
     .await
 }
@@ -192,13 +220,13 @@ async fn contract_events(
     get,
     path = "/events/perps",
     tag = "events",
-    summary = "Events emitted by the perps contract",
-    description = "Shortcut: exactly `/events/by-contract/{contract}` with the \
-                   contract pre-bound to the deployment's perps address \
-                   (resolved from the node's `app_config` at startup). Same \
-                   optional `user` / `names` filters, same feeds. Mounted only \
-                   when the deployment resolved a perps address.",
-    params(ContractEventsQuery),
+    summary = "Contract events of the perps contract",
+    description = "Shortcut: exactly `/events/contract` with the contract \
+                   pre-bound to the deployment's perps address (resolved from \
+                   the node's `app_config` at startup). Same optional `user` / \
+                   `names` filters, same feeds. Mounted only when the \
+                   deployment resolved a perps address.",
+    params(PerpsEventsQuery),
     responses(
         (status = 200, description = "One page of the perps contract's events, newest-first",
          body = Page<Event>),
@@ -210,28 +238,40 @@ async fn perps_events(
     db: web::Data<DatabaseConnection>,
     source: web::Data<Arc<dyn BlockSource>>,
     perps: web::Data<PerpsContract>,
-    query: web::Query<ContractEventsQuery>,
+    query: web::Query<PerpsEventsQuery>,
 ) -> Result<HttpResponse, ApiError> {
-    serve_contract_events(&db, source.get_ref(), perps.0, query.into_inner()).await
+    let q = query.into_inner();
+    serve_contract_events(
+        &db,
+        source.get_ref(),
+        perps.0,
+        q.user,
+        q.names,
+        q.first,
+        q.after,
+    )
+    .await
 }
 
 /// Run the contract-events feeds for `contract` and answer with the hydrated
-/// page — the shared body of `/events/by-contract/{contract}` and the
-/// `/events/perps` shortcut, which only differ in where the contract address
-/// comes from.
+/// page — the shared body of `/events/contract` and the `/events/perps`
+/// shortcut, which only differ in where the contract address comes from.
 async fn serve_contract_events(
     db: &DatabaseConnection,
     source: &Arc<dyn BlockSource>,
     contract: Addr,
-    q: ContractEventsQuery,
+    user: Option<Addr>,
+    names: Option<String>,
+    first: Option<i32>,
+    after: Option<String>,
 ) -> Result<HttpResponse, ApiError> {
-    let names = parse_names(q.names);
+    let names = parse_names(names);
 
-    let mut page = match q.user {
+    let mut page = match user {
         Some(address) => {
-            feeds::contract_events_involving(db, address, contract, names, q.first, q.after).await?
+            feeds::contract_events_involving(db, address, contract, names, first, after).await?
         },
-        None => feeds::contract_events(db, contract, names, q.first, q.after).await?,
+        None => feeds::contract_events(db, contract, names, first, after).await?,
     };
     hydrate::hydrate_events(source, &mut page.items).await?;
     Ok(HttpResponse::Ok().json(page))

--- a/dango/archive/projection/src/activity/http/services/transaction.rs
+++ b/dango/archive/projection/src/activity/http/services/transaction.rs
@@ -23,7 +23,8 @@ use {
     utoipa::{IntoParams, OpenApi},
 };
 
-/// The `/transactions` scope: the by-hash lookup and the "involving" feed.
+/// The `/transactions` scope: the content-hash lookup and the "involving"
+/// feed.
 pub(crate) fn services() -> Scope {
     web::scope("/transactions")
         .service(by_hash)
@@ -55,7 +56,7 @@ struct InvolvingQuery {
 
 #[utoipa::path(
     get,
-    path = "/transactions/by-hash/{hash}",
+    path = "/transactions/{hash}",
     tag = "transactions",
     summary = "Transactions by content hash",
     description = "Every unit whose transaction bytes hash to `hash`, \
@@ -71,7 +72,7 @@ struct InvolvingQuery {
         (status = 400, description = "Malformed hash"),
     ),
 )]
-#[get("/by-hash/{hash}")]
+#[get("/{hash}")]
 async fn by_hash(
     db: web::Data<DatabaseConnection>,
     source: web::Data<Arc<dyn BlockSource>>,

--- a/dango/archive/testing/src/lib.rs
+++ b/dango/archive/testing/src/lib.rs
@@ -261,8 +261,8 @@ impl PendingEnv {
         // The `/events/perps` shortcut anchors on whatever address is injected.
         // The tests' window produces no perps activity (it stays below the
         // first perps cron), so anchor the shortcut on the **bank** instead:
-        // every `/events/by-contract/{bank}` assertion can then be replayed on
-        // `/events/perps` verbatim — same code path, real fixtures.
+        // every `/events/contract?contract={bank}` assertion can then be
+        // replayed on `/events/perps` verbatim — same code path, real fixtures.
         let projections: Vec<Arc<dyn Projection>> =
             vec![Arc::new(ActivityProjection::new(ActivityConfig {
                 perps_contract: Some(contracts.bank),
@@ -409,7 +409,7 @@ impl Env {
         Ok(body)
     }
 
-    /// Poll `GET /transactions/by-hash/{hash}` until that tx is indexed or
+    /// Poll `GET /transactions/{hash}` until that tx is indexed or
     /// `timeout` elapses — the catch-up signal. The projection advances
     /// contiguously, so once a block's tx is visible every block below it has
     /// been ingested too. Returns the list of matching units. Tolerates the read
@@ -419,7 +419,7 @@ impl Env {
         hash: &str,
         timeout: Duration,
     ) -> anyhow::Result<serde_json::Value> {
-        let path = format!("/transactions/by-hash/{hash}");
+        let path = format!("/transactions/{hash}");
         let start = std::time::Instant::now();
         loop {
             if let Ok(Some(units)) = self.get_opt(&path).await
@@ -438,7 +438,7 @@ impl Env {
     /// a producer loop that pumps the chain forward until the backfill catches
     /// up. A transport error (read API not yet up) reads as "not indexed".
     pub async fn is_tx_indexed(&self, hash: &str) -> anyhow::Result<bool> {
-        match self.get_opt(&format!("/transactions/by-hash/{hash}")).await {
+        match self.get_opt(&format!("/transactions/{hash}")).await {
             Ok(Some(units)) => Ok(units.as_array().is_some_and(|units| !units.is_empty())),
             _ => Ok(false),
         }
@@ -477,7 +477,7 @@ impl Env {
     /// newest-first across pages — exercising cursor pagination end to end.
     /// `path` is the feed's REST path including any non-pagination query
     /// arguments, e.g. `/transactions/involving/0x..?role=sender` or
-    /// `/events/by-contract/0x..?names=sent`.
+    /// `/events/contract?contract=0x..&names=sent`.
     pub async fn collect_heights(&self, path: &str) -> anyhow::Result<Vec<u64>> {
         let sep = if path.contains('?') {
             '&'

--- a/dango/archive/testing/tests/backfill.rs
+++ b/dango/archive/testing/tests/backfill.rs
@@ -244,14 +244,14 @@ async fn backfill_then_live_then_query_coverage() {
 
     // ---- transactionsByHash ----
     let by_hash = env
-        .get(&format!("/transactions/by-hash/{marker_hash}"))
+        .get(&format!("/transactions/{marker_hash}"))
         .await
         .unwrap();
     assert_eq!(by_hash.as_array().unwrap().len(), 1);
     // an unknown hash maps to nothing.
     let unknown_hash = "0".repeat(64);
     let none = env
-        .get(&format!("/transactions/by-hash/{unknown_hash}"))
+        .get(&format!("/transactions/{unknown_hash}"))
         .await
         .unwrap();
     assert!(none.as_array().unwrap().is_empty());
@@ -328,11 +328,11 @@ async fn backfill_then_live_then_query_coverage() {
 
     // ---- contractEvents (bank) ----
     let sent_events = env
-        .collect_heights(&format!("/events/by-contract/{bank}?names=sent"))
+        .collect_heights(&format!("/events/contract?contract={bank}&names=sent"))
         .await
         .unwrap();
     let received_events = env
-        .collect_heights(&format!("/events/by-contract/{bank}?names=received"))
+        .collect_heights(&format!("/events/contract?contract={bank}&names=received"))
         .await
         .unwrap();
     eprintln!(
@@ -353,14 +353,14 @@ async fn backfill_then_live_then_query_coverage() {
     // an unknown contract has no events.
     let unknown_contract = Addr::try_from(vec![0xCDu8; 20]).unwrap().to_string();
     let no_events = env
-        .collect_heights(&format!("/events/by-contract/{unknown_contract}"))
+        .collect_heights(&format!("/events/contract?contract={unknown_contract}"))
         .await
         .unwrap();
     assert!(no_events.is_empty(), "an unknown contract has no events");
 
     // ---- contractEventsInvolving ----
     let ci4 = env
-        .collect_heights(&format!("/events/by-contract/{bank}?user={user4}"))
+        .collect_heights(&format!("/events/contract?contract={bank}&user={user4}"))
         .await
         .unwrap();
     assert_eq!(
@@ -370,14 +370,14 @@ async fn backfill_then_live_then_query_coverage() {
     );
     let ci4_received = env
         .collect_heights(&format!(
-            "/events/by-contract/{bank}?user={user4}&names=received"
+            "/events/contract?contract={bank}&user={user4}&names=received"
         ))
         .await
         .unwrap();
     assert_eq!(ci4_received, vec![marker_height]);
     let ci4_sent = env
         .collect_heights(&format!(
-            "/events/by-contract/{bank}?user={user4}&names=sent"
+            "/events/contract?contract={bank}&user={user4}&names=sent"
         ))
         .await
         .unwrap();
@@ -385,9 +385,9 @@ async fn backfill_then_live_then_query_coverage() {
 
     // ---- perpsEvents (the injected-anchor shortcut) ----
     // The harness anchors the shortcut on the bank (see
-    // `PendingEnv::start_indexer`), so every `/events/by-contract/{bank}` read
-    // above must be reproducible on `/events/perps` verbatim — same feeds,
-    // the contract argument pre-bound instead of path-supplied.
+    // `PendingEnv::start_indexer`), so every `/events/contract?contract={bank}`
+    // read above must be reproducible on `/events/perps` verbatim — same feeds,
+    // the contract argument pre-bound instead of caller-supplied.
     let pe_all = env.collect_heights("/events/perps").await.unwrap();
     assert_eq!(
         pe_all.len(),
@@ -422,16 +422,13 @@ async fn backfill_then_live_then_query_coverage() {
 
     // ===== eager payload hydration — the read paths back to the store =====
 
-    // GET /block/by-height/{height}: the full `{ block, outcome }` read straight
+    // GET /blocks/{height}: the full `{ block, outcome }` read straight
     // from the RocksDB store the fetcher populated, for the marker's own height.
-    let block = env
-        .get(&format!("/block/by-height/{marker_height}"))
-        .await
-        .unwrap();
+    let block = env.get(&format!("/blocks/{marker_height}")).await.unwrap();
     assert_eq!(
         block["block"]["info"]["height"].as_u64(),
         Some(marker_height),
-        "GET /block/by-height/{{height}} returns the stored block at that height",
+        "GET /blocks/{{height}} returns the stored block at that height",
     );
     assert!(
         block["outcome"].is_object(),
@@ -439,28 +436,28 @@ async fn backfill_then_live_then_query_coverage() {
     );
     // a height the source does not hold → 404.
     let absent = env
-        .get_opt(&format!("/block/by-height/{}", (total + 1000) as u64))
+        .get_opt(&format!("/blocks/{}", (total + 1000) as u64))
         .await
         .unwrap();
     assert!(absent.is_none(), "an un-ingested height is a 404");
 
-    // GET /block/latest: the block at the contiguous frontier. The projection
+    // GET /blocks/latest: the block at the contiguous frontier. The projection
     // has caught up to the last live block and the mock chain only produces on
     // broadcast, so the frontier — which always leads the projection — must sit
     // exactly at the tip: the marker (the lowest block) plus the `total`
     // contiguous blocks asserted above.
-    let latest = env.get("/block/latest").await.unwrap();
+    let latest = env.get("/blocks/latest").await.unwrap();
     let latest_height = latest["block"]["info"]["height"]
         .as_u64()
         .expect("latest height");
     assert_eq!(
         latest_height,
         marker_height + total as u64 - 1,
-        "GET /block/latest is the contiguous frontier (== the tip once caught up)",
+        "GET /blocks/latest is the contiguous frontier (== the tip once caught up)",
     );
     assert!(
         latest["outcome"].is_object(),
-        "...with the same {{ block, outcome }} shape as /block/by-height/{{height}}"
+        "...with the same {{ block, outcome }} shape as /blocks/{{height}}"
     );
 
     // ===== the API docs =====
@@ -470,13 +467,13 @@ async fn backfill_then_live_then_query_coverage() {
     // anchor (see `PendingEnv::start_indexer`).
     let spec = env.get("/openapi.json").await.unwrap();
     for path in [
-        "/block/by-height/{height}",
-        "/block/latest",
+        "/blocks/{height}",
+        "/blocks/latest",
         "/up",
-        "/transactions/by-hash/{hash}",
+        "/transactions/{hash}",
         "/transactions/involving/{address}",
         "/events",
-        "/events/by-contract/{contract}",
+        "/events/contract",
         "/events/perps",
     ] {
         assert!(
@@ -496,7 +493,7 @@ async fn backfill_then_live_then_query_coverage() {
     // Transaction.tx / Transaction.outcome: hydrated eagerly from the unit's
     // block (→ source.get → RocksDB).
     let hydrated = env
-        .get(&format!("/transactions/by-hash/{marker_hash}"))
+        .get(&format!("/transactions/{marker_hash}"))
         .await
         .unwrap();
     let unit = &hydrated[0];


### PR DESCRIPTION
Revise the archive read API's route naming per review with the API's original author:

- `/block/latest` -> `/blocks/latest`
- `/block/by-height/{height}` -> `/blocks/{height}`
- `/events/by-contract/{contract}` -> `/events/contract`, with the contract address as a required query parameter: the address is a filter, not a canonical identifier, so it does not belong in the path
- `/transactions/by-hash/{hash}` -> `/transactions/{hash}`

Collections are now uniformly plural, and the `by-*` segments are gone: a path parameter is reserved for the resource's canonical key (height, content hash). Same handlers, feeds, and responses; the only signature change is `/events/contract` reading the address from the query string.