### PR TITLE
feat(indexer-httpd): add `blockInfo` and `block` WebSocket subscriptions

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -2872,10 +2872,12 @@ A native WebSocket endpoint for real-time feeds, distinct from the `graphql-ws` 
 
 **Endpoint:** `GET /ws` (WebSocket upgrade). See [Constants](9-constants.md#endpoints).
 
-Two channels are served, both replacing `graphql-ws` subscriptions removed in this release:
+Four channels are served, replacing the corresponding `graphql-ws` subscriptions:
 
-- `fullBlock` — every finalized block (`Block` + `BlockOutcome`).
 - `perpsEvents` — perps-contract events grouped per block, with filters.
+- `blockInfo` — every finalized block's metadata (height, timestamp, hash).
+- `block` — every finalized block, without its execution outcome.
+- `fullBlock` — every finalized block in full (`Block` + `BlockOutcome`).
 
 ### 12.1 Protocol
 
@@ -2885,7 +2887,9 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 
 ```json
 {"method": "subscribe", "id": 1, "subscription": {"type": "perpsEvents", "pairIds": ["perp/btcusd"]}}
-{"method": "subscribe", "id": 2, "subscription": {"type": "fullBlock"}}
+{"method": "subscribe", "id": 2, "subscription": {"type": "blockInfo"}}
+{"method": "subscribe", "id": 3, "subscription": {"type": "block"}}
+{"method": "subscribe", "id": 4, "subscription": {"type": "fullBlock"}}
 {"method": "unsubscribe", "id": 1}
 {"method": "ping", "id": 9}
 ```
@@ -2902,19 +2906,21 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 {"channel": "subscriptionResponse", "id": 1, "data": {"method": "subscribe", "type": "perpsEvents"}}
 {"channel": "perpsEvents", "id": 1, "data": { ... }}
 {"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "..."}}
-{"channel": "fullBlock", "id": 2, "data": { ... }}
+{"channel": "blockInfo", "id": 2, "data": { ... }}
+{"channel": "block", "id": 3, "data": { ... }}
+{"channel": "fullBlock", "id": 4, "data": { ... }}
 {"channel": "pong", "id": 9}
 {"channel": "error", "error": {"code": "badRequest", "message": "..."}}
 ```
 
-| `channel`                 | Description                                                                                                                                             |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `subscriptionResponse`    | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                                                                              |
-| `perpsEvents`/`fullBlock` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§12.3](#123-reconnect-and-errors)) |
-| `pong`                    | Reply to a `ping`, echoing its `id`                                                                                                                     |
-| `error`                   | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§12.3](#123-reconnect-and-errors)                  |
+| `channel`                                     | Description                                                                                                                                             |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `subscriptionResponse`                        | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                                                                              |
+| `perpsEvents`/`blockInfo`/`block`/`fullBlock` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§12.3](#123-reconnect-and-errors)) |
+| `pong`                                        | Reply to a `ping`, echoing its `id`                                                                                                                     |
+| `error`                                       | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§12.3](#123-reconnect-and-errors)                  |
 
-Each frame on a subscription's channel (`perpsEvents` / `fullBlock`) carries either a `data` payload or an `error`; a client demultiplexes by `id` and branches on which key is present. Errors are co-located this way so a feed's failure arrives on the same channel its data does — see [§12.3](#123-reconnect-and-errors).
+Each frame on a subscription's channel (`perpsEvents` / `blockInfo` / `block` / `fullBlock`) carries either a `data` payload or an `error`; a client demultiplexes by `id` and branches on which key is present. Errors are co-located this way so a feed's failure arrives on the same channel its data does — see [§12.3](#123-reconnect-and-errors).
 
 **Heartbeat.** The server sends a WebSocket ping every 20 seconds and closes a connection it has heard nothing from for 60 seconds. A client either lets its WebSocket stack answer those pings, or sends `{"method": "ping"}` itself; either keeps an idle subscription alive.
 
@@ -2987,12 +2993,12 @@ Each data frame carries one block's matching events; only blocks with at least o
 | `clientOrderId` | `String?` | The caller-assigned client order id, if it has one          |
 | `data`          | `JSON`    | Raw event payload (same shape as [§9](#9-events-reference)) |
 
-#### `fullBlock`
+#### `blockInfo`
 
-Stream every finalized block in full — the same `FullBlock` shape (`block` + `outcome`) the REST `/block/full/{height}` route returns, one data frame per block.
+Stream every finalized block's metadata — the `info` field of `Block` (`height`, `timestamp`, `hash`), one data frame per block. The lightest way to follow the chain tip.
 
 ```json
-{"method": "subscribe", "id": 2, "subscription": {"type": "fullBlock", "since": 100000}}
+{"method": "subscribe", "id": 2, "subscription": {"type": "blockInfo", "since": 100000}}
 ```
 
 | Field   | Type  | Description                                                            |
@@ -3000,7 +3006,39 @@ Stream every finalized block in full — the same `FullBlock` shape (`block` + `
 | `since` | `Int` | Replay retained blocks from this height on connect; omit for live-only |
 
 ```json
-{"channel": "fullBlock", "id": 2, "data": {"block": { ... }, "outcome": { ... }}}
+{"channel": "blockInfo", "id": 2, "data": {"height": 100001, "timestamp": "1781740800.000000000", "hash": "813A81B8C4CBAF71A73CEDD69F502C5A5FEE4CB7391EB92FC29AB4E1A2A5C2A0"}}
+```
+
+#### `block`
+
+Stream every finalized block as produced by the consensus engine — metadata (`info`) plus transactions (`txs`), without the execution outcome. The same `Block` shape the REST `/block/info/{height}` route returns, one data frame per block.
+
+```json
+{"method": "subscribe", "id": 3, "subscription": {"type": "block", "since": 100000}}
+```
+
+| Field   | Type  | Description                                                            |
+| ------- | ----- | ---------------------------------------------------------------------- |
+| `since` | `Int` | Replay retained blocks from this height on connect; omit for live-only |
+
+```json
+{"channel": "block", "id": 3, "data": {"info": { ... }, "txs": [ ... ]}}
+```
+
+#### `fullBlock`
+
+Stream every finalized block in full — the same `FullBlock` shape (`block` + `outcome`) the REST `/block/full/{height}` route returns, one data frame per block.
+
+```json
+{"method": "subscribe", "id": 4, "subscription": {"type": "fullBlock", "since": 100000}}
+```
+
+| Field   | Type  | Description                                                            |
+| ------- | ----- | ---------------------------------------------------------------------- |
+| `since` | `Int` | Replay retained blocks from this height on connect; omit for live-only |
+
+```json
+{"channel": "fullBlock", "id": 4, "data": {"block": { ... }, "outcome": { ... }}}
 ```
 
 #### `broadcast`
@@ -3030,16 +3068,16 @@ Only a transport failure to the consensus node is an `error` frame:
 
 ### 12.3 Reconnect and errors
 
-Both subscription channels (`perpsEvents` and `fullBlock`) are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight`, or `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
+All four subscription channels are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight` for `perpsEvents`, `height` for `blockInfo`, `info.height` for `block`, `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
 
 Problems are delivered as `error`-keyed frames. An error that concerns a specific subscription rides that subscription's own channel and `id` — an `error` sibling of the `data` frames it would otherwise send — so a client handles a feed's failure on the same channel it reads from. An error with no subscription to attribute it to (an unparseable message, or an `unsubscribe` for an unknown `id`) arrives on the dedicated `error` channel instead, carrying the offending `id` when there is one.
 
-| `code`                | Meaning                                                                                                                                                                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `resync`              | `since` predates the retained window, or the feed lagged past it. The subscription ends; reconnect with a newer `since` and backfill the gap from the `perpsEvents` query ([§5.5](#55-trade-history)) or the `/block/full/*` REST routes. |
-| `tooManyRequests`     | The server's subscription limit was reached.                                                                                                                                                                                              |
-| `badRequest`          | The message could not be parsed, or the `id` is already in use.                                                                                                                                                                           |
-| `unknownSubscription` | An `unsubscribe` referenced an `id` with no open subscription.                                                                                                                                                                            |
+| `code`                | Meaning                                                                                                                                                                                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resync`              | `since` predates the retained window, or the feed lagged past it. The subscription ends; reconnect with a newer `since` and backfill the gap from the `perpsEvents` query ([§5.5](#55-trade-history)) or the `/block/info/*` / `/block/full/*` REST routes. |
+| `tooManyRequests`     | The server's subscription limit was reached.                                                                                                                                                                                                                |
+| `badRequest`          | The message could not be parsed, or the `id` is already in use.                                                                                                                                                                                             |
+| `unknownSubscription` | An `unsubscribe` referenced an `id` with no open subscription.                                                                                                                                                                                              |
 
 A subscription-scoped error (here, a terminal `resync` on the `perpsEvents` feed opened with `id: 1`):
 

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -15,12 +15,16 @@
 //! channel to attribute them to — an unparseable frame, or an `unsubscribe` for
 //! an unknown `id` — use the dedicated `error` channel.
 //!
-//! Two channel types are served, both reusing the in-memory validator stream
+//! Four channel types are served, all reusing the in-memory validator stream
 //! that backed the `full_block` / `perps_events` GraphQL subscriptions:
 //!
-//! - `fullBlock` — every finalized block (`{block, outcome}`).
 //! - `perpsEvents` — perps-contract events grouped per block, narrowed by the
 //!   `eventTypes` / `pairIds` / `users` / `orderIds` / `clientOrderIds` filters.
+//! - `blockInfo` — every finalized block's metadata
+//!   (`{height, timestamp, hash}`).
+//! - `block` — every finalized block without its execution outcome
+//!   (`{info, txs}`).
+//! - `fullBlock` — every finalized block in full (`{block, outcome}`).
 //!
 //! The transport is otherwise a thin shell over
 //! [`dango_indexer_stream::Context`]; only the framing differs from the SSE and
@@ -86,15 +90,20 @@ pub fn services() -> Resource {
                    Client messages are `method`-tagged JSON: `subscribe` — \
                    opening a `perpsEvents` feed (per-block perps events, \
                    narrowed by `eventTypes` / `pairIds` / `users` / `orderIds` \
-                   / `clientOrderIds` filters) or a `fullBlock` feed (every \
-                   finalized `{ block, outcome }`, the same shape as \
+                   / `clientOrderIds` filters), a `blockInfo` feed (every \
+                   finalized block's metadata, the `info` field of `Block`), \
+                   a `block` feed (every finalized block without its \
+                   execution outcome, the same shape as \
+                   `/block/info/{block_height}`), or a `fullBlock` feed \
+                   (every finalized `{ block, outcome }`, the same shape as \
                    `/block/full/{block_height}`) — plus `unsubscribe`, `ping`, \
                    and `broadcast` (submit a signed `Tx` over the socket). \
                    Server frames are `channel`-tagged: `subscriptionResponse`, \
-                   `fullBlock`, `perpsEvents`, `broadcast`, `pong`, and \
-                   `error`. The server pings every 20 seconds and closes a \
-                   socket idle for 60 seconds. **Swagger UI cannot open \
-                   WebSocket connections** — this entry is documentation only.",
+                   `perpsEvents`, `blockInfo`, `block`, `fullBlock`, \
+                   `broadcast`, `pong`, and `error`. The server pings every \
+                   20 seconds and closes a socket idle for 60 seconds. \
+                   **Swagger UI cannot open WebSocket connections** — this \
+                   entry is documentation only.",
     responses(
         (status = 101, description = "Switching Protocols — WebSocket handshake accepted; \
                                       all further traffic is JSON frames"),
@@ -170,6 +179,21 @@ enum Subscription {
         client_order_ids: Option<HashSet<String>>,
     },
 
+    /// Every finalized block's metadata (height, timestamp, hash) — the `info`
+    /// field of `Block`. Delivered on the `blockInfo` channel.
+    BlockInfo {
+        #[serde(default)]
+        since: Option<u64>,
+    },
+
+    /// Every finalized block as produced by the consensus engine — metadata
+    /// and transactions, without the execution outcome. Delivered on the
+    /// `block` channel.
+    Block {
+        #[serde(default)]
+        since: Option<u64>,
+    },
+
     /// Every finalized block in full (`Block` + `BlockOutcome`). Delivered on
     /// the `fullBlock` channel.
     FullBlock {
@@ -183,6 +207,8 @@ impl Subscription {
     fn channel(&self) -> &'static str {
         match self {
             Subscription::PerpsEvents { .. } => "perpsEvents",
+            Subscription::BlockInfo { .. } => "blockInfo",
+            Subscription::Block { .. } => "block",
             Subscription::FullBlock { .. } => "fullBlock",
         }
     }
@@ -474,6 +500,26 @@ fn open_stream(
 
             Ok(with_terminal("perpsEvents", id, frames))
         },
+        Subscription::BlockInfo { since } => {
+            let raw = stream_ctx
+                .blocks()
+                .subscribe(*since, |block| Some(block.block.info))
+                .map_err(|resync| resync.to_string())?;
+            let frames = guard_subscription_stream(raw, Some(guard))
+                .map(move |info| data_frame("blockInfo", id, &info));
+
+            Ok(with_terminal("blockInfo", id, frames))
+        },
+        Subscription::Block { since } => {
+            let raw = stream_ctx
+                .blocks()
+                .subscribe(*since, |block| Some(block.block.clone()))
+                .map_err(|resync| resync.to_string())?;
+            let frames = guard_subscription_stream(raw, Some(guard))
+                .map(move |block| data_frame("block", id, &block));
+
+            Ok(with_terminal("block", id, frames))
+        },
         Subscription::FullBlock { since } => {
             let raw = stream_ctx
                 .blocks()
@@ -646,6 +692,39 @@ mod tests {
             serde_json::from_str::<ClientMessage>(r#"{"method":"ping"}"#).unwrap(),
             ClientMessage::Ping { id: None }
         ));
+    }
+
+    #[test]
+    fn deserializes_block_info_and_block() {
+        // `blockInfo`, with a `since` cursor.
+        let message: ClientMessage = serde_json::from_str(
+            r#"{"method":"subscribe","id":3,"subscription":{"type":"blockInfo","since":42}}"#,
+        )
+        .unwrap();
+
+        let ClientMessage::Subscribe { id, subscription } = message else {
+            panic!("expected a subscribe message");
+        };
+
+        assert_eq!(id, 3);
+        assert_eq!(subscription.channel(), "blockInfo");
+        assert!(matches!(subscription, Subscription::BlockInfo {
+            since: Some(42)
+        }));
+
+        // `block`, without `since` (live-only).
+        let message: ClientMessage = serde_json::from_str(
+            r#"{"method":"subscribe","id":4,"subscription":{"type":"block"}}"#,
+        )
+        .unwrap();
+
+        let ClientMessage::Subscribe { id, subscription } = message else {
+            panic!("expected a subscribe message");
+        };
+
+        assert_eq!(id, 4);
+        assert_eq!(subscription.channel(), "block");
+        assert!(matches!(subscription, Subscription::Block { since: None }));
     }
 
     #[test]

--- a/dango/testing/tests/httpd/ws.rs
+++ b/dango/testing/tests/httpd/ws.rs
@@ -10,7 +10,7 @@ use {
     actix_http::ws,
     anyhow::anyhow,
     dango_app::Indexer,
-    dango_primitives::FullBlock,
+    dango_primitives::{Block, BlockInfo, FullBlock},
     dango_testing::{
         TestOption, build_app_service, create_perps_fill, pair_id, setup_perps_env,
         setup_test_naive_with_indexer,
@@ -81,6 +81,96 @@ where
 
 fn channel(message: &Value) -> Option<&str> {
     message.get("channel").and_then(Value::as_str)
+}
+
+/// Subscribing to `blockInfo` and `block` on one socket replays the retained
+/// window on each channel independently: both are acked, each frame parses into
+/// exactly its primitive — a bare `BlockInfo` (no transactions), a `Block` (no
+/// execution outcome); both types reject unknown fields, so parsing proves
+/// nothing extra leaked in — and the two channels report the same ascending
+/// heights, since they project the same ring.
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_block_info_and_block_streams_replay_blocks() -> anyhow::Result<()> {
+    let (mut suite, mut accounts, _, contracts, _, ctx, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default()).await;
+
+    let pair = pair_id();
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
+    create_perps_fill(&mut suite, &mut accounts, &contracts, &pair, 2_000, 3).await;
+    suite.app.indexer.wait_for_finish().await?;
+
+    let since = ctx.stream_context.blocks().floor().unwrap_or_default();
+
+    let local_set = tokio::task::LocalSet::new();
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let mut srv = actix_test::start(move || build_app_service(ctx.clone()));
+                let mut framed = srv
+                    .ws_at("/ws")
+                    .await
+                    .map_err(|err| anyhow!("ws upgrade failed: {err}"))?;
+
+                send(
+                    &mut framed,
+                    json!({"method": "subscribe", "id": 8, "subscription": {"type": "blockInfo", "since": since}}),
+                )
+                .await?;
+                send(
+                    &mut framed,
+                    json!({"method": "subscribe", "id": 9, "subscription": {"type": "block", "since": since}}),
+                )
+                .await?;
+
+                let messages = drain(&mut framed, 256).await?;
+
+                // Both subscriptions are acknowledged.
+                for id in [8, 9] {
+                    messages
+                        .iter()
+                        .find(|m| {
+                            channel(m) == Some("subscriptionResponse")
+                                && m["id"].as_u64() == Some(id)
+                        })
+                        .ok_or_else(|| anyhow!("no ack for subscription {id}; got {messages:?}"))?;
+                }
+
+                // `blockInfo` frames are tagged id = 8 and parse into a bare
+                // `BlockInfo`, with ascending heights.
+                let mut info_heights = Vec::new();
+                for frame in messages.iter().filter(|m| channel(m) == Some("blockInfo")) {
+                    assert_eq!(frame["id"].as_u64(), Some(8));
+                    let info: BlockInfo = serde_json::from_value(frame["data"].clone())
+                        .map_err(|err| anyhow!("frame data is not a BlockInfo: {err}"))?;
+                    info_heights.push(info.height);
+                }
+                assert!(
+                    info_heights.len() >= 2,
+                    "expected at least two blockInfo frames; got {messages:?}"
+                );
+                assert!(
+                    info_heights.windows(2).all(|w| w[1] > w[0]),
+                    "blockInfo heights must ascend: {info_heights:?}"
+                );
+
+                // `block` frames are tagged id = 9 and parse into a `Block`.
+                let mut block_heights = Vec::new();
+                for frame in messages.iter().filter(|m| channel(m) == Some("block")) {
+                    assert_eq!(frame["id"].as_u64(), Some(9));
+                    let block: Block = serde_json::from_value(frame["data"].clone())
+                        .map_err(|err| anyhow!("frame data is not a Block: {err}"))?;
+                    block_heights.push(block.info.height);
+                }
+
+                // Both channels project the same ring, so they replay the same
+                // height sequence.
+                assert_eq!(info_heights, block_heights);
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
 }
 
 /// Subscribing to `fullBlock` with a `since` replays the retained window then


### PR DESCRIPTION
Two new channels on the multiplexed `/ws` endpoint, ahead of the GraphQL API's deprecation: `blockInfo` streams every finalized block's metadata (`BlockInfo`), and `block` streams the block without its execution outcome (`Block`). Both project the same in-memory ring as `fullBlock` and inherit its `since` replay and resync semantics.

Documented in the API reference §12; covered by serde unit tests and an end-to-end test driving both channels over one socket.