### PR TITLE
feat(indexer-httpd): add a one-time `query` method to the WebSocket API

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -2890,15 +2890,18 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 {"method": "subscribe", "id": 2, "subscription": {"type": "blockInfo"}}
 {"method": "subscribe", "id": 3, "subscription": {"type": "block"}}
 {"method": "subscribe", "id": 4, "subscription": {"type": "fullBlock"}}
+{"method": "query", "id": 5, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
 {"method": "unsubscribe", "id": 1}
 {"method": "ping", "id": 9}
 ```
 
-| Field          | Type     | Description                                                |
-| -------------- | -------- | ---------------------------------------------------------- |
-| `method`       | `String` | `subscribe`, `unsubscribe`, or `ping`                      |
-| `id`           | `Int`    | Subscription handle; required on `subscribe`/`unsubscribe` |
-| `subscription` | `Object` | The feed selector; see [§12.2](#122-channels)              |
+| Field          | Type     | Description                                                                               |
+| -------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `method`       | `String` | `subscribe`, `unsubscribe`, `ping`, `broadcast`, or `query`                               |
+| `id`           | `Int`    | Operation handle, echoed on every resulting frame; optional on `ping`, required otherwise |
+| `subscription` | `Object` | The feed selector on `subscribe`; see [§12.2](#122-channels)                              |
+| `tx`           | `Object` | The signed `Tx` on `broadcast`; see [§12.2](#122-channels)                                |
+| `query`        | `Object` | The query request on `query`; see [§12.2](#122-channels)                                  |
 
 **Server → client:**
 
@@ -2909,6 +2912,7 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 {"channel": "blockInfo", "id": 2, "data": { ... }}
 {"channel": "block", "id": 3, "data": { ... }}
 {"channel": "fullBlock", "id": 4, "data": { ... }}
+{"channel": "query", "id": 5, "data": { ... }}
 {"channel": "pong", "id": 9}
 {"channel": "error", "error": {"code": "badRequest", "message": "..."}}
 ```
@@ -2917,6 +2921,7 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `subscriptionResponse`                        | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                                                                              |
 | `perpsEvents`/`blockInfo`/`block`/`fullBlock` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§12.3](#123-reconnect-and-errors)) |
+| `broadcast`/`query`                           | The single reply to a `broadcast`/`query` request, tagged with its `id`: a `data` payload or an `error` (see [§12.2](#122-channels))                    |
 | `pong`                                        | Reply to a `ping`, echoing its `id`                                                                                                                     |
 | `error`                                       | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§12.3](#123-reconnect-and-errors)                  |
 
@@ -3039,6 +3044,31 @@ Stream every finalized block in full — the same `FullBlock` shape (`block` + `
 
 ```json
 {"channel": "fullBlock", "id": 4, "data": {"block": { ... }, "outcome": { ... }}}
+```
+
+#### `query`
+
+Run a one-time, read-only query against the latest finalized state — a **read** request/response (one request, one reply), not a subscription stream. The request and reply are the same raw grug `Query` / `QueryResponse` shapes as REST `POST /query` ([§11.1](#111-query)); this lets a client already holding a `/ws` connection query state without opening a separate HTTP request.
+
+```json
+{"method": "query", "id": 5, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
+```
+
+| Field   | Type     | Description                                                     |
+| ------- | -------- | --------------------------------------------------------------- |
+| `id`    | `Int`    | Echoed on the reply frame                                       |
+| `query` | `Object` | The grug `Query` (same request payloads as [§11.1](#111-query)) |
+
+The reply rides the `query` channel. Success is a `data` frame holding the raw `QueryResponse`:
+
+```json
+{"channel": "query", "id": 5, "data": {"balance": {"denom": "hyp/all/btc", "amount": "12345"}}}
+```
+
+A failed query — an unknown contract, a contract query that errors, and so on — is an `error` frame with code `queryFailed`, carrying the same error message the REST route would return as a `400`. Note the asymmetry with `broadcast`: a mempool-rejected tx is still a `data` frame there, because `BroadcastTxOutcome` carries its own rejection, while `QueryResponse` is success-only, so any failure is an `error` frame. A failed query ends nothing — the socket and its subscriptions are unaffected, and the `id` is free to reuse.
+
+```json
+{"channel": "query", "id": 5, "error": {"code": "queryFailed", "message": "..."}}
 ```
 
 #### `broadcast`

--- a/dango/indexer/httpd/src/routes/query.rs
+++ b/dango/indexer/httpd/src/routes/query.rs
@@ -18,7 +18,7 @@ use {
                    GraphQL `queryApp` query.",
     request_body(
         content = serde_json::Value,
-        description = "A grug `Query` object, e.g. `{\"appConfig\": {}}`",
+        description = "A grug `Query` object, e.g. `{\"app_config\": {}}`",
         content_type = "application/json",
     ),
     responses(

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -2,7 +2,8 @@
 //!
 //! One socket carries any number of subscriptions, each identified by a
 //! client-chosen `id`. Client messages are `method`-tagged
-//! (`subscribe` / `unsubscribe` / `ping`); server messages are `channel`-tagged
+//! (`subscribe` / `unsubscribe` / `ping` / `broadcast` / `query`); server
+//! messages are `channel`-tagged
 //! (`subscriptionResponse` / `<channel>` / `pong`). The `id` of a `subscribe` is
 //! echoed on its acknowledgement and on every frame it produces, so concurrent
 //! subscriptions (e.g. several `perpsEvents` feeds with different filters) are
@@ -26,23 +27,29 @@
 //!   (`{info, txs}`).
 //! - `fullBlock` — every finalized block in full (`{block, outcome}`).
 //!
+//! Two one-shot request/response methods ride the same socket: `broadcast`
+//! (submit a signed transaction to the mempool) and `query` (run a read-only
+//! query against the latest finalized state, the same `Query`/`QueryResponse`
+//! shapes as REST `POST /query`). Each is answered with a single frame on its
+//! own channel, tagged with the request's `id`.
+//!
 //! The transport is otherwise a thin shell over
 //! [`dango_indexer_stream::Context`]; only the framing differs from the SSE and
 //! GraphQL transports. The message enums are left open (no `#[non_exhaustive]`
-//! barrier, but room in the protocol) so a future request/response write path
-//! (`broadcast` / `post`) and further read channels (`l2Book`, `candle`, …) can
-//! be added without breaking existing clients.
+//! barrier, but room in the protocol) so further read channels (`l2Book`,
+//! `candle`, …) can be added without breaking existing clients.
 
 use {
     crate::{
         context::FullContext,
+        graphql::query::core::CoreQuery,
         request_ip::RequesterIp,
         subscription_limiter::{ConnectionLimiter, SubscriptionLimiter, guard_subscription_stream},
     },
     actix_web::{HttpRequest, HttpResponse, Resource, guard, web},
     actix_ws::{AggregatedMessage, Session},
     dango_indexer_stream::{Context, make_perps_filter},
-    dango_primitives::{HttpRequestDetails, Tx},
+    dango_primitives::{HttpRequestDetails, Query, Tx},
     futures_util::{StreamExt, stream},
     serde::{Deserialize, Serialize},
     std::{collections::HashSet, pin::Pin, sync::Arc, time::Duration},
@@ -97,11 +104,13 @@ pub fn services() -> Resource {
                    `/block/info/{block_height}`), or a `fullBlock` feed \
                    (every finalized `{ block, outcome }`, the same shape as \
                    `/block/full/{block_height}`) — plus `unsubscribe`, `ping`, \
-                   and `broadcast` (submit a signed `Tx` over the socket). \
+                   `broadcast` (submit a signed `Tx` over the socket), and \
+                   `query` (run a one-time read-only state query, the same \
+                   `Query`/`QueryResponse` shapes as `POST /query`). \
                    Server frames are `channel`-tagged: `subscriptionResponse`, \
                    `perpsEvents`, `blockInfo`, `block`, `fullBlock`, \
-                   `broadcast`, `pong`, and `error`. The server pings every \
-                   20 seconds and closes a socket idle for 60 seconds. \
+                   `broadcast`, `query`, `pong`, and `error`. The server pings \
+                   every 20 seconds and closes a socket idle for 60 seconds. \
                    **Swagger UI cannot open WebSocket connections** — this \
                    entry is documentation only.",
     responses(
@@ -146,6 +155,13 @@ enum ClientMessage {
     /// default; this lets a client already holding a `/ws` connection broadcast
     /// without a separate HTTP request.
     Broadcast { id: u64, tx: Tx },
+
+    /// Run a one-time, read-only query against the latest finalized state.
+    /// Answered on the `query` channel: the raw `QueryResponse` (`data`) — the
+    /// same shape the REST `POST /query` returns — or an `error` frame if the
+    /// query fails. The REST route is the default; this lets a client already
+    /// holding a `/ws` connection query state without a separate HTTP request.
+    Query { id: u64, query: Query },
 }
 
 /// The feed a `subscribe` selects, discriminated by `type`.
@@ -455,6 +471,33 @@ async fn handle_text(
                     send(
                         session,
                         channel_error("broadcast", id, "broadcastFailed", &err.to_string()),
+                    )
+                    .await
+                },
+            }
+        },
+        ClientMessage::Query { id, query } => {
+            // Reject an `id` already bound to a live subscription on this socket,
+            // so the client can demultiplex the `query` reply unambiguously.
+            if streams.contains_key(&id) {
+                return send(
+                    session,
+                    channel_error("query", id, "badRequest", "id already in use"),
+                )
+                .await;
+            }
+
+            // Awaited inline: a query is a fast, in-process state read. Unlike
+            // `broadcast`, whose payload type carries its own rejection, a
+            // `QueryResponse` is success-only, so a failed query is an `error`
+            // frame — the WS mirror of the REST route's `400`. The reply drops
+            // the block height `query_app` reports, matching REST `/query`.
+            match CoreQuery::_query_app(&app_ctx.base, query).await {
+                Ok(res) => send(session, data_frame("query", id, &res.response)).await,
+                Err(err) => {
+                    send(
+                        session,
+                        channel_error("query", id, "queryFailed", &err.message),
                     )
                     .await
                 },
@@ -826,6 +869,59 @@ mod tests {
             ))
             .unwrap(),
             json!({"channel": "broadcast", "id": 5, "error": {"code": "broadcastFailed", "message": "connection refused"}}),
+        );
+    }
+
+    #[test]
+    fn deserializes_query() {
+        // A parameterless query variant.
+        let message: ClientMessage =
+            serde_json::from_str(r#"{"method":"query","id":5,"query":{"config":{}}}"#).unwrap();
+
+        let ClientMessage::Query { id, query } = message else {
+            panic!("expected a query message");
+        };
+
+        assert_eq!(id, 5);
+        assert!(matches!(query, Query::Config(_)));
+
+        // A variant with fields, proving the nested payload parses.
+        let message: ClientMessage = serde_json::from_str(
+            r#"{"method":"query","id":6,"query":{"balance":{"address":"0x33361de42571d6aa20c37daa6da4b5ab67bfaad9","denom":"hyp/all/btc"}}}"#,
+        )
+        .unwrap();
+
+        assert!(matches!(message, ClientMessage::Query {
+            id: 6,
+            query: Query::Balance(_)
+        }));
+    }
+
+    #[test]
+    fn serializes_query_frames() {
+        // A successful query rides a `data` frame on the `query` channel,
+        // carrying the raw `QueryResponse`.
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&data_frame(
+                "query",
+                5,
+                &json!({"balance": {"denom": "hyp/all/btc", "amount": "12345"}}),
+            ))
+            .unwrap(),
+            json!({"channel": "query", "id": 5, "data": {"balance": {"denom": "hyp/all/btc", "amount": "12345"}}}),
+        );
+
+        // A failed query is an `error` frame on the `query` channel — unlike
+        // `broadcast`, whose payload type carries its own rejection.
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&channel_error(
+                "query",
+                5,
+                "queryFailed",
+                "data not found",
+            ))
+            .unwrap(),
+            json!({"channel": "query", "id": 5, "error": {"code": "queryFailed", "message": "data not found"}}),
         );
     }
 }

--- a/dango/testing/tests/httpd/ws.rs
+++ b/dango/testing/tests/httpd/ws.rs
@@ -10,7 +10,7 @@ use {
     actix_http::ws,
     anyhow::anyhow,
     dango_app::Indexer,
-    dango_primitives::{Block, BlockInfo, FullBlock},
+    dango_primitives::{Block, BlockInfo, FullBlock, QueryResponse},
     dango_testing::{
         TestOption, build_app_service, create_perps_fill, pair_id, setup_perps_env,
         setup_test_naive_with_indexer,
@@ -455,6 +455,90 @@ async fn ws_ping_pong_and_unsubscribe() -> anyhow::Result<()> {
                 })
                 .await?;
                 assert_eq!(unsub_ack["id"].as_u64(), Some(2));
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+/// A `query` runs a one-time, read-only state query over the socket: the reply
+/// is a single `data` frame on the `query` channel carrying the raw
+/// `QueryResponse` — the same shape as REST `POST /query`. A failing query is
+/// answered with a co-located `queryFailed` error frame that ends nothing: the
+/// socket stays usable and the one-shot `id` becomes free to reuse.
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_query_roundtrip_and_error() -> anyhow::Result<()> {
+    let (suite, _accounts, _, _contracts, _, ctx, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default()).await;
+    suite.app.indexer.wait_for_finish().await?;
+
+    let local_set = tokio::task::LocalSet::new();
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let mut srv = actix_test::start(move || build_app_service(ctx.clone()));
+                let mut framed = srv
+                    .ws_at("/ws")
+                    .await
+                    .map_err(|err| anyhow!("ws upgrade failed: {err}"))?;
+
+                // A well-formed query is answered with the raw `QueryResponse`,
+                // tagged with the request's id.
+                send(
+                    &mut framed,
+                    json!({"method": "query", "id": 21, "query": {"config": {}}}),
+                )
+                .await?;
+                let reply = recv_until(&mut framed, |m| {
+                    channel(m) == Some("query") && m["id"].as_u64() == Some(21)
+                })
+                .await?;
+                let response: QueryResponse = serde_json::from_value(reply["data"].clone())
+                    .map_err(|err| anyhow!("frame data is not a QueryResponse: {err}"))?;
+                assert!(
+                    matches!(response, QueryResponse::Config(_)),
+                    "expected a config response: {reply:?}"
+                );
+
+                // A failing query — no contract lives at the zero address — is
+                // a co-located `queryFailed` error frame.
+                send(
+                    &mut framed,
+                    json!({"method": "query", "id": 22, "query": {"contract": {"address": "0x0000000000000000000000000000000000000000"}}}),
+                )
+                .await?;
+                let error = recv_until(&mut framed, |m| {
+                    channel(m) == Some("query") && m.get("error").is_some()
+                })
+                .await?;
+                assert_eq!(error["id"].as_u64(), Some(22));
+                assert_eq!(error["error"]["code"].as_str(), Some("queryFailed"));
+                assert!(
+                    !error["error"]["message"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .is_empty(),
+                    "queryFailed must carry the query error: {error:?}"
+                );
+
+                // The failure ended nothing: the socket still answers, and the
+                // one-shot id is free to reuse.
+                send(&mut framed, json!({"method": "ping", "id": 23})).await?;
+                let pong = recv_until(&mut framed, |m| channel(m) == Some("pong")).await?;
+                assert_eq!(pong["id"].as_u64(), Some(23));
+
+                send(
+                    &mut framed,
+                    json!({"method": "query", "id": 22, "query": {"config": {}}}),
+                )
+                .await?;
+                let reply = recv_until(&mut framed, |m| {
+                    channel(m) == Some("query") && m.get("data").is_some()
+                })
+                .await?;
+                assert_eq!(reply["id"].as_u64(), Some(22));
 
                 Ok::<(), anyhow::Error>(())
             })


### PR DESCRIPTION
Mirroring Hyperliquid's post/info design: a client already holding a `/ws` connection can now run a read-only state query without opening a separate HTTP request. The request carries a raw grug `Query`; the single reply rides the `query` channel with the request's `id`, holding the raw `QueryResponse` — the same shapes as REST `POST /query`. A failed query is answered with a co-located `queryFailed` error frame and ends nothing: the socket, its subscriptions, and the id remain usable.

Also fixes the REST `/query` OpenAPI example's casing (`app_config`, not `appConfig`) and documents the method in the API reference §12.