### PR TITLE
feat(indexer-httpd): add a `query` subscription to the WebSocket API

### DIFF
--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -2872,12 +2872,13 @@ A native WebSocket endpoint for real-time feeds, distinct from the `graphql-ws` 
 
 **Endpoint:** `GET /ws` (WebSocket upgrade). See [Constants](9-constants.md#endpoints).
 
-Four channels are served, replacing the corresponding `graphql-ws` subscriptions:
+Five channels are served, replacing the corresponding `graphql-ws` subscriptions:
 
 - `perpsEvents` — perps-contract events grouped per block, with filters.
 - `blockInfo` — every finalized block's metadata (height, timestamp, hash).
 - `block` — every finalized block, without its execution outcome.
 - `fullBlock` — every finalized block in full (`Block` + `BlockOutcome`).
+- `query` — a standing state query, re-run every `interval` blocks (also usable as a one-shot request/response method).
 
 ### 12.1 Protocol
 
@@ -2890,7 +2891,8 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 {"method": "subscribe", "id": 2, "subscription": {"type": "blockInfo"}}
 {"method": "subscribe", "id": 3, "subscription": {"type": "block"}}
 {"method": "subscribe", "id": 4, "subscription": {"type": "fullBlock"}}
-{"method": "query", "id": 5, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
+{"method": "subscribe", "id": 5, "subscription": {"type": "query", "query": {"app_config": {}}, "interval": 5}}
+{"method": "query", "id": 6, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
 {"method": "unsubscribe", "id": 1}
 {"method": "ping", "id": 9}
 ```
@@ -2912,20 +2914,21 @@ Client messages are tagged by `method`; server messages are tagged by `channel`.
 {"channel": "blockInfo", "id": 2, "data": { ... }}
 {"channel": "block", "id": 3, "data": { ... }}
 {"channel": "fullBlock", "id": 4, "data": { ... }}
-{"channel": "query", "id": 5, "data": { ... }}
+{"channel": "query", "id": 5, "data": {"blockHeight": 100001, "response": { ... }}}
+{"channel": "query", "id": 6, "data": { ... }}
 {"channel": "pong", "id": 9}
 {"channel": "error", "error": {"code": "badRequest", "message": "..."}}
 ```
 
-| `channel`                                     | Description                                                                                                                                             |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `subscriptionResponse`                        | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                                                                              |
-| `perpsEvents`/`blockInfo`/`block`/`fullBlock` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§12.3](#123-reconnect-and-errors)) |
-| `broadcast`/`query`                           | The single reply to a `broadcast`/`query` request, tagged with its `id`: a `data` payload or an `error` (see [§12.2](#122-channels))                    |
-| `pong`                                        | Reply to a `ping`, echoing its `id`                                                                                                                     |
-| `error`                                       | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§12.3](#123-reconnect-and-errors)                  |
+| `channel`                                             | Description                                                                                                                                             |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `subscriptionResponse`                                | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                                                                              |
+| `perpsEvents`/`blockInfo`/`block`/`fullBlock`/`query` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§12.3](#123-reconnect-and-errors)) |
+| `broadcast`/`query`                                   | The single reply to a `broadcast`/`query` request, tagged with its `id`: a `data` payload or an `error` (see [§12.2](#122-channels))                    |
+| `pong`                                                | Reply to a `ping`, echoing its `id`                                                                                                                     |
+| `error`                                               | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§12.3](#123-reconnect-and-errors)                  |
 
-Each frame on a subscription's channel (`perpsEvents` / `blockInfo` / `block` / `fullBlock`) carries either a `data` payload or an `error`; a client demultiplexes by `id` and branches on which key is present. Errors are co-located this way so a feed's failure arrives on the same channel its data does — see [§12.3](#123-reconnect-and-errors).
+Each frame on a subscription's channel (`perpsEvents` / `blockInfo` / `block` / `fullBlock` / `query`) carries either a `data` payload or an `error`; a client demultiplexes by `id` and branches on which key is present. Errors are co-located this way so a feed's failure arrives on the same channel its data does — see [§12.3](#123-reconnect-and-errors). Note that the `query` channel carries both a `query` *subscription*'s stream and the single reply to a one-shot `query` *request* — the client's own `id` bookkeeping tells them apart.
 
 **Heartbeat.** The server sends a WebSocket ping every 20 seconds and closes a connection it has heard nothing from for 60 seconds. A client either lets its WebSocket stack answer those pings, or sends `{"method": "ping"}` itself; either keeps an idle subscription alive.
 
@@ -3051,7 +3054,7 @@ Stream every finalized block in full — the same `FullBlock` shape (`block` + `
 Run a one-time, read-only query against the latest finalized state — a **read** request/response (one request, one reply), not a subscription stream. The request and reply are the same raw grug `Query` / `QueryResponse` shapes as REST `POST /query` ([§11.1](#111-query)); this lets a client already holding a `/ws` connection query state without opening a separate HTTP request.
 
 ```json
-{"method": "query", "id": 5, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
+{"method": "query", "id": 6, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
 ```
 
 | Field   | Type     | Description                                                     |
@@ -3062,14 +3065,33 @@ Run a one-time, read-only query against the latest finalized state — a **read*
 The reply rides the `query` channel. Success is a `data` frame holding the raw `QueryResponse`:
 
 ```json
-{"channel": "query", "id": 5, "data": {"balance": {"denom": "hyp/all/btc", "amount": "12345"}}}
+{"channel": "query", "id": 6, "data": {"balance": {"denom": "hyp/all/btc", "amount": "12345"}}}
 ```
 
-A failed query — an unknown contract, a contract query that errors, and so on — is an `error` frame with code `queryFailed`, carrying the same error message the REST route would return as a `400`. Note the asymmetry with `broadcast`: a mempool-rejected tx is still a `data` frame there, because `BroadcastTxOutcome` carries its own rejection, while `QueryResponse` is success-only, so any failure is an `error` frame. A failed query ends nothing — the socket and its subscriptions are unaffected, and the `id` is free to reuse.
+A failed query — an unknown contract, a contract query that errors, and so on — is an `error` frame with code `queryFailed`, carrying the same error message the REST route would return as a `400`. Note the asymmetry with `broadcast`: a mempool-rejected tx is still a `data` frame there, because `BroadcastTxOutcome` carries its own rejection, while `QueryResponse` is success-only, so any failure is an `error` frame. A failed one-shot query ends nothing — the socket and its subscriptions are unaffected, and the `id` is free to reuse.
 
 ```json
-{"channel": "query", "id": 5, "error": {"code": "queryFailed", "message": "..."}}
+{"channel": "query", "id": 6, "error": {"code": "queryFailed", "message": "..."}}
 ```
+
+**Subscribing to a query.** The same `query` payload can also be held open as a standing subscription: the server answers with an initial snapshot immediately, then re-runs the query once per block whose height is a multiple of `interval`, streaming the results on the `query` channel. The alignment is absolute — a tick fires when `height % interval == 0` — so every subscription with the same query and interval ticks at the same heights, and identical concurrent subscriptions are served from a single shared execution per tick.
+
+```json
+{"method": "subscribe", "id": 5, "subscription": {"type": "query", "query": {"app_config": {}}, "interval": 5}}
+```
+
+| Field      | Type     | Description                                                     |
+| ---------- | -------- | --------------------------------------------------------------- |
+| `query`    | `Object` | The grug `Query` (same request payloads as [§11.1](#111-query)) |
+| `interval` | `Int`    | Re-run once per this many blocks; must be ≥ 1, defaults to 1    |
+
+Unlike the one-shot reply, each subscription frame wraps the response with the block height it was served at:
+
+```json
+{"channel": "query", "id": 5, "data": {"blockHeight": 100005, "response": {"app_config": { ... }}}}
+```
+
+Each frame's `blockHeight` is strictly greater than the previous frame's; under executor lag a tick may be skipped when its result would duplicate the previous frame. The feed is live-only — there is no `since` replay, because historical state cannot be re-queried; on reconnect, simply resubscribe and take the fresh initial snapshot. A failed execution (including a failing initial snapshot, which arrives after the ack) ends the subscription with a single terminal `queryFailed` error frame; a feed that falls behind the retained window ends with the standard terminal `resync` frame.
 
 #### `broadcast`
 
@@ -3098,7 +3120,7 @@ Only a transport failure to the consensus node is an `error` frame:
 
 ### 12.3 Reconnect and errors
 
-All four subscription channels are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight` for `perpsEvents`, `height` for `blockInfo`, `info.height` for `block`, `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
+The four block-backed subscription channels (`perpsEvents`, `blockInfo`, `block`, `fullBlock`) are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight` for `perpsEvents`, `height` for `blockInfo`, `info.height` for `block`, `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. A `query` subscription is live-only — its frames carry a `blockHeight` too, but there is no `since` replay, because historical state cannot be re-queried; on reconnect, simply resubscribe and take the fresh initial snapshot. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
 
 Problems are delivered as `error`-keyed frames. An error that concerns a specific subscription rides that subscription's own channel and `id` — an `error` sibling of the `data` frames it would otherwise send — so a client handles a feed's failure on the same channel it reads from. An error with no subscription to attribute it to (an unparseable message, or an `unsubscribe` for an unknown `id`) arrives on the dedicated `error` channel instead, carrying the offending `id` when there is one.
 

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -3083,7 +3083,7 @@ A failed query — an unknown contract, a contract query that errors, and so on 
 | Field      | Type     | Description                                                     |
 | ---------- | -------- | --------------------------------------------------------------- |
 | `query`    | `Object` | The grug `Query` (same request payloads as [§11.1](#111-query)) |
-| `interval` | `Int`    | Re-run once per this many blocks; must be ≥ 1, defaults to 1    |
+| `interval` | `Int`    | Re-run once per this many blocks; must be ≥ 1, defaults to 10   |
 
 Unlike the one-shot reply, each subscription frame wraps the response with the block height it was served at:
 

--- a/dango/indexer/httpd/src/context.rs
+++ b/dango/indexer/httpd/src/context.rs
@@ -1,5 +1,8 @@
 use {
-    crate::traits::{ConsensusClient, QueryApp},
+    crate::{
+        query_memo::QueryMemo,
+        traits::{ConsensusClient, QueryApp},
+    },
     dango_indexer_sql::{
         EventCacheReader, entity::perps_trade::PerpsTrade, pubsub::PubSub,
         write::perps_trades::PerpsTradeCache,
@@ -40,6 +43,9 @@ pub struct FullContext {
     pub consensus_client: Arc<dyn ConsensusClient + Send + Sync>,
     pub event_cache: EventCacheReader,
     pub static_files_path: Option<String>,
+    /// Per-block memo for the `/ws` `query` subscription: identical queries
+    /// triggered by the same block are executed once and shared.
+    pub query_memo: Arc<QueryMemo>,
 }
 
 impl FullContext {
@@ -65,6 +71,7 @@ impl FullContext {
             base: MinimalContext::new(dango_app),
             consensus_client,
             static_files_path,
+            query_memo: Arc::new(QueryMemo::new()),
         }
     }
 

--- a/dango/indexer/httpd/src/lib.rs
+++ b/dango/indexer/httpd/src/lib.rs
@@ -5,6 +5,7 @@ pub mod graphql;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod middlewares;
+pub mod query_memo;
 pub mod request_ip;
 pub mod routes;
 pub mod server;

--- a/dango/indexer/httpd/src/query_memo.rs
+++ b/dango/indexer/httpd/src/query_memo.rs
@@ -1,0 +1,337 @@
+//! A per-block memo for the `/ws` `query` subscription.
+//!
+//! Chain state only changes at block boundaries, so a query's result is fully
+//! determined by the pair (block, query). When many subscribers hold the same
+//! standing query, every tick of a block would otherwise execute the query —
+//! including contract code, for `wasm_smart` — once per subscriber. The memo
+//! collapses that: the first asker for a (trigger height, query) pair runs the
+//! query, and every concurrent or later asker for the same pair awaits the
+//! same shared future.
+//!
+//! Two invariants keep the memo correct in the face of the commit/trigger
+//! race (a query triggered by block `N` executes against *latest* state, which
+//! may already be `N + 1`):
+//!
+//! - The generation advances on **trigger** heights only, which are monotonic
+//!   because the block ring is appended in strict height order. A response's
+//!   own reported height is opaque payload and never feeds back into the
+//!   memo's bookkeeping.
+//! - A response is always at least as new as its trigger key, because the ring
+//!   is appended after commit. A hit can therefore never serve state *older*
+//!   than the block that triggered it. The one path that could violate this —
+//!   a subscriber still processing trigger `N` after another subscriber has
+//!   advanced the generation to `N + 1` — bypasses the memo instead (see
+//!   [`QueryMemo::query_at`]).
+
+use {
+    crate::context::MinimalContext,
+    dango_primitives::{BorshSerExt, Query, QueryResponse},
+    futures_util::{
+        FutureExt,
+        future::{BoxFuture, Shared},
+    },
+    serde::Serialize,
+    std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    },
+};
+
+/// Bound on distinct queries memoized within one block. Beyond it, further
+/// distinct queries run uncached rather than grow the map — the memo is an
+/// optimization, never a requirement.
+const MEMO_MAX_ENTRIES: usize = 256;
+
+/// One query-subscription frame: the response and the block height it was
+/// served at. Serialized as a `query` channel data frame's `data` payload.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryFrame {
+    pub block_height: u64,
+    pub response: QueryResponse,
+}
+
+/// The shared, cloneable outcome of one query execution. `String` errors
+/// because [`Shared`] requires the output to be `Clone`, which the app's
+/// error type is not; errors are memoized like successes, since a
+/// deterministic failure repeats identically until state changes.
+type SharedQuery = Shared<BoxFuture<'static, Result<Arc<QueryFrame>, String>>>;
+
+/// Coalesces identical [`Query`] executions triggered by the same block. See
+/// the module docs for the invariants.
+#[derive(Default)]
+pub struct QueryMemo {
+    /// Locked only to look up or insert an entry — never across an `.await`.
+    inner: Mutex<MemoInner>,
+}
+
+#[derive(Default)]
+struct MemoInner {
+    /// The trigger height the current entries belong to. A lookup at a newer
+    /// height clears the map — that is the entire eviction policy, since old
+    /// heights never recur.
+    height: u64,
+
+    /// Live or completed executions for this generation, keyed by the query's
+    /// canonical Borsh bytes.
+    entries: HashMap<Vec<u8>, SharedQuery>,
+}
+
+impl QueryMemo {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the response for `query` as triggered by block `height`,
+    /// executing it at most once per (height, query) across all callers.
+    pub async fn query_at(
+        &self,
+        height: u64,
+        query: Query,
+        ctx: MinimalContext,
+    ) -> Result<Arc<QueryFrame>, String> {
+        // A query that cannot be serialized cannot be keyed; run it uncached.
+        // (Cannot actually happen for a `Query` that deserialized off the wire.)
+        let Ok(key) = query.to_borsh_vec() else {
+            return run_query(ctx, query).await;
+        };
+
+        let shared = {
+            let mut inner = self.inner.lock().unwrap();
+
+            if height > inner.height {
+                inner.entries.clear();
+                inner.height = height;
+            }
+
+            if height < inner.height {
+                // This caller is skewed behind the newest trigger. Its
+                // execution would read *current* state, so parking the result
+                // in the newer generation's map could serve, for that newer
+                // trigger, state older than the trigger itself. Bypass the
+                // memo: correctness over deduplication.
+                None
+            } else if let Some(shared) = inner.entries.get(&key) {
+                Some(shared.clone())
+            } else if inner.entries.len() >= MEMO_MAX_ENTRIES {
+                None
+            } else {
+                // Insert before awaiting, so concurrent askers coalesce onto
+                // this execution rather than starting their own.
+                let shared = run_query(ctx.clone(), query.clone()).boxed().shared();
+                inner.entries.insert(key, shared.clone());
+                Some(shared)
+            }
+        };
+
+        match shared {
+            Some(shared) => shared.await,
+            None => run_query(ctx, query).await,
+        }
+    }
+}
+
+/// Execute the query against the app and shape the outcome into the shared
+/// frame/error form. The frame reports the height the app actually served —
+/// which can exceed the trigger height, if a newer block committed between the
+/// trigger and the execution.
+async fn run_query(ctx: MinimalContext, query: Query) -> Result<Arc<QueryFrame>, String> {
+    ctx.dango_app
+        .query_app(query)
+        .await
+        .map(|(response, block_height)| {
+            Arc::new(QueryFrame {
+                block_height,
+                response,
+            })
+        })
+        .map_err(|err| err.to_string())
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::traits::QueryApp,
+        async_trait::async_trait,
+        dango_app::{AppError, AppResult},
+        dango_primitives::{BlockInfo, Hash256, QueryCodeRequest, TxOutcome, UnsignedTx},
+        futures_util::join,
+        std::sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    /// A `QueryApp` that counts `query_app` executions and answers every query
+    /// with `WasmRaw(None)` at a fixed height (or a fixed error).
+    struct MockApp {
+        calls: AtomicUsize,
+        height: u64,
+        fail: bool,
+    }
+
+    impl MockApp {
+        fn context(height: u64, fail: bool) -> (MinimalContext, Arc<Self>) {
+            let app = Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                height,
+                fail,
+            });
+
+            (MinimalContext::new(app.clone()), app)
+        }
+    }
+
+    #[async_trait]
+    impl QueryApp for MockApp {
+        async fn query_app(&self, _raw_req: Query) -> AppResult<(QueryResponse, u64)> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+
+            if self.fail {
+                return Err(AppError::vm("boom".to_string()));
+            }
+
+            Ok((QueryResponse::WasmRaw(None), self.height))
+        }
+
+        async fn simulate(&self, _unsigned_tx: UnsignedTx) -> AppResult<TxOutcome> {
+            unimplemented!("not exercised by the memo");
+        }
+
+        async fn chain_id(&self) -> AppResult<String> {
+            unimplemented!("not exercised by the memo");
+        }
+
+        async fn last_finalized_block(&self) -> AppResult<BlockInfo> {
+            unimplemented!("not exercised by the memo");
+        }
+    }
+
+    /// A distinct query per `seed`, for exercising the per-query keying.
+    fn query(seed: u8) -> Query {
+        Query::Code(QueryCodeRequest {
+            hash: Hash256::from_inner([seed; 32]),
+        })
+    }
+
+    #[test]
+    fn coalesces_identical_queries_at_same_height() {
+        let (ctx, app) = MockApp::context(5, false);
+        let memo = QueryMemo::new();
+
+        let (a, b, c) = futures::executor::block_on(async {
+            join!(
+                memo.query_at(5, query(1), ctx.clone()),
+                memo.query_at(5, query(1), ctx.clone()),
+                memo.query_at(5, query(1), ctx.clone()),
+            )
+        });
+
+        assert_eq!(app.calls.load(Ordering::SeqCst), 1);
+
+        // All askers share the very same response allocation.
+        let (a, b, c) = (a.unwrap(), b.unwrap(), c.unwrap());
+        assert!(Arc::ptr_eq(&a, &b));
+        assert!(Arc::ptr_eq(&b, &c));
+        assert_eq!(a.block_height, 5);
+    }
+
+    #[test]
+    fn distinct_queries_run_separately_and_both_cache() {
+        let (ctx, app) = MockApp::context(5, false);
+        let memo = QueryMemo::new();
+
+        futures::executor::block_on(async {
+            memo.query_at(5, query(1), ctx.clone()).await.unwrap();
+            memo.query_at(5, query(2), ctx.clone()).await.unwrap();
+            // Repeats hit the cache.
+            memo.query_at(5, query(1), ctx.clone()).await.unwrap();
+            memo.query_at(5, query(2), ctx.clone()).await.unwrap();
+        });
+
+        assert_eq!(app.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn newer_height_clears_and_reruns() {
+        let (ctx, app) = MockApp::context(5, false);
+        let memo = QueryMemo::new();
+
+        futures::executor::block_on(async {
+            memo.query_at(5, query(1), ctx.clone()).await.unwrap();
+            memo.query_at(6, query(1), ctx.clone()).await.unwrap();
+        });
+
+        assert_eq!(app.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn stale_trigger_bypasses_memo_without_polluting_it() {
+        let (ctx, app) = MockApp::context(6, false);
+        let memo = QueryMemo::new();
+
+        futures::executor::block_on(async {
+            // Generation advances to 6.
+            memo.query_at(6, query(1), ctx.clone()).await.unwrap();
+
+            // A caller skewed behind (trigger 5) runs uncached: it neither
+            // reads the generation-6 entry nor inserts one of its own.
+            memo.query_at(5, query(2), ctx.clone()).await.unwrap();
+            memo.query_at(5, query(2), ctx.clone()).await.unwrap();
+
+            // The generation-6 entry is untouched and still hits.
+            memo.query_at(6, query(1), ctx.clone()).await.unwrap();
+        });
+
+        assert_eq!(app.calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn cap_falls_back_to_uncached() {
+        let (ctx, app) = MockApp::context(5, false);
+        let memo = QueryMemo::new();
+
+        futures::executor::block_on(async {
+            // Fill the map to the cap, with multi-byte seeds that can never
+            // collide with the repeated-single-byte seeds `query()` produces.
+            for i in 0..MEMO_MAX_ENTRIES {
+                let mut bytes = [0u8; 32];
+                bytes[0] = (i / 256) as u8;
+                bytes[1] = (i % 256) as u8;
+                bytes[2] = 0xff;
+                memo.query_at(
+                    5,
+                    Query::Code(QueryCodeRequest {
+                        hash: Hash256::from_inner(bytes),
+                    }),
+                    ctx.clone(),
+                )
+                .await
+                .unwrap();
+            }
+            assert_eq!(app.calls.load(Ordering::SeqCst), MEMO_MAX_ENTRIES);
+
+            // Beyond the cap, a distinct query runs uncached — twice for two
+            // asks — while an already-cached query still hits.
+            memo.query_at(5, query(1), ctx.clone()).await.unwrap();
+            memo.query_at(5, query(1), ctx.clone()).await.unwrap();
+            assert_eq!(app.calls.load(Ordering::SeqCst), MEMO_MAX_ENTRIES + 2);
+        });
+    }
+
+    #[test]
+    fn errors_are_memoized() {
+        let (ctx, app) = MockApp::context(5, true);
+        let memo = QueryMemo::new();
+
+        let (a, b) = futures::executor::block_on(async {
+            join!(
+                memo.query_at(5, query(1), ctx.clone()),
+                memo.query_at(5, query(1), ctx.clone()),
+            )
+        });
+
+        assert_eq!(app.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(a.unwrap_err(), b.unwrap_err());
+    }
+}

--- a/dango/indexer/httpd/src/query_memo.rs
+++ b/dango/indexer/httpd/src/query_memo.rs
@@ -23,6 +23,8 @@
 //!   advanced the generation to `N + 1` — bypasses the memo instead (see
 //!   [`QueryMemo::query_at`]).
 
+#[cfg(feature = "metrics")]
+use metrics::{counter, describe_counter};
 use {
     crate::context::MinimalContext,
     dango_primitives::{BorshSerExt, Query, QueryResponse},
@@ -90,45 +92,73 @@ impl QueryMemo {
         query: Query,
         ctx: MinimalContext,
     ) -> Result<Arc<QueryFrame>, String> {
-        // A query that cannot be serialized cannot be keyed; run it uncached.
-        // (Cannot actually happen for a `Query` that deserialized off the wire.)
-        let Ok(key) = query.to_borsh_vec() else {
-            return run_query(ctx, query).await;
+        // How the lookup was answered: sharing an existing execution, starting
+        // the execution others will share, or bypassing the memo entirely.
+        enum Lookup {
+            Hit(SharedQuery),
+            Miss(SharedQuery),
+            Bypass,
+        }
+
+        let lookup = match query.to_borsh_vec() {
+            Ok(key) => {
+                let mut inner = self.inner.lock().unwrap();
+
+                if height > inner.height {
+                    inner.entries.clear();
+                    inner.height = height;
+                }
+
+                if height < inner.height {
+                    // This caller is skewed behind the newest trigger. Its
+                    // execution would read *current* state, so parking the
+                    // result in the newer generation's map could serve, for
+                    // that newer trigger, state older than the trigger itself.
+                    // Bypass the memo: correctness over deduplication.
+                    Lookup::Bypass
+                } else if let Some(shared) = inner.entries.get(&key) {
+                    Lookup::Hit(shared.clone())
+                } else if inner.entries.len() >= MEMO_MAX_ENTRIES {
+                    Lookup::Bypass
+                } else {
+                    // Insert before awaiting, so concurrent askers coalesce
+                    // onto this execution rather than starting their own.
+                    let shared = run_query(ctx.clone(), query.clone()).boxed().shared();
+                    inner.entries.insert(key, shared.clone());
+                    Lookup::Miss(shared)
+                }
+            },
+            // A query that cannot be serialized cannot be keyed; run it
+            // uncached. (Cannot actually happen for a `Query` that
+            // deserialized off the wire.)
+            Err(_) => Lookup::Bypass,
         };
 
-        let shared = {
-            let mut inner = self.inner.lock().unwrap();
+        #[cfg(feature = "metrics")]
+        counter!("ws.query_memo.lookups.total", "result" => match &lookup {
+            Lookup::Hit(_) => "hit",
+            Lookup::Miss(_) => "miss",
+            Lookup::Bypass => "bypass",
+        })
+        .increment(1);
 
-            if height > inner.height {
-                inner.entries.clear();
-                inner.height = height;
-            }
-
-            if height < inner.height {
-                // This caller is skewed behind the newest trigger. Its
-                // execution would read *current* state, so parking the result
-                // in the newer generation's map could serve, for that newer
-                // trigger, state older than the trigger itself. Bypass the
-                // memo: correctness over deduplication.
-                None
-            } else if let Some(shared) = inner.entries.get(&key) {
-                Some(shared.clone())
-            } else if inner.entries.len() >= MEMO_MAX_ENTRIES {
-                None
-            } else {
-                // Insert before awaiting, so concurrent askers coalesce onto
-                // this execution rather than starting their own.
-                let shared = run_query(ctx.clone(), query.clone()).boxed().shared();
-                inner.entries.insert(key, shared.clone());
-                Some(shared)
-            }
-        };
-
-        match shared {
-            Some(shared) => shared.await,
-            None => run_query(ctx, query).await,
+        match lookup {
+            Lookup::Hit(shared) | Lookup::Miss(shared) => shared.await,
+            Lookup::Bypass => run_query(ctx, query).await,
         }
     }
+}
+
+/// Register the memo's lookup counter. An idempotent, describe-only call,
+/// invoked once at server startup alongside the other metric registrations.
+#[cfg(feature = "metrics")]
+pub fn init_query_memo_metrics() {
+    describe_counter!(
+        "ws.query_memo.lookups.total",
+        "Query-memo lookups by result: hit (served from a shared execution), \
+         miss (started the execution others share), bypass (ran uncached — \
+         stale trigger, full map, or unkeyable query)"
+    );
 }
 
 /// Execute the query against the app and shape the outcome into the shared

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -242,7 +242,7 @@ enum Subscription {
 /// — matching the GraphQL `query_app` default, and keeping the load modest
 /// when many clients subscribe without choosing an interval. A client that
 /// wants per-block updates asks for `interval: 1` explicitly.
-fn default_query_interval() -> u64 {
+const fn default_query_interval() -> u64 {
     10
 }
 

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -16,7 +16,7 @@
 //! channel to attribute them to — an unparseable frame, or an `unsubscribe` for
 //! an unknown `id` — use the dedicated `error` channel.
 //!
-//! Four channel types are served, all reusing the in-memory validator stream
+//! Five channel types are served, all reusing the in-memory validator stream
 //! that backed the `full_block` / `perps_events` GraphQL subscriptions:
 //!
 //! - `perpsEvents` — perps-contract events grouped per block, narrowed by the
@@ -26,6 +26,10 @@
 //! - `block` — every finalized block without its execution outcome
 //!   (`{info, txs}`).
 //! - `fullBlock` — every finalized block in full (`{block, outcome}`).
+//! - `query` — a standing query: an initial snapshot at subscribe time, then a
+//!   re-run once per block whose height is a multiple of `interval`, each
+//!   frame a `{blockHeight, response}`. Identical concurrent subscriptions
+//!   share one execution per tick (see [`crate::query_memo`]).
 //!
 //! Two one-shot request/response methods ride the same socket: `broadcast`
 //! (submit a signed transaction to the mempool) and `query` (run a read-only
@@ -43,12 +47,13 @@ use {
     crate::{
         context::FullContext,
         graphql::query::core::CoreQuery,
+        query_memo::QueryFrame,
         request_ip::RequesterIp,
         subscription_limiter::{ConnectionLimiter, SubscriptionLimiter, guard_subscription_stream},
     },
     actix_web::{HttpRequest, HttpResponse, Resource, guard, web},
     actix_ws::{AggregatedMessage, Session},
-    dango_indexer_stream::{Context, make_perps_filter},
+    dango_indexer_stream::make_perps_filter,
     dango_primitives::{HttpRequestDetails, Query, Tx},
     futures_util::{StreamExt, stream},
     serde::{Deserialize, Serialize},
@@ -101,11 +106,13 @@ pub fn services() -> Resource {
                    finalized block's metadata, the `info` field of `Block`), \
                    a `block` feed (every finalized block without its \
                    execution outcome, the same shape as \
-                   `/block/info/{block_height}`), or a `fullBlock` feed \
+                   `/block/info/{block_height}`), a `fullBlock` feed \
                    (every finalized `{ block, outcome }`, the same shape as \
-                   `/block/full/{block_height}`) — plus `unsubscribe`, `ping`, \
-                   `broadcast` (submit a signed `Tx` over the socket), and \
-                   `query` (run a one-time read-only state query, the same \
+                   `/block/full/{block_height}`), or a `query` feed (a \
+                   standing read-only state query, re-run every `interval` \
+                   blocks) — plus `unsubscribe`, `ping`, `broadcast` (submit \
+                   a signed `Tx` over the socket), and `query` (run a \
+                   one-time read-only state query, the same \
                    `Query`/`QueryResponse` shapes as `POST /query`). \
                    Server frames are `channel`-tagged: `subscriptionResponse`, \
                    `perpsEvents`, `blockInfo`, `block`, `fullBlock`, \
@@ -216,6 +223,24 @@ enum Subscription {
         #[serde(default)]
         since: Option<u64>,
     },
+
+    /// A standing read-only query: an initial snapshot at subscribe time, then
+    /// a re-run once per block whose height is a multiple of `interval`, each
+    /// frame carrying `{blockHeight, response}` on the `query` channel.
+    ///
+    /// Live-only — there is no `since` replay, because historical state cannot
+    /// be re-queried; on reconnect, resubscribe and take the fresh snapshot.
+    Query {
+        query: Query,
+
+        #[serde(default = "default_query_interval")]
+        interval: u64,
+    },
+}
+
+/// A `query` subscription that does not say otherwise re-runs on every block.
+fn default_query_interval() -> u64 {
+    1
 }
 
 impl Subscription {
@@ -226,6 +251,7 @@ impl Subscription {
             Subscription::BlockInfo { .. } => "blockInfo",
             Subscription::Block { .. } => "block",
             Subscription::FullBlock { .. } => "fullBlock",
+            Subscription::Query { .. } => "query",
         }
     }
 }
@@ -430,12 +456,17 @@ async fn handle_text(
                 },
             };
 
-            match open_stream(id, &subscription, guard, &app_ctx.stream_context) {
+            match open_stream(id, &subscription, guard, app_ctx) {
                 Ok(frames) => {
                     streams.insert(id, frames);
                     send(session, ack(id, "subscribe", Some(channel))).await
                 },
-                Err(resync) => send(session, channel_error(channel, id, "resync", &resync)).await,
+                Err(SubscribeError::BadRequest(message)) => {
+                    send(session, channel_error(channel, id, "badRequest", &message)).await
+                },
+                Err(SubscribeError::Resync(message)) => {
+                    send(session, channel_error(channel, id, "resync", &message)).await
+                },
             }
         },
         ClientMessage::Unsubscribe { id } => {
@@ -506,6 +537,16 @@ async fn handle_text(
     }
 }
 
+/// Why a subscription could not be opened. Mapped to the co-located error
+/// frame's `code` at the `handle_text` call site.
+enum SubscribeError {
+    /// The request itself is invalid (e.g. a zero `interval`).
+    BadRequest(String),
+
+    /// The requested `since` predates the retained window.
+    Resync(String),
+}
+
 /// Open the validator stream for a subscription and project it to tagged JSON
 /// text frames. The `guard` is moved into the projected stream so it lives
 /// exactly as long as the subscription. On a connect-time resync (the requested
@@ -515,8 +556,10 @@ fn open_stream(
     id: u64,
     subscription: &Subscription,
     guard: Arc<crate::subscription_limiter::SubscriptionGuard>,
-    stream_ctx: &Context,
-) -> Result<FrameStream, String> {
+    app_ctx: &FullContext,
+) -> Result<FrameStream, SubscribeError> {
+    let stream_ctx = &app_ctx.stream_context;
+
     match subscription {
         Subscription::PerpsEvents {
             since,
@@ -537,7 +580,7 @@ fn open_stream(
             let raw = stream_ctx
                 .perps()
                 .subscribe(*since, filter)
-                .map_err(|resync| resync.to_string())?;
+                .map_err(|resync| SubscribeError::Resync(resync.to_string()))?;
             let frames = guard_subscription_stream(raw, Some(guard))
                 .map(move |block| data_frame("perpsEvents", id, &block));
 
@@ -547,7 +590,7 @@ fn open_stream(
             let raw = stream_ctx
                 .blocks()
                 .subscribe(*since, |block| Some(block.block.info))
-                .map_err(|resync| resync.to_string())?;
+                .map_err(|resync| SubscribeError::Resync(resync.to_string()))?;
             let frames = guard_subscription_stream(raw, Some(guard))
                 .map(move |info| data_frame("blockInfo", id, &info));
 
@@ -557,7 +600,7 @@ fn open_stream(
             let raw = stream_ctx
                 .blocks()
                 .subscribe(*since, |block| Some(block.block.clone()))
-                .map_err(|resync| resync.to_string())?;
+                .map_err(|resync| SubscribeError::Resync(resync.to_string()))?;
             let frames = guard_subscription_stream(raw, Some(guard))
                 .map(move |block| data_frame("block", id, &block));
 
@@ -567,11 +610,63 @@ fn open_stream(
             let raw = stream_ctx
                 .blocks()
                 .subscribe(*since, |block| Some(block.clone()))
-                .map_err(|resync| resync.to_string())?;
+                .map_err(|resync| SubscribeError::Resync(resync.to_string()))?;
             let frames = guard_subscription_stream(raw, Some(guard))
                 .map(move |block| data_frame("fullBlock", id, &block));
 
             Ok(with_terminal("fullBlock", id, frames))
+        },
+        Subscription::Query { query, interval } => {
+            if *interval == 0 {
+                return Err(SubscribeError::BadRequest(
+                    "`interval` must be >= 1".to_string(),
+                ));
+            }
+
+            let blocks = stream_ctx.blocks();
+
+            // The initial snapshot is keyed by the ring tip, so simultaneous
+            // identical subscriptions (e.g. a reconnect storm) share one
+            // execution. Height 0 covers the empty-ring case, before the first
+            // block is published.
+            let tip = blocks.tip().unwrap_or(0);
+
+            // The interval filter lives in the ring projection: non-matching
+            // blocks are suppressed (the subscriber's watermark still advances
+            // over them) and matching ones are projected to their height. The
+            // alignment is absolute — `height % interval == 0` — so every
+            // subscription with the same query and interval ticks at the same
+            // heights, which is what lets the memo collapse them.
+            let interval = *interval;
+            let raw = blocks
+                .subscribe(None, move |block| {
+                    let height = block.block.info.height;
+                    height.is_multiple_of(interval).then_some(height)
+                })
+                .map_err(|resync| SubscribeError::Resync(resync.to_string()))?;
+
+            let memo = app_ctx.query_memo.clone();
+            let base = app_ctx.base.clone();
+            let query = query.clone();
+
+            let initial = {
+                let memo = memo.clone();
+                let base = base.clone();
+                let query = query.clone();
+
+                stream::once(async move { memo.query_at(tip, query, base).await })
+            };
+            let ticks = raw.then(move |height| {
+                let memo = memo.clone();
+                let base = base.clone();
+                let query = query.clone();
+
+                async move { memo.query_at(height, query, base).await }
+            });
+
+            let items = guard_subscription_stream(initial.chain(ticks), Some(guard));
+
+            Ok(query_frames(id, items))
         },
     }
 }
@@ -595,6 +690,75 @@ where
     });
 
     Box::pin(frames.chain(terminal))
+}
+
+/// Project a `query` subscription's executions to tagged JSON text frames,
+/// enforcing the per-subscriber delivery contract:
+///
+/// - Each frame's `blockHeight` strictly exceeds the previous frame's. A tick
+///   whose result would duplicate an already-delivered height — possible when
+///   execution lags a full interval behind the ring, since a query always
+///   reads the *latest* state — is skipped, not re-sent.
+/// - A failed execution is a single terminal `queryFailed` error frame; the
+///   subscription ends without a trailing `resync`.
+/// - A feed that ends on its own (the ring outpaced the subscriber, or
+///   shutdown) closes with the standard terminal `resync` frame; there is no
+///   `since` replay, so "resync" here simply means resubscribe for a fresh
+///   snapshot.
+fn query_frames<S>(id: u64, items: S) -> FrameStream
+where
+    S: stream::Stream<Item = Result<Arc<QueryFrame>, String>> + Send + 'static,
+{
+    enum Tick {
+        Item(Result<Arc<QueryFrame>, String>),
+        Ended,
+    }
+
+    let tagged = items
+        .map(Tick::Item)
+        .chain(stream::once(async { Tick::Ended }));
+
+    let frames = tagged
+        .scan((None::<u64>, false), move |(last_height, done), tick| {
+            let out = if *done {
+                // A terminal frame has been emitted; end the stream. This is
+                // what keeps the chained `Ended` from adding a `resync` after
+                // a `queryFailed`.
+                None
+            } else {
+                Some(match tick {
+                    // The first frame is always delivered (a fresh chain
+                    // legitimately serves height 0); later ones must advance.
+                    Tick::Item(Ok(frame))
+                        if last_height.is_none_or(|last| frame.block_height > last) =>
+                    {
+                        *last_height = Some(frame.block_height);
+                        Some(data_frame("query", id, frame.as_ref()))
+                    },
+                    // A lag-induced repeat of an already-delivered height: the
+                    // state is unchanged, so the content is identical — skip.
+                    Tick::Item(Ok(_)) => None,
+                    Tick::Item(Err(message)) => {
+                        *done = true;
+                        Some(channel_error("query", id, "queryFailed", &message))
+                    },
+                    Tick::Ended => {
+                        *done = true;
+                        Some(channel_error(
+                            "query",
+                            id,
+                            "resync",
+                            "subscription ended; resubscribe for a fresh snapshot",
+                        ))
+                    },
+                })
+            };
+
+            std::future::ready(out)
+        })
+        .filter_map(std::future::ready);
+
+    Box::pin(frames)
 }
 
 // ---- serialization helpers ----
@@ -895,6 +1059,84 @@ mod tests {
             id: 6,
             query: Query::Balance(_)
         }));
+    }
+
+    #[test]
+    fn deserializes_query_subscription() {
+        let message: ClientMessage = serde_json::from_str(
+            r#"{"method":"subscribe","id":7,"subscription":{"type":"query","query":{"config":{}},"interval":5}}"#,
+        )
+        .unwrap();
+
+        let ClientMessage::Subscribe { id, subscription } = message else {
+            panic!("expected a subscribe message");
+        };
+
+        assert_eq!(id, 7);
+        assert_eq!(subscription.channel(), "query");
+
+        let Subscription::Query { query, interval } = subscription else {
+            panic!("expected a query subscription");
+        };
+
+        assert!(matches!(query, Query::Config(_)));
+        assert_eq!(interval, 5);
+
+        // An absent `interval` defaults to 1 (every block).
+        let message: ClientMessage = serde_json::from_str(
+            r#"{"method":"subscribe","id":8,"subscription":{"type":"query","query":{"config":{}}}}"#,
+        )
+        .unwrap();
+
+        let ClientMessage::Subscribe { subscription, .. } = message else {
+            panic!("expected a subscribe message");
+        };
+
+        assert!(matches!(subscription, Subscription::Query {
+            interval: 1,
+            ..
+        }));
+    }
+
+    #[test]
+    fn query_frame_stream_is_monotonic_with_terminal_error() {
+        use dango_primitives::QueryResponse;
+
+        let frame = |height: u64| {
+            Ok(Arc::new(QueryFrame {
+                block_height: height,
+                response: QueryResponse::WasmRaw(None),
+            }))
+        };
+
+        // A lag-induced duplicate height is skipped; a failed execution is a
+        // single terminal `queryFailed` frame with no trailing `resync`.
+        let items = stream::iter(vec![frame(5), frame(5), frame(6), Err("boom".to_string())]);
+        let got = futures::executor::block_on(query_frames(9, items).collect::<Vec<_>>());
+
+        assert_eq!(got.len(), 3);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&got[0]).unwrap(),
+            json!({"channel": "query", "id": 9, "data": {"blockHeight": 5, "response": {"wasm_raw": null}}}),
+        );
+        assert!(got[1].contains(r#""blockHeight":6"#));
+        assert_eq!(got[2], channel_error("query", 9, "queryFailed", "boom"));
+
+        // A feed that ends on its own closes with the terminal `resync` frame.
+        let items = stream::iter(vec![frame(5)]);
+        let got = futures::executor::block_on(query_frames(9, items).collect::<Vec<_>>());
+
+        assert_eq!(got.len(), 2);
+        assert!(got[1].contains(r#""code":"resync""#), "got: {:?}", got[1]);
+
+        // The first frame is delivered whatever its height — a fresh chain
+        // legitimately serves height 0 — and only repeats are skipped.
+        let items = stream::iter(vec![frame(0), frame(0), frame(1)]);
+        let got = futures::executor::block_on(query_frames(9, items).collect::<Vec<_>>());
+
+        assert_eq!(got.len(), 3, "got: {got:?}"); // heights 0 and 1, then resync
+        assert!(got[0].contains(r#""blockHeight":0"#));
+        assert!(got[1].contains(r#""blockHeight":1"#));
     }
 
     #[test]

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -238,9 +238,12 @@ enum Subscription {
     },
 }
 
-/// A `query` subscription that does not say otherwise re-runs on every block.
+/// A `query` subscription that does not say otherwise re-runs every 10 blocks
+/// — matching the GraphQL `query_app` default, and keeping the load modest
+/// when many clients subscribe without choosing an interval. A client that
+/// wants per-block updates asks for `interval: 1` explicitly.
 fn default_query_interval() -> u64 {
-    1
+    10
 }
 
 impl Subscription {
@@ -1082,7 +1085,7 @@ mod tests {
         assert!(matches!(query, Query::Config(_)));
         assert_eq!(interval, 5);
 
-        // An absent `interval` defaults to 1 (every block).
+        // An absent `interval` defaults to 10 (every tenth block).
         let message: ClientMessage = serde_json::from_str(
             r#"{"method":"subscribe","id":8,"subscription":{"type":"query","query":{"config":{}}}}"#,
         )
@@ -1093,7 +1096,7 @@ mod tests {
         };
 
         assert!(matches!(subscription, Subscription::Query {
-            interval: 1,
+            interval: 10,
             ..
         }));
     }

--- a/dango/indexer/httpd/src/server.rs
+++ b/dango/indexer/httpd/src/server.rs
@@ -27,7 +27,10 @@ use {
     utoipa_swagger_ui::SwaggerUi,
 };
 #[cfg(feature = "metrics")]
-use {crate::middlewares::metrics::init_httpd_metrics, actix_web_metrics::ActixWebMetricsBuilder};
+use {
+    crate::{middlewares::metrics::init_httpd_metrics, query_memo::init_query_memo_metrics},
+    actix_web_metrics::ActixWebMetricsBuilder,
+};
 
 /// The OpenAPI document of the node's HTTP API — the REST routes, plus
 /// documentation-only entries for the `/ws` WebSocket and the deprecated
@@ -158,6 +161,9 @@ pub async fn run_server(
 
     #[cfg(feature = "metrics")]
     init_httpd_metrics();
+
+    #[cfg(feature = "metrics")]
+    init_query_memo_metrics();
 
     let subscription_limiter = SubscriptionLimiter::new(
         httpd_config.max_subscriptions_per_connection,

--- a/dango/testing/tests/httpd/ws.rs
+++ b/dango/testing/tests/httpd/ws.rs
@@ -10,14 +10,16 @@ use {
     actix_http::ws,
     anyhow::anyhow,
     dango_app::Indexer,
-    dango_primitives::{Block, BlockInfo, FullBlock, QueryResponse},
+    dango_primitives::{Addressable, Block, BlockInfo, FullBlock, QueryResponse, ResultExt, coins},
     dango_testing::{
         TestOption, build_app_service, create_perps_fill, pair_id, setup_perps_env,
         setup_test_naive_with_indexer,
     },
+    dango_types::constants::usdc,
     futures_util::{SinkExt, Stream, StreamExt},
     serde_json::{Value, json},
-    std::time::Duration,
+    std::{collections::HashMap, sync::Arc, time::Duration},
+    tokio::sync::{Mutex, mpsc},
 };
 
 /// Per-read idle budget. The in-memory snapshot arrives promptly and the live
@@ -539,6 +541,186 @@ async fn ws_query_roundtrip_and_error() -> anyhow::Result<()> {
                 })
                 .await?;
                 assert_eq!(reply["id"].as_u64(), Some(22));
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+/// A `query` subscription streams `{blockHeight, response}` frames: an initial
+/// snapshot at subscribe time, then one frame per matching block. Two
+/// subscriptions holding the same query see identical payloads at equal
+/// heights (they are served from the shared per-block execution), each with
+/// strictly ascending heights.
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_query_subscription_streams_on_new_blocks() -> anyhow::Result<()> {
+    let (suite, mut accounts, _, _contracts, _, ctx, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default()).await;
+    suite.app.indexer.wait_for_finish().await?;
+
+    // A producer task minting one transfer block per trigger, so ticks arrive
+    // while the subscriptions are live.
+    let suite = Arc::new(Mutex::new(suite));
+    let (make_block, mut block_requests) = mpsc::channel::<u32>(1);
+    tokio::spawn(async move {
+        while block_requests.recv().await.is_some() {
+            let mut suite = suite.lock().await;
+            suite
+                .transfer(
+                    &mut accounts.user1,
+                    accounts.user2.address(),
+                    coins! { usdc::DENOM.clone() => 100 },
+                )
+                .await
+                .should_succeed();
+        }
+    });
+
+    let local_set = tokio::task::LocalSet::new();
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let mut srv = actix_test::start(move || build_app_service(ctx.clone()));
+                let mut framed = srv
+                    .ws_at("/ws")
+                    .await
+                    .map_err(|err| anyhow!("ws upgrade failed: {err}"))?;
+
+                // Two subscriptions holding the same query.
+                for id in [7, 8] {
+                    send(
+                        &mut framed,
+                        json!({"method": "subscribe", "id": id, "subscription": {"type": "query", "query": {"config": {}}, "interval": 1}}),
+                    )
+                    .await?;
+                }
+
+                // Both receive an initial snapshot whose response is a `Config`.
+                let mut last_heights: HashMap<u64, u64> = HashMap::new();
+                let mut payloads: HashMap<(u64, u64), Value> = HashMap::new();
+                for _ in 0..2 {
+                    let frame = recv_until(&mut framed, |m| {
+                        channel(m) == Some("query") && m.get("data").is_some()
+                    })
+                    .await?;
+                    let id = frame["id"].as_u64().unwrap();
+                    let height = frame["data"]["blockHeight"]
+                        .as_u64()
+                        .ok_or_else(|| anyhow!("missing blockHeight: {frame:?}"))?;
+                    let response: QueryResponse =
+                        serde_json::from_value(frame["data"]["response"].clone())?;
+                    assert!(
+                        matches!(response, QueryResponse::Config(_)),
+                        "expected a config response: {frame:?}"
+                    );
+                    payloads.insert((id, height), frame["data"].clone());
+                    last_heights.insert(id, height);
+                }
+                assert_eq!(last_heights.len(), 2, "both subscriptions must snapshot");
+                let initial_heights = last_heights.clone();
+
+                // Mint blocks until both subscriptions have ticked past their
+                // snapshot, asserting strict per-subscription height ascent.
+                make_block.send(1).await?;
+                make_block.send(1).await?;
+                while last_heights
+                    .iter()
+                    .any(|(id, height)| height <= &initial_heights[id])
+                {
+                    let frame = recv_until(&mut framed, |m| {
+                        channel(m) == Some("query") && m.get("data").is_some()
+                    })
+                    .await?;
+                    let id = frame["id"].as_u64().unwrap();
+                    let height = frame["data"]["blockHeight"].as_u64().unwrap();
+                    assert!(
+                        height > last_heights[&id],
+                        "heights must strictly ascend per subscription: {frame:?}"
+                    );
+                    payloads.insert((id, height), frame["data"].clone());
+                    last_heights.insert(id, height);
+                }
+
+                // Wherever the two subscriptions saw the same height — the
+                // initial snapshot guarantees at least one — the payloads are
+                // identical.
+                let mut shared = 0;
+                for ((id, height), data) in &payloads {
+                    let sibling = if *id == 7 { 8 } else { 7 };
+                    if let Some(other) = payloads.get(&(sibling, *height)) {
+                        assert_eq!(data, other, "same query at same height must match");
+                        shared += 1;
+                    }
+                }
+                assert!(shared > 0, "expected a height common to both subscriptions");
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+/// Query-subscription error handling: a zero `interval` is rejected with a
+/// co-located `badRequest`; a subscription whose query fails is acked (the
+/// stream opens), then ended by a single terminal `queryFailed` frame — with
+/// the socket staying usable throughout.
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_query_subscription_bad_interval_and_failing_query() -> anyhow::Result<()> {
+    let (suite, _accounts, _, _contracts, _, ctx, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default()).await;
+    suite.app.indexer.wait_for_finish().await?;
+
+    let local_set = tokio::task::LocalSet::new();
+    local_set
+        .run_until(async {
+            tokio::task::spawn_local(async move {
+                let mut srv = actix_test::start(move || build_app_service(ctx.clone()));
+                let mut framed = srv
+                    .ws_at("/ws")
+                    .await
+                    .map_err(|err| anyhow!("ws upgrade failed: {err}"))?;
+
+                // A zero interval is rejected up front, before any ack.
+                send(
+                    &mut framed,
+                    json!({"method": "subscribe", "id": 4, "subscription": {"type": "query", "query": {"config": {}}, "interval": 0}}),
+                )
+                .await?;
+                let error = recv_until(&mut framed, |m| {
+                    channel(m) == Some("query") && m.get("error").is_some()
+                })
+                .await?;
+                assert_eq!(error["id"].as_u64(), Some(4));
+                assert_eq!(error["error"]["code"].as_str(), Some("badRequest"));
+
+                // A failing query — no contract lives at the zero address — is
+                // acked, then ended by a terminal `queryFailed` (the initial
+                // snapshot is the failing execution).
+                send(
+                    &mut framed,
+                    json!({"method": "subscribe", "id": 5, "subscription": {"type": "query", "query": {"contract": {"address": "0x0000000000000000000000000000000000000000"}}}}),
+                )
+                .await?;
+                let ack = recv_until(&mut framed, |m| {
+                    channel(m) == Some("subscriptionResponse") && m["id"].as_u64() == Some(5)
+                })
+                .await?;
+                assert_eq!(ack["data"]["type"].as_str(), Some("query"));
+
+                let error = recv_until(&mut framed, |m| {
+                    channel(m) == Some("query") && m.get("error").is_some()
+                })
+                .await?;
+                assert_eq!(error["id"].as_u64(), Some(5));
+                assert_eq!(error["error"]["code"].as_str(), Some("queryFailed"));
+
+                // The failure ended only that subscription; the socket lives.
+                send(&mut framed, json!({"method": "ping", "id": 6})).await?;
+                let pong = recv_until(&mut framed, |m| channel(m) == Some("pong")).await?;
+                assert_eq!(pong["id"].as_u64(), Some(6));
 
                 Ok::<(), anyhow::Error>(())
             })


### PR DESCRIPTION
The client submits a grug `Query` and an `interval`; the server answers with an initial snapshot, then re-runs the query once per block whose height is a multiple of `interval`, streaming `{blockHeight, response}` frames on the `query` channel. Replaces the GraphQL `query_app` subscription.

Unlike GraphQL — which phases intervals per subscriber and repeats the work for every subscriber — ticks align to absolute block heights and are served through a per-block memo with singleflight, so any number of identical subscriptions cost one query execution per tick. Frames carry a strictly increasing `blockHeight` per subscriber; a failed execution ends the subscription with a single terminal `queryFailed` frame.