### PR TITLE
fix(explorer): use archive API for mainnet and testnet searches

### DIFF
--- a/ui/portal/web/tests/explorer-hooks.test.tsx
+++ b/ui/portal/web/tests/explorer-hooks.test.tsx
@@ -240,6 +240,42 @@ describe("explorer hooks", () => {
     });
   });
 
+  it("uses the testnet archive for concrete block explorer lookups", async () => {
+    publicClient.chain = { id: "dango-testnet-1" };
+    publicClient.queryBlock.mockResolvedValue({ blockHeight: 200, hash: "current-block" });
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        block: {
+          info: {
+            height: 125,
+            timestamp: "31536000",
+            hash: "archive-testnet-block",
+          },
+          txs: [],
+        },
+        outcome: {
+          app_hash: "archive-testnet-app-hash",
+          cron_outcomes: [],
+          tx_outcomes: [],
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useExplorerBlock("125"), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.searchBlock?.hash).toBe("archive-testnet-block"),
+    );
+
+    expect(publicClient.queryBlock).toHaveBeenCalledOnce();
+    expect((fetchMock.mock.calls[0]?.[0] as URL).toString()).toBe(
+      "https://api-archive-testnet.dango.zone/blocks/125",
+    );
+  });
+
   it("uses the mainnet archive for latest block explorer lookups", async () => {
     publicClient.chain = { id: "dango-1" };
     publicClient.queryBlock.mockResolvedValue({ blockHeight: 200, hash: "live-current-block" });

--- a/ui/portal/web/tests/explorer-hooks.test.tsx
+++ b/ui/portal/web/tests/explorer-hooks.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../../../store/src/hooks/usePublicClient.js", () => ({
 }));
 
 const publicClient = {
+  chain: { id: "dev-9" },
   getAccountInfo: vi.fn(),
   getAccountStatus: vi.fn(),
   getBalances: vi.fn(),
@@ -53,6 +54,7 @@ const calculateBalance = vi.fn(
 
 describe("explorer hooks", () => {
   beforeEach(() => {
+    publicClient.chain = { id: "dev-9" };
     storeHookMocks.usePublicClient.mockReturnValue(publicClient);
     storeHookMocks.usePrices.mockReturnValue({ calculateBalance });
     storeHookMocks.useAppConfig.mockReturnValue({
@@ -67,7 +69,15 @@ describe("explorer hooks", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
+
+  function jsonResponse(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }
 
   it("marks invalid block searches without querying a specific backend height", async () => {
     const currentBlock = { blockHeight: 100, hash: "current-block" };
@@ -159,6 +169,131 @@ describe("explorer hooks", () => {
     });
   });
 
+  it("uses the mainnet archive for concrete block explorer lookups", async () => {
+    publicClient.chain = { id: "dango-1" };
+    const currentBlock = { blockHeight: 200, hash: "current-block" };
+    publicClient.queryBlock.mockResolvedValue(currentBlock);
+    const sender = "0x73656e6465720000000000000000000000000000";
+    const txHash = "archive-tx-hash";
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        block: {
+          info: {
+            height: 125,
+            timestamp: "31536000.123456789",
+            hash: "archive-block",
+          },
+          txs: [
+            [
+              {
+                sender,
+                gas_limit: 100,
+                msgs: [{ transfer: { [sender]: { usdc: "1" } } }],
+              },
+              txHash,
+            ],
+          ],
+        },
+        outcome: {
+          app_hash: "archive-app-hash",
+          cron_outcomes: [{ ok: true }],
+          tx_outcomes: [
+            {
+              gas_limit: 100,
+              gas_used: 75,
+              result: { ok: null },
+              events: { msgs_and_backrun: { msgs: [] } },
+            },
+          ],
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useExplorerBlock("125"), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.searchBlock?.hash).toBe("archive-block"));
+
+    expect(publicClient.queryBlock).toHaveBeenCalledOnce();
+    expect(publicClient.queryBlock).toHaveBeenCalledWith();
+    expect((fetchMock.mock.calls[0]?.[0] as URL).toString()).toBe(
+      "https://api-archive-mainnet.dango.zone/blocks/125",
+    );
+    expect(result.current.data?.searchBlock).toMatchObject({
+      appHash: "archive-app-hash",
+      blockHeight: 125,
+      createdAt: "1971-01-01T00:00:00.123Z",
+      transactions: [
+        {
+          createdAt: "1971-01-01T00:00:00.123Z",
+          hash: txHash,
+          sender,
+          gasWanted: 100,
+          gasUsed: 75,
+          transactionIdx: 0,
+          transactionType: "TX",
+          hasSucceeded: true,
+        },
+      ],
+    });
+  });
+
+  it("uses the mainnet archive for latest block explorer lookups", async () => {
+    publicClient.chain = { id: "dango-1" };
+    publicClient.queryBlock.mockResolvedValue({ blockHeight: 200, hash: "live-current-block" });
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        block: {
+          info: {
+            height: 199,
+            timestamp: "31535999",
+            hash: "archive-latest-block",
+          },
+          txs: [],
+        },
+        outcome: {
+          app_hash: "archive-latest-app-hash",
+          cron_outcomes: [],
+          tx_outcomes: [],
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useExplorerBlock("latest"), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.searchBlock?.hash).toBe("archive-latest-block"),
+    );
+
+    expect(publicClient.queryBlock).toHaveBeenCalledOnce();
+    expect((fetchMock.mock.calls[0]?.[0] as URL).toString()).toBe(
+      "https://api-archive-mainnet.dango.zone/blocks/latest",
+    );
+    expect(result.current.data?.currentBlock.hash).toBe("live-current-block");
+  });
+
+  it("keeps future mainnet block detection on the live client without querying archive", async () => {
+    publicClient.chain = { id: "dango-1" };
+    publicClient.queryBlock.mockResolvedValue({ blockHeight: 100, hash: "current-block" });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useExplorerBlock("125"), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.isFutureBlock).toBe(true));
+
+    expect(publicClient.queryBlock).toHaveBeenCalledOnce();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.data?.searchBlock).toBeNull();
+  });
+
   it("surfaces backend failures for block explorer lookups", async () => {
     const queryError = new Error("block query unavailable");
     publicClient.queryBlock.mockRejectedValueOnce(queryError);
@@ -228,6 +363,70 @@ describe("explorer hooks", () => {
 
     await waitFor(() => expect(result.current.data).toEqual(indexedTransaction));
     expect(publicClient.searchTxs).toHaveBeenCalledWith({ hash: txHash });
+  });
+
+  it("uses the mainnet archive for direct transaction hash lookups", async () => {
+    publicClient.chain = { id: "dango-1" };
+    const txHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const sender = "0x73656e6465720000000000000000000000000000";
+    const contract = "0x636f6e7472616374000000000000000000000000";
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse([
+        {
+          blockHeight: 77,
+          idx: 3,
+          kind: "transaction",
+          hash: txHash,
+          sender,
+          success: true,
+          timestamp: "2026-06-08T12:00:00Z",
+          tx: {
+            sender,
+            gas_limit: 120,
+            msgs: [{ execute: { contract, msg: { ping: {} }, funds: {} } }],
+          },
+          outcome: {
+            transaction: {
+              gas_limit: 120,
+              gas_used: 80,
+              result: { ok: null },
+              events: { msgs_and_backrun: { msgs: [] } },
+            },
+          },
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useExplorerTransaction(txHash), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.hash).toBe(txHash));
+
+    expect(publicClient.searchTxs).not.toHaveBeenCalled();
+    expect((fetchMock.mock.calls[0]?.[0] as URL).toString()).toBe(
+      `https://api-archive-mainnet.dango.zone/transactions/${txHash.toUpperCase()}`,
+    );
+    expect(result.current.data).toMatchObject({
+      blockHeight: 77,
+      createdAt: "2026-06-08T12:00:00Z",
+      gasUsed: 80,
+      gasWanted: 120,
+      hasSucceeded: true,
+      messages: [
+        {
+          contractAddr: contract,
+          methodName: "execute",
+          orderIdx: 0,
+          senderAddr: sender,
+        },
+      ],
+      nestedEvents: JSON.stringify({ msgs_and_backrun: { msgs: [] } }),
+      sender,
+      transactionIdx: 3,
+      transactionType: "TX",
+    });
   });
 
   it("surfaces backend failures for direct transaction hash lookups", async () => {
@@ -346,6 +545,80 @@ describe("explorer hooks", () => {
     });
     expect(result.current.pagination.hasNextPage).toBe(true);
     expect(result.current.pagination.hasPreviousPage).toBe(false);
+  });
+
+  it("uses archive sender pagination with a local previous-page cursor stack on mainnet", async () => {
+    publicClient.chain = { id: "dango-1" };
+    const senderAddress = "0x73656e6465720000000000000000000000000000";
+    const firstPage = {
+      items: [
+        {
+          blockHeight: 10,
+          idx: 0,
+          kind: "transaction",
+          hash: "first-page",
+          sender: senderAddress,
+          success: true,
+          timestamp: "2026-06-08T12:00:00Z",
+          tx: { sender: senderAddress, gas_limit: 1, msgs: [] },
+          outcome: { transaction: { gas_limit: 1, gas_used: 1, result: { ok: null }, events: [] } },
+        },
+      ],
+      pageInfo: { hasNextPage: true, endCursor: "first-end" },
+    };
+    const secondPage = {
+      items: [
+        {
+          blockHeight: 9,
+          idx: 0,
+          kind: "transaction",
+          hash: "second-page",
+          sender: senderAddress,
+          success: true,
+          timestamp: "2026-06-08T12:00:01Z",
+          tx: { sender: senderAddress, gas_limit: 1, msgs: [] },
+          outcome: { transaction: { gas_limit: 1, gas_used: 1, result: { ok: null }, events: [] } },
+        },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: "second-end" },
+    };
+    const fetchMock = vi.fn((input: URL) => {
+      const after = input.searchParams.get("after");
+      return Promise.resolve(jsonResponse(after === "first-end" ? secondPage : firstPage));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useExplorerTransactionsBySender(senderAddress), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.nodes[0]?.hash).toBe("first-page"));
+    expect(result.current.pagination.hasNextPage).toBe(true);
+    expect(result.current.pagination.hasPreviousPage).toBe(false);
+
+    act(() => {
+      result.current.pagination.goNext();
+    });
+
+    await waitFor(() => expect(result.current.data?.nodes[0]?.hash).toBe("second-page"));
+    expect(result.current.pagination.hasNextPage).toBe(false);
+    expect(result.current.pagination.hasPreviousPage).toBe(true);
+
+    act(() => {
+      result.current.pagination.goPrev();
+    });
+
+    await waitFor(() => expect(result.current.data?.nodes[0]?.hash).toBe("first-page"));
+    expect(result.current.pagination.hasPreviousPage).toBe(false);
+    expect(publicClient.searchTxs).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls.map(([url]) => (url as URL).searchParams.get("after"))).toEqual([
+      null,
+      "first-end",
+      null,
+    ]);
+    expect(fetchMock.mock.calls.some(([url]) => (url as URL).searchParams.has("before"))).toBe(
+      false,
+    );
   });
 
   it("does not query sender transactions when disabled", () => {

--- a/ui/portal/web/tests/test-quality-guards.test.tsx
+++ b/ui/portal/web/tests/test-quality-guards.test.tsx
@@ -53,6 +53,7 @@ const reviewedHardcodedMessageLiteralCandidates = [
   "tests/pro-trade-history.test.tsx:Ethereum:1",
   "tests/search-token.test.tsx:Ethereum:1",
   "tests/trading-view.test.tsx:TradingView:1",
+  "tests/use-search-bar.test.tsx:Transfer:1",
 ].sort();
 const reviewedUserIndexTruthinessChecks = [
   "../../store/src/hooks/useBoosters.ts:enabled: enabled && !!userIndex,",

--- a/ui/portal/web/tests/use-search-bar.test.tsx
+++ b/ui/portal/web/tests/use-search-bar.test.tsx
@@ -1,8 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { m } from "@left-curve/foundation/paraglide/messages.js";
-
 import { useSearchBar } from "../../../store/src/hooks/useSearchBar";
 import { createQueryClientWrapper, createTestQueryClient } from "./utils/query-client";
 
@@ -33,7 +31,7 @@ const applets: Record<string, AppletMetadata> = {
   transfer: {
     id: "transfer",
     img: "/transfer.png",
-    title: m["applets.transfer.title"](),
+    title: "Transfer",
     keywords: ["send"],
     description: "Send funds",
     path: "/transfer",
@@ -81,6 +79,7 @@ function readJson(testId: string) {
 
 describe("useSearchBar", () => {
   const publicClient = {
+    chain: { id: "dev-9" },
     getContractInfo: vi.fn(),
     getAccountInfo: vi.fn(),
     getUser: vi.fn(),
@@ -89,6 +88,7 @@ describe("useSearchBar", () => {
   };
 
   beforeEach(() => {
+    publicClient.chain = { id: "dev-9" };
     storeHookMocks.useAppConfig.mockReturnValue({
       data: {
         accountFactory: {
@@ -108,7 +108,15 @@ describe("useSearchBar", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
+
+  function jsonResponse(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }
 
   it("starts with favorite applets, non-favorite applets, and known contracts", async () => {
     renderUseSearchBar();
@@ -175,6 +183,83 @@ describe("useSearchBar", () => {
     expect(queryClient.getQueryData(["block", "0"])).toEqual(block);
   });
 
+  it("uses archive lookups for mainnet block and transaction searches", async () => {
+    publicClient.chain = { id: "dango-1" };
+    const queryClient = renderUseSearchBar();
+    const hash = "a".repeat(64);
+    const sender = "0x73656e6465720000000000000000000000000000";
+    const fetchMock = vi.fn((input: URL) => {
+      if (input.pathname === "/blocks/123") {
+        return Promise.resolve(
+          jsonResponse({
+            block: {
+              info: {
+                height: 123,
+                timestamp: "2026-06-08T12:00:00Z",
+                hash: "archive-block",
+              },
+              txs: [],
+            },
+            outcome: {
+              app_hash: "archive-app-hash",
+              cron_outcomes: [],
+              tx_outcomes: [],
+            },
+          }),
+        );
+      }
+
+      return Promise.resolve(
+        jsonResponse([
+          {
+            blockHeight: 123,
+            idx: 0,
+            kind: "transaction",
+            hash,
+            sender,
+            success: true,
+            timestamp: "2026-06-08T12:00:00Z",
+            tx: { sender, gas_limit: 1, msgs: [] },
+            outcome: {
+              transaction: { gas_limit: 1, gas_used: 1, result: { ok: null }, events: [] },
+            },
+          },
+        ]),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    fireEvent.change(screen.getByLabelText("Search"), {
+      target: { value: "123" },
+    });
+
+    await waitFor(() => {
+      expect(readJson("result").block).toMatchObject({
+        blockHeight: 123,
+        hash: "archive-block",
+      });
+    });
+    expect(publicClient.queryBlock).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(["block", "123"])).toMatchObject({
+      blockHeight: 123,
+      hash: "archive-block",
+    });
+
+    fireEvent.change(screen.getByLabelText("Search"), {
+      target: { value: hash },
+    });
+
+    await waitFor(() => {
+      expect(readJson("result").txs).toMatchObject([{ hash, sender }]);
+    });
+    expect(publicClient.searchTxs).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(["tx", hash])).toMatchObject({ hash, sender });
+    expect(fetchMock.mock.calls.map(([url]) => (url as URL).pathname)).toEqual([
+      "/blocks/123",
+      `/transactions/${hash.toUpperCase()}`,
+    ]);
+  });
+
   it("clears backend-derived search results when the search text is cleared", async () => {
     const block = { height: 123, hash: "block-hash" };
     publicClient.queryBlock.mockResolvedValue(block);
@@ -225,6 +310,24 @@ describe("useSearchBar", () => {
     });
     expect(publicClient.searchTxs).toHaveBeenCalledWith({ hash });
     expect(queryClient.getQueryData(["tx", hash])).toEqual(tx);
+  });
+
+  it("normalizes 0x-prefixed transaction hashes before searching", async () => {
+    const queryClient = renderUseSearchBar();
+    const hash = "a".repeat(64);
+    const prefixedHash = `0x${hash}`;
+    const tx = { hash, sender: "0x73656e6465720000000000000000000000000000" };
+    publicClient.searchTxs.mockResolvedValue({ nodes: [tx] });
+
+    fireEvent.change(screen.getByLabelText("Search"), {
+      target: { value: prefixedHash },
+    });
+
+    await waitFor(() => {
+      expect(readJson("result").txs).toEqual([tx]);
+    });
+    expect(publicClient.searchTxs).toHaveBeenCalledWith({ hash });
+    expect(queryClient.getQueryData(["tx", prefixedHash])).toEqual(tx);
   });
 
   it("keeps transaction search empty when the backend returns no matching hash", async () => {

--- a/ui/portal/web/tests/use-search-bar.test.tsx
+++ b/ui/portal/web/tests/use-search-bar.test.tsx
@@ -183,82 +183,88 @@ describe("useSearchBar", () => {
     expect(queryClient.getQueryData(["block", "0"])).toEqual(block);
   });
 
-  it("uses archive lookups for mainnet block and transaction searches", async () => {
-    publicClient.chain = { id: "dango-1" };
-    const queryClient = renderUseSearchBar();
-    const hash = "a".repeat(64);
-    const sender = "0x73656e6465720000000000000000000000000000";
-    const fetchMock = vi.fn((input: URL) => {
-      if (input.pathname === "/blocks/123") {
-        return Promise.resolve(
-          jsonResponse({
-            block: {
-              info: {
-                height: 123,
-                timestamp: "2026-06-08T12:00:00Z",
-                hash: "archive-block",
+  it.each([
+    ["mainnet", "dango-1", "https://api-archive-mainnet.dango.zone"],
+    ["testnet", "dango-testnet-1", "https://api-archive-testnet.dango.zone"],
+  ])(
+    "uses archive lookups for %s block and transaction searches",
+    async (_, chainId, archiveUrl) => {
+      publicClient.chain = { id: chainId };
+      const queryClient = renderUseSearchBar();
+      const hash = "a".repeat(64);
+      const sender = "0x73656e6465720000000000000000000000000000";
+      const fetchMock = vi.fn((input: URL) => {
+        if (input.pathname === "/blocks/123") {
+          return Promise.resolve(
+            jsonResponse({
+              block: {
+                info: {
+                  height: 123,
+                  timestamp: "2026-06-08T12:00:00Z",
+                  hash: "archive-block",
+                },
+                txs: [],
               },
-              txs: [],
+              outcome: {
+                app_hash: "archive-app-hash",
+                cron_outcomes: [],
+                tx_outcomes: [],
+              },
+            }),
+          );
+        }
+
+        return Promise.resolve(
+          jsonResponse([
+            {
+              blockHeight: 123,
+              idx: 0,
+              kind: "transaction",
+              hash,
+              sender,
+              success: true,
+              timestamp: "2026-06-08T12:00:00Z",
+              tx: { sender, gas_limit: 1, msgs: [] },
+              outcome: {
+                transaction: { gas_limit: 1, gas_used: 1, result: { ok: null }, events: [] },
+              },
             },
-            outcome: {
-              app_hash: "archive-app-hash",
-              cron_outcomes: [],
-              tx_outcomes: [],
-            },
-          }),
+          ]),
         );
-      }
+      });
+      vi.stubGlobal("fetch", fetchMock);
 
-      return Promise.resolve(
-        jsonResponse([
-          {
-            blockHeight: 123,
-            idx: 0,
-            kind: "transaction",
-            hash,
-            sender,
-            success: true,
-            timestamp: "2026-06-08T12:00:00Z",
-            tx: { sender, gas_limit: 1, msgs: [] },
-            outcome: {
-              transaction: { gas_limit: 1, gas_used: 1, result: { ok: null }, events: [] },
-            },
-          },
-        ]),
-      );
-    });
-    vi.stubGlobal("fetch", fetchMock);
+      fireEvent.change(screen.getByLabelText("Search"), {
+        target: { value: "123" },
+      });
 
-    fireEvent.change(screen.getByLabelText("Search"), {
-      target: { value: "123" },
-    });
-
-    await waitFor(() => {
-      expect(readJson("result").block).toMatchObject({
+      await waitFor(() => {
+        expect(readJson("result").block).toMatchObject({
+          blockHeight: 123,
+          hash: "archive-block",
+        });
+      });
+      expect(publicClient.queryBlock).not.toHaveBeenCalled();
+      expect(queryClient.getQueryData(["block", "123"])).toMatchObject({
         blockHeight: 123,
         hash: "archive-block",
       });
-    });
-    expect(publicClient.queryBlock).not.toHaveBeenCalled();
-    expect(queryClient.getQueryData(["block", "123"])).toMatchObject({
-      blockHeight: 123,
-      hash: "archive-block",
-    });
 
-    fireEvent.change(screen.getByLabelText("Search"), {
-      target: { value: hash },
-    });
+      fireEvent.change(screen.getByLabelText("Search"), {
+        target: { value: hash },
+      });
 
-    await waitFor(() => {
-      expect(readJson("result").txs).toMatchObject([{ hash, sender }]);
-    });
-    expect(publicClient.searchTxs).not.toHaveBeenCalled();
-    expect(queryClient.getQueryData(["tx", hash])).toMatchObject({ hash, sender });
-    expect(fetchMock.mock.calls.map(([url]) => (url as URL).pathname)).toEqual([
-      "/blocks/123",
-      `/transactions/${hash.toUpperCase()}`,
-    ]);
-  });
+      await waitFor(() => {
+        expect(readJson("result").txs).toMatchObject([{ hash, sender }]);
+      });
+      expect(publicClient.searchTxs).not.toHaveBeenCalled();
+      expect(queryClient.getQueryData(["tx", hash])).toMatchObject({ hash, sender });
+      expect(fetchMock.mock.calls.map(([url]) => (url as URL).toString())).toEqual([
+        `${archiveUrl}/blocks/123`,
+        `${archiveUrl}/transactions/${hash.toUpperCase()}`,
+      ]);
+    },
+  );
 
   it("clears backend-derived search results when the search text is cleared", async () => {
     const block = { height: 123, hash: "block-hash" };

--- a/ui/portal/web/tests/utils/registerUser.ts
+++ b/ui/portal/web/tests/utils/registerUser.ts
@@ -15,10 +15,33 @@ const registrationLabels = {
 };
 
 export async function dismissActivateAccountModal(page: Page, timeout = 2_000): Promise<void> {
-  const heading = page.getByRole("heading", { name: registrationLabels.activateAccount });
+  const modalText = {
+    button: registrationLabels.doThisLater,
+    heading: registrationLabels.activateAccount,
+  };
 
-  const isVisible = await heading
-    .waitFor({ state: "visible", timeout })
+  const isVisible = await page
+    .waitForFunction(
+      (labels) => {
+        const normalizeText = (value: string | null) => value?.replace(/\s+/g, " ").trim() ?? "";
+        const isVisible = (element: Element) => {
+          const style = window.getComputedStyle(element);
+          const rect = element.getBoundingClientRect();
+          return (
+            style.visibility !== "hidden" &&
+            style.display !== "none" &&
+            rect.width > 0 &&
+            rect.height > 0
+          );
+        };
+
+        return Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6")).some(
+          (element) => isVisible(element) && normalizeText(element.textContent) === labels.heading,
+        );
+      },
+      modalText,
+      { timeout },
+    )
     .then(() => true)
     .catch(() => false);
 
@@ -26,10 +49,57 @@ export async function dismissActivateAccountModal(page: Page, timeout = 2_000): 
     return;
   }
 
-  const laterButton = page.getByRole("button", { name: registrationLabels.doThisLater });
-  await laterButton.waitFor({ state: "visible", timeout: 10_000 });
-  await laterButton.dispatchEvent("click");
-  await heading.waitFor({ state: "hidden", timeout: 10_000 });
+  await page.waitForFunction(
+    (labels) => {
+      const normalizeText = (value: string | null) => value?.replace(/\s+/g, " ").trim() ?? "";
+      const isVisible = (element: Element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+
+      const hasHeading = Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6")).some(
+        (element) => isVisible(element) && normalizeText(element.textContent) === labels.heading,
+      );
+      if (!hasHeading) return true;
+
+      const button = Array.from(document.querySelectorAll("button")).find(
+        (element) => isVisible(element) && normalizeText(element.textContent) === labels.button,
+      );
+
+      if (!button) return false;
+      button.click();
+      return true;
+    },
+    modalText,
+    { timeout: 10_000 },
+  );
+  await page.waitForFunction(
+    (labels) => {
+      const normalizeText = (value: string | null) => value?.replace(/\s+/g, " ").trim() ?? "";
+      const isVisible = (element: Element) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return (
+          style.visibility !== "hidden" &&
+          style.display !== "none" &&
+          rect.width > 0 &&
+          rect.height > 0
+        );
+      };
+
+      return !Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6")).some(
+        (element) => isVisible(element) && normalizeText(element.textContent) === labels.heading,
+      );
+    },
+    modalText,
+    { timeout: 10_000 },
+  );
 }
 
 /**

--- a/ui/store/src/archive/api.ts
+++ b/ui/store/src/archive/api.ts
@@ -1,0 +1,345 @@
+import type {
+  Address,
+  Chain,
+  GraphqlQueryResult,
+  IndexedBlock,
+  IndexedMessage,
+  IndexedTransaction,
+  Json,
+} from "@left-curve/types";
+
+const MAINNET_CHAIN_ID = "dango-1";
+const MAINNET_ARCHIVE_URL = "https://api-archive-mainnet.dango.zone";
+const EMPTY_PAGE_INFO = {
+  hasNextPage: false,
+  hasPreviousPage: false,
+  startCursor: null,
+  endCursor: null,
+};
+
+type ArchiveApi = {
+  queryBlock: (height?: number) => Promise<IndexedBlock | null>;
+  searchTxs: (
+    parameters: ArchiveSearchTxsParameters,
+  ) => Promise<GraphqlQueryResult<IndexedTransaction>>;
+};
+
+type ArchiveSearchTxsParameters = {
+  hash?: string;
+  senderAddress?: string;
+  first?: number;
+  after?: string;
+  sortBy?: string;
+};
+
+type ArchivePage<T> = {
+  items: T[];
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor?: string | null;
+  };
+};
+
+type ArchiveTransaction = {
+  blockHeight: number;
+  idx: number;
+  kind: "transaction" | "cron";
+  hash?: string | null;
+  sender?: string | null;
+  success: boolean;
+  timestamp: string;
+  tx?: ArchiveRawTx | null;
+  outcome?: ArchiveUnitOutcome | null;
+};
+
+type ArchiveFullBlock = {
+  block: {
+    info: {
+      height: number;
+      timestamp: unknown;
+      hash: string;
+    };
+    txs: [ArchiveRawTx, string][];
+  };
+  outcome: {
+    app_hash?: string;
+    appHash?: string;
+    cron_outcomes?: unknown[];
+    cronOutcomes?: unknown[];
+    tx_outcomes?: ArchiveTxOutcome[];
+    txOutcomes?: ArchiveTxOutcome[];
+  };
+};
+
+type ArchiveRawTx = {
+  sender?: string;
+  msgs?: unknown[];
+  gas_limit?: number | string;
+  gasLimit?: number | string;
+};
+
+type ArchiveUnitOutcome = {
+  transaction?: ArchiveTxOutcome;
+  cron?: unknown;
+};
+
+type ArchiveTxOutcome = {
+  gas_limit?: number | string;
+  gasLimit?: number | string;
+  gas_used?: number | string;
+  gasUsed?: number | string;
+  result?: unknown;
+  events?: unknown;
+};
+
+export function getArchiveApi(chain: Chain | undefined): ArchiveApi | null {
+  if (chain?.id !== MAINNET_CHAIN_ID) return null;
+
+  return {
+    queryBlock,
+    searchTxs,
+  };
+}
+
+async function queryBlock(height?: number): Promise<IndexedBlock | null> {
+  const blockPath = height === undefined ? "/blocks/latest" : `/blocks/${height}`;
+  const block = await archiveFetch<ArchiveFullBlock>(blockPath, undefined, {
+    allowNotFound: true,
+  });
+  return block ? normalizeBlock(block) : null;
+}
+
+async function searchTxs(
+  parameters: ArchiveSearchTxsParameters,
+): Promise<GraphqlQueryResult<IndexedTransaction>> {
+  if (parameters.hash) {
+    const hash = parameters.hash.replace(/^0x/i, "").toUpperCase();
+    const items = await archiveFetch<ArchiveTransaction[]>(
+      `/transactions/${encodeURIComponent(hash)}`,
+    );
+    return toGraphqlResult((items ?? []).map(normalizeTransaction));
+  }
+
+  if (parameters.senderAddress) {
+    const page = await archiveFetch<ArchivePage<ArchiveTransaction>>(
+      `/transactions/involving/${encodeURIComponent(parameters.senderAddress)}`,
+      {
+        role: "sender",
+        first: String(parameters.first ?? 10),
+        after: parameters.after,
+      },
+    );
+    if (!page) return toGraphqlResult([]);
+    return toGraphqlResult(page.items.map(normalizeTransaction), page.pageInfo);
+  }
+
+  return toGraphqlResult([]);
+}
+
+async function archiveFetch<T>(
+  path: string,
+  query?: Record<string, string | undefined>,
+  options: { allowNotFound?: boolean } = {},
+): Promise<T | null> {
+  const url = new URL(path, MAINNET_ARCHIVE_URL);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined) url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url);
+  if (response.status === 404 && options.allowNotFound) return null;
+  if (!response.ok) {
+    throw new Error(`archive request failed (${response.status}) for ${url.pathname}`);
+  }
+  return (await response.json()) as T;
+}
+
+function normalizeBlock(fullBlock: ArchiveFullBlock): IndexedBlock {
+  const blockHeight = fullBlock.block.info.height;
+  const createdAt = normalizeTimestamp(fullBlock.block.info.timestamp);
+  const txOutcomes = fullBlock.outcome.tx_outcomes ?? fullBlock.outcome.txOutcomes ?? [];
+  const cronOutcomes = fullBlock.outcome.cron_outcomes ?? fullBlock.outcome.cronOutcomes ?? [];
+
+  return {
+    blockHeight,
+    createdAt,
+    hash: fullBlock.block.info.hash,
+    appHash: fullBlock.outcome.app_hash ?? fullBlock.outcome.appHash ?? "",
+    cronsOutcomes: cronOutcomes.map((outcome) =>
+      stringifyJson(outcome),
+    ) as unknown as IndexedBlock["cronsOutcomes"],
+    transactions: fullBlock.block.txs.map(([tx, hash], idx) =>
+      normalizeRawTransaction({
+        blockHeight,
+        createdAt,
+        hash,
+        idx,
+        sender: tx.sender,
+        tx,
+        txOutcome: txOutcomes[idx],
+      }),
+    ),
+  };
+}
+
+function normalizeTransaction(transaction: ArchiveTransaction): IndexedTransaction {
+  const txOutcome = transaction.outcome?.transaction;
+
+  return normalizeRawTransaction({
+    blockHeight: transaction.blockHeight,
+    createdAt: transaction.timestamp,
+    hash: transaction.hash ?? "",
+    idx: transaction.idx,
+    kind: transaction.kind,
+    sender: transaction.sender ?? transaction.tx?.sender,
+    success: transaction.success,
+    tx: transaction.tx ?? undefined,
+    txOutcome,
+  });
+}
+
+function normalizeRawTransaction(parameters: {
+  blockHeight: number;
+  createdAt: string;
+  hash: string;
+  idx: number;
+  kind?: ArchiveTransaction["kind"];
+  sender?: string | null;
+  success?: boolean;
+  tx?: ArchiveRawTx;
+  txOutcome?: ArchiveTxOutcome;
+}): IndexedTransaction {
+  const success = parameters.success ?? isSuccessResult(parameters.txOutcome?.result);
+  const sender = (parameters.sender ?? "") as Address;
+  const gasWanted = toNumber(
+    parameters.tx?.gas_limit ??
+      parameters.tx?.gasLimit ??
+      parameters.txOutcome?.gas_limit ??
+      parameters.txOutcome?.gasLimit,
+  );
+  const gasUsed = toNumber(parameters.txOutcome?.gas_used ?? parameters.txOutcome?.gasUsed);
+
+  return {
+    blockHeight: parameters.blockHeight,
+    createdAt: parameters.createdAt,
+    transactionType: parameters.kind === "cron" ? "CRON" : "TX",
+    transactionIdx: parameters.idx,
+    sender,
+    hash: parameters.hash,
+    hasSucceeded: success,
+    errorMessage: extractErrorMessage(parameters.txOutcome?.result, success),
+    gasWanted,
+    gasUsed,
+    messages: normalizeMessages(parameters.tx?.msgs, {
+      blockHeight: parameters.blockHeight,
+      createdAt: parameters.createdAt,
+      sender,
+    }),
+    nestedEvents: stringifyJson(parameters.txOutcome?.events ?? []),
+  };
+}
+
+function normalizeMessages(
+  messages: unknown[] | undefined,
+  context: { blockHeight: number; createdAt: string; sender: Address },
+): IndexedMessage[] {
+  return (messages ?? []).map((message, orderIdx) => {
+    const { methodName, payload } = getMessageParts(message);
+    const contractAddr = getStringProperty(payload, "contract") ?? "";
+
+    return {
+      methodName,
+      blockHeight: context.blockHeight,
+      contractAddr: contractAddr as Address,
+      senderAddr: context.sender,
+      orderIdx,
+      createdAt: context.createdAt,
+      data: (isRecord(message) ? message : { [methodName]: payload }) as Record<string, Json>,
+    };
+  });
+}
+
+function getMessageParts(message: unknown): { methodName: string; payload: unknown } {
+  if (!isRecord(message)) return { methodName: "message", payload: message };
+  const [methodName, payload] = Object.entries(message)[0] ?? ["message", message];
+  return { methodName, payload };
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const property = value[key];
+  return typeof property === "string" ? property : undefined;
+}
+
+function toGraphqlResult<T>(
+  nodes: T[],
+  pageInfo?: ArchivePage<T>["pageInfo"],
+): GraphqlQueryResult<T> {
+  return {
+    pageInfo: {
+      ...EMPTY_PAGE_INFO,
+      hasNextPage: pageInfo?.hasNextPage ?? false,
+      endCursor: pageInfo?.endCursor ?? null,
+    },
+    edge: nodes.map((node, index) => ({
+      cursor: index === nodes.length - 1 ? (pageInfo?.endCursor ?? "") : "",
+      node,
+    })),
+    nodes,
+  };
+}
+
+function isSuccessResult(result: unknown): boolean {
+  if (!isRecord(result)) return true;
+  if ("ok" in result || "Ok" in result) return true;
+  if ("err" in result || "Err" in result || "error" in result) return false;
+  return true;
+}
+
+function extractErrorMessage(result: unknown, success: boolean): string {
+  if (success) return "";
+  if (!isRecord(result)) return stringifyJson(result);
+
+  const error = result.err ?? result.Err ?? result.error ?? result;
+  return typeof error === "string" ? error : stringifyJson(error);
+}
+
+function normalizeTimestamp(timestamp: unknown): string {
+  if (typeof timestamp === "string") {
+    const seconds = timestamp.match(/^(\d+)(?:\.(\d+))?$/);
+    if (seconds) {
+      return secondsToIso(seconds[1], seconds[2]);
+    }
+    return timestamp;
+  }
+
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    return new Date(timestamp * 1000).toISOString();
+  }
+
+  return stringifyJson(timestamp);
+}
+
+function stringifyJson(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value ?? null);
+  } catch {
+    return String(value);
+  }
+}
+
+function toNumber(value: number | string | undefined): number {
+  if (value === undefined) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function secondsToIso(seconds: string, fraction = ""): string {
+  const milliseconds = Number(seconds) * 1000 + Number(fraction.padEnd(3, "0").slice(0, 3));
+  return new Date(milliseconds).toISOString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ui/store/src/archive/api.ts
+++ b/ui/store/src/archive/api.ts
@@ -8,8 +8,10 @@ import type {
   Json,
 } from "@left-curve/types";
 
-const MAINNET_CHAIN_ID = "dango-1";
-const MAINNET_ARCHIVE_URL = "https://api-archive-mainnet.dango.zone";
+const ARCHIVE_URL_BY_CHAIN_ID: Record<string, string> = {
+  "dango-1": "https://api-archive-mainnet.dango.zone",
+  "dango-testnet-1": "https://api-archive-testnet.dango.zone",
+};
 const EMPTY_PAGE_INFO = {
   hasNextPage: false,
   hasPreviousPage: false,
@@ -93,28 +95,31 @@ type ArchiveTxOutcome = {
 };
 
 export function getArchiveApi(chain: Chain | undefined): ArchiveApi | null {
-  if (chain?.id !== MAINNET_CHAIN_ID) return null;
+  const archiveUrl = chain ? ARCHIVE_URL_BY_CHAIN_ID[chain.id] : undefined;
+  if (!archiveUrl) return null;
 
   return {
-    queryBlock,
-    searchTxs,
+    queryBlock: (height) => queryBlock(archiveUrl, height),
+    searchTxs: (parameters) => searchTxs(archiveUrl, parameters),
   };
 }
 
-async function queryBlock(height?: number): Promise<IndexedBlock | null> {
+async function queryBlock(archiveUrl: string, height?: number): Promise<IndexedBlock | null> {
   const blockPath = height === undefined ? "/blocks/latest" : `/blocks/${height}`;
-  const block = await archiveFetch<ArchiveFullBlock>(blockPath, undefined, {
+  const block = await archiveFetch<ArchiveFullBlock>(archiveUrl, blockPath, undefined, {
     allowNotFound: true,
   });
   return block ? normalizeBlock(block) : null;
 }
 
 async function searchTxs(
+  archiveUrl: string,
   parameters: ArchiveSearchTxsParameters,
 ): Promise<GraphqlQueryResult<IndexedTransaction>> {
   if (parameters.hash) {
     const hash = parameters.hash.replace(/^0x/i, "").toUpperCase();
     const items = await archiveFetch<ArchiveTransaction[]>(
+      archiveUrl,
       `/transactions/${encodeURIComponent(hash)}`,
     );
     return toGraphqlResult((items ?? []).map(normalizeTransaction));
@@ -122,6 +127,7 @@ async function searchTxs(
 
   if (parameters.senderAddress) {
     const page = await archiveFetch<ArchivePage<ArchiveTransaction>>(
+      archiveUrl,
       `/transactions/involving/${encodeURIComponent(parameters.senderAddress)}`,
       {
         role: "sender",
@@ -137,11 +143,12 @@ async function searchTxs(
 }
 
 async function archiveFetch<T>(
+  archiveUrl: string,
   path: string,
   query?: Record<string, string | undefined>,
   options: { allowNotFound?: boolean } = {},
 ): Promise<T | null> {
-  const url = new URL(path, MAINNET_ARCHIVE_URL);
+  const url = new URL(path, archiveUrl);
   for (const [key, value] of Object.entries(query ?? {})) {
     if (value !== undefined) url.searchParams.set(key, value);
   }

--- a/ui/store/src/hooks/explorer/useExplorerBlock.ts
+++ b/ui/store/src/hooks/explorer/useExplorerBlock.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { usePublicClient } from "../usePublicClient.js";
+import { getArchiveApi } from "../../archive/api.js";
 
 import type { IndexedBlock } from "@left-curve/types";
 
@@ -13,12 +14,32 @@ export type ExplorerBlockState = {
 
 export function useExplorerBlock(block: string) {
   const client = usePublicClient();
+  const archive = getArchiveApi(client.chain);
 
   return useQuery<ExplorerBlockState>({
-    queryKey: ["block_explorer", block],
+    queryKey: ["block_explorer", block, archive ? "archive" : "public"],
     queryFn: async () => {
       const isLatest = block === "latest";
       const parsedHeight = Number(block);
+
+      if (archive) {
+        const currentBlock = await client.queryBlock();
+        const isFutureBlock = parsedHeight > 0 && parsedHeight > currentBlock.blockHeight;
+        const isInvalidBlock = (!isLatest && Number.isNaN(parsedHeight)) || parsedHeight < 0;
+
+        const searchBlock =
+          isInvalidBlock || isFutureBlock
+            ? null
+            : await archive.queryBlock(isLatest ? undefined : parsedHeight);
+
+        return {
+          searchBlock,
+          currentBlock,
+          height: parsedHeight,
+          isFutureBlock,
+          isInvalidBlock,
+        };
+      }
 
       const [searchBlock, currentBlock] = await Promise.all([
         Number.isNaN(parsedHeight) && !isLatest

--- a/ui/store/src/hooks/explorer/useExplorerTransaction.ts
+++ b/ui/store/src/hooks/explorer/useExplorerTransaction.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { usePublicClient } from "../usePublicClient.js";
+import { getArchiveApi } from "../../archive/api.js";
 
 import type { IndexedTransaction } from "@left-curve/types";
 
@@ -7,11 +8,12 @@ export type UseExplorerTransactionReturn = IndexedTransaction | null;
 
 export function useExplorerTransaction(txHash: string) {
   const client = usePublicClient();
+  const archive = getArchiveApi(client.chain);
 
   return useQuery<UseExplorerTransactionReturn>({
-    queryKey: ["tx", txHash],
+    queryKey: ["tx", txHash, archive ? "archive" : "public"],
     queryFn: async () => {
-      const txs = await client.searchTxs({ hash: txHash });
+      const txs = await (archive ?? client).searchTxs({ hash: txHash });
       if (!txs.nodes.length) return null;
       return txs.nodes[0] || null;
     },

--- a/ui/store/src/hooks/explorer/useExplorerTransactionsBySender.ts
+++ b/ui/store/src/hooks/explorer/useExplorerTransactionsBySender.ts
@@ -1,14 +1,86 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { getArchiveApi } from "../../archive/api.js";
 import { usePublicClient } from "../usePublicClient.js";
 import { useQueryWithPagination } from "../useQueryWithPagination.js";
 
 import type { Address } from "@left-curve/types";
 
+const PAGE_SIZE = 10;
+
+type ArchivePaginationState = {
+  address: Address;
+  after?: string;
+  previousAfters: (string | undefined)[];
+};
+
 export function useExplorerTransactionsBySender(address: Address, enabled = true) {
   const client = usePublicClient();
+  const archive = getArchiveApi(client.chain);
+  const [archivePagination, setArchivePagination] = useState<ArchivePaginationState>({
+    address,
+    after: undefined,
+    previousAfters: [],
+  });
 
-  return useQueryWithPagination({
-    enabled: enabled && !!address,
+  const archiveState =
+    archivePagination.address === address
+      ? archivePagination
+      : { address, after: undefined, previousAfters: [] };
+
+  const archiveQuery = useQuery({
+    enabled: Boolean(archive && enabled && address),
+    queryKey: ["explorer_transactions", address, "archive", archiveState.after],
+    queryFn: () =>
+      archive!.searchTxs({
+        senderAddress: address,
+        first: PAGE_SIZE,
+        after: archiveState.after,
+      }),
+    placeholderData: keepPreviousData,
+  });
+
+  const publicQuery = useQueryWithPagination({
+    enabled: !archive && enabled && !!address,
     queryKey: ["explorer_transactions", address],
     queryFn: async ({ pageParam }) => client.searchTxs({ senderAddress: address, ...pageParam }),
   });
+
+  if (archive) {
+    const hasPreviousPage = archiveState.previousAfters.length > 0;
+
+    return {
+      ...archiveQuery,
+      pagination: {
+        goNext: () => {
+          const nextAfter = archiveQuery.data?.pageInfo.endCursor ?? undefined;
+          if (!archiveQuery.data?.pageInfo.hasNextPage || !nextAfter) return;
+          setArchivePagination((state) => ({
+            address,
+            after: nextAfter,
+            previousAfters:
+              state.address === address
+                ? [...state.previousAfters, archiveState.after]
+                : [undefined],
+          }));
+        },
+        goPrev: () => {
+          if (!hasPreviousPage) return;
+          setArchivePagination((state) => {
+            const previousAfters = state.address === address ? state.previousAfters : [];
+            const nextPreviousAfters = previousAfters.slice(0, -1);
+            return {
+              address,
+              after: previousAfters.at(-1),
+              previousAfters: nextPreviousAfters,
+            };
+          });
+        },
+        hasNextPage: archiveQuery.data?.pageInfo.hasNextPage ?? false,
+        hasPreviousPage,
+      },
+    };
+  }
+
+  return publicQuery;
 }

--- a/ui/store/src/hooks/explorer/useExplorerUserTransactions.ts
+++ b/ui/store/src/hooks/explorer/useExplorerUserTransactions.ts
@@ -1,5 +1,6 @@
 import { useQueries } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
+import { getArchiveApi } from "../../archive/api.js";
 import { usePublicClient } from "../usePublicClient.js";
 
 import type { Address, IndexedTransaction } from "@left-curve/types";
@@ -8,13 +9,14 @@ const PAGE_SIZE = 10;
 
 export function useExplorerUserTransactions(addresses: Address[]) {
   const client = usePublicClient();
+  const archive = getArchiveApi(client.chain);
   const [page, setPage] = useState(0);
 
   const transactionQueries = useQueries({
     queries: addresses.map((address) => ({
-      queryKey: ["explorer_user_transactions", address],
+      queryKey: ["explorer_user_transactions", address, archive ? "archive" : "public"],
       queryFn: async () => {
-        const result = await client.searchTxs({
+        const result = await (archive ?? client).searchTxs({
           senderAddress: address,
           first: 50,
           sortBy: "BLOCK_HEIGHT_DESC",

--- a/ui/store/src/hooks/useSearchBar.ts
+++ b/ui/store/src/hooks/useSearchBar.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useReducer, useState } from "react";
+import { getArchiveApi } from "../archive/api.js";
 import { usePublicClient } from "./usePublicClient.js";
 import { useAppConfig } from "./useAppConfig.js";
 
@@ -65,13 +66,14 @@ export function useSearchBar(parameters: UseSearchBarParameters) {
 
   const queryClient = useQueryClient();
   const client = usePublicClient();
+  const archive = getArchiveApi(client.chain);
 
   const allNotFavApplets = useMemo(() => {
     return Object.values(applets).filter((applet) => !favApplets.includes(applet.id));
   }, [applets, favApplets]);
 
   const { data: _, ...query } = useQuery({
-    queryKey: ["searchBar", searchText, favApplets],
+    queryKey: ["searchBar", searchText, favApplets, archive ? "archive" : "public"],
     queryFn: async ({ signal }) => {
       if (!searchText.length) {
         setSearchResult(noResult);
@@ -100,6 +102,7 @@ export function useSearchBar(parameters: UseSearchBarParameters) {
 
       const promises: Promise<unknown>[] = [];
       const { accountFactory } = appConfig;
+      const transactionHash = getTransactionHash(searchText);
 
       if (isValidAddress(searchText)) {
         // search for contract
@@ -118,11 +121,11 @@ export function useSearchBar(parameters: UseSearchBarParameters) {
             }
           })(),
         );
-      } else if (searchText.length === 64) {
+      } else if (transactionHash) {
         // search for tx hash
         promises.push(
           (async () => {
-            const txs = await client.searchTxs({ hash: searchText });
+            const txs = await (archive ?? client).searchTxs({ hash: transactionHash });
             if (txs.nodes.length) {
               setSearchResult({ txs: txs.nodes });
               queryClient.setQueryData(["tx", searchText], txs.nodes[0]);
@@ -132,9 +135,11 @@ export function useSearchBar(parameters: UseSearchBarParameters) {
       } else if (!Number.isNaN(Number(searchText))) {
         promises.push(
           (async () => {
-            const block = await client.queryBlock({ height: +searchText });
-            setSearchResult({ block });
-            queryClient.setQueryData(["block", searchText], block);
+            const block = archive
+              ? await archive.queryBlock(+searchText)
+              : await client.queryBlock({ height: +searchText });
+            setSearchResult({ block: block ?? undefined });
+            if (block) queryClient.setQueryData(["block", searchText], block);
           })(),
         );
       } else {
@@ -157,4 +162,9 @@ export function useSearchBar(parameters: UseSearchBarParameters) {
   });
 
   return { searchText, setSearchText, searchResult, allNotFavApplets, ...query };
+}
+
+function getTransactionHash(value: string): string | null {
+  const hash = value.replace(/^0x/i, "");
+  return /^[a-fA-F0-9]{64}$/.test(hash) ? hash : null;
 }


### PR DESCRIPTION
## Summary

Adds a temporary store-only archive API adapter for Dango mainnet and testnet explorer transaction and block searches. Hosted mainnet/testnet tx/block lookups now route through their archive APIs, while devnet and unsupported chains keep using the public client.

Archive URLs currently used:

- `dango-1`: `https://api-archive-mainnet.dango.zone`
- `dango-testnet-1`: `https://api-archive-testnet.dango.zone`

This includes archive response normalization into existing indexed block/transaction shapes, sender transaction pagination with `role=sender`, local previous-page cursor support, uppercase archive hash normalization, and archive-backed latest block lookup.

Also stabilizes the e2e `Activate Account` modal dismissal helper so the Playwright locator handler does not recursively intercept the explicit dismiss path.

## Validation

### Completed

- [x] `../../../node_modules/.pnpm/node_modules/.bin/vitest run tests/explorer-hooks.test.tsx tests/use-search-bar.test.tsx --config vitest.config.ts` - 59 tests passed
- [x] `../../../node_modules/.pnpm/node_modules/.bin/vitest run tests/test-quality-guards.test.tsx --config vitest.config.ts` - 12 tests passed
- [x] `./node_modules/.bin/biome check --write ui/store/src/archive/api.ts ui/portal/web/tests/explorer-hooks.test.tsx ui/portal/web/tests/use-search-bar.test.tsx`
- [x] `git diff --check`
- [x] Live testnet probes for `https://api-archive-testnet.dango.zone/up` and `/blocks/latest`
- [x] Live mainnet archive probes for `/blocks/latest`, `/blocks/{height}`, `/transactions/{HASH}`, and `/transactions/involving/{address}?role=sender&first=...&after=...`
- [x] Current CI has passed `Lint + Test`, `Testing localdango`, `Analyze (javascript-typescript)`, `Format`, and Rust build/check jobs on `cf340e83c`.

### Remaining

- [ ] Production build/browser verification is blocked in this checkout because `rsbuild.image-path-loader.ts` cannot resolve `@babel/parser`.
- [ ] Local targeted Playwright repro is blocked in this checkout because `tests/utils/injectWallet.ts` cannot resolve `viem`.
- [ ] GitHub `deploy` jobs need to rerun on the latest head after the testnet commit.

## Manual QA

Attempted to run a production-like portal build/dev server. The dev server advertised a local URL but compilation failed immediately on the existing missing `@babel/parser` dependency, so browser QA could not be completed from this environment.

Attempted the targeted transfer e2e locally after the helper fix, but the local checkout could not resolve `viem` from the Playwright test utility before executing the test.