### PR TITLE
perf(archive): seek-index + query timeout for name-filtered event feeds

### DIFF
--- a/dango/archive/projection/src/activity/DESIGN.md
+++ b/dango/archive/projection/src/activity/DESIGN.md
@@ -63,9 +63,10 @@ Two properties of the filters shape the schema:
   **included by default**; an optional `kind` filter narrows to transactions or
   cronjobs only (and `SENDER` + cron-only matches nothing).
 - **`contract_event_name` is always paired with `contract`** (never queried on
-  its own) and may be a **single value or a list**. It is also
-  **low-cardinality** — the busiest contract (perps) has ~15 distinct names — so
-  it is a **filter, never a seek column** (see Indexes).
+  its own) and may be a **single value or a list**. It is
+  **low-cardinality** — the busiest contract (perps) has ~15 distinct names — but
+  low cardinality does not make a *filter* cheap: paired with a hot contract it
+  needs its own `(contract, name)` **seek** index to stay bounded (see Indexes).
 
 ## Why one merged `events` table (not events + involvement)
 
@@ -247,7 +248,7 @@ event_index)`; the unit `(block_height, category, category_index)` joins
 `transactions(block_height, kind, idx)`. Distinct events are recovered with
 `DISTINCT ON` the position (a no-op at K = 1).
 
-**Indexes** (four). All carry the event-position `(block_height, category,
+**Indexes** (five). All carry the event-position `(block_height, category,
 category_index, event_index)`, so each is a backward scan ordered newest-first
 (keyset). On the two **attribute feeds** (by type, by contract) — the ones that
 `DISTINCT ON` the position — `address` **trails the position** as the
@@ -256,21 +257,34 @@ tiebreaker, so an event's participant rows are adjacent and the resolver's
 Scan → Unique → Limit, **no sort node** (verified via `EXPLAIN`; with `address`
 ASC — or with `contract_event_name` wedged before `address` — the planner adds
 an Incremental Sort). `contract_event_name` therefore sits at the very **tail**
-of the contract index: a pure in-index `= ANY()` filter (never a seek column,
-always paired with `contract`), costing the ordering nothing.
+of the un-filtered contract index, where it costs the ordering nothing — but the
+tail is useless for *filtering*: the position columns separate it from
+`contract`, so a `name =` predicate there is checked per row across the
+contract's whole slice, not sought. On a hot contract that slice is tens of
+millions of rows, so the name-filtered feed gets a **second** contract index
+leading with `(contract, contract_event_name)`.
 
 - `idx_…_addr_type` — `(address, event_type, …)` — **query 6** ("type-T events
   involving X" as a single seek). Plain index (`event_type` is NOT NULL).
 - `idx_…_addr_contract` — `(address, contract, …, contract_event_name)` —
   **queries 7/8** (contract events of C involving X, optionally a name list);
   address-led, no `DISTINCT ON`, so `contract_event_name` trails as the in-index
-  filter. Partial `WHERE contract IS NOT NULL`.
+  filter — bounded here because the **address** anchor already limits the scan
+  to one participant's events. Partial `WHERE contract IS NOT NULL`.
 - `idx_…_type` — `(event_type, …, address)` — **query 2** (events by type).
   Plain.
 - `idx_…_contract` — `(contract, …, address, contract_event_name)` —
-  **queries 3/4** (contract events of C, optionally a name list); `address`
-  trails the position (tiebreaker), `contract_event_name` at the tail (filter).
-  Partial.
+  **query 3** (contract events of C, *un-filtered*); `address` trails the
+  position (tiebreaker), `contract_event_name` at the tail (costs the ordering
+  nothing — but not a filter anchor, see above). Partial.
+- `idx_…_contract_name` — `(contract, contract_event_name, …, address)` —
+  **query 4** (contract events of C narrowed by a name list). Leading with
+  `(contract, name)` makes the name a **seek**: the query jumps to the
+  (contract, name) group, whose rows are already in position order, so it stays
+  a no-sort backward scan and a zero-match page returns at once instead of
+  walking the contract's whole slice. A companion to `idx_…_contract`, not a
+  replacement — neither column order serves both the filtered and the
+  un-filtered feed without a sort. Partial `WHERE contract IS NOT NULL`.
 
 The PK `(address, …)` itself serves **query 5** (events involving X) and, via
 `DISTINCT ON` the unit merged with `transactions.sender`, **query 1**.
@@ -368,14 +382,18 @@ LIMIT $N;
 ```
 
 The **name list** (Q4/Q8) is a plain `contract_event_name IN ($names…)`, never
-a per-name UNION: the column lives in the contract indexes (at the tail), so the
-filter is index-resident and rejects stay **off the heap**. The planner then
-picks one of two shapes by selectivity (both bounded by the ~15-name
-cardinality): a **non-selective** name keeps the ordered backward scan and
-short-circuits at N; a **selective** one is cheaper as a bitmap index scan on
-`(contract, name)` whose small match-set is sorted before the limit (confirmed
-via `EXPLAIN`). Either way the work is bounded by *(contract, name)* activity,
-not the table.
+a per-name UNION. **Q8** (address-anchored) keeps the name as an in-index filter
+that stays off the heap and is already bounded by the participant's own events.
+**Q4** (contract-anchored) is the trap: on the un-filtered contract index the
+name sits past the position columns, so `IN (…)` there is a per-row check over
+the contract's whole slice — a low- or zero-selectivity name (say one only a
+*different* contract emits) walks all of it, tens of millions of rows on a hot
+contract, seconds-to-minutes for an often-empty page, and a client disconnect
+does not cancel it. Q4 is therefore served by `idx_…_contract_name`, whose
+leading `(contract, contract_event_name)` turns `IN (…)` into a per-name seek:
+the match-set is already in position order, the work is bounded by
+*(contract, name)* activity, and a zero-match page returns at once
+(`EXPLAIN`-verified: `Limit` cost ~21k → ~34).
 
 ### Index summary — every feed is anchored by a selective seek
 
@@ -384,7 +402,7 @@ not the table.
 | Q1 tx involving X | `events` PK (involved) ∪ `transactions (sender, …)` → merge | 2 seeks + merge ~2N |
 | Q2 events by type T | `events (event_type, …, address)` + `DISTINCT ON` | seek + ~K·N |
 | Q3 contract events of C | `events (contract, …, address)` + `DISTINCT ON` | seek + ~K·N |
-| Q4 + name list | same index, `name = ANY()` in-index | seek + ~N/sel idx + N heap |
+| Q4 + name list | `events (contract, name, …)` seek | seek + N (small) |
 | Q5 events involving X | `events` PK `(address, …)` | seek + N |
 | Q6 + type T | `events (address, event_type, …)` | seek + N |
 | Q7 contract C involving X | `events (address, contract, …)` | seek + N (small) |
@@ -569,7 +587,11 @@ affects no written row, so changing it needs no re-backfill.
 
 Each runs the access path above verbatim: hand-written, `Binder`-parameterized
 SQL (`DISTINCT ON`, the involved ∪ sender union, the in-index `IN (…)` name
-list, the row-comparison keyset), mapped back to the sea-orm models. The
+list, the row-comparison keyset), mapped back to the sea-orm models, and run
+inside a transaction that applies `SET LOCAL statement_timeout` — a per-request
+bound scoped to the read path (ingest and migrations share the pool but not this
+transaction), so a pathological plan is cancelled server-side rather than
+pinning a pool connection past a client disconnect. The
 **type surface** — the `Transaction` / `Event` objects and the `UnitKind` /
 `AddressRole` enums — lives in `http/types.rs`; the **keyset machinery** —
 opaque `hex(json(tuple))` cursors, the page-size clamp, and the slim

--- a/dango/archive/projection/src/activity/http/feeds.rs
+++ b/dango/archive/projection/src/activity/http/feeds.rs
@@ -35,8 +35,8 @@ use {
     dango_archive_httpd::{ApiError, Binder, Page, PageInfo, decode_after, page_limit, paginate},
     dango_primitives::{Addr, Hash256},
     sea_orm::{
-        ColumnTrait, DatabaseConnection, DbBackend, EntityTrait, FromQueryResult, QueryFilter,
-        QueryOrder, Statement,
+        ColumnTrait, ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, DbErr,
+        EntityTrait, FromQueryResult, QueryFilter, QueryOrder, Statement, TransactionTrait,
     },
     serde::{Deserialize, Serialize},
 };
@@ -85,15 +85,17 @@ pub(crate) async fn transactions_by_hash(
     db: &DatabaseConnection,
     hash: Hash256,
 ) -> Result<Vec<Transaction>, ApiError> {
+    let txn = read_txn(db).await?;
     let rows = timed_query(
         "transactions_by_hash",
         transactions::Entity::find()
             .filter(transactions::Column::Hash.eq(hash.as_ref().to_vec()))
             .order_by_desc(transactions::Column::BlockHeight)
             .order_by_desc(transactions::Column::Idx)
-            .all(db),
+            .all(&txn),
     )
     .await?;
+    txn.commit().await?;
     rows.into_iter().map(Transaction::try_from).collect()
 }
 
@@ -193,11 +195,14 @@ pub(crate) async fn transactions_involving(
              ORDER BY t.block_height DESC, t.kind DESC, t.idx DESC LIMIT {fetch}"
         );
         let stmt = Statement::from_sql_and_values(DbBackend::Postgres, sql, binder.into_values());
-        timed_query(
+        let txn = read_txn(db).await?;
+        let rows = timed_query(
             "transactions_involving",
-            transactions::Entity::find().from_raw_sql(stmt).all(db),
+            transactions::Entity::find().from_raw_sql(stmt).all(&txn),
         )
-        .await?
+        .await?;
+        txn.commit().await?;
+        rows
     };
 
     paginate(
@@ -369,6 +374,26 @@ pub(crate) async fn contract_events_involving(
 
 // ---- shared feed plumbing ----
 
+/// Per-statement timeout for the read feeds, set via `SET LOCAL` so it is scoped
+/// to the feed's own transaction. Ingest and migrations share the pool but not
+/// this path, so they are never capped (a blanket role/pool timeout would also
+/// cut short a long index-building migration). A generous ceiling: the heaviest
+/// legitimate feed — a 50-row page — returns well under two seconds, so this
+/// only ever fires on a pathological plan, freeing the backend instead of
+/// letting a runaway query pin a pool connection (a client disconnect does not
+/// cancel a query already executing). Postgres-only, like every feed statement.
+const READ_TIMEOUT_STATEMENT: &str = "SET LOCAL statement_timeout = '15s'";
+
+/// Begin a read transaction with [`READ_TIMEOUT_STATEMENT`] applied. The caller
+/// runs its query against the returned transaction and commits it; on any error
+/// (a timeout included) the dropped transaction rolls back — harmless for a
+/// read.
+async fn read_txn(db: &DatabaseConnection) -> Result<DatabaseTransaction, DbErr> {
+    let txn = db.begin().await?;
+    txn.execute_unprepared(READ_TIMEOUT_STATEMENT).await?;
+    Ok(txn)
+}
+
 /// Wrap a feed's event query so each row also carries its stored payload: the
 /// inner query (already selected, ordered, and limited over `events`) becomes a
 /// subquery, and `data` is pulled per row by a **correlated** lookup on
@@ -406,7 +431,9 @@ async fn run_event_feed(
         with_event_data(&sql),
         binder.into_values(),
     );
-    let rows = timed_query(query, EventRow::find_by_statement(stmt).all(db)).await?;
+    let txn = read_txn(db).await?;
+    let rows = timed_query(query, EventRow::find_by_statement(stmt).all(&txn)).await?;
+    txn.commit().await?;
     paginate(
         rows,
         limit,

--- a/dango/archive/projection/src/activity/migrations.rs
+++ b/dango/archive/projection/src/activity/migrations.rs
@@ -1,6 +1,7 @@
 mod m20260610_000002_activity_transactions_create;
 mod m20260610_000003_activity_events_create;
 mod m20260610_000004_activity_event_data_create;
+mod m20260709_000005_activity_events_contract_name_index;
 
 use sea_orm_migration::MigrationTrait;
 
@@ -13,5 +14,6 @@ pub(super) fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260610_000002_activity_transactions_create::Migration),
         Box::new(m20260610_000003_activity_events_create::Migration),
         Box::new(m20260610_000004_activity_event_data_create::Migration),
+        Box::new(m20260709_000005_activity_events_contract_name_index::Migration),
     ]
 }

--- a/dango/archive/projection/src/activity/migrations/m20260610_000003_activity_events_create.rs
+++ b/dango/archive/projection/src/activity/migrations/m20260610_000003_activity_events_create.rs
@@ -59,8 +59,10 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
-        // Four secondary indexes serving the eight documented feeds. All carry
-        // the event-position `(block_height, category, category_index,
+        // Four secondary indexes serving the eight documented feeds (a fifth,
+        // `idx_activity_events_contract_name`, is added by a later migration to
+        // seek the name-filtered contract feed — see below). All carry the
+        // event-position `(block_height, category, category_index,
         // event_index)`, so each is a backward index scan ordered newest-first
         // (keyset-paginated). On the DISTINCT-ON feeds (by type, by contract)
         // `address` trails the position as the tiebreaker, so an event's
@@ -69,9 +71,13 @@ impl MigrationTrait for Migration {
         // Unique → Limit, with **no sort node** (verified via `EXPLAIN`; with
         // `address` ASC, or with `contract_event_name` wedged before `address`,
         // the planner adds an Incremental Sort). `contract_event_name` therefore
-        // sits at the very **tail** of the contract index — a pure in-index
-        // `= ANY(...)` filter (never a seek column, always paired with
-        // `contract`), costing the ordering nothing.
+        // sits at the very **tail** of the contract index — here a pure
+        // in-index `= ANY(...)` filter, not a seek column (the position
+        // columns separate it from `contract`, so a name predicate walks the
+        // contract's whole slice); a name-*filtered* feed instead seeks via
+        // the companion `(contract, contract_event_name, …)` index. Always
+        // paired with `contract`; at the tail it costs this index's ordering
+        // nothing.
         //
         // The type feeds are plain indexes (`event_type` is NOT NULL). The
         // contract feeds are partial on `contract IS NOT NULL` — only contract

--- a/dango/archive/projection/src/activity/migrations/m20260709_000005_activity_events_contract_name_index.rs
+++ b/dango/archive/projection/src/activity/migrations/m20260709_000005_activity_events_contract_name_index.rs
@@ -1,0 +1,61 @@
+use {
+    sea_orm::{ConnectionTrait, DatabaseBackend},
+    sea_orm_migration::prelude::*,
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // A companion to `idx_activity_events_contract` for the **name-filtered**
+        // contract-event feeds (`/events/contract?names=…`, `/events/perps`).
+        //
+        // That first index carries `contract_event_name` at its **tail** (after
+        // the event position), which is right for the un-filtered feed — an
+        // emitting contract's rows sit in position order, a clean backward scan.
+        // But it leaves the name a *residual* filter: Postgres seeks to the
+        // contract, then scans its whole slice checking the name per row. For a
+        // name matching few or none of that contract's events (say a name only a
+        // *different* contract emits) the scan walks the entire slice — tens of
+        // millions of rows on a hot contract, seconds-to-minutes for what is
+        // often an empty page.
+        //
+        // Leading with `(contract, contract_event_name)` turns the name into a
+        // **seek**: the query jumps straight to the (contract, name) group,
+        // whose rows are already in position order (the trailing columns are
+        // `POS_DESC` + the `address` tiebreaker), so it stays a no-sort backward
+        // scan and a zero-match page returns at once. The two indexes sit side
+        // by side — no single column order serves both the filtered and the
+        // un-filtered feed without a sort.
+        //
+        // Partial on `contract IS NOT NULL` (only contract events carry a
+        // contract / name) to match its sibling and stay small; `fillfactor`
+        // leaves leaf slack for the near-random `contract`-led prefix, exactly
+        // like the other event indexes (Postgres only — SQLite has no such knob).
+        let conn = manager.get_connection();
+        let storage = match manager.get_database_backend() {
+            DatabaseBackend::Postgres => "WITH (fillfactor = 85)",
+            _ => "",
+        };
+        conn.execute_unprepared(&format!(
+            "CREATE INDEX IF NOT EXISTS idx_activity_events_contract_name \
+             ON activity_events \
+             (contract, contract_event_name, block_height, category, category_index, event_index, address) \
+             {storage} WHERE contract IS NOT NULL"
+        ))
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS idx_activity_events_contract_name")
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

The name-filtered contract-event feeds (`GET /events/contract?names=…` and the
`/events/perps` shortcut) could take **82–150 s** for an often-empty page, and
the runaway query kept executing in Postgres after the client disconnected —
a trivially-triggered, unauthenticated DoS on the public archive API.

Root cause: `contract_event_name` sits at the **tail** of
`idx_activity_events_contract`, past the event-position columns, so a `names=`
filter is a per-row check, not a seek. A name matching few or none of a
contract's events (e.g. `limit_orders_matched`, which only the dex emits, asked
of perps) walks the contract's entire slice — ~177 M rows on perps. `LIMIT`
can't short-circuit a zero-match scan, and the API's DB role has no timeout.

This PR fixes it two ways:

1. **`perf`** — a companion index `idx_activity_events_contract_name`
   `(contract, contract_event_name, block_height, category, category_index,
   event_index, address)`, partial on `contract IS NOT NULL`. Leading with
   `(contract, name)` turns the filter into a **seek**: the query jumps to the
   `(contract, name)` group, already in position order, so a zero-match page
   returns at once. Companion to — not a replacement for — the existing contract
   index (the un-filtered feed still needs the name at the tail for its no-sort
   ordering). Added as migration `m20260709_000005`; already built via
   `CREATE INDEX CONCURRENTLY` on live mainnet (21 GB) and testnet (45 GB), so
   the migration's `CREATE INDEX IF NOT EXISTS` is a no-op there and builds on
   fresh / re-projected deployments.

2. **`feat`** — a per-request `SET LOCAL statement_timeout = '15s'` around every
   read feed (helper `read_txn`), scoped to the feed's own transaction so it
   caps only the read path. Ingest and migrations share the pool but not this
   transaction, so a long index-building migration is never cut short. Defence
   in depth: even a future pathological plan is cancelled server-side instead of
   pinning a pool connection past a client disconnect.

3. **`docs`** — update the activity `DESIGN.md` and the events-table migration
   comment: correct the earlier (incorrect) claim that the tail-name filter was
   bounded to `(contract, name)`, document the new seek index and the read
   timeout, and refresh the index summary.

### Result (measured live)

| Query (`/events/perps?names=…`) | Before | After |
|---|---|---|
| `does_not_exist` | 82 s | **0.11 s** |
| `limit_orders_matched` | >150 s (timeout) | **0.11 s** |
| `order_filled` (real name) | 0.16 s | 0.16 s (no regression) |

`EXPLAIN`: the `Limit` cost drops from ~21 485 to ~34.

## Validation

### Completed
- [x] `cargo check` + `clippy` clean on `dango-archive-projection`
- [x] `cargo test -p dango-archive-projection` — **12/12 pass**, including
      `feeds_execute_against_postgres` against a real Postgres (exercises the
      new migration **and** the `SET LOCAL` transaction wrapper) and the
      SQLite migration round-trip
- [x] Index built `CONCURRENTLY` on live mainnet + testnet; before/after
      timings measured against the live REST API (table above)
- [x] `EXPLAIN` confirms the new index is used as a seek (Limit cost 21 485 → 34)
- [x] Formatted with `cargo +nightly fmt`

### Remaining
- [ ] CI green
- [ ] Review

## Manual QA

Against the live archive (VPN):

```
curl 'http://hetzner7:9082/events/perps?names=does_not_exist'      # ~0.1s, empty
curl 'http://hetzner7:9082/events/perps?names=order_filled'        # ~0.16s, 50 items
curl 'http://hetzner8:9081/events/perps?names=does_not_exist'      # ~0.17s, empty (testnet)
```

The index is already live on both networks, so no deploy-time rebuild; the
migration only builds it on fresh / re-projected deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
