### PR TITLE
feat(indexer-httpd): add REST aliases for perps contract queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,6 +4252,7 @@ dependencies = [
  "dango-indexer-clickhouse",
  "dango-indexer-sql",
  "dango-indexer-stream",
+ "dango-order-book",
  "dango-primitives",
  "dango-types",
  "futures",

--- a/dango/exchange/order-book/src/types.rs
+++ b/dango/exchange/order-book/src/types.rs
@@ -179,6 +179,25 @@ pub struct QueryOrderResponse {
     pub client_order_id: Option<ClientOrderId>,
 }
 
+/// Response type of the order-by-client-order-ID query.
+///
+/// Includes the system-assigned `order_id`, which the caller — knowing only
+/// the client order ID — is typically after. The query inputs (`user`,
+/// `client_order_id`) are not echoed back, consistent with the other order
+/// query responses.
+#[dango_primitives::derive(Serde)]
+pub struct QueryOrderByClientOrderIdResponse {
+    pub order_id: OrderId,
+    pub pair_id: PairId,
+    pub size: Quantity,
+    pub limit_price: UsdPrice,
+    pub reduce_only: bool,
+    pub reserved_margin: UsdValue,
+    pub created_at: Timestamp,
+    pub tp: Option<ChildOrder>,
+    pub sl: Option<ChildOrder>,
+}
+
 #[dango_primitives::derive(Serde)]
 pub struct QueryOrdersByUserResponseItem {
     pub pair_id: PairId,

--- a/dango/exchange/perps/src/lib.rs
+++ b/dango/exchange/perps/src/lib.rs
@@ -314,6 +314,13 @@ pub fn query(ctx: ImmutableCtx, msg: QueryMsg) -> anyhow::Result<Json> {
             let res = query::query_orders_by_user(ctx, user)?;
             res.to_json_value()
         },
+        QueryMsg::OrderByClientOrderId {
+            user,
+            client_order_id,
+        } => {
+            let res = query::query_order_by_client_order_id(ctx, user, client_order_id)?;
+            res.to_json_value()
+        },
         QueryMsg::LiquidityDepth {
             pair_id,
             bucket_size,

--- a/dango/exchange/perps/src/query.rs
+++ b/dango/exchange/perps/src/query.rs
@@ -15,9 +15,10 @@ use {
     },
     anyhow::ensure,
     dango_order_book::{
-        ASKS, BIDS, DEPTHS, Dimensionless, LimitOrder, LiquidityDepth, LiquidityDepthResponse,
-        OrderId, PairId, QueryOrderResponse, QueryOrdersByUserResponseItem, UsdPrice, UsdValue,
-        VOLUMES, round_to_day,
+        ASKS, BIDS, ClientOrderId, DEPTHS, Dimensionless, LimitOrder, LiquidityDepth,
+        LiquidityDepthResponse, OrderId, PairId, QueryOrderByClientOrderIdResponse,
+        QueryOrderResponse, QueryOrdersByUserResponseItem, UsdPrice, UsdValue, VOLUMES,
+        round_to_day,
     },
     dango_primitives::{
         Addr, Bound, DEFAULT_PAGE_LIMIT, ImmutableCtx, Order as IterationOrder, StdResult, Storage,
@@ -247,6 +248,44 @@ pub fn query_orders_by_user(
     Ok(items)
 }
 
+/// Search `BIDS` and `ASKS` for an order with the given submitter and client
+/// order ID, via the `(user, client_order_id)` unique index.
+pub fn query_order_by_client_order_id(
+    ctx: ImmutableCtx,
+    user: Addr,
+    client_order_id: ClientOrderId,
+) -> StdResult<Option<QueryOrderByClientOrderIdResponse>> {
+    // Check `BIDS` (un-invert price).
+    if let Some(((pair_id, stored_price, order_id), order)) = BIDS
+        .idx
+        .client_order_id
+        .may_load(ctx.storage, (user, client_order_id))?
+    {
+        return Ok(Some(limit_order_to_cid_response(
+            pair_id,
+            !stored_price,
+            order_id,
+            order,
+        )));
+    }
+
+    // Check `ASKS` (price as-is).
+    if let Some(((pair_id, limit_price, order_id), order)) = ASKS
+        .idx
+        .client_order_id
+        .may_load(ctx.storage, (user, client_order_id))?
+    {
+        return Ok(Some(limit_order_to_cid_response(
+            pair_id,
+            limit_price,
+            order_id,
+            order,
+        )));
+    }
+
+    Ok(None)
+}
+
 fn limit_order_to_response(
     pair_id: PairId,
     limit_price: UsdPrice,
@@ -263,6 +302,25 @@ fn limit_order_to_response(
         tp: order.tp,
         sl: order.sl,
         client_order_id: order.client_order_id,
+    }
+}
+
+fn limit_order_to_cid_response(
+    pair_id: PairId,
+    limit_price: UsdPrice,
+    order_id: OrderId,
+    order: LimitOrder,
+) -> QueryOrderByClientOrderIdResponse {
+    QueryOrderByClientOrderIdResponse {
+        order_id,
+        pair_id,
+        size: order.size,
+        limit_price,
+        reduce_only: order.reduce_only,
+        reserved_margin: order.reserved_margin,
+        created_at: order.created_at,
+        tp: order.tp,
+        sl: order.sl,
     }
 }
 

--- a/dango/exchange/types/src/perps.rs
+++ b/dango/exchange/types/src/perps.rs
@@ -4,7 +4,8 @@ use {
     dango_order_book::{
         ChildOrder, ClientOrderId, ConditionalOrder, Dimensionless, FillId, FundingPerUnit,
         FundingRate, LiquidityDepthResponse, OrderId, OrderKind, PairId, Quantity,
-        QueryOrderResponse, QueryOrdersByUserResponseItem, TriggerDirection, UsdPrice, UsdValue,
+        QueryOrderByClientOrderIdResponse, QueryOrderResponse, QueryOrdersByUserResponseItem,
+        TriggerDirection, UsdPrice, UsdValue,
     },
     dango_primitives::{Addr, Duration, NonEmpty, Op, Order as IterationOrder, Part, Timestamp},
     std::{
@@ -1058,6 +1059,13 @@ pub enum QueryMsg {
     /// Query all limit orders of a single user.
     #[returns(BTreeMap<OrderId, QueryOrdersByUserResponseItem>)]
     OrdersByUser { user: Addr },
+
+    /// Query a single limit order by the submitting user and client order ID.
+    #[returns(Option<QueryOrderByClientOrderIdResponse>)]
+    OrderByClientOrderId {
+        user: Addr,
+        client_order_id: ClientOrderId,
+    },
 
     /// Query aggregated order book depth at a specific bucket size.
     #[returns(LiquidityDepthResponse)]

--- a/dango/indexer/httpd/Cargo.toml
+++ b/dango/indexer/httpd/Cargo.toml
@@ -33,6 +33,7 @@ dango-indexer-cache      = { workspace = true }
 dango-indexer-clickhouse = { workspace = true, features = ["async-graphql"] }
 dango-indexer-sql        = { workspace = true, features = ["async-graphql"] }
 dango-indexer-stream     = { workspace = true }
+dango-order-book         = { workspace = true }
 dango-primitives         = { workspace = true, features = ["async-graphql", "chrono", "tendermint"] }
 dango-types              = { workspace = true, features = ["async-graphql"] }
 futures                  = { workspace = true }

--- a/dango/indexer/httpd/src/context.rs
+++ b/dango/indexer/httpd/src/context.rs
@@ -7,9 +7,11 @@ use {
         EventCacheReader, entity::perps_trade::PerpsTrade, pubsub::PubSub,
         write::perps_trades::PerpsTradeCache,
     },
+    dango_primitives::{Addr, JsonDeExt, Query},
+    dango_types::config::AppConfig,
     sea_orm::{ConnectOptions, Database, DatabaseConnection},
     std::sync::Arc,
-    tokio::sync::RwLock,
+    tokio::sync::{OnceCell, RwLock},
 };
 
 /// The chain-query slice of [`FullContext`] — holds just the chain query app.
@@ -19,11 +21,40 @@ use {
 #[derive(Clone)]
 pub struct MinimalContext {
     pub dango_app: Arc<dyn QueryApp + Send + Sync>,
+    /// Address of the perps contract, resolved from the chain's app config on
+    /// first use (see [`Self::perps_address`]). Behind an `Arc` so that all
+    /// clones of the context — one per actix worker — share the one cache.
+    perps_address: Arc<OnceCell<Addr>>,
 }
 
 impl MinimalContext {
     pub fn new(dango_app: Arc<dyn QueryApp + Send + Sync>) -> Self {
-        Self { dango_app }
+        Self {
+            dango_app,
+            perps_address: Arc::new(OnceCell::new()),
+        }
+    }
+
+    /// The address of the perps contract, per the chain's app config.
+    ///
+    /// Resolved lazily on first call rather than at server construction, so
+    /// that serving does not depend on chain state being queryable at startup
+    /// (on a fresh chain, the app config exists only once the genesis state is
+    /// committed). A failed resolution is returned as an error and retried on
+    /// the next call; a success is cached for the life of the process — the
+    /// perps address only changes with a chain upgrade, which entails a node
+    /// restart anyway.
+    pub async fn perps_address(&self) -> anyhow::Result<Addr> {
+        self.perps_address
+            .get_or_try_init(|| async {
+                let (response, _) = self.dango_app.query_app(Query::app_config()).await?;
+
+                let app_config: AppConfig = response.into_app_config().deserialize_json()?;
+
+                Ok::<_, anyhow::Error>(app_config.addresses.perps)
+            })
+            .await
+            .copied()
     }
 }
 

--- a/dango/indexer/httpd/src/routes.rs
+++ b/dango/indexer/httpd/src/routes.rs
@@ -2,6 +2,7 @@ pub mod blocks;
 pub mod broadcast;
 pub mod graphql;
 pub mod index;
+pub mod perps;
 pub mod query;
 pub mod simulate;
 pub mod ws;

--- a/dango/indexer/httpd/src/routes/perps.rs
+++ b/dango/indexer/httpd/src/routes/perps.rs
@@ -1,0 +1,887 @@
+use {
+    crate::context::MinimalContext,
+    actix_web::{
+        Error, HttpResponse, Scope,
+        error::{
+            ErrorBadRequest, ErrorInternalServerError, ErrorNotFound, ErrorServiceUnavailable,
+        },
+        get, web,
+    },
+    dango_order_book::{ClientOrderId, OrderId, PairId, UsdPrice},
+    dango_primitives::{Addr, Json, Query},
+    dango_types::perps,
+    serde::Deserialize,
+    utoipa::IntoParams,
+};
+
+/// Routes under `/perps` — GET aliases for the perps contract's queries.
+///
+/// Each route mirrors one `wasm_smart` query to the perps contract, so that,
+/// e.g. `GET /perps/liquidity_depth?pair_id=perp/ethusd&bucket_size=10` is the
+/// same read as `POST /query` with body:
+///
+/// ```json
+/// {
+///   "wasm_smart": {
+///     "contract": "<perps address>",
+///     "msg": {
+///       "liquidity_depth": {
+///         "pair_id": "perp/ethusd",
+///         "bucket_size": "10"
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+/// The perps contract address is resolved from the chain's app config
+/// server-side ([`MinimalContext::perps_address`]); clients never pass it.
+/// Responses are the contract's response objects verbatim, so client-side
+/// types written for the contract queries can be reused as-is. Query
+/// parameters take the same wire encoding as the JSON fields they alias
+/// (numbers inside grug types are string-encoded, so `bucket_size=10` parses
+/// as a `UsdPrice`; plain Rust integers such as `limit` are unquoted).
+pub fn services() -> Scope {
+    web::scope("/perps")
+        .service(param)
+        .service(pair_param)
+        .service(pair_params)
+        .service(state)
+        .service(pair_state)
+        .service(pair_states)
+        .service(liquidity_depth)
+        .service(user_state)
+        // The literal `/order/...` routes are registered before
+        // `/order/{order_id}`, so that "by-user" and "by-client-order-id" are
+        // not captured as order IDs.
+        .service(orders_by_user)
+        .service(order_by_client_order_id)
+        .service(order)
+}
+
+/// Run a `wasm_smart` query against the perps contract and return the raw
+/// contract response.
+///
+/// Error mapping: the perps address not being resolvable is a 503 — the chain
+/// may not have committed its genesis state yet, and resolution is retried on
+/// the next request; a failed query is a 400 carrying the error message,
+/// mirroring `POST /query`.
+async fn query_perps(app_ctx: &MinimalContext, msg: &perps::QueryMsg) -> Result<Json, Error> {
+    let contract = app_ctx.perps_address().await.map_err(|err| {
+        ErrorServiceUnavailable(format!(
+            "failed to resolve the perps contract address: {err}"
+        ))
+    })?;
+
+    let query = Query::wasm_smart(contract, msg).map_err(ErrorInternalServerError)?;
+
+    let (response, _) = app_ctx
+        .dango_app
+        .query_app(query)
+        .await
+        .map_err(|err| ErrorBadRequest(err.to_string()))?;
+
+    Ok(response.into_wasm_smart())
+}
+
+/// Respond 200 with the JSON, or 404 if it is `null` — for the single-item
+/// lookups whose contract response is an `Option`.
+fn json_or_not_found(json: Json, what: String) -> Result<HttpResponse, Error> {
+    if json.is_null() {
+        Err(ErrorNotFound(format!("{what} not found")))
+    } else {
+        Ok(HttpResponse::Ok().json(json))
+    }
+}
+
+// ---- global and pair-level queries ----
+
+#[utoipa::path(
+    get,
+    path = "/perps/param",
+    tag = "perps",
+    summary = "Global parameters",
+    description = "Global parameters of the perps contract: fee rate \
+                   schedules, liquidation parameters, vault configuration, \
+                   referral parameters, etc. Alias of the contract's `param` \
+                   query; the response is the contract's `Param` object.",
+    responses(
+        (status = 200, description = "The contract's `Param` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/param")]
+pub async fn param(app_ctx: web::Data<MinimalContext>) -> Result<HttpResponse, Error> {
+    let response = query_perps(&app_ctx, &perps::QueryMsg::Param {}).await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/pair_param",
+    tag = "perps",
+    summary = "Pair parameters",
+    description = "Parameters of a single trading pair: tick size, minimum \
+                   order size, price band, open interest cap, margin ratios, \
+                   liquidity depth bucket sizes, etc. Alias of the contract's \
+                   `pair_param` query; the response is the contract's \
+                   `PairParam` object.",
+    params(PairIdQuery),
+    responses(
+        (status = 200, description = "The contract's `PairParam` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 404, description = "No pair with this ID"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/pair_param")]
+pub async fn pair_param(
+    query: web::Query<PairIdQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let PairIdQuery { pair_id } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::PairParam {
+        pair_id: pair_id.clone(),
+    })
+    .await?;
+
+    json_or_not_found(response, format!("pair `{pair_id}`"))
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/pair_params",
+    tag = "perps",
+    summary = "Enumerate pair parameters",
+    description = "Parameters of all trading pairs, as a map from pair ID to \
+                   `PairParam`. Alias of the contract's `pair_params` query. \
+                   Paginated: iteration starts after `start_after`, returning \
+                   at most `limit` entries; the contract picks the defaults \
+                   when omitted.",
+    params(PairsPageQuery),
+    responses(
+        (status = 200, description = "Map of pair ID to the contract's `PairParam` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/pair_params")]
+pub async fn pair_params(
+    query: web::Query<PairsPageQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let PairsPageQuery { start_after, limit } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::PairParams {
+        start_after,
+        limit,
+    })
+    .await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/state",
+    tag = "perps",
+    summary = "Global state",
+    description = "Global state of the perps contract: last funding time, \
+                   vault share supply, insurance fund and treasury balances. \
+                   Alias of the contract's `state` query; the response is the \
+                   contract's `State` object.",
+    responses(
+        (status = 200, description = "The contract's `State` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/state")]
+pub async fn state(app_ctx: web::Data<MinimalContext>) -> Result<HttpResponse, Error> {
+    let response = query_perps(&app_ctx, &perps::QueryMsg::State {}).await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/pair_state",
+    tag = "perps",
+    summary = "Pair state",
+    description = "State of a single trading pair: long and short open \
+                   interest, funding rate and accumulator, index price. Alias \
+                   of the contract's `pair_state` query; the response is the \
+                   contract's `PairState` object.",
+    params(PairIdQuery),
+    responses(
+        (status = 200, description = "The contract's `PairState` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 404, description = "No pair with this ID"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/pair_state")]
+pub async fn pair_state(
+    query: web::Query<PairIdQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let PairIdQuery { pair_id } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::PairState {
+        pair_id: pair_id.clone(),
+    })
+    .await?;
+
+    json_or_not_found(response, format!("pair `{pair_id}`"))
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/pair_states",
+    tag = "perps",
+    summary = "Enumerate pair states",
+    description = "States of all trading pairs, as a map from pair ID to \
+                   `PairState`. Alias of the contract's `pair_states` query. \
+                   Paginated: iteration starts after `start_after`, returning \
+                   at most `limit` entries; the contract picks the defaults \
+                   when omitted.",
+    params(PairsPageQuery),
+    responses(
+        (status = 200, description = "Map of pair ID to the contract's `PairState` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/pair_states")]
+pub async fn pair_states(
+    query: web::Query<PairsPageQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let PairsPageQuery { start_after, limit } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::PairStates {
+        start_after,
+        limit,
+    })
+    .await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/liquidity_depth",
+    tag = "perps",
+    summary = "Order book depth",
+    description = "Aggregated order book depth of one trading pair at one of \
+                   its pre-configured bucket sizes (see `bucket_sizes` in the \
+                   pair's `PairParam`). Alias of the contract's \
+                   `liquidity_depth` query; the response is the contract's \
+                   `LiquidityDepthResponse` object: `bids` and `asks` maps \
+                   from bucket price to aggregated size and notional. Bids \
+                   are best (highest) first when iterated in descending key \
+                   order; asks best (lowest) first in ascending key order.",
+    params(LiquidityDepthQuery),
+    responses(
+        (status = 200, description = "The contract's `LiquidityDepthResponse` object", body = serde_json::Value),
+        (status = 400, description = "The query failed, e.g. unknown pair or `bucket_size` not one of the pair's configured bucket sizes"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/liquidity_depth")]
+pub async fn liquidity_depth(
+    query: web::Query<LiquidityDepthQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let LiquidityDepthQuery {
+        pair_id,
+        bucket_size,
+        limit,
+    } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::LiquidityDepth {
+        pair_id,
+        bucket_size,
+        limit,
+    })
+    .await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+// ---- user-level queries ----
+
+#[utoipa::path(
+    get,
+    path = "/perps/user_state",
+    tag = "perps",
+    summary = "User state",
+    description = "State of one user: margin, vault shares, pending unlocks, \
+                   reserved margin, open order count, and positions (each \
+                   with its attached conditional orders). Alias of the \
+                   contract's `user_state_extended` query; the response is \
+                   the contract's `UserStateExtended` object. The `include_*` \
+                   flags opt into fields computed on the fly — equity, \
+                   available margin, maintenance margin, and per-position \
+                   unrealized PnL, unrealized funding and liquidation price; \
+                   fields not requested are `null`. `include_all=true` \
+                   computes everything, overriding the individual flags.",
+    params(UserStateQuery),
+    responses(
+        (status = 200, description = "The contract's `UserStateExtended` object", body = serde_json::Value),
+        (status = 400, description = "The query failed, e.g. the user has no state in the perps contract"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/user_state")]
+pub async fn user_state(
+    query: web::Query<UserStateQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let UserStateQuery {
+        user,
+        include_equity,
+        include_available_margin,
+        include_maintenance_margin,
+        include_unrealized_pnl,
+        include_unrealized_funding,
+        include_liquidation_price,
+        include_all,
+    } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::UserStateExtended {
+        user,
+        include_equity,
+        include_available_margin,
+        include_maintenance_margin,
+        include_unrealized_pnl,
+        include_unrealized_funding,
+        include_liquidation_price,
+        include_all,
+    })
+    .await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+// ---- order queries ----
+
+#[utoipa::path(
+    get,
+    path = "/perps/order/by-user",
+    tag = "perps",
+    summary = "Open orders of a user",
+    description = "All resting limit orders of one user, as a map from \
+                   system-assigned order ID to the order. Alias of the \
+                   contract's `orders_by_user` query. Unpaginated: a user's \
+                   open orders are bounded by the `max_open_orders` global \
+                   parameter.",
+    params(OrdersByUserQuery),
+    responses(
+        (status = 200, description = "Map of order ID to the contract's `QueryOrdersByUserResponseItem` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/order/by-user")]
+pub async fn orders_by_user(
+    query: web::Query<OrdersByUserQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let OrdersByUserQuery { user } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::OrdersByUser { user }).await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/order/by-client-order-id",
+    tag = "perps",
+    summary = "Open order by client order ID",
+    description = "The resting limit order of one user carrying the given \
+                   client-assigned order ID (unique among a user's resting \
+                   orders). Alias of the contract's `order_by_client_order_id` \
+                   query; the response is the contract's \
+                   `QueryOrderByClientOrderIdResponse` object, which includes \
+                   the system-assigned `order_id` — the piece of information \
+                   this lookup typically serves. Only resting orders are \
+                   found.",
+    params(OrderByClientOrderIdQuery),
+    responses(
+        (status = 200, description = "The contract's `QueryOrderByClientOrderIdResponse` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 404, description = "No resting order of this user carries this client order ID"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/order/by-client-order-id")]
+pub async fn order_by_client_order_id(
+    query: web::Query<OrderByClientOrderIdQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let OrderByClientOrderIdQuery {
+        user,
+        client_order_id,
+    } = query.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::OrderByClientOrderId {
+        user,
+        client_order_id,
+    })
+    .await?;
+
+    json_or_not_found(
+        response,
+        format!("order of user {user} with client order ID {client_order_id}"),
+    )
+}
+
+#[utoipa::path(
+    get,
+    path = "/perps/order/{order_id}",
+    tag = "perps",
+    summary = "Open order by ID",
+    description = "One resting limit order by its system-assigned order ID. \
+                   Alias of the contract's `order` query; the response is the \
+                   contract's `QueryOrderResponse` object. Only resting \
+                   orders are found — for filled or canceled orders, use the \
+                   perps event feeds.",
+    params(
+        ("order_id" = String, Path, description = "System-assigned order ID (a string-encoded integer)"),
+    ),
+    responses(
+        (status = 200, description = "The contract's `QueryOrderResponse` object", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+        (status = 404, description = "No resting order with this ID"),
+        (status = 503, description = "The perps contract address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/order/{order_id}")]
+pub async fn order(
+    path: web::Path<OrderId>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let order_id = path.into_inner();
+
+    let response = query_perps(&app_ctx, &perps::QueryMsg::Order { order_id }).await?;
+
+    json_or_not_found(response, format!("order {order_id}"))
+}
+
+// ---- request/response types ----
+
+#[derive(Deserialize, IntoParams)]
+pub struct PairIdQuery {
+    /// Trading pair ID, e.g. `perp/ethusd`.
+    #[param(value_type = String, example = "perp/ethusd")]
+    pair_id: PairId,
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct PairsPageQuery {
+    /// Pair ID after which iteration starts (exclusive). The contract starts
+    /// from the beginning when omitted.
+    #[param(value_type = Option<String>)]
+    start_after: Option<PairId>,
+
+    /// Maximum number of entries to return. The contract picks its default
+    /// page limit when omitted.
+    limit: Option<u32>,
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct LiquidityDepthQuery {
+    /// Trading pair ID, e.g. `perp/ethusd`.
+    #[param(value_type = String, example = "perp/ethusd")]
+    pair_id: PairId,
+
+    /// Price bucket size; must be one of the pair's configured
+    /// `bucket_sizes` (see the pair's `PairParam`).
+    #[param(value_type = String, example = "10")]
+    bucket_size: UsdPrice,
+
+    /// Maximum number of buckets per side. The contract picks its default
+    /// page limit when omitted.
+    limit: Option<u32>,
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct UserStateQuery {
+    /// Account address.
+    #[param(value_type = String)]
+    user: Addr,
+
+    /// Compute the user's equity.
+    #[serde(default)]
+    include_equity: bool,
+
+    /// Compute the user's available margin.
+    #[serde(default)]
+    include_available_margin: bool,
+
+    /// Compute the user's maintenance margin.
+    #[serde(default)]
+    include_maintenance_margin: bool,
+
+    /// Compute each position's unrealized PnL.
+    #[serde(default)]
+    include_unrealized_pnl: bool,
+
+    /// Compute each position's unrealized funding.
+    #[serde(default)]
+    include_unrealized_funding: bool,
+
+    /// Compute each position's liquidation price.
+    #[serde(default)]
+    include_liquidation_price: bool,
+
+    /// Compute all of the above, overriding the individual flags.
+    #[serde(default)]
+    include_all: bool,
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct OrdersByUserQuery {
+    /// Account address.
+    #[param(value_type = String)]
+    user: Addr,
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct OrderByClientOrderIdQuery {
+    /// Account address.
+    #[param(value_type = String)]
+    user: Addr,
+
+    /// The client-assigned order ID (a string-encoded integer, unique among
+    /// the user's resting orders).
+    #[param(value_type = String, example = "42")]
+    client_order_id: ClientOrderId,
+}
+
+// ---- tests ----
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::traits::QueryApp,
+        actix_web::{App, http::StatusCode, test},
+        async_trait::async_trait,
+        dango_app::{AppError, AppResult},
+        dango_order_book::{Quantity, QueryOrderByClientOrderIdResponse, UsdValue},
+        dango_primitives::{
+            BlockInfo, JsonSerExt, QueryResponse, Timestamp, TxOutcome, UnsignedTx,
+        },
+        dango_types::config::{AppAddresses, AppConfig},
+        std::sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    fn perps_addr() -> Addr {
+        Addr::mock(9)
+    }
+
+    fn user_addr() -> Addr {
+        Addr::mock(1)
+    }
+
+    /// A `QueryApp` that serves `app_config` (with [`perps_addr`] as the
+    /// perps contract, after a configurable number of failures) and answers
+    /// every `wasm_smart` query with the canned responder, recording the last
+    /// request for assertions.
+    struct MockApp {
+        respond: Box<dyn Fn(&Json) -> Json + Send + Sync>,
+        app_config_calls: AtomicUsize,
+        app_config_failures: AtomicUsize,
+        last_wasm_smart: Mutex<Option<(Addr, Json)>>,
+    }
+
+    impl MockApp {
+        fn context<F>(app_config_failures: usize, respond: F) -> (MinimalContext, Arc<Self>)
+        where
+            F: Fn(&Json) -> Json + Send + Sync + 'static,
+        {
+            let app = Arc::new(Self {
+                respond: Box::new(respond),
+                app_config_calls: AtomicUsize::new(0),
+                app_config_failures: AtomicUsize::new(app_config_failures),
+                last_wasm_smart: Mutex::new(None),
+            });
+
+            (MinimalContext::new(app.clone()), app)
+        }
+    }
+
+    #[async_trait]
+    impl QueryApp for MockApp {
+        async fn query_app(&self, raw_req: Query) -> AppResult<(QueryResponse, u64)> {
+            match raw_req {
+                Query::AppConfig(_) => {
+                    self.app_config_calls.fetch_add(1, Ordering::SeqCst);
+
+                    if self
+                        .app_config_failures
+                        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                            remaining.checked_sub(1)
+                        })
+                        .is_ok()
+                    {
+                        return Err(AppError::vm("app config not ready".to_string()));
+                    }
+
+                    let app_config = AppConfig {
+                        addresses: AppAddresses {
+                            perps: perps_addr(),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    };
+
+                    Ok((QueryResponse::AppConfig(app_config.to_json_value()?), 1))
+                },
+                Query::WasmSmart(req) => {
+                    let response = (self.respond)(&req.msg);
+
+                    *self.last_wasm_smart.lock().unwrap() = Some((req.contract, req.msg));
+
+                    Ok((QueryResponse::WasmSmart(response), 1))
+                },
+                _ => unimplemented!("not exercised by the perp routes"),
+            }
+        }
+
+        async fn simulate(&self, _unsigned_tx: UnsignedTx) -> AppResult<TxOutcome> {
+            unimplemented!("not exercised by the perp routes");
+        }
+
+        async fn chain_id(&self) -> AppResult<String> {
+            unimplemented!("not exercised by the perp routes");
+        }
+
+        async fn last_finalized_block(&self) -> AppResult<BlockInfo> {
+            unimplemented!("not exercised by the perp routes");
+        }
+    }
+
+    async fn get(ctx: &MinimalContext, uri: &str) -> (StatusCode, Json) {
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(ctx.clone()))
+                .service(services()),
+        )
+        .await;
+
+        let response =
+            test::call_service(&app, test::TestRequest::get().uri(uri).to_request()).await;
+        let status = response.status();
+        let body = test::read_body(response).await;
+
+        // Error responses carry a plain-text body; substitute `null` so
+        // callers can assert on the status alone.
+        let json = serde_json::from_slice(&body).unwrap_or(Json::null());
+
+        (status, json)
+    }
+
+    fn cid_order_response() -> QueryOrderByClientOrderIdResponse {
+        QueryOrderByClientOrderIdResponse {
+            order_id: OrderId::new(10),
+            pair_id: "perp/ethusd".parse().unwrap(),
+            size: Quantity::new_int(5),
+            limit_price: UsdPrice::new_int(1_500),
+            reduce_only: false,
+            reserved_margin: UsdValue::new_int(750),
+            created_at: Timestamp::from_seconds(1),
+            tp: None,
+            sl: None,
+        }
+    }
+
+    #[actix_web::test]
+    async fn aliases_query_the_perps_contract_and_cache_its_address() {
+        let canned = dango_primitives::json!({ "max_open_orders": 100 });
+        let canned_clone = canned.clone();
+        let (ctx, app) = MockApp::context(0, move |_| canned_clone.clone());
+
+        let (status, body) = get(&ctx, "/perps/param").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, canned);
+
+        // The query went to the perps contract, carrying the `param` message.
+        let (contract, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        assert_eq!(contract, perps_addr());
+        assert_eq!(msg, perps::QueryMsg::Param {}.to_json_value().unwrap());
+
+        // A second request reuses the cached address: still one `app_config`
+        // query.
+        let (status, _) = get(&ctx, "/perps/param").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(app.app_config_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[actix_web::test]
+    async fn failed_address_resolution_is_a_503_and_is_retried() {
+        let (ctx, app) = MockApp::context(1, |_| Json::null());
+
+        let (status, _) = get(&ctx, "/perps/state").await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+        // The failure is not cached: the next request retries and succeeds.
+        let (status, _) = get(&ctx, "/perps/state").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(app.app_config_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[actix_web::test]
+    async fn single_item_lookups_respond_404_on_null() {
+        let (ctx, app) = MockApp::context(0, |_| Json::null());
+
+        let (status, _) = get(&ctx, "/perps/pair_param?pair_id=perp/ethusd").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        let (status, _) = get(&ctx, "/perps/pair_state?pair_id=perp/ethusd").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        let (status, _) = get(
+            &ctx,
+            &format!(
+                "/perps/order/by-client-order-id?user={}&client_order_id=7",
+                user_addr(),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        let (status, _) = get(&ctx, "/perps/order/123").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        // The path parameter parsed into the order ID.
+        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            msg,
+            perps::QueryMsg::Order {
+                order_id: OrderId::new(123),
+            }
+            .to_json_value()
+            .unwrap(),
+        );
+    }
+
+    #[actix_web::test]
+    async fn orders_by_user_is_a_passthrough() {
+        let (ctx, app) = MockApp::context(0, |_| dango_primitives::json!({}));
+
+        let (status, _) = get(&ctx, &format!("/perps/order/by-user?user={}", user_addr())).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            msg,
+            perps::QueryMsg::OrdersByUser { user: user_addr() }
+                .to_json_value()
+                .unwrap(),
+        );
+    }
+
+    #[actix_web::test]
+    async fn order_by_client_order_id_is_a_passthrough() {
+        let (ctx, app) = MockApp::context(0, |_| cid_order_response().to_json_value().unwrap());
+
+        let uri = format!(
+            "/perps/order/by-client-order-id?user={}&client_order_id=7",
+            user_addr(),
+        );
+
+        // The contract response passes through untouched.
+        let (status, body) = get(&ctx, &uri).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, cid_order_response().to_json_value().unwrap());
+
+        // The query params parsed into the contract query message.
+        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            msg,
+            perps::QueryMsg::OrderByClientOrderId {
+                user: user_addr(),
+                client_order_id: ClientOrderId::new(7),
+            }
+            .to_json_value()
+            .unwrap(),
+        );
+    }
+
+    #[actix_web::test]
+    async fn user_state_forwards_the_include_flags() {
+        let (ctx, app) = MockApp::context(0, |_| dango_primitives::json!({}));
+
+        let (status, _) = get(
+            &ctx,
+            &format!(
+                "/perps/user_state?user={}&include_equity=true&include_all=true",
+                user_addr(),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            msg,
+            perps::QueryMsg::UserStateExtended {
+                user: user_addr(),
+                include_equity: true,
+                include_available_margin: false,
+                include_maintenance_margin: false,
+                include_unrealized_pnl: false,
+                include_unrealized_funding: false,
+                include_liquidation_price: false,
+                include_all: true,
+            }
+            .to_json_value()
+            .unwrap(),
+        );
+    }
+
+    #[actix_web::test]
+    async fn liquidity_depth_forwards_typed_params() {
+        let (ctx, app) = MockApp::context(0, |_| dango_primitives::json!({}));
+
+        let (status, _) = get(
+            &ctx,
+            "/perps/liquidity_depth?pair_id=perp/ethusd&bucket_size=10&limit=5",
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            msg,
+            perps::QueryMsg::LiquidityDepth {
+                pair_id: "perp/ethusd".parse().unwrap(),
+                bucket_size: UsdPrice::new_int(10),
+                limit: Some(5),
+            }
+            .to_json_value()
+            .unwrap(),
+        );
+    }
+}

--- a/dango/indexer/httpd/src/server.rs
+++ b/dango/indexer/httpd/src/server.rs
@@ -61,6 +61,17 @@ use {
         crate::routes::query::query,
         crate::routes::simulate::simulate,
         crate::routes::broadcast::broadcast,
+        crate::routes::perps::param,
+        crate::routes::perps::pair_param,
+        crate::routes::perps::pair_params,
+        crate::routes::perps::state,
+        crate::routes::perps::pair_state,
+        crate::routes::perps::pair_states,
+        crate::routes::perps::liquidity_depth,
+        crate::routes::perps::user_state,
+        crate::routes::perps::orders_by_user,
+        crate::routes::perps::order_by_client_order_id,
+        crate::routes::perps::order,
         crate::routes::ws::ws_doc,
         crate::routes::graphql::graphql_doc,
     ),
@@ -70,6 +81,13 @@ use {
         (name = "chain", description = "Chain reads and writes proxied to the node: \
                                         state queries, transaction simulation, \
                                         transaction broadcast"),
+        (name = "perps", description = "GET aliases for the perps contract's queries. \
+                                       Each route mirrors one `wasm_smart` query to \
+                                       the perps contract — same read as `POST /query`, \
+                                       with the contract address resolved server-side \
+                                       and the parameters taken from the query string. \
+                                       Responses are the contract's response objects, \
+                                       verbatim."),
         (name = "websocket", description = "Realtime feeds over a multiplexed WebSocket"),
         (name = "graphql", description = "Deprecated GraphQL API — scheduled for removal"),
     )
@@ -96,6 +114,7 @@ where
             .service(routes::index::requester_ip)
             .service(routes::index::sentry_raise)
             .service(routes::blocks::services())
+            .service(routes::perps::services())
             .service(routes::ws::services())
             .service(routes::query::query)
             .service(routes::simulate::simulate)
@@ -297,6 +316,17 @@ mod tests {
             "/query",
             "/simulate",
             "/broadcast",
+            "/perps/param",
+            "/perps/pair_param",
+            "/perps/pair_params",
+            "/perps/state",
+            "/perps/pair_state",
+            "/perps/pair_states",
+            "/perps/liquidity_depth",
+            "/perps/user_state",
+            "/perps/order/by-user",
+            "/perps/order/by-client-order-id",
+            "/perps/order/{order_id}",
             "/ws",
             "/graphql",
         ] {

--- a/dango/testing/src/request.rs
+++ b/dango/testing/src/request.rs
@@ -338,6 +338,39 @@ where
     Ok(serde_json::from_slice(&text_response)?)
 }
 
+pub async fn call_api_post<R, B>(
+    app: App<
+        impl ServiceFactory<
+            ServiceRequest,
+            Response = ServiceResponse<impl MessageBody>,
+            Config = (),
+            InitError = (),
+            Error = actix_web::Error,
+        > + 'static,
+    >,
+    uri: &str,
+    body: &B,
+) -> anyhow::Result<R>
+where
+    R: DeserializeOwned,
+    B: Serialize,
+{
+    let app = actix_web::test::init_service(app).await;
+
+    let request = actix_web::test::TestRequest::post()
+        .uri(uri)
+        .set_json(body)
+        .to_request();
+
+    let res = try_call_service(&app, request)
+        .await
+        .map_err(|err| anyhow!("failed to call service: {err:?}"))?;
+
+    let text_response = read_body(res).await;
+
+    Ok(serde_json::from_slice(&text_response)?)
+}
+
 pub async fn call_api_with_headers<R>(
     app: App<
         impl ServiceFactory<

--- a/dango/testing/tests/indexer_infra/api.rs
+++ b/dango/testing/tests/indexer_infra/api.rs
@@ -1,11 +1,17 @@
 use {
     assert_json_diff::assert_json_include,
     assertor::*,
-    dango_primitives::{Block, BlockOutcome},
-    dango_testing::{
-        TestOption, build_app_service, call_api, call_api_with_headers,
-        setup_test_naive_with_indexer, setup_test_naive_with_indexer_and_create_blocks,
+    dango_math::Uint64,
+    dango_order_book::{OrderKind, Quantity, TimeInForce, UsdPrice},
+    dango_primitives::{
+        Addressable, Block, BlockOutcome, Coins, QuerierExt, ResultExt, btree_map, btree_set,
     },
+    dango_testing::{
+        TestOption, build_app_service, call_api, call_api_post, call_api_with_headers, pair_id,
+        setup_perps_env, setup_test_naive_with_indexer,
+        setup_test_naive_with_indexer_and_create_blocks,
+    },
+    dango_types::perps,
     serde_json::json,
 };
 
@@ -133,6 +139,17 @@ async fn openapi_spec_is_served() -> anyhow::Result<()> {
                     "/query",
                     "/simulate",
                     "/broadcast",
+                    "/perps/param",
+                    "/perps/pair_param",
+                    "/perps/pair_params",
+                    "/perps/state",
+                    "/perps/pair_state",
+                    "/perps/pair_states",
+                    "/perps/liquidity_depth",
+                    "/perps/user_state",
+                    "/perps/order/by-user",
+                    "/perps/order/by-client-order-id",
+                    "/perps/order/{order_id}",
                     "/ws",
                     "/graphql",
                 ] {
@@ -141,6 +158,254 @@ async fn openapi_spec_is_served() -> anyhow::Result<()> {
                         "the spec should document {path}",
                     );
                 }
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+/// The `/perps/*` aliases: each returns exactly what the equivalent raw
+/// `wasm_smart` query returns through `POST /query`, with the parameters
+/// parsed from the URL.
+#[tokio::test(flavor = "multi_thread")]
+async fn perps_aliases_mirror_contract_queries() -> anyhow::Result<()> {
+    let (mut suite, mut accounts, _, contracts, _, httpd_context, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
+
+    // Oracle prices ($2,000 ETH) and margin for user1 and user2.
+    setup_perps_env(&mut suite, &mut accounts, &contracts, 2_000, 100_000).await;
+
+    // The test genesis configures no liquidity depth bucket sizes; add one so
+    // the `liquidity_depth` alias has something to return. Depth bookkeeping
+    // tracks orders placed after the bucket size is configured, so this comes
+    // before the orders. The current parameters are read back from the chain
+    // and re-submitted with only `bucket_sizes` changed.
+    let param: perps::Param = suite
+        .query_wasm_smart(contracts.perps, perps::QueryParamRequest {})
+        .should_succeed();
+    let pair_param: Option<perps::PairParam> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryPairParamRequest {
+            pair_id: pair_id(),
+        })
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param,
+                pair_params: btree_map! {
+                    pair_id() => perps::PairParam {
+                        bucket_sizes: btree_set! { UsdPrice::new_int(100) },
+                        ..pair_param.expect("the test genesis should have the pair")
+                    },
+                },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // Two resting bids for user1, priced below the oracle price so they rest
+    // on the book rather than cross; the second carries a client order ID.
+    for (price, client_order_id) in [(1_500, None), (1_400, Some(Uint64::new(42)))] {
+        suite
+            .execute(
+                &mut accounts.user1,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(
+                    perps::SubmitOrderRequest {
+                        pair_id: pair_id(),
+                        size: Quantity::new_int(5),
+                        kind: OrderKind::Limit {
+                            limit_price: UsdPrice::new_int(price),
+                            time_in_force: TimeInForce::GoodTilCanceled,
+                            client_order_id,
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
+                    },
+                )),
+                Coins::new(),
+            )
+            .await
+            .should_succeed();
+    }
+
+    let user = accounts.user1.address();
+    let perps_contract = contracts.perps;
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                // Parity: every alias returns what the equivalent raw query
+                // returns.
+                for (alias, msg) in [
+                    ("/perps/param".to_string(), json!({ "param": {} })),
+                    (
+                        format!("/perps/pair_param?pair_id={}", pair_id()),
+                        json!({ "pair_param": { "pair_id": pair_id() } }),
+                    ),
+                    (
+                        "/perps/pair_params".to_string(),
+                        json!({ "pair_params": {} }),
+                    ),
+                    ("/perps/state".to_string(), json!({ "state": {} })),
+                    (
+                        format!("/perps/pair_state?pair_id={}", pair_id()),
+                        json!({ "pair_state": { "pair_id": pair_id() } }),
+                    ),
+                    (
+                        "/perps/pair_states".to_string(),
+                        json!({ "pair_states": {} }),
+                    ),
+                    (
+                        format!("/perps/user_state?user={user}&include_all=true"),
+                        json!({ "user_state_extended": { "user": user, "include_all": true } }),
+                    ),
+                    (
+                        format!("/perps/order/by-user?user={user}"),
+                        json!({ "orders_by_user": { "user": user } }),
+                    ),
+                    (
+                        format!("/perps/order/by-client-order-id?user={user}&client_order_id=42"),
+                        json!({
+                            "order_by_client_order_id": {
+                                "user": user,
+                                "client_order_id": "42",
+                            },
+                        }),
+                    ),
+                ] {
+                    let alias_response = call_api::<serde_json::Value>(
+                        build_app_service(httpd_context.clone()),
+                        &alias,
+                    )
+                    .await?;
+
+                    let query_response = call_api_post::<serde_json::Value, _>(
+                        build_app_service(httpd_context.clone()),
+                        "/query",
+                        &json!({ "wasm_smart": { "contract": perps_contract, "msg": msg } }),
+                    )
+                    .await?;
+
+                    assert_eq!(
+                        alias_response, query_response["wasm_smart"],
+                        "alias {alias} should mirror the raw query",
+                    );
+                }
+
+                // The two resting bids show up in the aggregated depth at the
+                // pair's first configured bucket size.
+                let pair_param = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/perps/pair_param?pair_id={}", pair_id()),
+                )
+                .await?;
+                let bucket_size = pair_param["bucket_sizes"][0]
+                    .as_str()
+                    .expect("pair should have at least one bucket size")
+                    .to_string();
+
+                let depth = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!(
+                        "/perps/liquidity_depth?pair_id={}&bucket_size={bucket_size}",
+                        pair_id(),
+                    ),
+                )
+                .await?;
+                assert!(
+                    !depth["bids"].as_object().unwrap().is_empty(),
+                    "the resting bids should aggregate into at least one bucket",
+                );
+
+                // `user_state` computes the opt-in fields when asked.
+                let user_state = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/perps/user_state?user={user}&include_all=true"),
+                )
+                .await?;
+                assert!(
+                    !user_state["equity"].is_null(),
+                    "include_all should compute the equity",
+                );
+
+                // The full order map, from which the two orders' system-
+                // assigned IDs are learned.
+                let orders = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/perps/order/by-user?user={user}"),
+                )
+                .await?;
+                let order_ids = orders
+                    .as_object()
+                    .unwrap()
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                assert_that!(order_ids).has_length(2);
+
+                let oldest = order_ids
+                    .iter()
+                    .min_by_key(|id| id.parse::<u64>().unwrap())
+                    .unwrap()
+                    .clone();
+                let newest = order_ids
+                    .iter()
+                    .max_by_key(|id| id.parse::<u64>().unwrap())
+                    .unwrap()
+                    .clone();
+
+                // The path-parameter lookup returns the order in the
+                // `QueryOrderResponse` shape: the `by-user` item plus the
+                // order's user.
+                let order = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/perps/order/{oldest}"),
+                )
+                .await?;
+                let mut expected = orders[&oldest].as_object().unwrap().clone();
+                expected.insert("user".to_string(), json!(user));
+                assert_eq!(order, serde_json::Value::Object(expected));
+
+                // An order ID not on the book is a 404 (a non-JSON body,
+                // surfacing here as an error).
+                let missing = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    "/perps/order/999999",
+                )
+                .await;
+                assert_that!(missing).is_err();
+
+                // The client-order-ID lookup returns the contract's
+                // `QueryOrderByClientOrderIdResponse`: the `by-user` item
+                // fields, plus the system-assigned `order_id`, minus the
+                // `client_order_id` the caller already knows.
+                let by_cid = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/perps/order/by-client-order-id?user={user}&client_order_id=42"),
+                )
+                .await?;
+                let mut expected = orders[&newest].as_object().unwrap().clone();
+                expected.remove("client_order_id");
+                expected.insert("order_id".to_string(), json!(newest));
+                assert_eq!(by_cid, serde_json::Value::Object(expected));
+
+                // No resting order carries this client order ID: a 404.
+                let unknown_cid = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/perps/order/by-client-order-id?user={user}&client_order_id=43"),
+                )
+                .await;
+                assert_that!(unknown_cid).is_err();
 
                 Ok::<(), anyhow::Error>(())
             })

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -1083,3 +1083,50 @@ async fn batch_referral_commissions_rollback() {
         "referee's cumulative referral data must be unchanged after batch rollback"
     );
 }
+
+/// The `orders_by_user` query is deliberately unpaginated: a user's resting
+/// orders are bounded by `Param::max_open_orders`, and the query returns all
+/// of them, however many there are.
+#[tokio::test]
+async fn orders_by_user_returns_all_orders() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    // 35 resting bids — more than `DEFAULT_PAGE_LIMIT` (30), the fallback
+    // most enumerative queries would truncate at — submitted in batches of
+    // `max_action_batch_size` (5), at distinct prices within the price band.
+    for batch in 0..7i128 {
+        let submits = (0..5i128)
+            .map(|i| SubmitOrCancelOrderRequest::Submit(limit_bid(1_200 + batch * 5 + i, 1, None)))
+            .collect::<Vec<_>>();
+
+        suite
+            .execute(
+                &mut accounts.user1,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::BatchUpdateOrders(
+                    NonEmpty::new(submits).unwrap(),
+                )),
+                Coins::new(),
+            )
+            .await
+            .should_succeed();
+    }
+
+    let all: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+    assert_eq!(all.len(), 35);
+}

--- a/dango/testing/tests/perps/client_order_id.rs
+++ b/dango/testing/tests/perps/client_order_id.rs
@@ -2,8 +2,8 @@ use {
     crate::register_oracle_prices,
     dango_math::{Uint64, Uint128},
     dango_order_book::{
-        ClientOrderId, OrderId, OrderKind, Quantity, QueryOrdersByUserResponseItem, TimeInForce,
-        UsdPrice,
+        ClientOrderId, OrderId, OrderKind, Quantity, QueryOrderByClientOrderIdResponse,
+        QueryOrdersByUserResponseItem, TimeInForce, UsdPrice,
     },
     dango_primitives::{Addressable, Coins, QuerierExt, ResultExt},
     dango_testing::{TestOption, pair_id, setup_test_naive},
@@ -124,6 +124,139 @@ async fn submit_cancel_resubmit_by_client_order_id() {
         1,
         "the re-submitted order should be on the book"
     );
+}
+
+/// The `order_by_client_order_id` query: look a resting order up via the
+/// `(user, client_order_id)` unique index, on either book side, learning the
+/// system-assigned order ID. Misses — an ID the user never used, another
+/// user's ID, a canceled order — return `None`.
+#[tokio::test]
+async fn query_order_by_client_order_id() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let pair = pair_id();
+    let bid_cid: ClientOrderId = Uint64::new(42);
+    let ask_cid: ClientOrderId = Uint64::new(43);
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    // A resting bid ($1,500, below the $2,000 oracle price) and a resting ask
+    // ($2,500, above it), each carrying a client order ID.
+    for (size, price, cid) in [(5, 1_500, bid_cid), (-5, 2_500, ask_cid)] {
+        suite
+            .execute(
+                &mut accounts.user1,
+                contracts.perps,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(
+                    perps::SubmitOrderRequest {
+                        pair_id: pair.clone(),
+                        size: Quantity::new_int(size),
+                        kind: OrderKind::Limit {
+                            limit_price: UsdPrice::new_int(price),
+                            time_in_force: TimeInForce::GoodTilCanceled,
+                            client_order_id: Some(cid),
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
+                    },
+                )),
+                Coins::new(),
+            )
+            .await
+            .should_succeed();
+    }
+
+    // Cross-check the system-assigned order IDs against the by-user query.
+    let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
+            user: accounts.user1.address(),
+        })
+        .should_succeed();
+    assert_eq!(orders.len(), 2);
+
+    // The bid is found, with the correct system order ID and the un-inverted
+    // limit price.
+    let bid: QueryOrderByClientOrderIdResponse = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
+            user: accounts.user1.address(),
+            client_order_id: bid_cid,
+        })
+        .should_succeed()
+        .expect("the bid should be found by its client order ID");
+    let bid_item = orders
+        .get(&bid.order_id)
+        .expect("the returned order ID should be one of the user's orders");
+    assert_eq!(bid_item.client_order_id, Some(bid_cid));
+    assert_eq!(bid.pair_id, pair);
+    assert_eq!(bid.size, Quantity::new_int(5));
+    assert_eq!(bid.limit_price, UsdPrice::new_int(1_500));
+    assert_eq!(bid.created_at, bid_item.created_at);
+
+    // The ask is found too — covers the `ASKS` branch of the lookup.
+    let ask: QueryOrderByClientOrderIdResponse = suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
+            user: accounts.user1.address(),
+            client_order_id: ask_cid,
+        })
+        .should_succeed()
+        .expect("the ask should be found by its client order ID");
+    assert_eq!(
+        orders
+            .get(&ask.order_id)
+            .expect("the returned order ID should be one of the user's orders")
+            .client_order_id,
+        Some(ask_cid),
+    );
+    assert_eq!(ask.size, Quantity::new_int(-5));
+    assert_eq!(ask.limit_price, UsdPrice::new_int(2_500));
+
+    // A client order ID the user never used: `None`.
+    suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
+            user: accounts.user1.address(),
+            client_order_id: Uint64::new(99),
+        })
+        .should_succeed_and(Option::is_none);
+
+    // The index is scoped per sender: another user querying the same client
+    // order ID gets `None`.
+    suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
+            user: accounts.user2.address(),
+            client_order_id: bid_cid,
+        })
+        .should_succeed_and(Option::is_none);
+
+    // After canceling the bid, the lookup returns `None`.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::CancelOrder(
+                perps::CancelOrderRequest::OneByClientOrderId(bid_cid),
+            )),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
+            user: accounts.user1.address(),
+            client_order_id: bid_cid,
+        })
+        .should_succeed_and(Option::is_none);
 }
 
 /// Cancelling a `client_order_id` that the sender never used (or has


### PR DESCRIPTION
Add GET routes under /perps that mirror wasm_smart queries to the perps contract, so that e.g. the order book depth can be fetched with GET /perps/liquidity_depth?pair_id=...&bucket_size=... instead of a hand-built POST /query body:

- /perps/param, /perps/state
- /perps/pair_param, /perps/pair_params
- /perps/pair_state, /perps/pair_states
- /perps/liquidity_depth
- /perps/user_state (the user_state_extended query)
- /perps/order/{order_id}, /perps/order/by-user, /perps/order/by-client-order-id

The perps contract address is resolved lazily from the chain's app config on first use and cached for the life of the process; clients never pass it. Responses are the contract's response objects verbatim, so client-side types written for contract queries can be reused as-is. The routes are documented in the OpenAPI spec under a new "perps" tag.

In support of the above, one addition to the perps contract query API: an order_by_client_order_id query, backed by the existing (user, client_order_id) unique index on the order book, returning the order along with its system-assigned order ID.

---------


Claude-Session: https://claude.ai/code/session_01AXMg5kr5YH1RFEUxyxMthJ