### PR TITLE
feat(indexer-httpd): add REST aliases for account-related queries

### DIFF
--- a/dango/indexer/httpd/src/context.rs
+++ b/dango/indexer/httpd/src/context.rs
@@ -8,7 +8,7 @@ use {
         write::perps_trades::PerpsTradeCache,
     },
     dango_primitives::{Addr, JsonDeExt, Query},
-    dango_types::config::AppConfig,
+    dango_types::config::{AppAddresses, AppConfig},
     sea_orm::{ConnectOptions, Database, DatabaseConnection},
     std::sync::Arc,
     tokio::sync::{OnceCell, RwLock},
@@ -21,40 +21,49 @@ use {
 #[derive(Clone)]
 pub struct MinimalContext {
     pub dango_app: Arc<dyn QueryApp + Send + Sync>,
-    /// Address of the perps contract, resolved from the chain's app config on
-    /// first use (see [`Self::perps_address`]). Behind an `Arc` so that all
+    /// Addresses of the Dango contracts, resolved from the chain's app config
+    /// on first use (see [`Self::app_addresses`]). Behind an `Arc` so that all
     /// clones of the context — one per actix worker — share the one cache.
-    perps_address: Arc<OnceCell<Addr>>,
+    app_addresses: Arc<OnceCell<AppAddresses>>,
 }
 
 impl MinimalContext {
     pub fn new(dango_app: Arc<dyn QueryApp + Send + Sync>) -> Self {
         Self {
             dango_app,
-            perps_address: Arc::new(OnceCell::new()),
+            app_addresses: Arc::new(OnceCell::new()),
         }
     }
 
-    /// The address of the perps contract, per the chain's app config.
+    /// The addresses of the Dango contracts, per the chain's app config.
     ///
     /// Resolved lazily on first call rather than at server construction, so
     /// that serving does not depend on chain state being queryable at startup
     /// (on a fresh chain, the app config exists only once the genesis state is
     /// committed). A failed resolution is returned as an error and retried on
     /// the next call; a success is cached for the life of the process — the
-    /// perps address only changes with a chain upgrade, which entails a node
-    /// restart anyway.
-    pub async fn perps_address(&self) -> anyhow::Result<Addr> {
-        self.perps_address
+    /// contract addresses only change with a chain upgrade, which entails a
+    /// node restart anyway.
+    pub async fn app_addresses(&self) -> anyhow::Result<&AppAddresses> {
+        self.app_addresses
             .get_or_try_init(|| async {
                 let (response, _) = self.dango_app.query_app(Query::app_config()).await?;
 
                 let app_config: AppConfig = response.into_app_config().deserialize_json()?;
 
-                Ok::<_, anyhow::Error>(app_config.addresses.perps)
+                Ok::<_, anyhow::Error>(app_config.addresses)
             })
             .await
-            .copied()
+    }
+
+    /// The address of the perps contract, per the chain's app config.
+    pub async fn perps_address(&self) -> anyhow::Result<Addr> {
+        Ok(self.app_addresses().await?.perps)
+    }
+
+    /// The address of the account factory contract, per the chain's app config.
+    pub async fn account_factory_address(&self) -> anyhow::Result<Addr> {
+        Ok(self.app_addresses().await?.account_factory)
     }
 }
 

--- a/dango/indexer/httpd/src/routes.rs
+++ b/dango/indexer/httpd/src/routes.rs
@@ -1,7 +1,10 @@
+pub mod account;
 pub mod blocks;
 pub mod broadcast;
 pub mod graphql;
 pub mod index;
+#[cfg(test)]
+pub mod mock_app;
 pub mod perps;
 pub mod query;
 pub mod simulate;

--- a/dango/indexer/httpd/src/routes/account.rs
+++ b/dango/indexer/httpd/src/routes/account.rs
@@ -1,0 +1,462 @@
+use {
+    crate::context::MinimalContext,
+    actix_web::{
+        Error, HttpResponse, Scope,
+        error::{ErrorBadRequest, ErrorInternalServerError, ErrorServiceUnavailable},
+        get, web,
+    },
+    dango_primitives::{Addr, ByteArray, Denom, Json, JsonDeExt, Query},
+    // The account module is imported under an alias: the actix macro on the
+    // `account` handler below generates a unit struct of that name, which
+    // would collide with the module.
+    dango_types::{account::QueryMsg as AccountQueryMsg, account_factory},
+    serde::{Deserialize, Serialize},
+    utoipa::IntoParams,
+};
+
+/// Routes under `/account` — GET aliases for account-related queries, all
+/// keyed by an account address in the path.
+///
+/// Casing convention (as elsewhere): URL path segments are kebab-case; query
+/// parameters keep the snake_case spelling and string encoding of the
+/// contract wire fields they forward to.
+///
+/// Unlike the `/perps` aliases, which all target the one perps contract, the
+/// routes here resolve the target of the query in three different ways:
+///
+/// - `/{address}` and `/{address}/user` are `wasm_smart` queries to the
+///   account factory, whose address comes from the chain's app config
+///   ([`MinimalContext::account_factory_address`]).
+/// - `/{address}/seen-nonces` and `/{address}/session-seen-nonces` are
+///   `wasm_smart` queries to the account contract at `{address}` itself.
+/// - `/{address}/balances` is the chain-level `balances` query — no contract
+///   involved at all.
+pub fn services() -> Scope {
+    web::scope("/account")
+        .service(account)
+        .service(user)
+        .service(seen_nonces)
+        .service(session_seen_nonces)
+        .service(balances)
+}
+
+/// Run a `wasm_smart` query against the given contract and return the raw
+/// contract response. A failed query is a 400 carrying the error message,
+/// mirroring `POST /query`.
+async fn query_wasm_smart<M>(
+    app_ctx: &MinimalContext,
+    contract: Addr,
+    msg: &M,
+) -> Result<Json, Error>
+where
+    M: Serialize,
+{
+    let query = Query::wasm_smart(contract, msg).map_err(ErrorInternalServerError)?;
+
+    let (response, _) = app_ctx
+        .dango_app
+        .query_app(query)
+        .await
+        .map_err(|err| ErrorBadRequest(err.to_string()))?;
+
+    Ok(response.into_wasm_smart())
+}
+
+/// Resolve the account factory address, mapping a failure to a 503 — the
+/// chain may not have committed its genesis state yet; resolution is retried
+/// on the next request.
+async fn factory_address(app_ctx: &MinimalContext) -> Result<Addr, Error> {
+    app_ctx.account_factory_address().await.map_err(|err| {
+        ErrorServiceUnavailable(format!(
+            "failed to resolve the account factory address: {err}"
+        ))
+    })
+}
+
+#[utoipa::path(
+    get,
+    path = "/account/{address}",
+    tag = "account",
+    summary = "Account parameters",
+    description = "Parameters of the account at the given address: its \
+                   account index and the index of the user who owns it. \
+                   Alias of the account factory's `account` query; the \
+                   response is the factory's `Account` object. An address \
+                   not registered in the factory fails the query (a 400 \
+                   carrying the contract's error).",
+    params(
+        ("address" = String, Path, description = "Account address"),
+    ),
+    responses(
+        (status = 200, description = "The factory's `Account` object", body = serde_json::Value),
+        (status = 400, description = "The query failed, e.g. no account with this address"),
+        (status = 503, description = "The account factory address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/{address}")]
+pub async fn account(
+    path: web::Path<Addr>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let address = path.into_inner();
+    let factory = factory_address(&app_ctx).await?;
+
+    let response = query_wasm_smart(&app_ctx, factory, &account_factory::QueryMsg::Account {
+        address,
+    })
+    .await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/account/{address}/user",
+    tag = "account",
+    summary = "User owning an account",
+    description = "The user who owns the account at the given address — \
+                   which may be the user's master account or any of their \
+                   subaccounts. The response is the factory's `User` object, \
+                   verbatim: the user's index, username, keys, and all their \
+                   accounts keyed by account index (the master account is \
+                   the lowest index). Composed from the factory's `account` \
+                   and `user` queries.",
+    params(
+        ("address" = String, Path, description = "Address of any of the user's accounts"),
+    ),
+    responses(
+        (status = 200, description = "The factory's `User` object", body = serde_json::Value),
+        (status = 400, description = "The query failed, e.g. no account with this address"),
+        (status = 503, description = "The account factory address could not be resolved"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/{address}/user")]
+pub async fn user(
+    path: web::Path<Addr>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let address = path.into_inner();
+    let factory = factory_address(&app_ctx).await?;
+
+    // First resolve which user owns the account...
+    let account_info: account_factory::Account =
+        query_wasm_smart(&app_ctx, factory, &account_factory::QueryMsg::Account {
+            address,
+        })
+        .await?
+        .deserialize_json()
+        .map_err(ErrorInternalServerError)?;
+
+    // ...then return that user, verbatim.
+    let response = query_wasm_smart(
+        &app_ctx,
+        factory,
+        &account_factory::QueryMsg::User(account_factory::UserIndexOrName::Index(
+            account_info.owner,
+        )),
+    )
+    .await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/account/{address}/seen-nonces",
+    tag = "account",
+    summary = "Seen transaction nonces",
+    description = "The most recent transaction nonces recorded by the \
+                   account at the given address for standard (master-key) \
+                   credentials — needed to pick a valid nonce when building \
+                   a transaction. Alias of the account contract's \
+                   `seen_nonces` query; the response is an array of nonces. \
+                   An address that is not an account contract fails the \
+                   query (a 400).",
+    params(
+        ("address" = String, Path, description = "Account address"),
+    ),
+    responses(
+        (status = 200, description = "The set of seen nonces, as a JSON array", body = serde_json::Value),
+        (status = 400, description = "The query failed, e.g. the address is not an account contract"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/{address}/seen-nonces")]
+pub async fn seen_nonces(
+    path: web::Path<Addr>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let address = path.into_inner();
+
+    let response = query_wasm_smart(&app_ctx, address, &AccountQueryMsg::SeenNonces {}).await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/account/{address}/session-seen-nonces",
+    tag = "account",
+    summary = "Seen nonces of a session key",
+    description = "The most recent transaction nonces recorded by the \
+                   account at the given address for the given session key. \
+                   Alias of the account contract's `session_seen_nonces` \
+                   query; the response is an array of nonces.",
+    params(
+        ("address" = String, Path, description = "Account address"),
+        SessionSeenNoncesQuery,
+    ),
+    responses(
+        (status = 200, description = "The set of seen nonces, as a JSON array", body = serde_json::Value),
+        (status = 400, description = "The query failed, e.g. the address is not an account contract"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/{address}/session-seen-nonces")]
+pub async fn session_seen_nonces(
+    path: web::Path<Addr>,
+    query: web::Query<SessionSeenNoncesQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let address = path.into_inner();
+    let SessionSeenNoncesQuery { session_key } = query.into_inner();
+
+    let response = query_wasm_smart(&app_ctx, address, &AccountQueryMsg::SessionSeenNonces {
+        session_key,
+    })
+    .await?;
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/account/{address}/balances",
+    tag = "account",
+    summary = "Balances of an address",
+    description = "Balances held by the given address in all denoms, as a \
+                   map from denom to amount. Alias of the chain-level \
+                   `balances` query — the address does not have to be a \
+                   Dango account; any address works. Paginated: iteration \
+                   starts after the `start_after` denom (exclusive), \
+                   returning at most `limit` entries; the chain picks the \
+                   defaults when omitted.",
+    params(
+        ("address" = String, Path, description = "Any address"),
+        BalancesQuery,
+    ),
+    responses(
+        (status = 200, description = "Map of denom to amount", body = serde_json::Value),
+        (status = 400, description = "The query failed"),
+    ),
+)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+#[get("/{address}/balances")]
+pub async fn balances(
+    path: web::Path<Addr>,
+    query: web::Query<BalancesQuery>,
+    app_ctx: web::Data<MinimalContext>,
+) -> Result<HttpResponse, Error> {
+    let address = path.into_inner();
+    let BalancesQuery { start_after, limit } = query.into_inner();
+
+    let (response, _) = app_ctx
+        .dango_app
+        .query_app(Query::balances(address, start_after, limit))
+        .await
+        .map_err(|err| ErrorBadRequest(err.to_string()))?;
+
+    Ok(HttpResponse::Ok().json(response.into_balances()))
+}
+
+// ---- request types ----
+
+#[derive(Deserialize, IntoParams)]
+pub struct SessionSeenNoncesQuery {
+    /// The session public key (33 bytes), in the same base64 encoding as on
+    /// the JSON wire. URL-encode the value, as base64 may contain `+`, `/`
+    /// and `=`.
+    #[param(value_type = String)]
+    session_key: ByteArray<33>,
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct BalancesQuery {
+    /// Denom after which iteration starts (exclusive). The chain starts from
+    /// the beginning when omitted.
+    #[param(value_type = Option<String>)]
+    start_after: Option<Denom>,
+
+    /// Maximum number of entries to return. The chain picks its default page
+    /// limit when omitted.
+    limit: Option<u32>,
+}
+
+// ---- tests ----
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::routes::mock_app::{MockApp, factory_addr, get, user_addr},
+        actix_web::http::StatusCode,
+        dango_primitives::{Coins, JsonSerExt, QueryBalancesRequest, json},
+        dango_types::constants::usdc,
+    };
+
+    #[actix_web::test]
+    async fn account_route_queries_the_factory() {
+        let canned = json!({ "index": 12, "owner": 7 });
+        let canned_clone = canned.clone();
+        let (ctx, app) = MockApp::context(0, move |_, _| canned_clone.clone());
+
+        let (status, body) = get(&ctx, &format!("/account/{}", user_addr())).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, canned);
+
+        assert_eq!(
+            app.last_wasm_smart(),
+            (
+                factory_addr(),
+                account_factory::QueryMsg::Account {
+                    address: user_addr(),
+                }
+                .to_json_value()
+                .unwrap(),
+            ),
+        );
+    }
+
+    #[actix_web::test]
+    async fn user_route_composes_the_two_factory_queries() {
+        let user_json = json!({ "index": 7, "name": "larry" });
+        let user_json_clone = user_json.clone();
+
+        // Answer the `account` query with an account owned by user 7, and the
+        // `user` query with the canned user.
+        let (ctx, app) = MockApp::context(0, move |_, msg| {
+            if msg.get("account").is_some() {
+                json!({ "index": 12, "owner": 7 })
+            } else {
+                user_json_clone.clone()
+            }
+        });
+
+        let (status, body) = get(&ctx, &format!("/account/{}/user", user_addr())).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, user_json);
+
+        // Both queries went to the factory: first the account lookup, then
+        // the user lookup with the owner index from the first response.
+        assert_eq!(app.wasm_smart_requests(), vec![
+            (
+                factory_addr(),
+                account_factory::QueryMsg::Account {
+                    address: user_addr(),
+                }
+                .to_json_value()
+                .unwrap(),
+            ),
+            (
+                factory_addr(),
+                account_factory::QueryMsg::User(account_factory::UserIndexOrName::Index(7))
+                    .to_json_value()
+                    .unwrap(),
+            ),
+        ]);
+    }
+
+    #[actix_web::test]
+    async fn nonce_routes_query_the_account_itself() {
+        let (ctx, app) = MockApp::context(0, |_, _| json!([1, 2, 3]));
+
+        let (status, body) = get(&ctx, &format!("/account/{}/seen-nonces", user_addr())).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, json!([1, 2, 3]));
+
+        // The queried contract is the account at the path address.
+        assert_eq!(
+            app.last_wasm_smart(),
+            (
+                user_addr(),
+                AccountQueryMsg::SeenNonces {}.to_json_value().unwrap(),
+            ),
+        );
+
+        // The session variant forwards the key, given in the wire's base64
+        // encoding (URL-encoded).
+        let session_key = ByteArray::<33>::from([7; 33]);
+        let encoded = session_key
+            .to_string()
+            .replace('+', "%2B")
+            .replace('/', "%2F")
+            .replace('=', "%3D");
+
+        let (status, _) = get(
+            &ctx,
+            &format!(
+                "/account/{}/session-seen-nonces?session_key={encoded}",
+                user_addr(),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        assert_eq!(
+            app.last_wasm_smart(),
+            (
+                user_addr(),
+                AccountQueryMsg::SessionSeenNonces { session_key }
+                    .to_json_value()
+                    .unwrap(),
+            ),
+        );
+    }
+
+    #[actix_web::test]
+    async fn balances_route_issues_the_chain_query() {
+        // Note: the binding is named `coins`, not `balances`, as the actix
+        // macro on the `balances` handler above generates a unit struct of
+        // that name, which a `let balances` would be parsed against.
+        let coins = Coins::one(usdc::DENOM.clone(), 100).unwrap();
+        let (ctx, app) = MockApp::context_with_balances(0, coins.clone(), |_, _| Json::null());
+
+        let (status, body) = get(
+            &ctx,
+            &format!(
+                "/account/{}/balances?start_after={}&limit=5",
+                user_addr(),
+                usdc::DENOM.clone(),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, coins.to_json_value().unwrap());
+
+        assert_eq!(app.last_balances_request(), QueryBalancesRequest {
+            address: user_addr(),
+            start_after: Some(usdc::DENOM.clone()),
+            limit: Some(5),
+        });
+    }
+
+    #[actix_web::test]
+    async fn factory_resolution_failure_is_a_503_and_the_cache_is_shared() {
+        let (ctx, app) = MockApp::context(1, |_, _| json!({}));
+
+        // The first resolution attempt fails; nothing is cached.
+        let (status, _) = get(&ctx, &format!("/account/{}", user_addr())).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+        // The next request retries and succeeds.
+        let (status, _) = get(&ctx, &format!("/account/{}", user_addr())).await;
+        assert_eq!(status, StatusCode::OK);
+
+        // The perps routes share the same cache: no further app config query.
+        let (status, _) = get(&ctx, "/perps/param").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(app.app_config_calls(), 2);
+    }
+}

--- a/dango/indexer/httpd/src/routes/mock_app.rs
+++ b/dango/indexer/httpd/src/routes/mock_app.rs
@@ -1,0 +1,193 @@
+//! A mock [`QueryApp`](crate::traits::QueryApp) shared by the route alias
+//! tests in this directory. Compiled only for tests: the module is
+//! `#[cfg(test)]`-gated in `routes.rs`.
+
+use {
+    crate::{context::MinimalContext, traits::QueryApp},
+    actix_web::{App, http::StatusCode, test, web},
+    async_trait::async_trait,
+    dango_app::{AppError, AppResult},
+    dango_primitives::{
+        Addr, BlockInfo, Coins, Json, JsonSerExt, Query, QueryBalancesRequest, QueryResponse,
+        TxOutcome, UnsignedTx,
+    },
+    dango_types::config::{AppAddresses, AppConfig},
+    std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+/// The perps contract address served by the mock's app config.
+pub fn perps_addr() -> Addr {
+    Addr::mock(9)
+}
+
+/// The account factory address served by the mock's app config.
+pub fn factory_addr() -> Addr {
+    Addr::mock(8)
+}
+
+/// An arbitrary user account address.
+pub fn user_addr() -> Addr {
+    Addr::mock(1)
+}
+
+/// A `QueryApp` that serves `app_config` (with [`perps_addr`] and
+/// [`factory_addr`] as the contract addresses, after a configurable number of
+/// failures), answers every `wasm_smart` query with the canned responder, and
+/// answers `balances` queries with a canned coin set — recording the requests
+/// for assertions.
+pub struct MockApp {
+    respond: Box<dyn Fn(Addr, &Json) -> Json + Send + Sync>,
+    balances: Coins,
+    app_config_calls: AtomicUsize,
+    app_config_failures: AtomicUsize,
+    wasm_smart_requests: Mutex<Vec<(Addr, Json)>>,
+    last_balances_request: Mutex<Option<QueryBalancesRequest>>,
+}
+
+impl MockApp {
+    /// A context whose responder receives `(contract, msg)` for every
+    /// `wasm_smart` query.
+    pub fn context<F>(app_config_failures: usize, respond: F) -> (MinimalContext, Arc<Self>)
+    where
+        F: Fn(Addr, &Json) -> Json + Send + Sync + 'static,
+    {
+        Self::context_with_balances(app_config_failures, Coins::new(), respond)
+    }
+
+    /// Same as [`Self::context`], with a canned response for `balances`
+    /// queries.
+    pub fn context_with_balances<F>(
+        app_config_failures: usize,
+        balances: Coins,
+        respond: F,
+    ) -> (MinimalContext, Arc<Self>)
+    where
+        F: Fn(Addr, &Json) -> Json + Send + Sync + 'static,
+    {
+        let app = Arc::new(Self {
+            respond: Box::new(respond),
+            balances,
+            app_config_calls: AtomicUsize::new(0),
+            app_config_failures: AtomicUsize::new(app_config_failures),
+            wasm_smart_requests: Mutex::new(Vec::new()),
+            last_balances_request: Mutex::new(None),
+        });
+
+        (MinimalContext::new(app.clone()), app)
+    }
+
+    /// Number of `app_config` queries served so far, for asserting the
+    /// address cache.
+    pub fn app_config_calls(&self) -> usize {
+        self.app_config_calls.load(Ordering::SeqCst)
+    }
+
+    /// All `wasm_smart` requests received so far, as `(contract, msg)`.
+    pub fn wasm_smart_requests(&self) -> Vec<(Addr, Json)> {
+        self.wasm_smart_requests.lock().unwrap().clone()
+    }
+
+    /// The most recent `wasm_smart` request, as `(contract, msg)`.
+    pub fn last_wasm_smart(&self) -> (Addr, Json) {
+        self.wasm_smart_requests
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("no wasm_smart request recorded")
+    }
+
+    /// The most recent `balances` request.
+    pub fn last_balances_request(&self) -> QueryBalancesRequest {
+        self.last_balances_request
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("no balances request recorded")
+    }
+}
+
+#[async_trait]
+impl QueryApp for MockApp {
+    async fn query_app(&self, raw_req: Query) -> AppResult<(QueryResponse, u64)> {
+        match raw_req {
+            Query::AppConfig(_) => {
+                self.app_config_calls.fetch_add(1, Ordering::SeqCst);
+
+                if self
+                    .app_config_failures
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok()
+                {
+                    return Err(AppError::vm("app config not ready".to_string()));
+                }
+
+                let app_config = AppConfig {
+                    addresses: AppAddresses {
+                        perps: perps_addr(),
+                        account_factory: factory_addr(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+
+                Ok((QueryResponse::AppConfig(app_config.to_json_value()?), 1))
+            },
+            Query::WasmSmart(req) => {
+                let response = (self.respond)(req.contract, &req.msg);
+
+                self.wasm_smart_requests
+                    .lock()
+                    .unwrap()
+                    .push((req.contract, req.msg));
+
+                Ok((QueryResponse::WasmSmart(response), 1))
+            },
+            Query::Balances(req) => {
+                *self.last_balances_request.lock().unwrap() = Some(req);
+
+                Ok((QueryResponse::Balances(self.balances.clone()), 1))
+            },
+            _ => unimplemented!("not exercised by the route alias tests"),
+        }
+    }
+
+    async fn simulate(&self, _unsigned_tx: UnsignedTx) -> AppResult<TxOutcome> {
+        unimplemented!("not exercised by the route alias tests");
+    }
+
+    async fn chain_id(&self) -> AppResult<String> {
+        unimplemented!("not exercised by the route alias tests");
+    }
+
+    async fn last_finalized_block(&self) -> AppResult<BlockInfo> {
+        unimplemented!("not exercised by the route alias tests");
+    }
+}
+
+/// GET `uri` against an app with the `/perps` and `/account` route groups
+/// mounted, returning the status and the JSON body — `null` for the
+/// plain-text bodies of error responses, so callers can assert on the status
+/// alone.
+pub async fn get(ctx: &MinimalContext, uri: &str) -> (StatusCode, Json) {
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(ctx.clone()))
+            .service(crate::routes::perps::services())
+            .service(crate::routes::account::services()),
+    )
+    .await;
+
+    let response = test::call_service(&app, test::TestRequest::get().uri(uri).to_request()).await;
+    let status = response.status();
+    let body = test::read_body(response).await;
+
+    let json = serde_json::from_slice(&body).unwrap_or(Json::null());
+
+    (status, json)
+}

--- a/dango/indexer/httpd/src/routes/perps.rs
+++ b/dango/indexer/httpd/src/routes/perps.rs
@@ -584,126 +584,11 @@ pub struct OrderByClientOrderIdQuery {
 mod tests {
     use {
         super::*,
-        crate::traits::QueryApp,
-        actix_web::{App, http::StatusCode, test},
-        async_trait::async_trait,
-        dango_app::{AppError, AppResult},
+        crate::routes::mock_app::{MockApp, get, perps_addr, user_addr},
+        actix_web::http::StatusCode,
         dango_order_book::{Quantity, QueryOrderByClientOrderIdResponse, UsdValue},
-        dango_primitives::{
-            BlockInfo, JsonSerExt, QueryResponse, Timestamp, TxOutcome, UnsignedTx,
-        },
-        dango_types::config::{AppAddresses, AppConfig},
-        std::sync::{
-            Arc, Mutex,
-            atomic::{AtomicUsize, Ordering},
-        },
+        dango_primitives::{JsonSerExt, Timestamp},
     };
-
-    fn perps_addr() -> Addr {
-        Addr::mock(9)
-    }
-
-    fn user_addr() -> Addr {
-        Addr::mock(1)
-    }
-
-    /// A `QueryApp` that serves `app_config` (with [`perps_addr`] as the
-    /// perps contract, after a configurable number of failures) and answers
-    /// every `wasm_smart` query with the canned responder, recording the last
-    /// request for assertions.
-    struct MockApp {
-        respond: Box<dyn Fn(&Json) -> Json + Send + Sync>,
-        app_config_calls: AtomicUsize,
-        app_config_failures: AtomicUsize,
-        last_wasm_smart: Mutex<Option<(Addr, Json)>>,
-    }
-
-    impl MockApp {
-        fn context<F>(app_config_failures: usize, respond: F) -> (MinimalContext, Arc<Self>)
-        where
-            F: Fn(&Json) -> Json + Send + Sync + 'static,
-        {
-            let app = Arc::new(Self {
-                respond: Box::new(respond),
-                app_config_calls: AtomicUsize::new(0),
-                app_config_failures: AtomicUsize::new(app_config_failures),
-                last_wasm_smart: Mutex::new(None),
-            });
-
-            (MinimalContext::new(app.clone()), app)
-        }
-    }
-
-    #[async_trait]
-    impl QueryApp for MockApp {
-        async fn query_app(&self, raw_req: Query) -> AppResult<(QueryResponse, u64)> {
-            match raw_req {
-                Query::AppConfig(_) => {
-                    self.app_config_calls.fetch_add(1, Ordering::SeqCst);
-
-                    if self
-                        .app_config_failures
-                        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
-                            remaining.checked_sub(1)
-                        })
-                        .is_ok()
-                    {
-                        return Err(AppError::vm("app config not ready".to_string()));
-                    }
-
-                    let app_config = AppConfig {
-                        addresses: AppAddresses {
-                            perps: perps_addr(),
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    };
-
-                    Ok((QueryResponse::AppConfig(app_config.to_json_value()?), 1))
-                },
-                Query::WasmSmart(req) => {
-                    let response = (self.respond)(&req.msg);
-
-                    *self.last_wasm_smart.lock().unwrap() = Some((req.contract, req.msg));
-
-                    Ok((QueryResponse::WasmSmart(response), 1))
-                },
-                _ => unimplemented!("not exercised by the perp routes"),
-            }
-        }
-
-        async fn simulate(&self, _unsigned_tx: UnsignedTx) -> AppResult<TxOutcome> {
-            unimplemented!("not exercised by the perp routes");
-        }
-
-        async fn chain_id(&self) -> AppResult<String> {
-            unimplemented!("not exercised by the perp routes");
-        }
-
-        async fn last_finalized_block(&self) -> AppResult<BlockInfo> {
-            unimplemented!("not exercised by the perp routes");
-        }
-    }
-
-    async fn get(ctx: &MinimalContext, uri: &str) -> (StatusCode, Json) {
-        let app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(ctx.clone()))
-                .service(services()),
-        )
-        .await;
-
-        let response =
-            test::call_service(&app, test::TestRequest::get().uri(uri).to_request()).await;
-        let status = response.status();
-        let body = test::read_body(response).await;
-
-        // Error responses carry a plain-text body; substitute `null` so
-        // callers can assert on the status alone.
-        let json = serde_json::from_slice(&body).unwrap_or(Json::null());
-
-        (status, json)
-    }
 
     fn cid_order_response() -> QueryOrderByClientOrderIdResponse {
         QueryOrderByClientOrderIdResponse {
@@ -723,14 +608,14 @@ mod tests {
     async fn aliases_query_the_perps_contract_and_cache_its_address() {
         let canned = dango_primitives::json!({ "max_open_orders": 100 });
         let canned_clone = canned.clone();
-        let (ctx, app) = MockApp::context(0, move |_| canned_clone.clone());
+        let (ctx, app) = MockApp::context(0, move |_, _| canned_clone.clone());
 
         let (status, body) = get(&ctx, "/perps/param").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, canned);
 
         // The query went to the perps contract, carrying the `param` message.
-        let (contract, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        let (contract, msg) = app.last_wasm_smart();
         assert_eq!(contract, perps_addr());
         assert_eq!(msg, perps::QueryMsg::Param {}.to_json_value().unwrap());
 
@@ -738,12 +623,12 @@ mod tests {
         // query.
         let (status, _) = get(&ctx, "/perps/param").await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(app.app_config_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(app.app_config_calls(), 1);
     }
 
     #[actix_web::test]
     async fn failed_address_resolution_is_a_503_and_is_retried() {
-        let (ctx, app) = MockApp::context(1, |_| Json::null());
+        let (ctx, app) = MockApp::context(1, |_, _| Json::null());
 
         let (status, _) = get(&ctx, "/perps/state").await;
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
@@ -751,12 +636,12 @@ mod tests {
         // The failure is not cached: the next request retries and succeeds.
         let (status, _) = get(&ctx, "/perps/state").await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(app.app_config_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(app.app_config_calls(), 2);
     }
 
     #[actix_web::test]
     async fn single_item_lookups_respond_404_on_null() {
-        let (ctx, app) = MockApp::context(0, |_| Json::null());
+        let (ctx, app) = MockApp::context(0, |_, _| Json::null());
 
         let (status, _) = get(&ctx, "/perps/pair-param?pair_id=perp/ethusd").await;
         assert_eq!(status, StatusCode::NOT_FOUND);
@@ -778,7 +663,7 @@ mod tests {
         assert_eq!(status, StatusCode::NOT_FOUND);
 
         // The path parameter parsed into the order ID.
-        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        let (_, msg) = app.last_wasm_smart();
         assert_eq!(
             msg,
             perps::QueryMsg::Order {
@@ -791,12 +676,12 @@ mod tests {
 
     #[actix_web::test]
     async fn orders_by_user_is_a_passthrough() {
-        let (ctx, app) = MockApp::context(0, |_| dango_primitives::json!({}));
+        let (ctx, app) = MockApp::context(0, |_, _| dango_primitives::json!({}));
 
         let (status, _) = get(&ctx, &format!("/perps/order/by-user?user={}", user_addr())).await;
         assert_eq!(status, StatusCode::OK);
 
-        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        let (_, msg) = app.last_wasm_smart();
         assert_eq!(
             msg,
             perps::QueryMsg::OrdersByUser { user: user_addr() }
@@ -807,7 +692,7 @@ mod tests {
 
     #[actix_web::test]
     async fn order_by_client_order_id_is_a_passthrough() {
-        let (ctx, app) = MockApp::context(0, |_| cid_order_response().to_json_value().unwrap());
+        let (ctx, app) = MockApp::context(0, |_, _| cid_order_response().to_json_value().unwrap());
 
         let uri = format!(
             "/perps/order/by-client-order-id?user={}&client_order_id=7",
@@ -820,7 +705,7 @@ mod tests {
         assert_eq!(body, cid_order_response().to_json_value().unwrap());
 
         // The query params parsed into the contract query message.
-        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        let (_, msg) = app.last_wasm_smart();
         assert_eq!(
             msg,
             perps::QueryMsg::OrderByClientOrderId {
@@ -834,7 +719,7 @@ mod tests {
 
     #[actix_web::test]
     async fn user_state_forwards_the_include_flags() {
-        let (ctx, app) = MockApp::context(0, |_| dango_primitives::json!({}));
+        let (ctx, app) = MockApp::context(0, |_, _| dango_primitives::json!({}));
 
         let (status, _) = get(
             &ctx,
@@ -846,7 +731,7 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK);
 
-        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        let (_, msg) = app.last_wasm_smart();
         assert_eq!(
             msg,
             perps::QueryMsg::UserStateExtended {
@@ -866,7 +751,7 @@ mod tests {
 
     #[actix_web::test]
     async fn liquidity_depth_forwards_typed_params() {
-        let (ctx, app) = MockApp::context(0, |_| dango_primitives::json!({}));
+        let (ctx, app) = MockApp::context(0, |_, _| dango_primitives::json!({}));
 
         let (status, _) = get(
             &ctx,
@@ -875,7 +760,7 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::OK);
 
-        let (_, msg) = app.last_wasm_smart.lock().unwrap().clone().unwrap();
+        let (_, msg) = app.last_wasm_smart();
         assert_eq!(
             msg,
             perps::QueryMsg::LiquidityDepth {

--- a/dango/indexer/httpd/src/server.rs
+++ b/dango/indexer/httpd/src/server.rs
@@ -72,6 +72,11 @@ use {
         crate::routes::perps::orders_by_user,
         crate::routes::perps::order_by_client_order_id,
         crate::routes::perps::order,
+        crate::routes::account::account,
+        crate::routes::account::user,
+        crate::routes::account::seen_nonces,
+        crate::routes::account::session_seen_nonces,
+        crate::routes::account::balances,
         crate::routes::ws::ws_doc,
         crate::routes::graphql::graphql_doc,
     ),
@@ -88,6 +93,11 @@ use {
                                        and the parameters taken from the query string. \
                                        Responses are the contract's response objects, \
                                        verbatim."),
+        (name = "account", description = "GET aliases for account-related queries, keyed \
+                                          by account address: account parameters and the \
+                                          owning user from the account factory, seen \
+                                          nonces from the account contract itself, and \
+                                          chain-level balances."),
         (name = "websocket", description = "Realtime feeds over a multiplexed WebSocket"),
         (name = "graphql", description = "Deprecated GraphQL API — scheduled for removal"),
     )
@@ -115,6 +125,7 @@ where
             .service(routes::index::sentry_raise)
             .service(routes::blocks::services())
             .service(routes::perps::services())
+            .service(routes::account::services())
             .service(routes::ws::services())
             .service(routes::query::query)
             .service(routes::simulate::simulate)
@@ -327,6 +338,11 @@ mod tests {
             "/perps/order/by-user",
             "/perps/order/by-client-order-id",
             "/perps/order/{order_id}",
+            "/account/{address}",
+            "/account/{address}/user",
+            "/account/{address}/seen-nonces",
+            "/account/{address}/session-seen-nonces",
+            "/account/{address}/balances",
             "/ws",
             "/graphql",
         ] {

--- a/dango/testing/tests/indexer_infra/api.rs
+++ b/dango/testing/tests/indexer_infra/api.rs
@@ -4,14 +4,15 @@ use {
     dango_math::Uint64,
     dango_order_book::{OrderKind, Quantity, TimeInForce, UsdPrice},
     dango_primitives::{
-        Addressable, Block, BlockOutcome, Coins, QuerierExt, ResultExt, btree_map, btree_set,
+        Addressable, Block, BlockOutcome, ByteArray, Coins, QuerierExt, ResultExt, btree_map,
+        btree_set,
     },
     dango_testing::{
         TestOption, build_app_service, call_api, call_api_post, call_api_with_headers, pair_id,
         setup_perps_env, setup_test_naive_with_indexer,
         setup_test_naive_with_indexer_and_create_blocks,
     },
-    dango_types::perps,
+    dango_types::{account_factory, perps},
     serde_json::json,
 };
 
@@ -150,6 +151,11 @@ async fn openapi_spec_is_served() -> anyhow::Result<()> {
                     "/perps/order/by-user",
                     "/perps/order/by-client-order-id",
                     "/perps/order/{order_id}",
+                    "/account/{address}",
+                    "/account/{address}/user",
+                    "/account/{address}/seen-nonces",
+                    "/account/{address}/session-seen-nonces",
+                    "/account/{address}/balances",
                     "/ws",
                     "/graphql",
                 ] {
@@ -406,6 +412,186 @@ async fn perps_aliases_mirror_contract_queries() -> anyhow::Result<()> {
                 )
                 .await;
                 assert_that!(unknown_cid).is_err();
+
+                Ok::<(), anyhow::Error>(())
+            })
+            .await
+        })
+        .await?
+}
+
+/// The `/account/*` aliases: account parameters, the owning user (composed
+/// from two factory queries), seen nonces from the account contract itself,
+/// and chain-level balances — each mirroring the equivalent raw query
+/// through `POST /query`.
+#[tokio::test(flavor = "multi_thread")]
+async fn account_aliases_mirror_contract_queries() -> anyhow::Result<()> {
+    let (mut suite, mut accounts, _, contracts, _, httpd_context, _, _, _db_guard) =
+        setup_test_naive_with_indexer(TestOption::default().with_mocked_clickhouse()).await;
+
+    // Register a subaccount for user1, so the owning user has two accounts.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.account_factory,
+            &account_factory::ExecuteMsg::RegisterAccount {},
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    let master = accounts.user1.address();
+    let factory = contracts.account_factory;
+
+    let local_set = tokio::task::LocalSet::new();
+
+    local_set
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                // `/account/{address}`: the factory's `Account` object,
+                // verbatim.
+                let account = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/account/{master}"),
+                )
+                .await?;
+
+                let raw = call_api_post::<serde_json::Value, _>(
+                    build_app_service(httpd_context.clone()),
+                    "/query",
+                    &json!({ "wasm_smart": {
+                        "contract": factory,
+                        "msg": { "account": { "address": master } },
+                    } }),
+                )
+                .await?;
+                assert_eq!(account, raw["wasm_smart"]);
+
+                // `/account/{address}/user`: equals the raw `user` query by
+                // the owner index taken from the `account` response...
+                let user = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/account/{master}/user"),
+                )
+                .await?;
+
+                let raw = call_api_post::<serde_json::Value, _>(
+                    build_app_service(httpd_context.clone()),
+                    "/query",
+                    &json!({ "wasm_smart": {
+                        "contract": factory,
+                        "msg": { "user": { "index": account["owner"] } },
+                    } }),
+                )
+                .await?;
+                assert_eq!(user, raw["wasm_smart"]);
+
+                // ...contains both accounts, the master being the lowest
+                // account index...
+                let accounts_map = user["accounts"].as_object().unwrap();
+                assert_eq!(accounts_map.len(), 2);
+
+                let master_index = accounts_map
+                    .keys()
+                    .map(|index| index.parse::<u64>().unwrap())
+                    .min()
+                    .unwrap();
+                assert_eq!(
+                    accounts_map[master_index.to_string().as_str()],
+                    json!(master),
+                    "the lowest account index should be the master account",
+                );
+
+                // ...and is the same whether looked up via the master or the
+                // subaccount address.
+                let subaccount = accounts_map
+                    .values()
+                    .find(|address| **address != json!(master))
+                    .expect("the user should have a subaccount")
+                    .as_str()
+                    .unwrap()
+                    .to_string();
+
+                let via_subaccount = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/account/{subaccount}/user"),
+                )
+                .await?;
+                assert_eq!(via_subaccount, user);
+
+                // `/account/{address}/seen-nonces`: non-empty — user1 has
+                // sent a transaction — and equal to the raw query against
+                // the account contract itself.
+                let nonces = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/account/{master}/seen-nonces"),
+                )
+                .await?;
+                assert!(
+                    !nonces.as_array().unwrap().is_empty(),
+                    "the master account has sent a transaction, so it should \
+                     have recorded a nonce",
+                );
+
+                let raw = call_api_post::<serde_json::Value, _>(
+                    build_app_service(httpd_context.clone()),
+                    "/query",
+                    &json!({ "wasm_smart": {
+                        "contract": master,
+                        "msg": { "seen_nonces": {} },
+                    } }),
+                )
+                .await?;
+                assert_eq!(nonces, raw["wasm_smart"]);
+
+                // `/account/{address}/session-seen-nonces`: no session key
+                // has signed anything, so the alias and the raw query both
+                // return the empty set. The key travels in its base64 wire
+                // encoding, URL-encoded.
+                let session_key = ByteArray::<33>::from([7; 33]);
+                let encoded = session_key
+                    .to_string()
+                    .replace('+', "%2B")
+                    .replace('/', "%2F")
+                    .replace('=', "%3D");
+
+                let session_nonces = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/account/{master}/session-seen-nonces?session_key={encoded}"),
+                )
+                .await?;
+                assert_eq!(session_nonces, json!([]));
+
+                let raw = call_api_post::<serde_json::Value, _>(
+                    build_app_service(httpd_context.clone()),
+                    "/query",
+                    &json!({ "wasm_smart": {
+                        "contract": master,
+                        "msg": { "session_seen_nonces": { "session_key": session_key } },
+                    } }),
+                )
+                .await?;
+                assert_eq!(session_nonces, raw["wasm_smart"]);
+
+                // `/account/{address}/balances`: the chain-level query — note
+                // the different response envelope.
+                let balances = call_api::<serde_json::Value>(
+                    build_app_service(httpd_context.clone()),
+                    &format!("/account/{master}/balances"),
+                )
+                .await?;
+                assert!(
+                    !balances.as_object().unwrap().is_empty(),
+                    "user1 should hold genesis balances",
+                );
+
+                let raw = call_api_post::<serde_json::Value, _>(
+                    build_app_service(httpd_context.clone()),
+                    "/query",
+                    &json!({ "balances": { "address": master } }),
+                )
+                .await?;
+                assert_eq!(balances, raw["balances"]);
 
                 Ok::<(), anyhow::Error>(())
             })


### PR DESCRIPTION
Add GET routes under /account, all keyed by an account address in the path:

- `/account/{address}` — the account factory's `account` query: the account's index and the index of the user who owns it.
- `/account/{address}/user` — the user who owns the account (master or subaccount alike), composed from the factory's `account` and `user` queries; the response is the factory's `User` object verbatim, whose `accounts` map lists the master account (lowest index) and all subaccounts.
- `/account/{address}/seen-nonces` — the account contract's `seen_nonces` query, needed to pick a valid nonce when building a transaction.
- `/account/{address}/session-seen-nonces?session_key=` — same, for a given session key (base64 wire encoding, URL-encoded).
- `/account/{address}/balances` — the chain-level `balances` query; works for any address, paginated by `start_after`/`limit`.

Unlike the /perps aliases, which all target the one perps contract, the routes here resolve the query target in three ways: the account factory (from the app config), the account contract at the path address itself, and no contract at all (the chain-level balances query).

In support of this, the lazily-cached perps address on MinimalContext is generalized to cache the whole AppAddresses from one app_config query, with per-contract getters; and the mock QueryApp used by the route unit tests is extracted into a shared test-only module, generalized to record all wasm_smart requests and to answer balances queries.

---------


Claude-Session: https://claude.ai/code/session_01AXMg5kr5YH1RFEUxyxMthJ