### PR TITLE
feat(deploy): add one-shot block-cleanup bot playbook and just recipe

### DIFF
--- a/deploy/block-cleanup.yml
+++ b/deploy/block-cleanup.yml
@@ -1,0 +1,20 @@
+---
+# One-shot: delete an inclusive block height range from a node's local
+# blocks/ dir. Always run with --limit <server> (e.g. --limit hetzner1) —
+# the role refuses to run against more than one host.
+- hosts: full-app
+  become: true
+  become_user: "{{ deploy_user }}"
+  remote_user: deploy
+  collections:
+    - community.docker
+  pre_tasks:
+    - name: Get deploy user info
+      getent:
+        database: passwd
+        key: "{{ deploy_user }}"
+    - name: Set deploy_home fact
+      set_fact:
+        deploy_home: "{{ ansible_facts.getent_passwd[deploy_user][4] }}"
+  roles:
+    - block-cleanup

--- a/deploy/inventory
+++ b/deploy/inventory
@@ -7,6 +7,24 @@ deploy_user="deploy"
 # Per-host alias groups: `--limit hetzner7` works with any playbook, and other
 # groups can include the host by name via `:children`. The inventory hostname
 # stays the tailscale IP so host_vars/<ip>.yml keeps applying.
+[hetzner1]
+100.126.8.2
+
+[hetzner2]
+100.90.163.19
+
+[hetzner3]
+100.76.197.30
+
+[hetzner4]
+100.109.200.70
+
+[hetzner5]
+100.72.62.100
+
+[hetzner6]
+100.66.152.68
+
 [hetzner7]
 100.126.43.113
 

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -332,6 +332,21 @@ stop-batch-block-backup network:
       --limit batch-block-backup-{{network}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-stop-batch-block-backup.log"
 
+# ------------------------------ Block Cleanup ---------------------------------
+
+# One-shot: delete an inclusive block height range from a node's local blocks/
+# dir, then exit. Make sure the range is already archived in the
+# dango-<network>-batches bucket before running! The playbook waits for the bot
+# to finish, prints its logs, and fails if it exited non-zero.
+# Usage: just block-cleanup mainnet hetzner1 1 1000000
+#        just block-cleanup testnet hetzner2 1 500000 latest true   # dry run
+block-cleanup network server start_height end_height tag="latest" dry_run="false":
+  mkdir -p "{{justfile_directory()}}/logs" \
+    && uv run ansible-playbook block-cleanup.yml \
+      -e '{"network": "{{network}}", "block_cleanup_start_height": {{start_height}}, "block_cleanup_end_height": {{end_height}}, "block_cleanup_tag": "{{tag}}", "block_cleanup_dry_run": "{{dry_run}}"}' \
+      --limit {{server}} \
+      2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-block-cleanup.log"
+
 # ----------------------------- Dango Assistant --------------------------------
 
 deploy-dango-assistant tag="latest":

--- a/deploy/roles/block-cleanup/defaults/main.yml
+++ b/deploy/roles/block-cleanup/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+block_cleanup_dir: "{{ deploy_home }}/block-cleanup"
+block_cleanup_image: "ghcr.io/left-curve/bots/block-cleanup"
+block_cleanup_tag: "latest"
+# Log what would be deleted without touching the disk.
+block_cleanup_dry_run: false
+# Host path to the node's `blocks/` directory, keyed by network. Leave a
+# network unset to auto-detect the active full-app deployment's blocks dir at
+# deploy time (recommended). Set it explicitly to pin a fixed path.
+block_cleanup_blocks_dir: {}

--- a/deploy/roles/block-cleanup/tasks/main.yml
+++ b/deploy/roles/block-cleanup/tasks/main.yml
@@ -1,0 +1,137 @@
+---
+- name: Require an explicit network and height range
+  assert:
+    that:
+      - network is defined
+      - block_cleanup_start_height is defined
+      - block_cleanup_start_height | int > 0
+      - block_cleanup_end_height is defined
+      - block_cleanup_end_height | int >= block_cleanup_start_height | int
+    fail_msg: >-
+      network, block_cleanup_start_height and block_cleanup_end_height are
+      required, with 0 < start_height <= end_height. The bot never picks a
+      deletion range on its own.
+
+- name: Refuse to run on more than one host
+  assert:
+    that: ansible_play_hosts | length == 1
+    fail_msg: >-
+      block-cleanup deletes blocks from disk; target exactly one server
+      with --limit <server> (this play matched:
+      {{ ansible_play_hosts | join(', ') }}).
+  run_once: true
+
+- name: "{{ network }} - Auto-detect active deployment blocks_dir"
+  when: block_cleanup_blocks_dir[network] is not defined
+  block:
+    - name: "{{ network }} - Read active deployment marker"
+      slurp:
+        src: "{{ deploy_home }}/deployments/{{ network }}.json"
+      register: block_cleanup_deploy_marker
+
+    - name: "{{ network }} - Parse active deployment name"
+      set_fact:
+        block_cleanup_active_deployment: >-
+          {{ (block_cleanup_deploy_marker.content
+              | b64decode | from_json).current_deployment }}
+
+    # DANGO_DIRECTORY is the node's persistent data dir (decoupled from the
+    # blue/green deployment dir) mounted at /root/.dango; the block shard tree
+    # lives at <DANGO_DIRECTORY>/indexer/blocks on the host.
+    - name: "{{ network }} - Read DANGO_DIRECTORY from active deployment"
+      ansible.builtin.command:
+        cmd: >-
+          grep -m1 '^DANGO_DIRECTORY=' {{ deploy_home }}/deployments/{{
+          block_cleanup_active_deployment }}/.env
+      register: block_cleanup_dango_line
+      changed_when: false
+      failed_when: false
+
+    - name: "{{ network }} - Derive blocks_dir from DANGO_DIRECTORY"
+      set_fact:
+        block_cleanup_resolved_blocks_dir: >-
+          {{ block_cleanup_dango_line.stdout
+             | regex_replace('^DANGO_DIRECTORY=', '') | trim }}/indexer/blocks
+
+- name: "{{ network }} - Use configured blocks_dir override"
+  when: block_cleanup_blocks_dir[network] is defined
+  set_fact:
+    block_cleanup_resolved_blocks_dir: >-
+      {{ block_cleanup_blocks_dir[network] }}
+
+- name: "{{ network }} - Check blocks_dir exists"
+  stat:
+    path: "{{ block_cleanup_resolved_blocks_dir }}"
+  register: block_cleanup_blocks_stat
+
+- name: "{{ network }} - Fail if blocks_dir is missing"
+  fail:
+    msg: >-
+      blocks_dir '{{ block_cleanup_resolved_blocks_dir }}' was not found
+      on {{ inventory_hostname }}. Ensure the full-app node is deployed for
+      {{ network }}, or set
+      block_cleanup_blocks_dir['{{ network }}'] explicitly.
+  when: not block_cleanup_blocks_stat.stat.exists
+
+- name: "{{ network }} - Create directory"
+  file:
+    path: "{{ block_cleanup_dir }}/{{ network }}"
+    state: directory
+    mode: "0755"
+
+- name: "{{ network }} - Template .env"
+  template:
+    src: env.j2
+    dest: "{{ block_cleanup_dir }}/{{ network }}/.env"
+    mode: "0600"
+
+- name: "{{ network }} - Template docker-compose.yml"
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{ block_cleanup_dir }}/{{ network }}/docker-compose.yml"
+    mode: "0644"
+
+- name: "{{ network }} - Login to GHCR"
+  community.docker.docker_login:
+    registry: ghcr.io
+    username: "{{ ghcr_user }}"
+    password: "{{ ghcr_token }}"
+  no_log: true
+
+- name: "{{ network }} - Launch one-shot cleanup"
+  community.docker.docker_compose_v2:
+    project_src: "{{ block_cleanup_dir }}/{{ network }}"
+    pull: always
+    state: present
+    recreate: always
+
+- name: "{{ network }} - Logout from GHCR"
+  community.docker.docker_login:
+    registry: ghcr.io
+    state: absent
+
+- name: "{{ network }} - Wait for the bot to finish"
+  ansible.builtin.command:
+    cmd: docker wait block-cleanup-{{ network }}
+  register: block_cleanup_exit
+  changed_when: false
+
+- name: "{{ network }} - Collect logs"
+  ansible.builtin.command:
+    cmd: docker logs --tail 200 block-cleanup-{{ network }}
+  register: block_cleanup_logs
+  changed_when: false
+
+# Strip ANSI color codes so the output is readable in Ansible's JSON display.
+- name: "{{ network }} - Show logs"
+  debug:
+    msg: >-
+      {{ (block_cleanup_logs.stdout_lines + block_cleanup_logs.stderr_lines)
+         | map('regex_replace', '\x1b\[[0-9;]*m', '') | list }}
+
+- name: "{{ network }} - Fail if the bot exited non-zero"
+  fail:
+    msg: >-
+      block-cleanup exited with code {{ block_cleanup_exit.stdout | trim }};
+      see logs above.
+  when: block_cleanup_exit.stdout | trim != '0'

--- a/deploy/roles/block-cleanup/templates/docker-compose.yml.j2
+++ b/deploy/roles/block-cleanup/templates/docker-compose.yml.j2
@@ -1,0 +1,21 @@
+# Explicit project name so this stack doesn't collide with other bots that
+# share a "<bot>/{{ network }}" directory layout (Compose otherwise derives the
+# project name from the parent dir, "{{ network }}", and treats their
+# containers as orphans of each other).
+name: block-cleanup-{{ network }}
+
+services:
+  block-cleanup:
+    image: {{ block_cleanup_image }}:{{ block_cleanup_tag }}
+    pull_policy: always
+    container_name: block-cleanup-{{ network }}
+    # One-shot job: deletes the configured height range and exits.
+    restart: "no"
+    labels:
+      dango_network: "{{ network }}"
+      service_name: "block_cleanup"
+    env_file:
+      - .env
+    volumes:
+      # Read-write: the bot deletes block files in place.
+      - {{ block_cleanup_resolved_blocks_dir }}:/data/blocks

--- a/deploy/roles/block-cleanup/templates/env.j2
+++ b/deploy/roles/block-cleanup/templates/env.j2
@@ -1,0 +1,17 @@
+# Managed by Ansible (roles/block-cleanup) — do not edit by hand.
+
+# The node's blocks/ dir is bind-mounted READ-WRITE at /data/blocks (see
+# docker-compose.yml); block files live at /data/blocks/<r>/<r>/<r>/<height>.borsh.xz.
+blocks_dir=/data/blocks
+
+# Inclusive height range to delete. Make sure the range is already archived in
+# the dango-{{ network }}-batches bucket before deleting!
+start_height={{ block_cleanup_start_height }}
+end_height={{ block_cleanup_end_height }}
+
+# Log what would be deleted without touching the disk.
+dry_run={{ 'true' if block_cleanup_dry_run | bool else 'false' }}
+
+# Disable ANSI colors in the bot's log output so `docker logs` and the
+# Ansible log capture stay readable.
+NO_COLOR=1


### PR DESCRIPTION
## Summary

Adds a deploy for the [block-cleanup bot](https://github.com/left-curve/bots/pkgs/container/bots%2Fblock-cleanup) — a one-shot job that deletes an inclusive block height range from a node's local `blocks/` dir (after the range has been archived to the `dango-<network>-batches` bucket), then exits.

- New `block-cleanup` Ansible role + `block-cleanup.yml` playbook, modeled on `batch-block-backup`: the node's `blocks/` dir is auto-detected from the active full-app deployment marker (`deployments/<network>.json` → `DANGO_DIRECTORY` → `<dir>/indexer/blocks`) and bind-mounted **read-write** into the container.
- One-shot semantics: `restart: "no"`, then the playbook `docker wait`s for the bot to exit, prints its logs (ANSI codes stripped, `NO_COLOR=1` set in the env), and fails the play if the bot exited non-zero.
- Guardrails: the role asserts an explicit height range (`0 < start <= end`) and refuses to run against more than one host, so a forgotten `--limit` can't wipe blocks fleet-wide.
- New just recipe: `just block-cleanup <network> <server> <start_height> <end_height> [tag] [dry_run]`, e.g. `just block-cleanup testnet hetzner2 1 999999`.
- Inventory: added `hetzner1`–`hetzner6` per-host alias groups (hetzner7/8 already existed) so `--limit <server>` works with any playbook.

## Validation

### Completed
- [x] `yamllint -d relaxed` clean on the new playbook/role files
- [x] Dry run on testnet/hetzner2 (heights 1–1000): reported 1000 files / ~4.7 MB, deleted nothing
- [x] Real run heights 1–1000 on testnet/hetzner2: deleted 1000 files, exit 0, totals matched the dry run
- [x] Real run heights 1–999999 on testnet/hetzner2: deleted 998,999 files (~4.7 GB), `heights_missing=1000` exactly matching the previously-deleted range
- [x] Playbook fails the play when the bot exits non-zero (`docker wait` + assert)

### Remaining
- [ ] First run on mainnet (hetzner1) once a range is confirmed archived

## Manual QA

1. `just block-cleanup testnet hetzner2 <start> <end> latest true` — verify the dry-run totals look right.
2. Re-run without the dry-run flag; verify `files_deleted`/`bytes_deleted` match and exit code is 0.
3. Spot-check a shard dir on the host (e.g. `ls <blocks_dir>/1/0/0/`) to confirm files are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)