### PR TITLE
docs(perps): rewrite API reference for REST and WebSocket

### DIFF
--- a/book/perps/4-liquidation-and-adl.md
+++ b/book/perps/4-liquidation-and-adl.md
@@ -82,7 +82,7 @@ ADL does not fill the counter-party's resting limit orders; their position is fo
 
 Liquidation fills (both order-book and ADL) carry **zero trading fees** for both taker and maker.
 
-Order-book fills during liquidation emit `order_filled` events with a `fill_id` just like regular matches (see the [events reference](8-api.md#9-events-reference)); ADL fills do _not_ — they use the separate `deleveraged` and `liquidated` events, which carry no `fill_id`, because ADL is a position transfer at the bankruptcy price rather than an order-book match.
+Order-book fills during liquidation emit `order_filled` events with a `fill_id` just like regular matches (see the [events reference](8-api.md#7-events-reference)); ADL fills do _not_ — they use the separate `deleveraged` and `liquidated` events, which carry no `fill_id`, because ADL is a position transfer at the bankruptcy price rather than an order-book match.
 
 ## 4. Liquidation fee
 

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -1,521 +1,418 @@
 # API Reference
 
-This chapter documents the complete API for the Dango perpetual futures exchange. All interactions with the chain go through a single **GraphQL endpoint** that supports queries, mutations, and WebSocket subscriptions.
+Every Dango deployment exposes its data and trading surface over two HTTP servers:
 
-## 1. Transport
+- the **Live API** — the consensus node, which talks to CometBFT, performs state transitions, and serves the latest chain state, transaction broadcasting, and real-time streaming; and
+- the **Archive API** — the archive node, which ingests finalized blocks, analyzes them, and serves structured historical data backed by SQL databases.
 
-### 1.1 HTTP
+The Live API speaks **REST** and **WebSocket**; the Archive API speaks **REST**. This chapter is a guide to both. The exhaustive, always-current endpoint reference lives in each server's interactive documentation (see [§1.2](#12-interactive-reference)); this chapter covers the concepts that reference cannot express — the two-server model, the transaction lifecycle and signing, the WebSocket protocol, and the perps-specific semantics — and points to the interactive docs for the mechanical detail.
 
-All queries and mutations use a standard GraphQL POST request.
+> **Deprecation notice.** Dango nodes historically exposed a single **GraphQL** endpoint, which backed the frontend and most trading bots. GraphQL is being **phased out** in favor of the REST + WebSocket surface documented here, and the monolithic server is being split into the two servers above. New integrations should target REST + WebSocket. The GraphQL endpoint remains available during the transition but is unmaintained and will be removed; it is not documented here.
 
-**Endpoint:** See [Constants](9-constants.md#endpoints).
+## 1. Overview
 
-**Headers:**
+### 1.1 The two APIs
 
-| Header         | Value              |
-| -------------- | ------------------ |
-| `Content-Type` | `application/json` |
+| I want to… | Use | Transport |
+| ---------- | --- | --------- |
+| Read the **latest** chain state (prices, my positions, order book, parameters) | Live API | REST `POST /query`, `GET /perps/*`, `GET /account/*` |
+| Submit a transaction (trade, deposit, vault, account ops) | Live API | REST `POST /simulate` + `POST /broadcast` |
+| **Stream** real-time data (fills, blocks, order book) | Live API | WebSocket `GET /ws` |
+| Read **structured history** (past fills, transactions, events) | Archive API | REST feeds (`/transactions/*`, `/events/*`) |
+| Read a **full block** at any height | Archive API | REST `GET /blocks/{height}` |
 
-**Request body:**
+The division reflects where the data lives. The Live API answers from the node's in-memory and latest-committed state — it is always current but keeps only a shallow window of history. The Archive API answers from SQL databases populated by analyzing every block — it reaches back to genesis but trails the chain tip slightly (see [§6.1](#61-feed-model)).
 
-```json
-{
-  "query": "query { ... }",
-  "variables": { ... }
-}
-```
+A quick mental model for readers coming from other venues: `POST /query` is the universal read (Dango's analogue of Hyperliquid's `/info`), and the `GET /perps/*` and `GET /account/*` routes are typed shortcuts over it; `POST /broadcast` is the universal write (the analogue of Hyperliquid's `/exchange`).
 
-**Example — query chain status:**
+### 1.2 Interactive reference
 
-```bash
-curl -X POST https://<host>/graphql \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "{ queryStatus { block { blockHeight timestamp } chainId } }"}'
-```
+Both servers **auto-generate an OpenAPI specification and a Swagger UI** from the handlers themselves, served at `/docs/` (with the raw spec at `/openapi.json`). This is the source of truth for paths, HTTP methods, query and path **parameters**, and status codes — it can never drift from the code, because it is generated from it. Hitting the base path of either server (`GET /`) redirects to its docs.
 
-**Response:**
+| API | Interactive docs |
+| --- | ---------------- |
+| Live | `https://<live-host>/docs/` |
+| Archive | `https://<archive-host>/docs/` |
 
-```json
-{
-  "data": {
-    "queryStatus": {
-      "block": {
-        "blockHeight": 123456,
-        "timestamp": "2026-01-15T12:00:00"
-      },
-      "chainId": "dango-1"
-    }
-  }
-}
-```
+See [Constants](9-constants.md#endpoints) for the concrete hostnames.
 
-### 1.2 WebSocket
+One caveat shapes how this chapter divides labor with Swagger: the Live API's read handlers return their contract responses as **opaque JSON**, so Swagger documents their _parameters_ but not their _response shapes_. Those response shapes are documented here, in the [Types reference](#8-types-reference). The Archive API's feeds return typed objects, so Swagger documents their responses in full; this chapter describes them only in outline. And OpenAPI cannot model WebSocket traffic at all, so the entire [WebSocket section](#5-live-api--real-time-websocket) lives here.
 
-Subscriptions (real-time data) use WebSocket with the `graphql-ws` protocol. A separate native WebSocket API (not `graphql-ws`) serves the `fullBlock` and `perpsEvents` feeds — see [§12](#12-new-in-v0260-websocket-api).
+### 1.3 Base URLs
 
-**Endpoint:** See [Constants](9-constants.md#endpoints).
+See [Constants](9-constants.md#endpoints) for the mainnet and testnet hostnames of both servers, the WebSocket URL, and the testnet faucet.
 
-**Connection handshake:**
+## 2. Conventions
 
-```json
-{
-  "type": "connection_init",
-  "payload": {}
-}
-```
+These conventions apply across both servers. Reading them first keeps the rest of the chapter terse.
 
-**Subscribe:**
+### 2.1 Data types and encoding
 
-```json
-{
-  "id": "1",
-  "type": "subscribe",
-  "payload": {
-    "query": "subscription { perpsTrades(pairId: \"perp/btcusd\") { fillPrice fillSize } }"
-  }
-}
-```
+All requests and responses are JSON. Contract-specific message keys are **snake_case**.
 
-**Messages arrive as:**
+The perps exchange's numeric types are **signed fixed-point decimals with 6 decimal places**, built on [`dango_types::Number`](https://github.com/left-curve/left-curve/blob/main/dango/exchange/types/src/typed_number.rs). They are serialized as **strings** to avoid floating-point loss:
 
-```json
-{
-  "id": "1",
-  "type": "next",
-  "payload": {
-    "data": {
-      "perpsTrades": { ... }
-    }
-  }
-}
-```
+| Type alias | Dimension | Example usage | Example value |
+| ---------- | --------- | ------------- | ------------- |
+| `Dimensionless` | (pure scalar) | Fee rates, margin ratios, slippage | `"0.050000"` |
+| `Quantity` | quantity | Position size, order size, open interest | `"-0.500000"` |
+| `UsdValue` | usd | Margin, PnL, notional, fees | `"10000.000000"` |
+| `UsdPrice` | usd / quantity | Oracle price, limit price, entry price | `"65000.000000"` |
+| `FundingPerUnit` | usd / quantity | Cumulative funding accumulator | `"0.000123"` |
+| `FundingRate` | per day | Funding rate, funding rate cap | `"0.000500"` |
 
-### 1.3 Pagination
+Additional scalar types:
 
-List queries use **cursor-based pagination** (Relay Connection specification).
+| Type | Encoding | Description |
+| ---- | -------- | ----------- |
+| `Uint128` | string | Large integer (e.g. vault shares) |
+| `u64` | number or string | Gas limit, block height |
+| `u32` | number | User index, account index, nonce |
+| `Timestamp` | string | Seconds since the Unix epoch, fixed-point decimal with up to 9 fractional digits (nanosecond precision), trailing zeros elided — so `"1700000000"`, `"1700000000.5"`, and `"1700000000.123456789"` are all valid. Some feeds instead render time as an RFC 3339 / ISO 8601 string; each is noted where it appears. |
+| `Duration` | string | Seconds, same fixed-point encoding as `Timestamp` |
 
-| Parameter | Type     | Description                               |
-| --------- | -------- | ----------------------------------------- |
-| `first`   | `Int`    | Return the first N items                  |
-| `after`   | `String` | Cursor — return items after this          |
-| `last`    | `Int`    | Return the last N items                   |
-| `before`  | `String` | Cursor — return items before this         |
-| `sortBy`  | `Enum`   | `BLOCK_HEIGHT_ASC` or `BLOCK_HEIGHT_DESC` |
+### 2.2 Identifiers
 
-**Response shape:**
+| Type | Format | Example |
+| ---- | ------ | ------- |
+| `PairId` | `perp/<base><quote>` | `"perp/btcusd"`, `"perp/ethusd"` |
+| `OrderId` | `Uint64` (string), system-assigned | `"42"` |
+| `ClientOrderId` | `Uint64` (string), caller-assigned | `"42"` |
+| `FillId` | `Uint64` (string), per-match | `"17"` |
+| `Addr` | lowercase hex, `0x`-prefixed | `"0x1234…abcd"` |
+| `Hash256` | 64-char **uppercase** hex, **no** `0x` prefix | `"A1B2C3D4…"` |
+| `UserIndex` | `u32` | `0` |
+| `AccountIndex` | `u32` | `1` |
+| `Username` | 1–15 chars, `[a-z0-9_]` | `"alice"` |
+
+`Addr` and `Hash256` use different text dialects — an address is lowercase and `0x`-prefixed, a hash is bare uppercase. EVM tooling typically displays hashes (e.g. Hyperlane message IDs) as `0x`-prefixed lowercase; strip the prefix and uppercase the rest before passing one to Dango, or the request fails to deserialize.
+
+### 2.3 Pagination
+
+The two servers paginate differently, reflecting their backing stores.
+
+**Live API — contract-native paging.** The enumerating `GET /perps/*` and `GET /account/*` reads forward the contract's own `start_after` / `limit` scheme: iteration begins _after_ the `start_after` key (a `PairId`, `Addr`, or `Denom`, exclusive) and returns at most `limit` entries. Omit both to start from the beginning with the contract's default page size. To page, pass the last key of one response as the next `start_after`.
+
+**Archive API — keyset paging.** Every Archive feed is newest-first and keyset-paginated on `first` (page size, max 50, default 50) and `after` (an opaque cursor). The response is an envelope:
 
 ```json
 {
+  "items": [ /* … */ ],
   "pageInfo": {
     "hasNextPage": true,
-    "hasPreviousPage": false,
-    "startCursor": "abc...",
-    "endCursor": "xyz..."
-  },
-  "nodes": [ ... ]
+    "endCursor": "6f7b…"
+  }
 }
 ```
 
-Use `first` + `after` for forward pagination, `last` + `before` for backward.
+Roll the page's `endCursor` back in as the next request's `after` to fetch the following page; stop when `hasNextPage` is `false`. The cursor is opaque — treat it as a token, do not parse it.
 
-### 1.4 Multi-query
+### 2.4 Errors
 
-When you need to fetch multiple pieces of state (e.g. oracle prices and user positions), use the **multi-query** to execute them **atomically within a single block**. This is the preferred method over issuing separate GraphQL requests, which may be evaluated at different block heights and return an inconsistent snapshot.
+**Live API REST.** Errors map to HTTP status codes: `400` (malformed body or failed query), `404` (single-item lookup found nothing), `503` (a contract address could not be resolved yet — the chain has not committed its genesis state; retry), `500` (transport failure to the consensus node). The body carries the error message.
 
-Wrap the individual queries in a `multi` array:
+**Archive API REST.** Errors are a JSON envelope with the matching status: `400` (malformed argument or cursor), `404` (absent resource), `500` (internal). For example, a bad cursor:
 
-```graphql
-query {
-  queryApp(request: {
-    multi: [
-      {
-        wasm_smart: {
-          contract: "ORACLE_CONTRACT",
-          msg: { prices: {} }
-        }
-      },
-      {
-        wasm_smart: {
-          contract: "PERPS_CONTRACT",
-          msg: {
-            user_state: { user: "0x1234...abcd" }
-          }
-        }
-      }
-    ]
-  })
-}
+```json
+{ "error": "invalid cursor: …" }
 ```
 
-**Response:**
+**WebSocket.** Errors ride the socket as `error`-keyed frames; see [§5.5](#55-reconnect-and-errors) for the frame shape and the code catalog.
+
+### 2.5 Casing
+
+URL **path segments** are kebab-case (`/perps/liquidity-depth`, `/perps/order/by-user`). **Query parameters** keep the snake_case spelling and the wire encoding of the contract fields they forward to — so a numeric grug type stays string-encoded in the query string (`bucket_size=10` parses as a `UsdPrice`), while a plain integer is unquoted (`limit=20`).
+
+## 3. Live API — reading state
+
+All reads in this section answer from the **latest finalized state** and require no authentication.
+
+### 3.1 The universal query
+
+`POST /query` runs any read-only query against the latest state. The body is a raw grug `Query` object; the response is the raw `QueryResponse`. This is the lowest-level, most general read — every typed shortcut in [§3.2](#32-typed-read-shortcuts) desugars to one of these.
+
+**Example — query a contract:**
+
+```bash
+curl -X POST https://<live-host>/query \
+  -H 'Content-Type: application/json' \
+  -d '{"wasm_smart": {"contract": "PERPS_CONTRACT", "msg": {"state": {}}}}'
+```
+
+The response is keyed by the request variant:
+
+```json
+{ "wasm_smart": { /* the contract's State object */ } }
+```
+
+The body accepts any `Query` variant — for example `{"app_config": {}}`, `{"balance": {"address": "0x…", "denom": "bridge/usdc"}}`, or a smart-contract query as above. Some perps reads have no typed shortcut and are reached only this way — for instance a user's cumulative trading volume:
+
+```json
+{ "wasm_smart": { "contract": "PERPS_CONTRACT", "msg": { "volume": { "user": "0x…", "since": null } } } }
+```
+
+**Multi-query.** To fetch several pieces of state as one **atomic snapshot at a single block height**, wrap them in `multi`. This is the correct way to read, say, oracle prices and a user's positions together — issuing two separate requests may straddle a block boundary and return an inconsistent pair.
 
 ```json
 {
   "multi": [
-    { "Ok": { "wasm_smart": { /* oracle prices */ } } },
-    { "Ok": { "wasm_smart": { /* user state */ } } }
+    { "wasm_smart": { "contract": "ORACLE_CONTRACT", "msg": { "prices": {} } } },
+    { "wasm_smart": { "contract": "PERPS_CONTRACT", "msg": { "user_state": { "user": "0x…" } } } }
   ]
 }
 ```
 
-Each element in the response array corresponds to the query at the same index in the request. Individual queries that fail return `{"Err": "..."}` without aborting the others.
+The response is an array of results positionally matching the requests; each is `{"Ok": …}` or `{"Err": "…"}`, and one failure does not abort the others.
 
-## 2. Authentication and transactions
+### 3.2 Typed read shortcuts
 
-### 2.1 Transaction structure
+Typed `GET` routes wrap the most common perps and account reads: the parameters are validated and documented, the target contract address is resolved server-side (clients never pass it), and the response is the contract's response object verbatim. Use the [interactive docs](#12-interactive-reference) for the exhaustive parameter detail; the **response shapes** are documented in the [Types reference](#8-types-reference).
 
-Every write operation is wrapped in a signed **transaction** (`Tx`):
+**Perps reads** — all resolve to a query against the perps contract:
+
+| Route | Returns | Notes |
+| ----- | ------- | ----- |
+| `GET /perps/param` | [`Param`](#param) | Global parameters |
+| `GET /perps/state` | [`State`](#state) | Global state |
+| `GET /perps/pair-param?pair_id=` | [`PairParam`](#pairparam) | One pair; `404` if unknown |
+| `GET /perps/pair-params?start_after=&limit=` | map of `PairId` → `PairParam` | All pairs, paginated |
+| `GET /perps/pair-state?pair_id=` | [`PairState`](#pairstate) | One pair; `404` if unknown |
+| `GET /perps/pair-states?start_after=&limit=` | map of `PairId` → `PairState` | All pairs, paginated |
+| `GET /perps/liquidity-depth?pair_id=&bucket_size=&limit=` | [`LiquidityDepthResponse`](#liquiditydepthresponse) | Order book depth (worked below) |
+| `GET /perps/user-state?user=&include_*=` | [`UserStateExtended`](#userstate) | One user's margin, positions, orders |
+| `GET /perps/order/by-user?user=` | map of `OrderId` → order | A user's resting limit orders |
+| `GET /perps/order/by-client-order-id?user=&client_order_id=` | order | Resolve a client order id to its `OrderId`; `404` if none |
+| `GET /perps/order/{order_id}` | order | One resting limit order; `404` if none |
+
+Each of the four one-item lookups (`pair-param`, `pair-state`, `order/{id}`, `order/by-client-order-id`) responds `404` when the item does not exist, rather than `200` with a `null` body.
+
+**Account reads:**
+
+| Route | Returns | Target |
+| ----- | ------- | ------ |
+| `GET /account/{address}` | `Account` (its index + owning user index) | Account factory |
+| `GET /account/{address}/user` | `User` (index, username, keys, all accounts) | Account factory |
+| `GET /account/{address}/seen-nonces` | array of seen nonces | The account contract itself |
+| `GET /account/{address}/session-seen-nonces?session_key=` | array of seen nonces | The account contract itself |
+| `GET /account/{address}/balances?start_after=&limit=` | map of denom → amount | Chain-level (any address) |
+
+The `seen-nonces` routes back nonce selection when building a transaction — see [§4.2](#42-transaction-structure-and-nonces). URL-encode the `session_key`, as its base64 form may contain `+`, `/`, and `=`.
+
+#### Worked example — order book depth
+
+This one read is worked in full as the template for the rest. It also has a WebSocket twin ([§5.3](#53-standing-query-channels)): same parameters, same response.
+
+> **Server** Live · **Auth** none · **State** latest finalized
+
+**REST** — `GET /perps/liquidity-depth`
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `pair_id` | `PairId` | yes | Trading pair, e.g. `perp/ethusd` |
+| `bucket_size` | `UsdPrice` | yes | Price-bucket granularity. Must be one of the pair's configured `bucket_sizes` (see [`PairParam`](#pairparam)). |
+| `limit` | `u32` | no | Max buckets per side; the contract's default when omitted. |
+
+```bash
+curl 'https://<live-host>/perps/liquidity-depth?pair_id=perp/ethusd&bucket_size=10&limit=20'
+```
+
+**WebSocket** twin — channel `perpsLiquidityDepth`, same parameters plus `interval` (blocks between refreshes; ≥ 1, default 10; use `1` for per-block updates):
+
+```json
+{"method":"subscribe","id":1,"subscription":{"type":"perpsLiquidityDepth","pair_id":"perp/ethusd","bucket_size":"10","limit":20,"interval":1}}
+```
+
+**Response** — both forms return the same object (the WebSocket frame wraps it as `{blockHeight, response}`):
 
 ```json
 {
-  "sender": "0x1234...abcd",
+  "bids": {
+    "2999.000000": { "size": "12.500000", "notional": "37487.500000" },
+    "2998.000000": { "size": "8.200000",  "notional": "24583.600000" }
+  },
+  "asks": {
+    "3001.000000": { "size": "10.000000", "notional": "30010.000000" }
+  }
+}
+```
+
+`bids` and `asks` are maps from bucket price to that bucket's aggregated `size` (absolute contracts) and `notional` (USD). Bids read best (highest) first in descending key order; asks best (lowest) first in ascending key order.
+
+**Errors** — `400` unknown pair, or `bucket_size` not one of the pair's configured sizes. `503` the chain has not committed genesis yet (retry).
+
+**See also** — [Order matching](2-order-matching.md) for how the book forms; [`PairParam`](#pairparam) for the valid `bucket_sizes`.
+
+> **Note.** A handful of GraphQL-only reads — searching users by public key, and enumerating a user's accounts — have no REST twin yet. They remain on the deprecated GraphQL endpoint and will be replaced; the account address forms above cover the common cases in the meantime.
+
+### 3.3 Blocks and node status
+
+The Live API serves the **recent** tail of blocks from the node's on-disk cache. For deep history, use the Archive API ([§6.2](#62-blocks)).
+
+| Route | Returns |
+| ----- | ------- |
+| `GET /block/info` · `GET /block/info/{height}` | Block metadata + transactions (a `Block`) |
+| `GET /block/result` · `GET /block/result/{height}` | The block's execution outcome (a `BlockOutcome`) |
+| `GET /block/full` · `GET /block/full/{height}` | Both together (a `FullBlock`, `{block, outcome}`) |
+| `GET /block/full/range?from=&to=` | A gap-free run of full blocks, capped at 20 per request |
+| `GET /up` | Liveness + indexing status |
+
+The `/block/full/{height}` shape matches the WebSocket `fullBlock` channel ([§5.2](#52-streaming-channels)). `/up` proves the chain is answering and the indexer database is reachable: `is_running` is whether the latest finalized block is younger than 30 seconds, and `indexed_block_height` is the highest block the indexer has written.
+
+## 4. Live API — transactions
+
+Every write — trading, margin, vault, and account operations — is a signed **transaction** (`Tx`) broadcast to the Live API. This section covers the lifecycle, the signing scheme, and the catalog of messages. The mechanics behind each operation live in the dedicated chapters ([Order matching](2-order-matching.md), [Vault](5-vault.md), …); here we document the wire format.
+
+### 4.1 Transaction lifecycle
+
+```mermaid
+graph LR
+    A[Compose<br/>messages] --> B[Fetch metadata<br/>chain_id, user_index, nonce]
+    B --> C[Simulate<br/>POST /simulate]
+    C --> D[Set gas limit]
+    D --> E[Build SignDoc]
+    E --> F[Sign]
+    F --> G[Broadcast<br/>POST /broadcast]
+```
+
+1. **Compose messages** — build the contract execute message(s) ([§4.7](#47-account-and-key-messages)–[§4.9](#49-vault-messages)).
+2. **Fetch metadata** — the chain ID, the sender's `user_index`, and the next nonce (see [§4.2](#42-transaction-structure-and-nonces)).
+3. **Simulate** — dry-run to estimate gas ([§4.5](#45-simulating-and-gas)).
+4. **Set gas limit** — the simulation's `gas_used`, plus ~770,000 for signature-verification overhead.
+5. **Build the SignDoc** — assemble `{sender, gas_limit, messages, data}` ([§4.3](#43-signing)).
+6. **Sign** — with the chosen key.
+7. **Broadcast** — submit the signed `Tx` ([§4.6](#46-broadcasting)).
+
+### 4.2 Transaction structure and nonces
+
+A transaction wraps one or more messages with authentication metadata and a credential:
+
+```json
+{
+  "sender": "0x1234…abcd",
   "gas_limit": 1500000,
   "msgs": [
-    {
-      "execute": {
-        "contract": "PERPS_CONTRACT",
-        "msg": { ... },
-        "funds": {}
-      }
-    }
+    { "execute": { "contract": "PERPS_CONTRACT", "msg": { /* … */ }, "funds": {} } }
   ],
-  "data": { ... },
-  "credential": { ... }
+  "data": { "user_index": 0, "chain_id": "dango-1", "nonce": 42, "expiry": null },
+  "credential": { /* … */ }
 }
 ```
 
-| Field        | Type         | Description                                        |
-| ------------ | ------------ | -------------------------------------------------- |
-| `sender`     | `Addr`       | Account address sending the transaction            |
-| `gas_limit`  | `u64`        | Maximum gas units for execution                    |
-| `msgs`       | `[Message]`  | Non-empty list of messages to execute atomically   |
-| `data`       | `Metadata`   | Authentication metadata (see [§2.2](#22-metadata)) |
-| `credential` | `Credential` | Cryptographic proof of sender authorization        |
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `sender` | `Addr` | Account sending the transaction |
+| `gas_limit` | `u64` | Maximum gas units |
+| `msgs` | `[Message]` | Non-empty list, executed **atomically** — all succeed or all fail |
+| `data` | `Metadata` | `{user_index, chain_id, nonce, expiry}` (see below) |
+| `credential` | `Credential` | Cryptographic proof of authorization ([§4.3](#43-signing)) |
 
-Messages execute **atomically** — either all succeed or all fail.
-
-### 2.2 Metadata
-
-The `data` field contains authentication metadata:
+The primary message is `execute`, targeting a contract with a snake_case `msg` and optional `funds` (a map of denom → amount string, `{}` for none):
 
 ```json
-{
-  "user_index": 0,
-  "chain_id": "dango-1",
-  "nonce": 42,
-  "expiry": null
-}
+{ "execute": { "contract": "PERPS_CONTRACT", "msg": { "trade": { "deposit": {} } }, "funds": { "bridge/usdc": "1000000000" } } }
 ```
 
-| Field        | Type                | Description                                    |
-| ------------ | ------------------- | ---------------------------------------------- |
-| `user_index` | `u32`               | The user index that owns the sender account    |
-| `chain_id`   | `String`            | Chain identifier (prevents cross-chain replay) |
-| `nonce`      | `u32`               | Replay protection nonce                        |
-| `expiry`     | `Timestamp \| null` | Optional expiration; `null` = no expiry        |
+USDC uses **6 decimals** (1 USDC = `1000000` base units); all bridged tokens use the `bridge/` prefix.
 
-**Nonce semantics.** Dango uses **unordered nonces** with a sliding window, similar to [the approach used by Hyperliquid](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/nonces-and-api-wallets#hyperliquid-nonces). Crucially, nonces are tracked **per signer**, in two separate namespaces:
+**Nonces.** Dango uses **unordered nonces** with a sliding window, similar to [Hyperliquid's scheme](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/nonces-and-api-wallets#hyperliquid-nonces). Nonces are tracked **per signer**, in two namespaces: a **standard credential** (master key) draws from one account-wide window; a **session credential** draws from its own window, keyed by the session public key — so several clients (e.g. one bot per session key) can drive one account concurrently without colliding. Within a window, the account keeps the 20 most recently seen nonces; a transaction is accepted if its nonce is unused, newer than the oldest in the window, and no greater than the newest seen plus 100.
 
-- A **standard credential** (signed with a master key) draws from a single account-wide window.
-- A **session credential** draws from its own window, keyed by the session public key. This lets several clients — for example, one bot per session key — drive the same account concurrently without their nonces colliding.
+Pick the next nonce client-side by querying the relevant window against **the sender's own account contract** ([§3.2](#32-typed-read-shortcuts)):
 
-Within either window, the account keeps the 20 most recently seen nonces. A transaction is accepted if its nonce has not been used before, is newer than the oldest nonce in the window, and is no greater than the newest seen nonce plus 100. Transactions may therefore arrive out of order without being rejected. Windows are never pruned.
+- A standard signer reads `GET /account/{address}/seen-nonces` and uses `max + 1` (or `0` if empty).
+- A session signer reads `GET /account/{address}/session-seen-nonces?session_key=<base64>` and uses `max + 1` of that array; if that window is empty, it falls back to the standard window's `max + 1`, or `0` if the account has never transacted.
 
-The _first_ nonce accepted into an empty window is bounded:
+### 4.3 Signing
 
-- For a standard window — or a session window on an account that has never sent a transaction — the first nonce must be less than 100.
-- For a session window on an account that _has_ transacted, the first nonce must be **greater than the account's standard-nonce high-water mark** (the largest nonce in the standard window). This rejects replays of session transactions that were signed before per-session windows existed. A client that picks `max + 1` always satisfies it.
-
-SDK implementations should choose the next nonce client-side by querying the relevant window. Both queries target the **account's own contract** (the `sender` address) and return the seen nonces as an ascending array of integers.
-
-A standard signer queries:
-
-```json
-{ "seen_nonces": {} }
-```
-
-and uses `max + 1` (or `0` if the array is empty).
-
-A session signer queries (where `session_key` is the base64-encoded 33-byte compressed public key):
-
-```json
-{ "session_seen_nonces": { "session_key": "<base64>" } }
-```
-
-and uses `max + 1` of that array. If the session window is empty, it falls back to the standard window's `max + 1` (the floor above), or `0` if the account has never transacted.
-
-### 2.3 Message format
-
-The primary message type for interacting with contracts is `execute`:
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "submit_order": {
-          "pair_id": "perp/btcusd",
-          "size": "0.100000",
-          "kind": {
-            "market": {
-              "max_slippage": "0.010000"
-            }
-          },
-          "reduce_only": false
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-| Field      | Type    | Description                                                                |
-| ---------- | ------- | -------------------------------------------------------------------------- |
-| `contract` | `Addr`  | Target contract address                                                    |
-| `msg`      | `JSON`  | Contract-specific execute message (snake_case keys)                        |
-| `funds`    | `Coins` | Tokens to send with the message: `{"<denom>": "<amount>"}` or `{}` if none |
-
-The `funds` field is a map of denomination to amount string. For example, depositing 1000 USDC:
-
-```json
-{
-  "funds": {
-    "bridge/usdc": "1000000000"
-  }
-}
-```
-
-USDC uses **6 decimal places** in its base unit (1 USDC = `1000000` base units). All bridged tokens use the `bridge/` prefix.
-
-### 2.4 Signing methods
-
-The `credential` field wraps a `StandardCredential` or `SessionCredential`. A `StandardCredential` identifies the signing key and contains the signature:
+The `credential` wraps a `StandardCredential` (a key identifier + signature) or a `SessionCredential` ([§4.4](#44-session-keys)). Three signature schemes are supported:
 
 **Passkey (Secp256r1 / WebAuthn):**
 
 ```json
-{
-  "standard": {
-    "key_hash": "A1B2C3D4...64HEX",
-    "signature": {
-      "passkey": {
-        "authenticator_data": "<base64>",
-        "client_data": "<base64>",
-        "sig": "<base64>"
-      }
-    }
-  }
-}
+{ "standard": { "key_hash": "A1B2…", "signature": { "passkey": { "authenticator_data": "<base64>", "client_data": "<base64>", "sig": "<base64>" } } } }
 ```
 
-- `sig`: 64-byte Secp256r1 signature (base64-encoded)
-- `client_data`: base64-encoded WebAuthn client data JSON (challenge = base64url of SHA-256 of SignDoc)
-- `authenticator_data`: base64-encoded WebAuthn authenticator data
+`sig` is a 64-byte Secp256r1 signature; `client_data` is the base64-encoded WebAuthn client-data JSON (its `challenge` is the base64url of the SHA-256 of the SignDoc); `authenticator_data` is the base64-encoded authenticator data.
 
 **Secp256k1:**
 
 ```json
-{
-  "standard": {
-    "key_hash": "A1B2C3D4...64HEX",
-    "signature": {
-      "secp256k1": "<base64>"
-    }
-  }
-}
+{ "standard": { "key_hash": "A1B2…", "signature": { "secp256k1": "<base64>" } } }
 ```
 
-- 64-byte Secp256k1 signature (base64-encoded)
+A 64-byte Secp256k1 signature, base64-encoded.
 
 **EIP-712 (Ethereum wallets):**
 
 ```json
+{ "standard": { "key_hash": "A1B2…", "signature": { "eip712": { "typed_data": "<base64>", "sig": "<base64>" } } } }
+```
+
+`sig` is a 65-byte signature (64-byte Secp256k1 + 1-byte recovery id); `typed_data` is the base64-encoded EIP-712 typed-data JSON.
+
+**The SignDoc.** The signed payload mirrors the transaction but replaces `credential` with the structured `data`:
+
+```json
 {
-  "standard": {
-    "key_hash": "A1B2C3D4...64HEX",
-    "signature": {
-      "eip712": {
-        "typed_data": "<base64>",
-        "sig": "<base64>"
-      }
-    }
-  }
+  "sender": "0x1234…abcd",
+  "gas_limit": 1500000,
+  "messages": [ /* … */ ],
+  "data": { "chain_id": "dango-1", "expiry": null, "nonce": 42, "user_index": 0 }
 }
 ```
 
-- `sig`: 65-byte signature (64-byte Secp256k1 + 1-byte recovery ID; base64-encoded)
-- `typed_data`: base64-encoded JSON of the EIP-712 typed data object
+To sign: serialize the SignDoc to **canonical JSON** (keys sorted alphabetically), hash with **SHA-256**, and sign the hash. For Passkey, that hash is the WebAuthn `challenge`; for EIP-712, the SignDoc is mapped to a typed-data structure and signed via `eth_signTypedData_v4`.
 
-### 2.5 Session credentials
+### 4.4 Session keys
 
-Session keys allow delegated signing without requiring the master key for every transaction.
+Session keys allow delegated signing without the master key on every transaction. A `SessionCredential` carries the session key, its expiry, a SignDoc signature by the session key, and an `authorization` — the `SessionInfo` signed by the master key:
 
 ```json
 {
   "session": {
-    "session_info": {
-      "session_key": "<base64>",
-      "expire_at": "1700000000"
-    },
+    "session_info": { "session_key": "<base64>", "expire_at": "1700000000" },
     "session_signature": "<base64>",
-    "authorization": {
-      "key_hash": "A1B2C3D4...64HEX",
-      "signature": { ... }
-    }
+    "authorization": { "key_hash": "A1B2…", "signature": { /* standard signature */ } }
   }
 }
 ```
 
-| Field               | Type                 | Description                                        |
-| ------------------- | -------------------- | -------------------------------------------------- |
-| `session_info`      | `SessionInfo`        | Session key public key + expiration                |
-| `session_signature` | `ByteArray<64>`      | SignDoc signed by the session key (base64-encoded) |
-| `authorization`     | `StandardCredential` | SessionInfo signed by the user's master key        |
+### 4.5 Simulating and gas
 
-### 2.6 SignDoc
+`POST /simulate` dry-runs an `UnsignedTx` (the transaction without a `credential`) and returns its `TxOutcome`:
 
-The **SignDoc** is the data structure that gets signed. It mirrors the transaction but replaces the `credential` with the structured `Metadata`:
+```bash
+curl -X POST https://<live-host>/simulate \
+  -H 'Content-Type: application/json' \
+  -d '{"sender": "0x1234…abcd", "msgs": [ /* … */ ], "data": {"user_index": 0, "chain_id": "dango-1", "nonce": 42, "expiry": null}}'
+```
 
 ```json
-{
-  "data": {
-    "chain_id": "dango-1",
-    "expiry": null,
-    "nonce": 42,
-    "user_index": 0
-  },
-  "gas_limit": 1500000,
-  "messages": [ ... ],
-  "sender": "0x1234...abcd"
-}
+{ "gas_limit": 100000000, "gas_used": 750000, "result": { "Ok": null }, "events": { /* … */ } }
 ```
 
-**Signing process:**
+Simulation **skips signature verification**, so add **770,000 gas** (the Secp256k1 verification cost) to `gas_used` when setting the final `gas_limit`. `result` is `{"Ok": null}` on success or `{"Err": {"error": "…"}}` on failure; the reported `gas_limit` is the simulation ceiling, not the value to use — use `gas_used`.
 
-1. Serialize the SignDoc to **canonical JSON** (fields sorted alphabetically).
-2. Hash the serialized bytes with **SHA-256**.
-3. Sign the hash with the appropriate key.
+### 4.6 Broadcasting
 
-For Passkey (WebAuthn), the SHA-256 hash becomes the `challenge` in the WebAuthn request. For EIP-712, the SignDoc is mapped to an EIP-712 typed data structure and signed via `eth_signTypedData_v4`.
+`POST /broadcast` submits a signed `Tx` to the mempool and returns a `BroadcastTxOutcome`. This is a **mempool receipt, not block inclusion**:
 
-### 2.7 Signing flow
-
-The full transaction lifecycle:
-
-1. **Compose messages** — build the contract execute message(s).
-2. **Fetch metadata** — query chain ID, the account's user_index, and the next available nonce. Standard signers read the nonce from the account-wide window; session signers read it from their per-session-key window (see [§2.2](#22-metadata)).
-3. **Simulate** — send an `UnsignedTx` to estimate gas (see [§2.8](#28-gas-estimation)).
-4. **Set gas limit** — use the simulation result, adding ~770,000 for signature verification overhead.
-5. **Build SignDoc** — assemble `{sender, gas_limit, messages, data}`.
-6. **Sign** — sign the SignDoc with the chosen method.
-7. **Broadcast** — submit the signed `Tx` via `broadcastTxSync` (see [§2.9](#29-broadcasting)).
-
-### 2.8 Gas estimation
-
-Use the `simulate` query to dry-run a transaction:
-
-```graphql
-query Simulate($tx: UnsignedTx!) {
-  simulate(tx: $tx)
-}
+```bash
+curl -X POST https://<live-host>/broadcast \
+  -H 'Content-Type: application/json' \
+  -d '{"sender": "0x1234…abcd", "gas_limit": 1500000, "msgs": [ /* … */ ], "data": { /* … */ }, "credential": { /* … */ }}'
 ```
-
-**Variables:**
 
 ```json
-{
-  "tx": {
-    "sender": "0x1234...abcd",
-    "msgs": [
-      {
-        "execute": {
-          "contract": "PERPS_CONTRACT",
-          "msg": {
-            "trade": {
-              "deposit": {}
-            }
-          },
-          "funds": {
-            "bridge/usdc": "1000000000"
-          }
-        }
-      }
-    ],
-    "data": {
-      "user_index": 0,
-      "chain_id": "dango-1",
-      "nonce": 42,
-      "expiry": null
-    }
-  }
-}
+{ "tx_hash": "…", "check_tx": { "gas_limit": 1500000, "gas_used": 12000, "result": { "Ok": null }, "events": { /* … */ } } }
 ```
 
-**Response:**
+An **accepted** transaction returns `200` with `check_tx.result` = `{"Ok": null}`; a **mempool-rejected** transaction also returns `200`, but with `check_tx.result` an `{"Err": …}` (it never entered a block). Only a transport failure to the consensus node returns `500`. To confirm block inclusion, poll the transaction hash, or watch the [event stream](#52-streaming-channels). A client already holding a WebSocket connection can broadcast over it instead ([§5.4](#54-one-shot-requests-over-websocket)).
 
-```json
-{
-  "data": {
-    "simulate": {
-      "gas_limit": null,
-      "gas_used": 750000,
-      "result": {
-        "ok": [ ... ]
-      }
-    }
-  }
-}
-```
+### 4.7 Account and key messages
 
-Simulation skips signature verification. Add **770,000 gas** (Secp256k1 verification cost) to `gas_used` when setting `gas_limit` in the final transaction.
+New users, subaccounts, and key changes go through the **account factory** contract (`ACCOUNT_FACTORY_CONTRACT`), not the perps contract.
 
-### 2.9 Broadcasting
-
-Submit a signed transaction:
-
-```graphql
-mutation BroadcastTx($tx: Tx!) {
-  broadcastTxSync(tx: $tx)
-}
-```
-
-**Variables:**
-
-```json
-{
-  "tx": {
-    "sender": "0x1234...abcd",
-    "gas_limit": 1500000,
-    "msgs": [ ... ],
-    "data": {
-      "user_index": 0,
-      "chain_id": "dango-1",
-      "nonce": 42,
-      "expiry": null
-    },
-    "credential": {
-      "standard": {
-        "key_hash": "...",
-        "signature": { ... }
-      }
-    }
-  }
-}
-```
-
-The mutation returns the transaction outcome as JSON.
-
-## 3. Account management
-
-Dango uses **smart accounts** instead of externally-owned accounts (EOAs). A user profile is identified by a `UserIndex` and may own 1 master account and 0-4 subaccounts. Keys are associated with the user profile, not individual accounts.
-
-### 3.1 Register user
-
-Creating a new user profile is a two-step process:
-
-**Step 1 — Register.** Call `register_user` on the account factory: use the **the account factory address itself as sender**, and `null` for the `data` and `credential` fields.
+**Register a user** — a two-step process. First call `register_user` on the factory, using the **factory address itself as `sender`** and `null` for `data` and `credential`:
 
 ```json
 {
@@ -527,18 +424,10 @@ Creating a new user profile is a two-step process:
         "contract": "ACCOUNT_FACTORY_CONTRACT",
         "msg": {
           "register_user": {
-            "key": {
-              "secp256r1": "<base64>"
-            },
-            "key_hash": "A1B2C3D4...64HEX",
+            "key": { "secp256r1": "<base64>" },
+            "key_hash": "A1B2…",
             "seed": 12345,
-            "signature": {
-              "passkey": {
-                "authenticator_data": "<base64>",
-                "client_data": "<base64>",
-                "sig": "<base64>"
-              }
-            }
+            "signature": { "passkey": { "authenticator_data": "<base64>", "client_data": "<base64>", "sig": "<base64>" } }
           }
         },
         "funds": {}
@@ -550,2589 +439,429 @@ Creating a new user profile is a two-step process:
 }
 ```
 
-| Field       | Type        | Description                                                    |
-| ----------- | ----------- | -------------------------------------------------------------- |
-| `key`       | `Key`       | The user's initial public key (see [§10.3](#103-enums))        |
-| `key_hash`  | `Hash256`   | Client-chosen hash identifying this key                        |
-| `seed`      | `u32`       | Arbitrary number for address variety                           |
-| `signature` | `Signature` | Signature over `{"chain_id": "dango-1"}` proving key ownership |
+The master account is created **inactive** (spam prevention); the new address is returned in the transaction events. **Second**, send it at least the `minimum_deposit` (10 USDC = `10000000` `bridge/usdc` on mainnet), from an existing Dango account or bridged in via Hyperlane, and the account activates on receipt. To confirm a bridged deposit arrived, query the mailbox's `delivered` method with the Hyperlane message id via `POST /query` (`Hash256` uppercase, no `0x`); a `true` result is permanent and means the funds are spendable.
 
-A master account is created in the **inactive** state (for the purpose of spam prevention). The new account address is returned in the transaction events.
-
-**Step 2 — Activate.** Send at least the `minimum_deposit` (10 USDC = `10000000` `bridge/usdc` on mainnet) to the new master account address. The transfer can either come from an existing Dango account, or from another chain via Hyperlane bridging. Upon receipt, the account activates itself and becomes ready to use. To programmatically confirm that a bridged transfer has arrived, see [§3.10](#310-query-bridge-deposit-delivery).
-
-#### 3.1.1 Funding a new account via the faucet (testnet)
-
-On testnet there is nothing of value to bridge, so in place of Step 2 you can call the public **faucet** to mint test tokens directly to the new master account. The account activates as soon as it receives the tokens. _The faucet exists on testnet only; there is no faucet on mainnet._
-
-**Endpoint:** `GET https://faucet-testnet.dango.zone/mint/{address}` (see [Constants](9-constants.md#endpoints)).
-
-A freshly registered account is empty and owns exactly one account, so it passes the faucet's eligibility checks and the bare call succeeds:
-
-```bash
-curl 'https://faucet-testnet.dango.zone/mint/0xYOUR_ACCOUNT_ADDRESS'
-```
-
-| Path parameter | Type   | Description                                                     |
-| -------------- | ------ | --------------------------------------------------------------- |
-| `address`      | `Addr` | The new master account's address, hex-encoded with `0x` prefix. |
-
-| Query parameter | Type   | Default | Description                                                                                                                                                                                                                                                      |
-| --------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `skip_check`    | `bool` | `false` | When `false`, the faucet mints only to a brand-new account: it refuses if the address already holds any balance, or if the owning user has more than one account. Set to `true` to bypass both checks and mint unconditionally. The web app sets this to `true`. |
-
-A successful call mints the following test tokens to the address (current amounts):
-
-| Token   | Denom         | Amount  | Decimals |
-| ------- | ------------- | ------- | -------- |
-| USDC    | `bridge/usdc` | 200,000 | 6        |
-| Ether   | `bridge/eth`  | 50      | 18       |
-| Bitcoin | `bridge/btc`  | 2       | 8        |
-| Solana  | `bridge/sol`  | 1,040   | 9        |
-| XRP     | `bridge/xrp`  | 61,500  | 6        |
-
-**Response.** On success, returns `200 OK` with the resulting transaction as JSON (hash, block height, events, outcome). On failure, returns `400 Bad Request` with a JSON error body, e.g.:
+**Register a subaccount** — from an existing account of the user (max 5 accounts per user):
 
 ```json
-{
-  "error": "Tokens already minted",
-  "address": "0x..."
-}
+{ "execute": { "contract": "ACCOUNT_FACTORY_CONTRACT", "msg": { "register_account": {} }, "funds": {} } }
 ```
 
-The eligibility errors (only when `skip_check` is not set) are `"Tokens already minted"` and `"User already have multiple accounts"`. Transaction-level failures return `"Broadcast failed!"`, `"Tx failed"`, or `"Tx broadcasted but not found"` with the broadcast outcome under `data`.
-
-A `GET /health` endpoint returns `{ "version": "<faucet version>" }` and can be used to check that the faucet is reachable.
-
-### 3.2 Register subaccount
-
-Create an additional account for an existing user (maximum 5 accounts per user):
+**Update a key** — add or remove a key on the user profile:
 
 ```json
-{
-  "execute": {
-    "contract": "ACCOUNT_FACTORY_CONTRACT",
-    "msg": {
-      "register_account": {}
-    },
-    "funds": {}
-  }
-}
+{ "execute": { "contract": "ACCOUNT_FACTORY_CONTRACT", "msg": { "update_key": { "key_hash": "A1B2…", "key": { "insert": { "secp256k1": "<base64>" } } } }, "funds": {} } }
 ```
 
-Must be sent from an existing account owned by the user.
+Use `"key": "delete"` to remove.
 
-### 3.3 Account address derivation
-
-#### 3.3.1 Master account
-
-The first account of a new user ([§3.1](#31-register-user)) is derived as:
-
-```plain
-address := ripemd160(sha256(deployer || code_hash || seed || key_hash || key_tag || key))
-```
-
-where `||` denotes byte concatenation.
-
-The preimage layout (122 bytes total):
-
-| Byte range  | Size | Field       | Description                                                                                                   |
-| ----------- | ---- | ----------- | ------------------------------------------------------------------------------------------------------------- |
-| `[0..20)`   | 20   | `deployer`  | The `ACCOUNT_FACTORY_CONTRACT` address (see [Constants](9-constants.md#dango-contract-addresses))             |
-| `[20..52)`  | 32   | `code_hash` | The code hash of the Dango single-signature account contract (see [Constants](9-constants.md#code-hashes))    |
-| `[52..56)`  | 4    | `seed`      | User-chosen `u32`, big-endian — arbitrary value for frontrunning protection                                   |
-| `[56..88)`  | 32   | `key_hash`  | Client-chosen 32-byte identifier for the key (see [§3.8](#38-query-users-by-key) for hashing rules)           |
-| `[88..89)`  | 1    | `key_tag`   | Key type: `0` = Secp256r1, `1` = Secp256k1, `2` = Ethereum                                                    |
-| `[89..122)` | 33   | `key`       | Secp256r1 / Secp256k1: 33-byte compressed public key. Ethereum: 13 zero bytes followed by the 20-byte address |
-
-#### 3.3.2 Subaccount
-
-```plain
-address := ripemd160(sha256(deployer || code_hash || account_index))
-```
-
-The preimage layout (56 bytes total):
-
-| Byte range | Size | Field           | Description                                                                                                |
-| ---------- | ---- | --------------- | ---------------------------------------------------------------------------------------------------------- |
-| `[0..20)`  | 20   | `deployer`      | The `ACCOUNT_FACTORY_CONTRACT` address (see [Constants](9-constants.md#dango-contract-addresses))          |
-| `[20..52)` | 32   | `code_hash`     | The code hash of the Dango single-signature account contract (see [Constants](9-constants.md#code-hashes)) |
-| `[52..56)` | 4    | `account_index` | Global account index, `u32`, big-endian                                                                    |
-
-The global account index is a chain-wide monotonic counter maintained by the account factory; it is incremented for every account created across all users, so every account has a unique index.
-
-### 3.4 Update key
-
-Associate or disassociate a key with the user profile.
-
-**Add a key:**
+**Set the username** — a one-time, cosmetic label (1–15 chars, `[a-z0-9_]`), not used in any business logic:
 
 ```json
-{
-  "execute": {
-    "contract": "ACCOUNT_FACTORY_CONTRACT",
-    "msg": {
-      "update_key": {
-        "key_hash": "A1B2C3D4...64HEX",
-        "key": {
-          "insert": {
-            "secp256k1": "<base64>"
-          }
-        }
-      }
-    },
-    "funds": {}
-  }
-}
+{ "execute": { "contract": "ACCOUNT_FACTORY_CONTRACT", "msg": { "update_username": "alice" }, "funds": {} } }
 ```
 
-**Remove a key:**
+**Address derivation.** A master account's address is `ripemd160(sha256(deployer ‖ code_hash ‖ seed ‖ key_hash ‖ key_tag ‖ key))` (122-byte preimage); a subaccount's is `ripemd160(sha256(deployer ‖ code_hash ‖ account_index))` (56-byte preimage). See [Constants](9-constants.md) for `deployer` (the factory address) and the account `code_hash`; `key_tag` is `0` Secp256r1, `1` Secp256k1, `2` Ethereum.
+
+**Testnet faucet.** On testnet, in place of the activating deposit, call the public faucet to mint test tokens to a fresh account: `GET https://<faucet-host>/mint/{address}`. See [Constants](9-constants.md#endpoints) for the host. It mints USDC, ETH, BTC, SOL, and XRP, and the account activates on receipt. There is no faucet on mainnet.
+
+### 4.8 Trading messages
+
+All trading messages target the perps contract under the `trade` key: `{"execute": {"contract": "PERPS_CONTRACT", "msg": {"trade": {…}}, "funds": {…}}}`. Only the inner `trade` object is shown below.
+
+**Deposit margin** — attach USDC as `funds`; it is credited to `user_state.margin` at $1 per USDC. An optional `to` routes the deposit to another perp account (defaults to the sender):
 
 ```json
-{
-  "execute": {
-    "contract": "ACCOUNT_FACTORY_CONTRACT",
-    "msg": {
-      "update_key": {
-        "key_hash": "A1B2C3D4...64HEX",
-        "key": "delete"
-      }
-    },
-    "funds": {}
-  }
-}
+{ "deposit": {} }
 ```
 
-### 3.5 Update username
-
-Set the user's human-readable username (one-time operation):
+**Withdraw margin** — converts USD back to USDC (floor-rounded) and transfers it to the sender:
 
 ```json
-{
-  "execute": {
-    "contract": "ACCOUNT_FACTORY_CONTRACT",
-    "msg": {
-      "update_username": "alice"
-    },
-    "funds": {}
-  }
-}
+{ "withdraw": { "amount": "500.000000" } }
 ```
 
-Username rules: 1–15 characters, lowercase `a-z`, digits `0-9`, and underscore `_` only.
-
-The username is cosmetic only — used for human-readable display on the frontend. It is not used in any business logic of the exchange.
-
-### 3.6 Query user
-
-```graphql
-query {
-  user(userIndex: 0) {
-    userIndex
-    createdBlockHeight
-    createdAt
-    publicKeys {
-      keyHash
-      publicKey
-      keyType
-      createdBlockHeight
-      createdAt
-    }
-    accounts {
-      accountIndex
-      address
-      createdBlockHeight
-      createdAt
-    }
-  }
-}
-```
-
-The `keyType` enum values are: `SECP256R1`, `SECP256K1`, `ETHEREUM`.
-
-### 3.7 Query user by username
-
-Look up a user by their username via a smart contract query against the account factory:
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "ACCOUNT_FACTORY_CONTRACT",
-      msg: {
-        user: {
-          name: "alice"
-        }
-      }
-    }
-  })
-}
-```
-
-**Response:**
+**Submit a market order** — fills immediately against the book (IOC behavior); any unfilled remainder is discarded, and the transaction reverts if nothing fills. `size` is signed (**positive = buy, negative = sell**):
 
 ```json
-{
-  "index": 42,
-  "name": "alice",
-  "accounts": {
-    "100": "0xabcd...1234"
-  },
-  "keys": {
-    "A1B2C3...": {
-      "ethereum": "0x1234...abcd"
-    }
-  }
-}
+{ "submit_order": { "pair_id": "perp/btcusd", "size": "0.100000", "kind": { "market": { "max_slippage": "0.010000" } }, "reduce_only": false } }
 ```
 
-You can also look up by index: `{ "user": { "index": 42 } }`.
-
-### 3.8 Query users by key
-
-Search for users by public key or key hash. Useful when you know a user's key but not their index or username.
-
-```graphql
-query {
-  users(publicKeyHash: "A1B2C3D4...64HEX", first: 10) {
-    nodes {
-      userIndex
-      createdBlockHeight
-      createdAt
-      publicKeys {
-        keyHash
-        publicKey
-        keyType
-        createdBlockHeight
-        createdAt
-      }
-      accounts {
-        accountIndex
-        address
-        createdBlockHeight
-        createdTxHash
-        createdAt
-      }
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-  }
-}
-```
-
-Filter by `publicKeyHash` or by `publicKey` (the raw key value). The key hash is computed differently depending on key type:
-
-| Key type    | Input to SHA-256                                            |
-| ----------- | ----------------------------------------------------------- |
-| `ETHEREUM`  | UTF-8 bytes of the lowercase hex address (with `0x` prefix) |
-| `SECP256K1` | Compressed public key bytes (33 bytes)                      |
-| `SECP256R1` | WebAuthn credential ID bytes                                |
-
-The resulting hash is hex-encoded in uppercase.
-
-### 3.9 Query accounts
-
-```graphql
-query {
-  accounts(userIndex: 0, first: 10) {
-    nodes {
-      accountIndex
-      address
-      createdBlockHeight
-      createdTxHash
-      createdAt
-      users {
-        userIndex
-      }
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-  }
-}
-```
-
-Filter by `userIndex` to get all accounts for a specific user, or by `address` for a specific account.
-
-### 3.10 Query bridge deposit delivery
-
-Deposits bridged in from another chain (see [§3.1](#31-register-user) Step 2) arrive as Hyperlane **warp route** transfers: the warp contract on the origin chain dispatches a Hyperlane message, an off-chain relayer submits it to the Dango **mailbox** contract, and the mailbox verifies the message, records it as delivered, and credits the bridged tokens to the recipient account — all within a single transaction.
-
-To monitor a pending deposit, query the mailbox's `delivered` method with the Hyperlane message ID:
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "MAILBOX_CONTRACT",
-      msg: {
-        delivered: {
-          message_id: "A1B2C3D4...64HEX"
-        }
-      }
-    }
-  })
-}
-```
-
-| Parameter    | Type      | Description                                           |
-| ------------ | --------- | ----------------------------------------------------- |
-| `message_id` | `Hash256` | Hyperlane message ID of the warp transfer (see below) |
-
-**Response:** `true` if the message has been delivered, `false` otherwise. Delivery and crediting are atomic, so once the query returns `true` the tokens are spendable in the recipient account — and if this was the activating deposit of a new master account, the account is active. Deliveries are recorded permanently, so the result never reverts to `false`.
-
-**Obtaining the message ID.** The message ID is the keccak256 hash of the encoded Hyperlane message. The mailbox on the origin chain returns it from the `dispatch()` call and emits it in the `DispatchId` event, so it can be read from the origin-chain transaction receipt.
-
-**Encoding.** `Hash256` is parsed strictly as 64 hex characters, **uppercase, without the `0x` prefix** (see [§10.2](#102-identifiers)). EVM tooling typically displays message IDs as `0x`-prefixed lowercase — strip the prefix and uppercase the rest, otherwise the query fails with a deserialization error.
-
-For continuous monitoring, poll this query at a block interval using the `queryApp` subscription ([§8.4](#84-contract-query-polling)). Alternatively, subscribe to the event stream ([§8.6](#86-event-stream)) filtered to the `mailbox_process_id` event, which the mailbox emits upon delivery; the filter value must use the same uppercase, unprefixed format:
-
-```graphql
-subscription {
-  events(
-    filter: [
-      {
-        type: "mailbox_process_id",
-        data: [
-          {
-            path: ["message_id"],
-            checkMode: EQUAL,
-            value: ["A1B2C3D4...64HEX"]
-          }
-        ]
-      }
-    ]
-  ) {
-    type
-    data
-    blockHeight
-    createdAt
-  }
-}
-```
-
-## 4. Market data
-
-### 4.1 Global parameters
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        param: {}
-      }
-    }
-  })
-}
-```
-
-**Response:**
+**Submit a limit order** — rests on the book. `time_in_force` is `"GTC"` (default), `"IOC"`, or `"POST"`; `client_order_id` is an optional caller-assigned id (unique among the sender's resting orders) that enables same-block cancel:
 
 ```json
-{
-  "max_unlocks": 5,
-  "max_open_orders": 50,
-  "max_action_batch_size": 5,
-  "maker_fee_rates": {
-    "base": "0.000000",
-    "tiers": {}
-  },
-  "taker_fee_rates": {
-    "base": "0.001000",
-    "tiers": {}
-  },
-  "protocol_fee_rate": "0.100000",
-  "liquidation_fee_rate": "0.010000",
-  "liquidation_buffer_ratio": "0.000000",
-  "funding_period": "3600",
-  "vault_total_weight": "10.000000",
-  "vault_cooldown_period": "604800",
-  "referral_active": true,
-  "min_referrer_volume": "0.000000",
-  "referrer_commission_rates": {
-    "base": "0.000000",
-    "tiers": {}
-  }
-}
+{ "submit_order": { "pair_id": "perp/btcusd", "size": "-0.500000", "kind": { "limit": { "limit_price": "65000.000000", "time_in_force": "GTC", "client_order_id": "42" } }, "reduce_only": false } }
 ```
 
-| Field                       | Type            | Description                                                                      |
-| --------------------------- | --------------- | -------------------------------------------------------------------------------- |
-| `max_unlocks`               | `usize`         | Max concurrent vault unlock requests per user                                    |
-| `max_open_orders`           | `usize`         | Max resting limit orders per user (all pairs)                                    |
-| `max_action_batch_size`     | `usize`         | Max actions in a single [`batch_update_orders`](#66-batch-update-orders) message |
-| `maker_fee_rates`           | `RateSchedule`  | Volume-tiered maker fee rates                                                    |
-| `taker_fee_rates`           | `RateSchedule`  | Volume-tiered taker fee rates                                                    |
-| `protocol_fee_rate`         | `Dimensionless` | Fraction of trading fees routed to treasury                                      |
-| `liquidation_fee_rate`      | `Dimensionless` | Insurance fund fee on liquidations                                               |
-| `liquidation_buffer_ratio`  | `Dimensionless` | Post-liquidation equity buffer above maintenance margin                          |
-| `funding_period`            | `Duration`      | Interval between funding collections                                             |
-| `vault_total_weight`        | `Dimensionless` | Sum of all pairs' vault liquidity weights                                        |
-| `vault_cooldown_period`     | `Duration`      | Waiting time before vault withdrawal release                                     |
-| `referral_active`           | `bool`          | Whether the referral commission system is active                                 |
-| `min_referrer_volume`       | `UsdValue`      | Minimum lifetime volume to become a referrer                                     |
-| `referrer_commission_rates` | `RateSchedule`  | Volume-tiered referrer commission rates                                          |
+Both order forms accept optional `tp` / `sl` child orders (take-profit / stop-loss), each `{trigger_price, max_slippage, size}` with `size: null` closing the whole position — attached to the resulting position after fill. For time-in-force and matching mechanics, see [Order matching](2-order-matching.md).
 
-A `RateSchedule` has two fields: `base` (the default rate) and `tiers` (a map of volume threshold to rate; highest qualifying tier wins).
-
-For fee mechanics, see [Order matching §8](2-order-matching.md#8-trading-fees).
-
-### 4.2 Global state
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        state: {}
-      }
-    }
-  })
-}
-```
-
-**Response:**
+**Cancel an order** — by system id, by client id, or all:
 
 ```json
-{
-  "last_funding_time": "1700000000.123456789",
-  "vault_share_supply": "500000000",
-  "insurance_fund": "25000.000000",
-  "treasury": "12000.000000"
-}
+{ "cancel_order": { "one": "42" } }
+{ "cancel_order": { "one_by_client_order_id": "42" } }
+{ "cancel_order": "all" }
 ```
 
-| Field                | Type        | Description                  |
-| -------------------- | ----------- | ---------------------------- |
-| `last_funding_time`  | `Timestamp` | Last funding collection time |
-| `vault_share_supply` | `Uint128`   | Total vault share tokens     |
-| `insurance_fund`     | `UsdValue`  | Insurance fund balance       |
-| `treasury`           | `UsdValue`  | Accumulated protocol fees    |
-
-### 4.3 Pair parameters
-
-**All pairs:**
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        pair_params: {
-          start_after: null,
-          limit: 30
-        }
-      }
-    }
-  })
-}
-```
-
-**Single pair:**
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        pair_param: {
-          pair_id: "perp/btcusd"
-        }
-      }
-    }
-  })
-}
-```
-
-**Response (single pair):**
+**Batch update** — apply a non-empty list of submit/cancel actions atomically; later actions observe earlier ones, and any failure reverts the whole batch. The list length must not exceed `Param.max_action_batch_size`; conditional orders are not allowed in a batch. Useful for atomic quote replacement (`cancel: all` then re-submits):
 
 ```json
-{
-  "tick_size": "1.000000",
-  "min_order_size": "10.000000",
-  "max_abs_oi": "1000000.000000",
-  "max_abs_funding_rate": "0.000500",
-  "initial_margin_ratio": "0.050000",
-  "maintenance_margin_ratio": "0.025000",
-  "impact_size": "10000.000000",
-  "vault_liquidity_weight": "1.000000",
-  "vault_half_spread": "0.001000",
-  "vault_max_quote_size": "50000.000000",
-  "max_limit_price_deviation": "0.100000",
-  "max_market_slippage": "0.100000",
-  "bucket_sizes": ["1.000000", "5.000000", "10.000000"]
-}
+{ "batch_update_orders": [ { "cancel": "all" }, { "submit": { /* SubmitOrderRequest */ } } ] }
 ```
 
-| Field                       | Type            | Description                                                        |
-| --------------------------- | --------------- | ------------------------------------------------------------------ |
-| `tick_size`                 | `UsdPrice`      | Minimum price increment for limit orders                           |
-| `min_order_size`            | `UsdValue`      | Minimum notional value (reduce-only exempt)                        |
-| `max_abs_oi`                | `Quantity`      | Maximum open interest per side                                     |
-| `max_abs_funding_rate`      | `FundingRate`   | Daily funding rate cap                                             |
-| `initial_margin_ratio`      | `Dimensionless` | Margin to open (e.g. 0.05 = 20x max leverage)                      |
-| `maintenance_margin_ratio`  | `Dimensionless` | Margin to stay open (liquidation threshold)                        |
-| `impact_size`               | `UsdValue`      | Notional for impact price calculation                              |
-| `vault_liquidity_weight`    | `Dimensionless` | Vault allocation weight for this pair                              |
-| `vault_half_spread`         | `Dimensionless` | Half the vault's bid-ask spread                                    |
-| `vault_max_quote_size`      | `Quantity`      | Maximum vault resting size per side                                |
-| `max_limit_price_deviation` | `Dimensionless` | Max symmetric deviation of a limit price from oracle at submission |
-| `max_market_slippage`       | `Dimensionless` | Max `max_slippage` a user may set on a market or TP/SL child order |
-| `bucket_sizes`              | `[UsdPrice]`    | Price bucket granularities for depth queries                       |
-
-For the relationship between margin ratios and leverage, see [Risk §2](6-risk.md).
-
-### 4.4 Pair state
-
-**All pairs:**
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        pair_states: {
-          start_after: null,
-          limit: 30
-        }
-      }
-    }
-  })
-}
-```
-
-**Single pair:**
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        pair_state: {
-          pair_id: "perp/btcusd"
-        }
-      }
-    }
-  })
-}
-```
-
-**Response:**
+**Submit a conditional order (TP/SL)** — always reduce-only, executed as a market order when the oracle crosses `trigger_price`. `trigger_direction` is `"above"` (oracle ≥ trigger) or `"below"` (oracle ≤ trigger); `size: null` closes the whole position:
 
 ```json
-{
-  "long_oi": "12500.000000",
-  "short_oi": "10300.000000",
-  "funding_per_unit": "0.000123",
-  "funding_rate": "0.000050"
-}
+{ "submit_conditional_order": { "pair_id": "perp/btcusd", "size": "-0.100000", "trigger_price": "70000.000000", "trigger_direction": "above", "max_slippage": "0.020000" } }
 ```
 
-| Field              | Type             | Description                                         |
-| ------------------ | ---------------- | --------------------------------------------------- |
-| `long_oi`          | `Quantity`       | Total long open interest                            |
-| `short_oi`         | `Quantity`       | Total short open interest                           |
-| `funding_per_unit` | `FundingPerUnit` | Cumulative funding accumulator                      |
-| `funding_rate`     | `FundingRate`    | Current per-day funding rate (positive = longs pay) |
-
-For funding mechanics, see [Funding](3-funding.md).
-
-### 4.5 Order book depth
-
-Query aggregated order book depth at a given price bucket granularity:
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        liquidity_depth: {
-          pair_id: "perp/btcusd",
-          bucket_size: "10.000000",
-          limit: 20
-        }
-      }
-    }
-  })
-}
-```
-
-| Parameter     | Type       | Description                                               |
-| ------------- | ---------- | --------------------------------------------------------- |
-| `pair_id`     | `PairId`   | Trading pair                                              |
-| `bucket_size` | `UsdPrice` | Price aggregation granularity (must be in `bucket_sizes`) |
-| `limit`       | `u32?`     | Max number of price levels per side                       |
-
-**Response:**
+**Cancel a conditional order** — by `(pair_id, trigger_direction)`, all for a pair, or all:
 
 ```json
-{
-  "bids": {
-    "64990.000000": {
-      "size": "12.500000",
-      "notional": "812375.000000"
-    },
-    "64980.000000": {
-      "size": "8.200000",
-      "notional": "532836.000000"
-    }
-  },
-  "asks": {
-    "65010.000000": {
-      "size": "10.000000",
-      "notional": "650100.000000"
-    },
-    "65020.000000": {
-      "size": "5.500000",
-      "notional": "357610.000000"
-    }
-  }
-}
+{ "cancel_conditional_order": { "one": { "pair_id": "perp/btcusd", "trigger_direction": "above" } } }
+{ "cancel_conditional_order": { "all_for_pair": { "pair_id": "perp/btcusd" } } }
+{ "cancel_conditional_order": "all" }
 ```
 
-Each level contains:
-
-| Field      | Type       | Description                       |
-| ---------- | ---------- | --------------------------------- |
-| `size`     | `Quantity` | Absolute order size in the bucket |
-| `notional` | `UsdValue` | USD notional (size × price)       |
-
-### 4.6 Pair statistics
-
-**All pairs:**
-
-```graphql
-query {
-  allPerpsPairStats {
-    pairId
-    currentPrice
-    price24HAgo
-    volume24H
-    priceChange24H
-  }
-}
-```
-
-**Single pair:**
-
-```graphql
-query {
-  perpsPairStats(pairId: "perp/btcusd") {
-    pairId
-    currentPrice
-    price24HAgo
-    volume24H
-    priceChange24H
-  }
-}
-```
-
-| Field            | Type          | Description                                        |
-| ---------------- | ------------- | -------------------------------------------------- |
-| `pairId`         | `String!`     | Pair identifier                                    |
-| `currentPrice`   | `BigDecimal`  | Current price (nullable)                           |
-| `price24HAgo`    | `BigDecimal`  | Price 24 hours ago (nullable)                      |
-| `volume24H`      | `BigDecimal!` | 24h trading volume in USD                          |
-| `priceChange24H` | `BigDecimal`  | 24h price change percentage (e.g. `5.25` = +5.25%) |
-
-### 4.7 Historical candles
-
-```graphql
-query {
-  perpsCandles(
-    pairId: "perp/btcusd",
-    interval: ONE_HOUR,
-    laterThan: "2026-01-01T00:00:00Z",
-    earlierThan: "2026-01-02T00:00:00Z",
-    first: 24
-  ) {
-    nodes {
-      pairId
-      interval
-      open
-      high
-      low
-      close
-      volume
-      volumeUsd
-      timeStart
-      timeStartUnix
-      timeEnd
-      timeEndUnix
-      minBlockHeight
-      maxBlockHeight
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-  }
-}
-```
-
-| Parameter     | Type              | Description                          |
-| ------------- | ----------------- | ------------------------------------ |
-| `pairId`      | `String!`         | Trading pair (e.g. `"perp/btcusd"`)  |
-| `interval`    | `CandleInterval!` | Candle interval                      |
-| `laterThan`   | `DateTime`        | Candles after this time (inclusive)  |
-| `earlierThan` | `DateTime`        | Candles before this time (exclusive) |
-
-**CandleInterval values:** `ONE_SECOND`, `ONE_MINUTE`, `FIVE_MINUTES`, `FIFTEEN_MINUTES`, `ONE_HOUR`, `FOUR_HOURS`, `ONE_DAY`, `ONE_WEEK`.
-
-**PerpsCandle fields:**
-
-| Field            | Type         | Description                   |
-| ---------------- | ------------ | ----------------------------- |
-| `open`           | `BigDecimal` | Opening price                 |
-| `high`           | `BigDecimal` | Highest price                 |
-| `low`            | `BigDecimal` | Lowest price                  |
-| `close`          | `BigDecimal` | Closing price                 |
-| `volume`         | `BigDecimal` | Volume in base units          |
-| `volumeUsd`      | `BigDecimal` | Volume in USD                 |
-| `timeStart`      | `String`     | Period start (ISO 8601)       |
-| `timeStartUnix`  | `Int`        | Period start (Unix timestamp) |
-| `timeEnd`        | `String`     | Period end (ISO 8601)         |
-| `timeEndUnix`    | `Int`        | Period end (Unix timestamp)   |
-| `minBlockHeight` | `Int`        | First block in this candle    |
-| `maxBlockHeight` | `Int`        | Last block in this candle     |
-
-### 4.8 Fees and revenue
-
-```graphql
-query {
-  perpsFeesAndRevenue(
-    from: "2026-01-01T00:00:00Z",
-    to: "2026-02-01T00:00:00Z"
-  ) {
-    from
-    to
-    feeEventsCount
-    protocolFee
-    vaultFee
-    refereeRebate
-    referrerPayout
-    volumeUsd
-  }
-}
-```
-
-| Parameter | Type        | Description                    |
-| --------- | ----------- | ------------------------------ |
-| `from`    | `DateTime!` | Window lower bound (inclusive) |
-| `to`      | `DateTime!` | Window upper bound (inclusive) |
-
-`from` must be less than or equal to `to`.
-
-**Resolution.** Windows shorter than 3 days are served from per-block rows with microsecond-precise bounds. Windows of 3 days or more are served from the `perps_fees_hourly` materialized view; bounds are snapped to the enclosing hours, so a request that overlaps partial hours at either end includes those hours' full aggregates.
-
-**PerpsFeesAndRevenue fields:**
-
-| Field            | Type          | Description                                                     |
-| ---------------- | ------------- | --------------------------------------------------------------- |
-| `from`           | `String!`     | Lower bound echoed back as ISO 8601                             |
-| `to`             | `String!`     | Upper bound echoed back as ISO 8601                             |
-| `feeEventsCount` | `Int!`        | Number of `FeeDistributed` events aggregated in the window      |
-| `protocolFee`    | `BigDecimal!` | Protocol fee accrued (USD)                                      |
-| `vaultFee`       | `BigDecimal!` | Vault fee accrued (USD), already net of referral commissions    |
-| `refereeRebate`  | `BigDecimal!` | Referral commissions paid back to referees (USD)                |
-| `referrerPayout` | `BigDecimal!` | Referral commissions paid out to referrers (USD)                |
-| `volumeUsd`      | `BigDecimal!` | USD notional volume from `OrderFilled` and `Deleveraged` events |
-
-Total protocol revenue over the window is `protocolFee + vaultFee`. The total fee paid by users is `protocolFee + vaultFee + refereeRebate + referrerPayout`; `refereeRebate` and `referrerPayout` are informational totals of referral commissions distributed.
-
-This query backs the Dango entry on DefiLlama: <https://defillama.com/protocol/dango>.
-
-## 5. User state and orders
-
-### 5.1 User state
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        user_state: {
-          user: "0x1234...abcd"
-        }
-      }
-    }
-  })
-}
-```
-
-**Response:**
+**Liquidate** — permissionless; force-closes all positions of an under-margined user. Reverts unless the target is below maintenance margin. Sent under the `maintain` key, not `trade`:
 
 ```json
-{
-  "margin": "10000.000000",
-  "vault_shares": "0",
-  "positions": {
-    "perp/btcusd": {
-      "size": "0.500000",
-      "entry_price": "64500.000000",
-      "entry_funding_per_unit": "0.000100",
-      "conditional_order_above": {
-        "order_id": "55",
-        "size": "-0.500000",
-        "trigger_price": "70000.000000",
-        "max_slippage": "0.020000"
-      },
-      "conditional_order_below": null
-    }
-  },
-  "unlocks": [],
-  "reserved_margin": "500.000000",
-  "open_order_count": 2
-}
+{ "execute": { "contract": "PERPS_CONTRACT", "msg": { "maintain": { "liquidate": { "user": "0x5678…ef01" } } }, "funds": {} } }
 ```
-
-| Field              | Type                    | Description                              |
-| ------------------ | ----------------------- | ---------------------------------------- |
-| `margin`           | `UsdValue`              | Deposited margin (USD)                   |
-| `vault_shares`     | `Uint128`               | Vault liquidity shares owned             |
-| `positions`        | `Map<PairId, Position>` | Open positions by pair                   |
-| `unlocks`          | `[Unlock]`              | Pending vault withdrawals                |
-| `reserved_margin`  | `UsdValue`              | Margin reserved for resting limit orders |
-| `open_order_count` | `usize`                 | Number of resting limit orders           |
-
-**Position:**
-
-| Field                     | Type                     | Description                                       |
-| ------------------------- | ------------------------ | ------------------------------------------------- |
-| `size`                    | `Quantity`               | Position size (positive = long, negative = short) |
-| `entry_price`             | `UsdPrice`               | Average entry price                               |
-| `entry_funding_per_unit`  | `FundingPerUnit`         | Funding accumulator at last modification          |
-| `conditional_order_above` | `ConditionalOrder\|null` | TP/SL that triggers when oracle >= trigger_price  |
-| `conditional_order_below` | `ConditionalOrder\|null` | TP/SL that triggers when oracle <= trigger_price  |
-
-**ConditionalOrder** (embedded in Position):
-
-| Field           | Type             | Description                                                          |
-| --------------- | ---------------- | -------------------------------------------------------------------- |
-| `order_id`      | `OrderId`        | Internal ID for price-time priority                                  |
-| `size`          | `Quantity\|null` | Size to close (sign opposes position); `null` closes entire position |
-| `trigger_price` | `UsdPrice`       | Oracle price that activates this order                               |
-| `max_slippage`  | `Dimensionless`  | Slippage tolerance for the market order at trigger                   |
-
-**Unlock:**
-
-| Field               | Type        | Description             |
-| ------------------- | ----------- | ----------------------- |
-| `end_time`          | `Timestamp` | When cooldown completes |
-| `amount_to_release` | `UsdValue`  | USD value to release    |
-
-Returns `null` if the user has no state.
-
-**Enumerate all user states (paginated):**
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        user_states: {
-          start_after: null,
-          limit: 10
-        }
-      }
-    }
-  })
-}
-```
-
-Returns: `{ "<address>": <UserState>, ... }`
-
-### 5.2 Open orders
-
-Query all resting limit orders for a user:
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        orders_by_user: {
-          user: "0x1234...abcd"
-        }
-      }
-    }
-  })
-}
-```
-
-**Response:**
-
-```json
-{
-  "42": {
-    "pair_id": "perp/btcusd",
-    "size": "0.500000",
-    "limit_price": "63000.000000",
-    "reduce_only": false,
-    "reserved_margin": "1575.000000",
-    "created_at": "1700000000"
-  }
-}
-```
-
-The response is a map of `OrderId` → order details. This query returns only resting **limit orders**. Conditional (TP/SL) orders are stored on the position itself and can be queried via `user_state` (see [§5.1](#51-user-state), `conditional_order_above` / `conditional_order_below` fields).
-
-| Field             | Type        | Description                                         |
-| ----------------- | ----------- | --------------------------------------------------- |
-| `pair_id`         | `PairId`    | Trading pair                                        |
-| `size`            | `Quantity`  | Order size (positive = buy, negative = sell)        |
-| `limit_price`     | `UsdPrice`  | Limit price                                         |
-| `reduce_only`     | `bool`      | Whether the order only reduces an existing position |
-| `reserved_margin` | `UsdValue`  | Margin reserved for this order                      |
-| `created_at`      | `Timestamp` | Creation time                                       |
-
-### 5.3 Single order
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        order: {
-          order_id: "42"
-        }
-      }
-    }
-  })
-}
-```
-
-**Response:**
-
-```json
-{
-  "user": "0x1234...abcd",
-  "pair_id": "perp/btcusd",
-  "size": "0.500000",
-  "limit_price": "63000.000000",
-  "reduce_only": false,
-  "reserved_margin": "1575.000000",
-  "created_at": "1700000000"
-}
-```
-
-| Field             | Type        | Description                                         |
-| ----------------- | ----------- | --------------------------------------------------- |
-| `user`            | `Addr`      | Order owner                                         |
-| `pair_id`         | `PairId`    | Trading pair                                        |
-| `size`            | `Quantity`  | Order size (positive = buy, negative = sell)        |
-| `limit_price`     | `UsdPrice`  | Limit price                                         |
-| `reduce_only`     | `bool`      | Whether the order only reduces an existing position |
-| `reserved_margin` | `UsdValue`  | Margin reserved for this order                      |
-| `created_at`      | `Timestamp` | Creation time                                       |
-
-Returns `null` if the order does not exist.
-
-### 5.4 Trading volume
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        volume: {
-          user: "0x1234...abcd",
-          since: null
-        }
-      }
-    }
-  })
-}
-```
-
-| Parameter | Type         | Description                            |
-| --------- | ------------ | -------------------------------------- |
-| `user`    | `Addr`       | Account address                        |
-| `since`   | `Timestamp?` | Start time; `null` for lifetime volume |
-
-Returns a `UsdValue` string (e.g. `"1250000.000000"`).
-
-### 5.5 Trade history
-
-Query historical perps events such as fills, liquidations, and order lifecycle:
-
-```graphql
-query {
-  perpsEvents(
-    userAddr: "0x1234...abcd",
-    eventType: "order_filled",
-    pairId: "perp/btcusd",
-    first: 50,
-    sortBy: BLOCK_HEIGHT_DESC
-  ) {
-    nodes {
-      idx
-      blockHeight
-      txHash
-      eventType
-      userAddr
-      pairId
-      data
-      createdAt
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-  }
-}
-```
-
-| Parameter     | Type     | Description                                          |
-| ------------- | -------- | ---------------------------------------------------- |
-| `userAddr`    | `String` | Filter by user address                               |
-| `eventType`   | `String` | Filter by event type (see [§9](#9-events-reference)) |
-| `pairId`      | `String` | Filter by trading pair                               |
-| `blockHeight` | `Int`    | Filter by block height                               |
-
-The `data` field contains the event-specific payload as JSON. For example, an `order_filled` event:
-
-```json
-{
-  "order_id": "42",
-  "pair_id": "perp/btcusd",
-  "user": "0x1234...abcd",
-  "fill_price": "65000.000000",
-  "fill_size": "0.100000",
-  "closing_size": "0.000000",
-  "opening_size": "0.100000",
-  "realized_pnl": "0.000000",
-  "realized_funding": "0.000000",
-  "fee": "6.500000",
-  "client_order_id": "42",
-  "fill_id": "17",
-  "is_maker": false,
-  "remaining_order_size": "0.000000",
-  "remaining_position_size": "0.100000"
-}
-```
-
-### 5.6 Extended user state
-
-Query user state with additional computed fields (equity, available margin, maintenance margin, and per-position unrealized PnL/funding):
-
-```graphql
-query {
-  queryApp(request: {
-    wasm_smart: {
-      contract: "PERPS_CONTRACT",
-      msg: {
-        user_state_extended: {
-          user: "0x1234...abcd",
-          include_equity: true,
-          include_available_margin: true,
-          include_maintenance_margin: true,
-          include_unrealized_pnl: true,
-          include_unrealized_funding: true,
-          include_liquidation_price: true
-        }
-      }
-    }
-  })
-}
-```
-
-| Parameter                    | Type   | Description                                              |
-| ---------------------------- | ------ | -------------------------------------------------------- |
-| `user`                       | `Addr` | Account address                                          |
-| `include_equity`             | `bool` | Compute and return the user's equity                     |
-| `include_available_margin`   | `bool` | Compute and return the user's free margin                |
-| `include_maintenance_margin` | `bool` | Compute and return the user's maintenance margin         |
-| `include_unrealized_pnl`     | `bool` | Compute and return per-position unrealized PnL           |
-| `include_unrealized_funding` | `bool` | Compute and return per-position unrealized funding costs |
-| `include_liquidation_price`  | `bool` | Compute and return per-position liquidation price        |
-
-**Response:**
-
-```json
-{
-  "margin": "10000.000000",
-  "vault_shares": "0",
-  "unlocks": [],
-  "reserved_margin": "500.000000",
-  "open_order_count": 2,
-  "equity": "10250.000000",
-  "available_margin": "8625.000000",
-  "maintenance_margin": "1875.000000",
-  "positions": {
-    "perp/ethusd": {
-      "size": "5.000000",
-      "entry_price": "2000.000000",
-      "entry_funding_per_unit": "0.000000",
-      "conditional_order_above": null,
-      "conditional_order_below": null,
-      "unrealized_pnl": "250.000000",
-      "unrealized_funding": "0.000000",
-      "liquidation_price": "1052.631578"
-    }
-  }
-}
-```
-
-| Field                | Type                            | Description                                                                                               |
-| -------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `margin`             | `UsdValue`                      | The user's deposited margin                                                                               |
-| `vault_shares`       | `Uint128`                       | Vault shares owned by this user                                                                           |
-| `unlocks`            | `[Unlock]`                      | Pending vault withdrawal cooldowns                                                                        |
-| `reserved_margin`    | `UsdValue`                      | Margin reserved for resting limit orders                                                                  |
-| `open_order_count`   | `usize`                         | Number of resting limit orders                                                                            |
-| `equity`             | `UsdValue\|null`                | margin + unrealized PnL − unrealized funding; `null` if not requested                                     |
-| `available_margin`   | `UsdValue\|null`                | margin − initial margin requirements − reserved margin; `null` if not requested                           |
-| `maintenance_margin` | `UsdValue\|null`                | sum of `\|size\| * oracle_price * maintenance_margin_ratio` across all positions; `null` if not requested |
-| `positions`          | `Map<PairId, PositionExtended>` | Open positions with optional computed data (see below)                                                    |
-
-**PositionExtended:**
-
-| Field                     | Type                     | Description                                                                                                                   |
-| ------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `size`                    | `Quantity`               | Positive = long, negative = short                                                                                             |
-| `entry_price`             | `UsdPrice`               | Average entry price                                                                                                           |
-| `entry_funding_per_unit`  | `FundingPerUnit`         | Funding accumulator at last update                                                                                            |
-| `conditional_order_above` | `ConditionalOrder\|null` | TP/SL that triggers when oracle >= trigger_price                                                                              |
-| `conditional_order_below` | `ConditionalOrder\|null` | TP/SL that triggers when oracle <= trigger_price                                                                              |
-| `unrealized_pnl`          | `UsdValue\|null`         | `size * (oracle_price - entry_price)`; positive = profit; `null` if not requested                                             |
-| `unrealized_funding`      | `UsdValue\|null`         | `size * (current_funding_per_unit - entry_funding_per_unit)`; positive = cost; `null` if not requested                        |
-| `liquidation_price`       | `UsdPrice\|null`         | Oracle price that triggers account liquidation (other prices held constant); `null` if not requested or no valid price exists |
-
-`equity` reflects the total account value including unrealized positions. `available_margin` is the amount the user can withdraw or use for new orders. `maintenance_margin` is the minimum equity required to keep positions open — if equity falls below this threshold the account becomes liquidatable.
-
-## 6. Trading operations
-
-Each message is wrapped in a `Tx` as described in [§2](#2-authentication-and-transactions) and broadcast via `broadcastTxSync`.
-
-### 6.1 Deposit margin
-
-Deposit USDC into the trading margin account:
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "deposit": {}
-      }
-    },
-    "funds": {
-      "bridge/usdc": "1000000000"
-    }
-  }
-}
-```
-
-The deposited USDC is converted to USD at a fixed rate of \$1 per USDC and credited to `user_state.margin`. In this example, `1000000000` base units = 1,000 USDC = \$1,000.
-
-USDC bridged in from another chain must arrive in the account before it can be deposited; to confirm delivery of a bridge transfer, see [§3.10](#310-query-bridge-deposit-delivery).
-
-### 6.2 Withdraw margin
-
-Withdraw USD from the trading margin account:
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "withdraw": {
-          "amount": "500.000000"
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-| Field    | Type       | Description            |
-| -------- | ---------- | ---------------------- |
-| `amount` | `UsdValue` | USD amount to withdraw |
-
-The USD amount is converted to USDC at the fixed rate of \$1 per USDC (floor-rounded) and transferred to the sender.
-
-### 6.3 Submit market order
-
-Buy or sell at the best available prices with a slippage tolerance:
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "submit_order": {
-          "pair_id": "perp/btcusd",
-          "size": "0.100000",
-          "kind": {
-            "market": {
-              "max_slippage": "0.010000"
-            }
-          },
-          "reduce_only": false
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-| Field          | Type            | Description                                                |
-| -------------- | --------------- | ---------------------------------------------------------- |
-| `pair_id`      | `PairId`        | Trading pair (e.g. `"perp/btcusd"`)                        |
-| `size`         | `Quantity`      | Contract size — **positive = buy, negative = sell**        |
-| `max_slippage` | `Dimensionless` | Maximum slippage as a fraction of oracle price (0.01 = 1%) |
-| `reduce_only`  | `bool`          | If `true`, only the position-closing portion executes      |
-| `tp`           | `ChildOrder?`   | Optional take-profit child order (see below)               |
-| `sl`           | `ChildOrder?`   | Optional stop-loss child order (see below)                 |
-
-Market orders execute immediately (IOC behavior). Any unfilled remainder is discarded. If nothing fills, the transaction reverts.
-
-**Child orders (TP/SL):** When `tp` or `sl` is provided, a conditional order is automatically attached to the resulting position after fill. See [ChildOrder](#childorder) in the types reference.
-
-```json
-{
-  "tp": {
-    "trigger_price": "70000.000000",
-    "max_slippage": "0.020000",
-    "size": null
-  },
-  "sl": {
-    "trigger_price": "60000.000000",
-    "max_slippage": "0.020000",
-    "size": null
-  }
-}
-```
-
-| Field           | Type             | Description                                                          |
-| --------------- | ---------------- | -------------------------------------------------------------------- |
-| `trigger_price` | `UsdPrice`       | Oracle price that activates this order                               |
-| `max_slippage`  | `Dimensionless`  | Slippage tolerance for the market order at trigger                   |
-| `size`          | `Quantity\|null` | Size to close (sign opposes position); `null` closes entire position |
-
-For order matching mechanics, see [Order matching](2-order-matching.md).
-
-### 6.4 Submit limit order
-
-Place a resting order on the book:
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "submit_order": {
-          "pair_id": "perp/btcusd",
-          "size": "-0.500000",
-          "kind": {
-            "limit": {
-              "limit_price": "65000.000000",
-              "time_in_force": "GTC",
-              "client_order_id": "42"
-            }
-          },
-          "reduce_only": false
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-| Field             | Type             | Description                                                            |
-| ----------------- | ---------------- | ---------------------------------------------------------------------- |
-| `limit_price`     | `UsdPrice`       | Limit price — must be aligned to `tick_size`                           |
-| `time_in_force`   | `TimeInForce`    | `"GTC"` (default), `"IOC"`, or `"POST"` — see below                    |
-| `client_order_id` | `ClientOrderId?` | Optional caller-assigned id for in-flight cancel — see below           |
-| `reduce_only`     | `bool`           | If `true`, only position-closing portion is kept                       |
-| `tp`              | `ChildOrder?`    | Optional take-profit child order (see [§6.3](#63-submit-market-order)) |
-| `sl`              | `ChildOrder?`    | Optional stop-loss child order (see [§6.3](#63-submit-market-order))   |
-
-**Time-in-force options:**
-
-- **GTC** (Good-Til-Canceled, default): the matching portion fills immediately; any unfilled remainder is stored on the book. Margin is reserved for the unfilled portion.
-- **IOC** (Immediate-Or-Cancel): fills as much as possible against the book, then discards any unfilled remainder. Errors if nothing fills at all.
-- **POST** (Post-Only): the entire order is placed on the book without matching. Rejected if the limit price would cross the best offer on the opposite side.
-
-**Client order id:**
-
-`client_order_id` is a caller-assigned `Uint64` that lets an algo trader cancel an order in the same block it was submitted, without round-tripping through the server response to learn the system-assigned `OrderId`. Cancel via [`CancelOrderRequest::OneByClientOrderId`](#65-cancel-order).
-
-- Uniqueness scope: per-sender, across the sender's _active_ (resting) limit orders only. The contract does not remember client order ids of orders that have been canceled or filled, so they can be reused freely.
-- Submitting a second order with a `client_order_id` that the sender already has on the book fails with `duplicate_data`.
-- Not allowed with `time_in_force: "IOC"` — IOC never enters the book, so the alias would be unreachable. Submission is rejected with a clear error.
-
-### 6.5 Cancel order
-
-**Cancel a single order by system-assigned `OrderId`:**
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "cancel_order": {
-          "one": "42"
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-**Cancel a single order by caller-assigned `ClientOrderId`:**
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "cancel_order": {
-          "one_by_client_order_id": "42"
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-This resolves to the active order owned by the sender that carries the given `client_order_id` (see [§6.4](#64-submit-limit-order)). It bails if no such order exists. The lookup is per-sender, so two traders can independently use the same `client_order_id` value without colliding.
-
-Pattern: an algo trader can submit and cancel in the same block by reusing the `client_order_id` they assigned at submission, without waiting for the server response.
-
-**Cancel all orders:**
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "cancel_order": "all"
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-Cancellation releases reserved margin and decrements `open_order_count`.
-
-### 6.6 Batch update orders
-
-Apply a sequence of submit and cancel actions atomically. Actions execute in order; later actions observe the state written by earlier ones. If any action fails, the whole message reverts and no partial state is persisted.
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "batch_update_orders": [
-          { "cancel": "all" },
-          {
-            "submit": {
-              "pair_id": "perp/btcusd",
-              "size": "0.100000",
-              "kind": {
-                "limit": {
-                  "limit_price": "64000.000000",
-                  "time_in_force": "POST",
-                  "client_order_id": "1"
-                }
-              },
-              "reduce_only": false
-            }
-          },
-          {
-            "submit": {
-              "pair_id": "perp/btcusd",
-              "size": "-0.100000",
-              "kind": {
-                "limit": {
-                  "limit_price": "66000.000000",
-                  "time_in_force": "POST",
-                  "client_order_id": "2"
-                }
-              },
-              "reduce_only": false
-            }
-          }
-        ]
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-The payload is a JSON array of `SubmitOrCancelOrderRequest` values. Each entry is one of:
-
-- `{ "submit": { … } }` — same shape as [`submit_order`](#64-submit-limit-order) (every field of `SubmitOrderRequest`).
-- `{ "cancel": <CancelOrderRequest> }` — any variant of [`CancelOrderRequest`](#103-enums): `{ "one": "..." }`, `{ "one_by_client_order_id": "..." }`, or the string `"all"`.
-
-**Constraints:**
-
-- The list must be non-empty.
-- The list length must not exceed [`Param.max_action_batch_size`](#41-global-parameters); the chain rejects oversize batches before any action runs.
-- Conditional (TP/SL) orders are not supported in batches — use [`submit_conditional_order`](#67-submit-conditional-order-tpsl) / [`cancel_conditional_order`](#68-cancel-conditional-order) for those.
-
-**Atomicity:** every storage write the earlier actions made — including realized fills that mutated counterparties' state — is discarded if a later action fails. Events are emitted only for the successful-batch case; a reverting batch surfaces just the top-level transaction failure.
-
-**Example use case — atomic book replacement:**
-
-An algo trader refreshing quotes at a new reference price can send a single `batch_update_orders` carrying `{ "cancel": "all" }` followed by the new `submit` entries. The old orders are canceled (freeing reserved margin) before the new submits run their margin checks, and if any new submit would fail (margin check, price band, OI cap, …) the old orders are restored along with the rest of the batch.
-
-**Reusing a `client_order_id` within one batch:** a `{ "cancel": { "one_by_client_order_id": "X" } }` entry releases the id before a later `{ "submit": { … "client_order_id": "X" } }` runs, so the same id can be rebound to a new order within a single message.
-
-### 6.7 Submit conditional order (TP/SL)
-
-Place a take-profit or stop-loss order that triggers when the oracle price crosses a threshold:
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "submit_conditional_order": {
-          "pair_id": "perp/btcusd",
-          "size": "-0.100000",
-          "trigger_price": "70000.000000",
-          "trigger_direction": "above",
-          "max_slippage": "0.020000"
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-| Field               | Type               | Description                                        |
-| ------------------- | ------------------ | -------------------------------------------------- |
-| `pair_id`           | `PairId`           | Trading pair                                       |
-| `size`              | `Quantity`         | Size to close — sign must oppose the position      |
-| `trigger_price`     | `UsdPrice`         | Oracle price that activates this order             |
-| `trigger_direction` | `TriggerDirection` | `"above"` or `"below"` (see below)                 |
-| `max_slippage`      | `Dimensionless`    | Slippage tolerance for the market order at trigger |
-
-**Trigger direction:**
-
-| Direction | Triggers when                 | Use case                                    |
-| --------- | ----------------------------- | ------------------------------------------- |
-| `above`   | oracle_price >= trigger_price | Take-profit for longs, stop-loss for shorts |
-| `below`   | oracle_price <= trigger_price | Stop-loss for longs, take-profit for shorts |
-
-Conditional orders are always **reduce-only** with zero reserved margin. When triggered, they execute as market orders.
-
-### 6.8 Cancel conditional order
-
-Conditional orders are identified by `(pair_id, trigger_direction)`, not by order ID.
-
-**Cancel a single conditional order:**
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "cancel_conditional_order": {
-          "one": {
-            "pair_id": "perp/btcusd",
-            "trigger_direction": "above"
-          }
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-**Cancel all conditional orders for a specific pair:**
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "cancel_conditional_order": {
-          "all_for_pair": {
-            "pair_id": "perp/btcusd"
-          }
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-**Cancel all conditional orders:**
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "trade": {
-        "cancel_conditional_order": "all"
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-### 6.9 Liquidate (permissionless)
-
-Force-close all positions of an undercollateralized user. This message can be sent by anyone (liquidation bots):
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "maintain": {
-        "liquidate": {
-          "user": "0x5678...ef01"
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-The transaction reverts if the user is not below the maintenance margin. Unfilled positions are ADL'd against counter-parties at the bankruptcy price. For mechanics, see [Liquidation & ADL](4-liquidation-and-adl.md).
-
-## 7. Vault operations
-
-The counterparty vault provides liquidity for the exchange. Users can deposit margin into the vault to earn trading fees, and withdraw with a cooldown period.
-
-### 7.1 Add liquidity
-
-Transfer margin from the trading account to the vault:
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "vault": {
-        "add_liquidity": {
-          "amount": "1000.000000",
-          "min_shares_to_mint": "900000"
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-| Field                | Type       | Description                                        |
-| -------------------- | ---------- | -------------------------------------------------- |
-| `amount`             | `UsdValue` | USD margin amount to transfer to the vault         |
-| `min_shares_to_mint` | `Uint128?` | Revert if fewer shares are minted (slippage guard) |
-
-Shares are minted proportionally to the vault's current NAV. For vault mechanics, see [Vault](5-vault.md).
-
-### 7.2 Remove liquidity
-
-Request a withdrawal from the vault (initiates cooldown):
-
-```json
-{
-  "execute": {
-    "contract": "PERPS_CONTRACT",
-    "msg": {
-      "vault": {
-        "remove_liquidity": {
-          "shares_to_burn": "500000"
-        }
-      }
-    },
-    "funds": {}
-  }
-}
-```
-
-| Field            | Type      | Description              |
-| ---------------- | --------- | ------------------------ |
-| `shares_to_burn` | `Uint128` | Number of shares to burn |
-
-Shares are burned immediately. The corresponding USD value enters a cooldown queue. After `vault_cooldown_period` elapses, funds are automatically credited back to the user's trading margin.
-
-## 8. Real-time subscriptions (graphql-ws)
-
-All subscriptions in this section use the `graphql-ws` WebSocket transport described in [§1.2](#12-websocket). The `fullBlock` and `perpsEvents` feeds use the native WebSocket API instead — see [§12](#12-new-in-v0260-websocket-api).
-
-### 8.1 Perps candles
-
-Stream OHLCV candlestick data for a perpetual pair:
-
-```graphql
-subscription {
-  perpsCandles(pairId: "perp/btcusd", interval: ONE_MINUTE) {
-    pairId
-    interval
-    open
-    high
-    low
-    close
-    volume
-    volumeUsd
-    timeStart
-    timeStartUnix
-    timeEnd
-    timeEndUnix
-    minBlockHeight
-    maxBlockHeight
-  }
-}
-```
-
-Pushes updated candle data as new trades occur. Fields match the `PerpsCandle` type in [§4.7](#47-historical-candles).
-
-### 8.2 Perps trades
-
-Stream real-time trade fills for a pair:
-
-```graphql
-subscription {
-  perpsTrades(pairId: "perp/btcusd") {
-    orderId
-    pairId
-    user
-    fillPrice
-    fillSize
-    closingSize
-    openingSize
-    realizedPnl
-    fee
-    createdAt
-    blockHeight
-    tradeIdx
-    isMaker
-  }
-}
-```
-
-**Behavior:** On connection, cached recent trades are replayed first, then new trades stream in real-time.
-
-| Field         | Type       | Description                                                                                              |
-| ------------- | ---------- | -------------------------------------------------------------------------------------------------------- |
-| `orderId`     | `String`   | Order ID that produced this fill                                                                         |
-| `pairId`      | `String`   | Trading pair                                                                                             |
-| `user`        | `String`   | Account address                                                                                          |
-| `fillPrice`   | `String`   | Execution price                                                                                          |
-| `fillSize`    | `String`   | Filled size (positive = buy, negative = sell)                                                            |
-| `closingSize` | `String`   | Portion that closed existing position                                                                    |
-| `openingSize` | `String`   | Portion that opened new position                                                                         |
-| `realizedPnl` | `String`   | PnL realized on this fill, including funding settled on the pre-existing position; excludes trading fees |
-| `fee`         | `String`   | Trading fee charged                                                                                      |
-| `createdAt`   | `String`   | Timestamp (ISO 8601)                                                                                     |
-| `blockHeight` | `Int`      | Block in which the trade occurred                                                                        |
-| `tradeIdx`    | `Int`      | Index within the block                                                                                   |
-| `isMaker`     | `Boolean?` | True for the maker side of a match, false for the taker side; null for trades executed before v0.16.0    |
-
-### 8.3 Perps events
-
-Perps-contract events are streamed over the native WebSocket API, on the `perpsEvents` channel — see [§12.2](#122-channels). For deep history, use the `perpsEvents` query ([§5.5](#55-trade-history)).
-
-### 8.4 Contract query polling
-
-Poll any contract query at a regular block interval:
-
-```graphql
-subscription {
-  queryApp(
-    request: {
-      wasm_smart: {
-        contract: "PERPS_CONTRACT",
-        msg: {
-          user_state: {
-            user: "0x1234...abcd"
-          }
-        }
-      }
-    },
-    blockInterval: 5
-  ) {
-    response
-    blockHeight
-  }
-}
-```
-
-| Parameter       | Type             | Default | Description                  |
-| --------------- | ---------------- | ------- | ---------------------------- |
-| `request`       | `GrugQueryInput` | —       | Any valid `queryApp` request |
-| `blockInterval` | `Int`            | `10`    | Push updates every N blocks  |
-
-Common use cases:
-
-- **User state** — monitor margin, positions, and order counts.
-- **Order book depth** — track bid/ask levels.
-- **Pair states** — monitor open interest and funding.
-
-### 8.5 Block stream
-
-Subscribe to new blocks as they are finalized:
-
-```graphql
-subscription {
-  block {
-    blockHeight
-    hash
-    appHash
-    createdAt
-  }
-}
-```
-
-### 8.6 Event stream
-
-Subscribe to events with optional filtering:
-
-```graphql
-subscription {
-  events(
-    sinceBlockHeight: 100000,
-    filter: [
-      {
-        type: "order_filled",
-        data: [
-          {
-            path: ["user"],
-            checkMode: EQUAL,
-            value: ["0x1234...abcd"]
-          }
-        ]
-      }
-    ]
-  ) {
-    type
-    method
-    eventStatus
-    data
-    blockHeight
-    createdAt
-  }
-}
-```
-
-| Filter field | Type           | Description                                     |
-| ------------ | -------------- | ----------------------------------------------- |
-| `type`       | `String`       | Event type name                                 |
-| `data`       | `[FilterData]` | Conditions on the event's JSON data             |
-| `path`       | `[String]`     | JSON path to the field                          |
-| `checkMode`  | `CheckValue`   | `EQUAL` (exact match) or `CONTAINS` (substring) |
-| `value`      | `[JSON]`       | Values to match against                         |
-
-## 9. Events reference
-
-The perps contract emits the following events. These can be queried via `perpsEvents` ([§5.5](#55-trade-history)) or streamed in real time via the WebSocket `perpsEvents` channel ([§12.2](#122-channels)) or the generic `events` subscription ([§8.6](#86-event-stream)).
-
-### Margin events
-
-| Event       | Fields           | Description      |
-| ----------- | ---------------- | ---------------- |
-| `deposited` | `user`, `amount` | Margin deposited |
-| `withdrew`  | `user`, `amount` | Margin withdrawn |
-
-### Vault events
-
-| Event                 | Fields                                        | Description                        |
-| --------------------- | --------------------------------------------- | ---------------------------------- |
-| `liquidity_added`     | `user`, `amount`, `shares_minted`             | LP deposited to vault              |
-| `liquidity_unlocking` | `user`, `amount`, `shares_burned`, `end_time` | LP withdrawal initiated (cooldown) |
-| `liquidity_released`  | `user`, `amount`                              | Cooldown completed, funds released |
-
-### Order events
-
-| Event             | Fields                                                                                                                                                                                                                                 | Description                     |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `order_filled`    | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `realized_funding?`, `fee`, `client_order_id?`, `fill_id?`, `is_maker?`, `remaining_order_size?`, `remaining_position_size?` | Order partially or fully filled |
-| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?`                                                                                                                                                               | Limit order placed on book      |
-| `order_resized`   | `order_id`, `pair_id`, `user`, `old_size`, `new_size`, `client_order_id?`                                                                                                                                                              | Reduce-only order shrunk        |
-| `order_removed`   | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?`                                                                                                                                                                            | Order removed from book         |
-
-`client_order_id` is `null` if the order was submitted without one. Off-chain consumers can use it to correlate fills, persistence, resizes, and removal with the originally-submitted client id.
-
-`order_resized` is emitted when a resting reduce-only order's size is reduced in place rather than removed. When a user's position shrinks, their resting reduce-only orders are clamped so their absolute sizes sum to no more than the new position; an order whose clamped size is still non-zero is rewritten smaller and emits this event, while one clamped all the way to zero is removed and emits `order_removed` instead. `old_size` and `new_size` carry the same sign, with `new_size` strictly smaller in absolute value. Resizing is automatic — there is no manual resize operation, so this event never results from a user action; a user can only place or cancel orders, and a manual cancellation emits `order_removed`.
-
-`fill_id` groups the two sides of a single order-book match. When a taker crosses a resting maker, two `order_filled` events are emitted — one for each side — and both carry the same `fill_id`. Successive matches use consecutive ids (strictly increasing), so a taker that crosses two makers in the same transaction produces four events with two distinct `fill_id` values. `fill_id` is `null` for trades executed before v0.15.0 — fill IDs were not assigned prior to that release. Not emitted for ADL fills, which use the [`deleveraged` and `liquidated` events](#liquidation-events) instead.
-
-`is_maker` is `true` for the maker side of a match and `false` for the taker side. Within a single match's pair of `order_filled` events (sharing one `fill_id`), exactly one carries `is_maker = true` and one carries `is_maker = false`. `is_maker` is `null` for trades executed before v0.16.0 — the maker/taker flag was not recorded prior to that release.
-
-`realized_pnl` on `order_filled` and `deleveraged` (and `adl_realized_pnl` on `liquidated`) reports the closing PnL on the fill — price movement on the closed portion. The funding settled on the user's pre-existing position immediately before the fill is reported separately as `realized_funding` (or `adl_realized_funding` on `liquidated`).
-
-`realized_funding` is `null` for events emitted before v0.17.0 — funding was bundled into `realized_pnl` (and `adl_realized_pnl`) prior to that release. From v0.17.0 onward the field is always present and `realized_pnl + realized_funding` equals the pre-v0.17.0 lump sum.
-
-Trading fees are reported separately in the `fee` field on `order_filled`; ADL and deleverage fills incur no trading fees.
-
-`remaining_position_size` reports the size of the affected position **after** the event is applied — positive for a long, negative for a short, and zero when the position was closed entirely. It lets consumers track a position's live size directly instead of accumulating the per-event `closing_size` / `opening_size` (or `adl_size`) deltas. It refers to the fill's user (taker or maker) on `order_filled`, the counter-party on `deleveraged`, and the liquidated user on `liquidated`. A liquidation closes each pair with its own `liquidated` event, so each event reports the resulting size for its own pair. The field is `null` for events emitted before v0.26.0 — the resulting size was not recorded prior to that release.
-
-`remaining_order_size` (on `order_filled` only) reports the order's remaining unfilled size **after** this fill, carrying the same sign as the order's side. It is non-zero when the order is only partially filled and zero once it is fully filled; for the taker side it is the incoming order's remainder (which may then rest on the book or be discarded), and for the maker side the resting order's remainder. The field is `null` for trades executed before v0.26.0 — the remaining order size was not recorded prior to that release.
-
-### Conditional order events
-
-| Event                         | Fields                                                                          | Description                   |
-| ----------------------------- | ------------------------------------------------------------------------------- | ----------------------------- |
-| `conditional_order_placed`    | `pair_id`, `user`, `trigger_price`, `trigger_direction`, `size`, `max_slippage` | TP/SL order created           |
-| `conditional_order_triggered` | `pair_id`, `user`, `trigger_price`, `trigger_direction`, `oracle_price`         | TP/SL triggered by price move |
-| `conditional_order_removed`   | `pair_id`, `user`, `trigger_direction`, `reason`                                | TP/SL removed                 |
-
-### Liquidation events
-
-| Event              | Fields                                                                                                              | Description                      |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `liquidated`       | `user`, `pair_id`, `adl_size`, `adl_price`, `adl_realized_pnl`, `adl_realized_funding?`, `remaining_position_size?` | Position liquidated in a pair    |
-| `deleveraged`      | `user`, `pair_id`, `closing_size`, `fill_price`, `realized_pnl`, `realized_funding?`, `remaining_position_size?`    | Counter-party hit by ADL         |
-| `bad_debt_covered` | `liquidated_user`, `amount`, `insurance_fund_remaining`                                                             | Insurance fund absorbed bad debt |
-
-### ReasonForOrderRemoval
-
-| Value                    | Description                                                                  |
-| ------------------------ | ---------------------------------------------------------------------------- |
-| `filled`                 | Order fully filled                                                           |
-| `canceled`               | User voluntarily canceled                                                    |
-| `position_closed`        | Position was closed (conditional orders only)                                |
-| `self_trade_prevention`  | Order crossed user's own order on the opposite side                          |
-| `liquidated`             | User was liquidated                                                          |
-| `deleveraged`            | User was hit by auto-deleveraging                                            |
-| `slippage_exceeded`      | Conditional order triggered but could not fill within slippage               |
-| `price_band_violation`   | Resting price drifted outside the per-pair band before match                 |
-| `slippage_cap_tightened` | Conditional order's stored max_slippage now exceeds the pair's tightened cap |
 
 For liquidation and ADL mechanics, see [Liquidation & ADL](4-liquidation-and-adl.md).
 
-## 10. Types reference
+### 4.9 Vault messages
 
-### 10.1 Numeric types
+The counterparty vault provides liquidity and earns trading fees. Messages target the perps contract under the `vault` key.
 
-All numeric types are **signed fixed-point decimals with 6 decimal places**, built on [`dango_types::Number`](https://github.com/left-curve/left-curve/blob/main/dango/exchange/types/src/typed_number.rs). They are serialized as strings:
-
-| Type alias       | Dimension      | Example usage                          | Example value    |
-| ---------------- | -------------- | -------------------------------------- | ---------------- |
-| `Dimensionless`  | (pure scalar)  | Fee rates, margin ratios, slippage     | `"0.050000"`     |
-| `Quantity`       | quantity       | Position size, order size, OI          | `"-0.500000"`    |
-| `UsdValue`       | usd            | Margin, PnL, notional, fees            | `"10000.000000"` |
-| `UsdPrice`       | usd / quantity | Oracle price, limit price, entry price | `"65000.000000"` |
-| `FundingPerUnit` | usd / quantity | Cumulative funding accumulator         | `"0.000123"`     |
-| `FundingRate`    | per day        | Funding rate cap                       | `"0.000500"`     |
-
-Additional integer types:
-
-| Type      | Encoding         | Description                       |
-| --------- | ---------------- | --------------------------------- |
-| `Uint128` | String           | Large integer (e.g. vault shares) |
-| `u64`     | Number or String | Gas limit, timestamps             |
-| `u32`     | Number           | User index, account index, nonce  |
-
-### 10.2 Identifiers
-
-| Type                 | Format                          | Example                          |
-| -------------------- | ------------------------------- | -------------------------------- |
-| `PairId`             | `perp/<base><quote>`            | `"perp/btcusd"`, `"perp/ethusd"` |
-| `OrderId`            | `Uint64` (string)               | `"42"`                           |
-| `ConditionalOrderId` | `Uint64` (shared counter)       | `"43"`                           |
-| `ClientOrderId`      | `Uint64` (caller-assigned)      | `"42"`                           |
-| `FillId`             | `Uint64` (per-match identifier) | `"17"`                           |
-| `Addr`               | Hex address                     | `"0x1234...abcd"`                |
-| `Hash256`            | 64-char uppercase hex           | `"A1B2C3D4E5F6..."`              |
-| `UserIndex`          | `u32`                           | `0`                              |
-| `AccountIndex`       | `u32`                           | `1`                              |
-| `Username`           | 1–15 chars, `[a-z0-9_]`         | `"alice"`                        |
-| `Timestamp`          | Seconds since epoch (decimal)   | `"1700000000.123456789"`         |
-| `Duration`           | Seconds (decimal)               | `"3600"` (1 hour)                |
-
-`Timestamp` and `Duration` are encoded as fixed-point decimal strings with up to 9 fractional digits (nanosecond precision); trailing zeros are elided. So `"1700000000"`, `"1700000000.5"`, and `"1700000000.123456789"` are all valid `Timestamp` values.
-
-### 10.3 Enums
-
-**OrderKind:**
+**Add liquidity** — transfer margin from the trading account into the vault, minting shares at the vault's current NAV. `min_shares_to_mint` is an optional slippage guard:
 
 ```json
-{
-  "market": {
-    "max_slippage": "0.010000"
-  }
-}
+{ "execute": { "contract": "PERPS_CONTRACT", "msg": { "vault": { "add_liquidity": { "amount": "1000.000000", "min_shares_to_mint": "900000" } } }, "funds": {} } }
 ```
+
+**Remove liquidity** — burn shares immediately; the USD value enters a cooldown queue and is credited back to trading margin after `Param.vault_cooldown_period`:
 
 ```json
-{
-  "limit": {
-    "limit_price": "65000.000000",
-    "time_in_force": "GTC",
-    "client_order_id": "42"
-  }
-}
+{ "execute": { "contract": "PERPS_CONTRACT", "msg": { "vault": { "remove_liquidity": { "shares_to_burn": "500000" } } }, "funds": {} } }
 ```
 
-`client_order_id` is optional. Defaults to `null` when omitted; not allowed with `time_in_force: "IOC"`.
+For vault mechanics, see [Vault](5-vault.md).
 
-**TimeInForce:** `"GTC"` | `"IOC"` | `"POST"` (defaults to `"GTC"` if omitted)
+## 5. Live API — real-time WebSocket
 
-**TriggerDirection:**
+The Live API serves real-time data over a single **multiplexed WebSocket** at `GET /ws`. One socket carries any number of subscriptions and one-shot requests. This section is the authoritative reference for the protocol, because OpenAPI cannot model WebSocket traffic — the interactive docs list the endpoint but cannot describe its frames.
 
-```json
-"above"
-```
+### 5.1 Protocol
 
-```json
-"below"
-```
-
-**CancelOrderRequest:**
-
-```json
-{
-  "one": "42"
-}
-```
-
-```json
-{
-  "one_by_client_order_id": "42"
-}
-```
-
-```json
-"all"
-```
-
-**SubmitOrderRequest:**
-
-```json
-{
-  "pair_id": "perp/btcusd",
-  "size": "-0.500000",
-  "kind": {
-    "limit": {
-      "limit_price": "65000.000000",
-      "time_in_force": "GTC",
-      "client_order_id": "42"
-    }
-  },
-  "reduce_only": false,
-  "tp": null,
-  "sl": null
-}
-```
-
-Same shape used by [`submit_order`](#64-submit-limit-order) and each `submit` entry in [`batch_update_orders`](#66-batch-update-orders).
-
-**SubmitOrCancelOrderRequest:**
-
-```json
-{ "submit": { /* SubmitOrderRequest */ } }
-```
-
-```json
-{ "cancel": { "one": "42" } }
-```
-
-```json
-{ "cancel": "all" }
-```
-
-One action inside a [`batch_update_orders`](#66-batch-update-orders) list. Conditional (TP/SL) orders are not supported.
-
-**CancelConditionalOrderRequest:**
-
-```json
-{
-  "one": {
-    "pair_id": "perp/btcusd",
-    "trigger_direction": "above"
-  }
-}
-```
-
-```json
-{
-  "all_for_pair": {
-    "pair_id": "perp/btcusd"
-  }
-}
-```
-
-```json
-"all"
-```
-
-**Key:**
-
-```json
-{
-  "secp256r1": "<base64>"
-}
-```
-
-```json
-{
-  "secp256k1": "<base64>"
-}
-```
-
-```json
-{
-  "ethereum": "0x1234...abcd"
-}
-```
-
-**Credential:**
-
-```json
-{
-  "standard": {
-    "key_hash": "...",
-    "signature": { ... }
-  }
-}
-```
-
-```json
-{
-  "session": {
-    "session_info": { ... },
-    "session_signature": "...",
-    "authorization": { ... }
-  }
-}
-```
-
-**CandleInterval** (GraphQL enum):
-
-`ONE_SECOND` | `ONE_MINUTE` | `FIVE_MINUTES` | `FIFTEEN_MINUTES` | `ONE_HOUR` | `FOUR_HOURS` | `ONE_DAY` | `ONE_WEEK`
-
-### 10.4 Response types
-
-**Param** (global parameters) — see [§4.1](#41-global-parameters) for all fields.
-
-**PairParam** (per-pair parameters) — see [§4.3](#43-pair-parameters) for all fields.
-
-**PairState:**
-
-| Field              | Type             | Description                                         |
-| ------------------ | ---------------- | --------------------------------------------------- |
-| `long_oi`          | `Quantity`       | Total long open interest                            |
-| `short_oi`         | `Quantity`       | Total short open interest                           |
-| `funding_per_unit` | `FundingPerUnit` | Cumulative funding accumulator                      |
-| `funding_rate`     | `FundingRate`    | Current per-day funding rate (positive = longs pay) |
-
-**State** (global state) — see [§4.2](#42-global-state) for all fields.
-
-**UserState** — see [§5.1](#51-user-state) for all fields.
-
-**UserStateExtended** — see [§5.6](#56-extended-user-state) for all fields.
-
-**Position:**
-
-| Field                     | Type                     | Description                                      |
-| ------------------------- | ------------------------ | ------------------------------------------------ |
-| `size`                    | `Quantity`               | Positive = long, negative = short                |
-| `entry_price`             | `UsdPrice`               | Average entry price                              |
-| `entry_funding_per_unit`  | `FundingPerUnit`         | Funding accumulator at last update               |
-| `conditional_order_above` | `ConditionalOrder\|null` | TP/SL that triggers when oracle >= trigger_price |
-| `conditional_order_below` | `ConditionalOrder\|null` | TP/SL that triggers when oracle <= trigger_price |
-
-<a id="conditionalorder"></a>**ConditionalOrder** (embedded in Position):
-
-| Field           | Type             | Description                                                          |
-| --------------- | ---------------- | -------------------------------------------------------------------- |
-| `order_id`      | `OrderId`        | Internal ID for price-time priority                                  |
-| `size`          | `Quantity\|null` | Size to close (sign opposes position); `null` closes entire position |
-| `trigger_price` | `UsdPrice`       | Oracle price that activates this order                               |
-| `max_slippage`  | `Dimensionless`  | Slippage tolerance for the market order at trigger                   |
-
-<a id="childorder"></a>**ChildOrder** (TP/SL attached to a parent order):
-
-| Field           | Type             | Description                                                          |
-| --------------- | ---------------- | -------------------------------------------------------------------- |
-| `trigger_price` | `UsdPrice`       | Oracle price that activates this order                               |
-| `max_slippage`  | `Dimensionless`  | Slippage tolerance for the market order at trigger                   |
-| `size`          | `Quantity\|null` | Size to close (sign opposes position); `null` closes entire position |
-
-**Unlock:**
-
-| Field               | Type        | Description             |
-| ------------------- | ----------- | ----------------------- |
-| `end_time`          | `Timestamp` | When cooldown completes |
-| `amount_to_release` | `UsdValue`  | USD value to release    |
-
-**QueryOrderResponse:**
-
-| Field             | Type        | Description                                         |
-| ----------------- | ----------- | --------------------------------------------------- |
-| `user`            | `Addr`      | Order owner                                         |
-| `pair_id`         | `PairId`    | Trading pair                                        |
-| `size`            | `Quantity`  | Order size                                          |
-| `limit_price`     | `UsdPrice`  | Limit price                                         |
-| `reduce_only`     | `bool`      | Whether the order only reduces an existing position |
-| `reserved_margin` | `UsdValue`  | Margin reserved for this order                      |
-| `created_at`      | `Timestamp` | Creation time                                       |
-
-**LiquidityDepthResponse:**
-
-| Field  | Type                            | Description             |
-| ------ | ------------------------------- | ----------------------- |
-| `bids` | `Map<UsdPrice, LiquidityDepth>` | Bid-side depth by price |
-| `asks` | `Map<UsdPrice, LiquidityDepth>` | Ask-side depth by price |
-
-**LiquidityDepth:**
-
-| Field      | Type       | Description                   |
-| ---------- | ---------- | ----------------------------- |
-| `size`     | `Quantity` | Absolute order size in bucket |
-| `notional` | `UsdValue` | USD notional (size × price)   |
-
-**User** (account factory):
-
-| Field      | Type                      | Description                      |
-| ---------- | ------------------------- | -------------------------------- |
-| `index`    | `UserIndex`               | User's numerical index           |
-| `name`     | `Username`                | User's username                  |
-| `accounts` | `Map<AccountIndex, Addr>` | Accounts owned (index → address) |
-| `keys`     | `Map<Hash256, Key>`       | Associated keys (hash → key)     |
-
-**Account:**
-
-| Field   | Type           | Description            |
-| ------- | -------------- | ---------------------- |
-| `index` | `AccountIndex` | Account's unique index |
-| `owner` | `UserIndex`    | Owning user's index    |
-
-## 11. New in v0.26.0: REST API
-
-Plain REST endpoints for the most common operations, as an alternative to the GraphQL endpoint in [§1.1](#11-http). Each is a `POST` whose body is the raw object — no GraphQL `{query, variables}` wrapper — and whose response is the raw result JSON. They exist for bots and algo traders that expect a REST + WebSocket surface rather than GraphQL.
-
-**Endpoint:** See [Constants](9-constants.md#endpoints).
-
-**Headers:**
-
-| Header         | Value              |
-| -------------- | ------------------ |
-| `Content-Type` | `application/json` |
-
-### 11.1 Query
-
-Run a read-only query against the latest finalized state. The body is a single `Query` object — the same shape the GraphQL `queryApp` takes as its `request` — and the response is the matching `QueryResponse`. Historical queries are not supported; there is no `height` parameter.
-
-**Example — query a smart contract:**
-
-```bash
-curl -X POST https://<host>/query \
-  -H 'Content-Type: application/json' \
-  -d '{"wasm_smart": {"contract": "PERPS_CONTRACT", "msg": {"state": {}}}}'
-```
-
-**Response** — the `QueryResponse`, keyed by the request variant:
-
-```json
-{
-  "wasm_smart": { ... }
-}
-```
-
-The body accepts any `Query` variant — for example `{"app_config": {}}`, `{"balance": { ... }}`, or `{"multi": [ ... ]}` to batch several queries atomically (see [§1.4](#14-multi-query)).
-
-### 11.2 Simulate
-
-Dry-run an `UnsignedTx` to estimate gas. The body is the `UnsignedTx`; the response is the `TxOutcome`. Simulation skips signature verification — add **770,000 gas** (Secp256k1 verification cost) to `gas_used` when setting `gas_limit` on the final transaction (see [§2.8](#28-gas-estimation)).
-
-**Request body** — an `UnsignedTx`:
-
-```json
-{
-  "sender": "0x1234...abcd",
-  "msgs": [ ... ],
-  "data": {
-    "user_index": 0,
-    "chain_id": "dango-1",
-    "nonce": 42,
-    "expiry": null
-  }
-}
-```
-
-**Example:**
-
-```bash
-curl -X POST https://<host>/simulate \
-  -H 'Content-Type: application/json' \
-  -d '{"sender": "0x1234...abcd", "msgs": [ ... ], "data": { ... }}'
-```
-
-**Response** — the `TxOutcome`:
-
-```json
-{
-  "gas_limit": 100000000,
-  "gas_used": 750000,
-  "result": {
-    "Ok": null
-  },
-  "events": { ... }
-}
-```
-
-`result` is the standard-library `Result` serialization: `{"Ok": null}` on success (the `Ok` value is `()`), or `{"Err": {"error": "...", "backtrace": "..."}}` on failure. `events` is the per-stage event tree (`withhold`, `authenticate`, `msgs_and_backrun`, `finalize`). `gas_limit` is the simulation ceiling (the node's `query_gas_limit`), not the gas you should set on the final transaction — use `gas_used` for that.
-
-### 11.3 Broadcast
-
-Submit a signed `Tx` to the mempool. The body is the `Tx`; the response is the `BroadcastTxOutcome`. This is a mempool receipt, **not** block inclusion: an accepted transaction returns `200` with `check_tx.result` set to `{"Ok": null}`, and a mempool-rejected transaction also returns `200` but with `check_tx.result` an `{"Err": ...}` object (it never entered a block). Only a transport failure to the consensus node returns `500`.
-
-**Request body** — a signed `Tx`:
-
-```json
-{
-  "sender": "0x1234...abcd",
-  "gas_limit": 1500000,
-  "msgs": [ ... ],
-  "data": {
-    "user_index": 0,
-    "chain_id": "dango-1",
-    "nonce": 42,
-    "expiry": null
-  },
-  "credential": {
-    "standard": {
-      "key_hash": "...",
-      "signature": { ... }
-    }
-  }
-}
-```
-
-**Example:**
-
-```bash
-curl -X POST https://<host>/broadcast \
-  -H 'Content-Type: application/json' \
-  -d '{"sender": "0x1234...abcd", "gas_limit": 1500000, "msgs": [ ... ], "data": { ... }, "credential": { ... }}'
-```
-
-**Response** — the `BroadcastTxOutcome`:
-
-```json
-{
-  "tx_hash": "...",
-  "check_tx": {
-    "gas_limit": 1500000,
-    "gas_used": 12000,
-    "result": {
-      "Ok": null
-    },
-    "events": { ... }
-  }
-}
-```
-
-`check_tx` is a `CheckTxOutcome` produced by mempool admission (the `withhold` and `authenticate` stages only), so its `gas_used` is small and its `events` cover just those stages. `result` is `{"Ok": null}` if admitted, or `{"Err": {"error": "...", "backtrace": "..."}}` if rejected.
-
-## 12. New in v0.26.0: WebSocket API
-
-A native WebSocket endpoint for real-time feeds, distinct from the `graphql-ws` endpoint in [§1.2](#12-websocket). It follows the multiplexed, message-oriented convention used by major exchanges: one socket carries any number of subscriptions, the client opens and closes them with JSON messages, and every frame is a single JSON object.
-
-**Endpoint:** `GET /ws` (WebSocket upgrade). See [Constants](9-constants.md#endpoints).
-
-Five channels are served, replacing the corresponding `graphql-ws` subscriptions:
-
-- `perpsEvents` — perps-contract events grouped per block, with filters.
-- `blockInfo` — every finalized block's metadata (height, timestamp, hash).
-- `block` — every finalized block, without its execution outcome.
-- `fullBlock` — every finalized block in full (`Block` + `BlockOutcome`).
-- `query` — a standing state query, re-run every `interval` blocks (also usable as a one-shot request/response method).
-
-### 12.1 Protocol
-
-Client messages are tagged by `method`; server messages are tagged by `channel`. A `subscribe` carries a client-chosen integer `id` that is the subscription handle: it is echoed on the acknowledgement and on every data frame the subscription produces, and is used to `unsubscribe`. One socket can therefore carry several subscriptions — for example several `perpsEvents` feeds with different filters — that the client demultiplexes by `id`.
+Client messages are tagged by `method`; server messages are tagged by `channel`. A `subscribe` carries a client-chosen integer `id` — the subscription handle, echoed on the acknowledgement and on every frame the subscription produces, and used to `unsubscribe`. So one socket can carry several subscriptions (e.g. multiple `perpsEvents` feeds with different filters), demultiplexed by `id`.
 
 **Client → server:**
 
 ```json
 {"method": "subscribe", "id": 1, "subscription": {"type": "perpsEvents", "pairIds": ["perp/btcusd"]}}
 {"method": "subscribe", "id": 2, "subscription": {"type": "blockInfo"}}
-{"method": "subscribe", "id": 3, "subscription": {"type": "block"}}
-{"method": "subscribe", "id": 4, "subscription": {"type": "fullBlock"}}
 {"method": "subscribe", "id": 5, "subscription": {"type": "query", "query": {"app_config": {}}, "interval": 5}}
-{"method": "query", "id": 6, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
 {"method": "unsubscribe", "id": 1}
+{"method": "broadcast", "id": 7, "tx": { /* signed Tx */ }}
+{"method": "query", "id": 8, "query": {"balance": {"address": "0x…", "denom": "bridge/usdc"}}}
 {"method": "ping", "id": 9}
 ```
 
-| Field          | Type     | Description                                                                               |
-| -------------- | -------- | ----------------------------------------------------------------------------------------- |
-| `method`       | `String` | `subscribe`, `unsubscribe`, `ping`, `broadcast`, or `query`                               |
-| `id`           | `Int`    | Operation handle, echoed on every resulting frame; optional on `ping`, required otherwise |
-| `subscription` | `Object` | The feed selector on `subscribe`; see [§12.2](#122-channels)                              |
-| `tx`           | `Object` | The signed `Tx` on `broadcast`; see [§12.2](#122-channels)                                |
-| `query`        | `Object` | The query request on `query`; see [§12.2](#122-channels)                                  |
+| `method` | Description |
+| -------- | ----------- |
+| `subscribe` / `unsubscribe` | Open / close a subscription by `id` |
+| `broadcast` | Submit a signed `Tx` over the socket ([§5.4](#54-one-shot-requests-over-websocket)) |
+| `query` | Run a one-shot read over the socket ([§5.4](#54-one-shot-requests-over-websocket)) |
+| `ping` | Application heartbeat (`id` optional) |
 
 **Server → client:**
 
 ```json
 {"channel": "subscriptionResponse", "id": 1, "data": {"method": "subscribe", "type": "perpsEvents"}}
-{"channel": "perpsEvents", "id": 1, "data": { ... }}
-{"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "..."}}
-{"channel": "blockInfo", "id": 2, "data": { ... }}
-{"channel": "block", "id": 3, "data": { ... }}
-{"channel": "fullBlock", "id": 4, "data": { ... }}
-{"channel": "query", "id": 5, "data": {"blockHeight": 100001, "response": { ... }}}
-{"channel": "query", "id": 6, "data": { ... }}
+{"channel": "perpsEvents", "id": 1, "data": { /* … */ }}
+{"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "…"}}
+{"channel": "query", "id": 5, "data": {"blockHeight": 100001, "response": { /* … */ }}}
 {"channel": "pong", "id": 9}
-{"channel": "error", "error": {"code": "badRequest", "message": "..."}}
+{"channel": "error", "error": {"code": "badRequest", "message": "…"}}
 ```
 
-| `channel`                                             | Description                                                                                                                                             |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `subscriptionResponse`                                | Acknowledges a `subscribe`/`unsubscribe`, echoing its `id`                                                                                              |
-| `perpsEvents`/`blockInfo`/`block`/`fullBlock`/`query` | A frame on a subscription's channel, tagged with its `id`: a `data` payload, or an `error` that ended the feed (see [§12.3](#123-reconnect-and-errors)) |
-| `broadcast`/`query`                                   | The single reply to a `broadcast`/`query` request, tagged with its `id`: a `data` payload or an `error` (see [§12.2](#122-channels))                    |
-| `pong`                                                | Reply to a `ping`, echoing its `id`                                                                                                                     |
-| `error`                                               | A connection-level problem with no subscription to attribute it to (e.g. an unparseable frame); see [§12.3](#123-reconnect-and-errors)                  |
+Every frame on a subscription's channel carries either a `data` payload or an `error` (co-located so a feed's failure arrives on the same channel its data does — see [§5.5](#55-reconnect-and-errors)); a client branches on which key is present. A connection-level problem with no subscription to attribute it to (an unparseable frame, or an `unsubscribe` for an unknown `id`) uses the dedicated `error` channel.
 
-Each frame on a subscription's channel (`perpsEvents` / `blockInfo` / `block` / `fullBlock` / `query`) carries either a `data` payload or an `error`; a client demultiplexes by `id` and branches on which key is present. Errors are co-located this way so a feed's failure arrives on the same channel its data does — see [§12.3](#123-reconnect-and-errors). Note that the `query` channel carries both a `query` *subscription*'s stream and the single reply to a one-shot `query` *request* — the client's own `id` bookkeeping tells them apart.
+**Heartbeat.** The server pings every 20 seconds and closes a socket it has heard nothing from for 60 seconds. Let your WebSocket stack answer those pings, or send `{"method": "ping"}` yourself.
 
-**Heartbeat.** The server sends a WebSocket ping every 20 seconds and closes a connection it has heard nothing from for 60 seconds. A client either lets its WebSocket stack answer those pings, or sends `{"method": "ping"}` itself; either keeps an idle subscription alive.
+### 5.2 Streaming channels
 
-### 12.2 Channels
+Four channels stream one frame per finalized block. All are served from an **in-memory window of recent blocks**, so they are not for deep history — backfill from the Archive API ([§6](#6-archive-api--structured-history)). Each accepts an optional `since` (replay retained blocks from that height on connect; omit for live-only).
 
-#### `perpsEvents`
+| `type` / channel | Frame `data` | Description |
+| ---------------- | ------------ | ----------- |
+| `perpsEvents` | `{blockHeight, createdAt, events[]}` | The block's perps-contract events (order lifecycle, fills, liquidations, deleveraging), filterable |
+| `blockInfo` | `{height, timestamp, hash}` | Block metadata — the lightest way to follow the tip |
+| `block` | `{info, txs}` | A block without its execution outcome (matches `GET /block/info/{height}`) |
+| `fullBlock` | `{block, outcome}` | A block in full (matches `GET /block/full/{height}`) |
 
-Stream every event emitted by the perps contract — order lifecycle, fills, liquidations, and deleveraging — grouped per block. Served from an in-memory window of recent blocks, so deep history is not available here; use the `perpsEvents` query ([§5.5](#55-trade-history)) for that.
+**`perpsEvents` filters.** Five optional filters — `eventTypes`, `pairIds`, `users`, `orderIds`, `clientOrderIds` — **AND** together. Omitting a filter matches everything on that field; passing an _empty_ array matches nothing. Values match the event's canonical string form (pass the same `0x`-address / decimal-id forms the API returns elsewhere). A `client_order_id` is unique only per sender, so combine `clientOrderIds` with `users` to single out one trader's order. Only blocks with at least one matching event are delivered:
 
 ```json
-{"method": "subscribe", "id": 1, "subscription": {
-  "type": "perpsEvents",
-  "since": 100000,
-  "eventTypes": ["order_filled", "liquidated"],
-  "pairIds": ["perp/btcusd"],
-  "users": ["0x1234...abcd"],
-  "orderIds": ["100"],
-  "clientOrderIds": ["42"]
-}}
+{"method":"subscribe","id":1,"subscription":{"type":"perpsEvents","since":100000,"eventTypes":["order_filled","liquidated"],"pairIds":["perp/btcusd"],"users":["0x1234…abcd"]}}
 ```
-
-| Field            | Type       | Description                                                            |
-| ---------------- | ---------- | ---------------------------------------------------------------------- |
-| `since`          | `Int`      | Replay retained blocks from this height on connect; omit for live-only |
-| `eventTypes`     | `[String]` | Keep only these event types (see [§9](#9-events-reference))            |
-| `pairIds`        | `[String]` | Keep only these trading pairs                                          |
-| `users`          | `[String]` | Keep only events whose `user` is one of these addresses                |
-| `orderIds`       | `[String]` | Keep only events whose `order_id` is one of these                      |
-| `clientOrderIds` | `[String]` | Keep only events whose `client_order_id` is one of these               |
-
-**Filter semantics.** The five filters AND together. Omitting a filter does not filter on that field (matches everything); passing an _empty_ array matches nothing. Each value is matched verbatim against the event's canonical string form, so pass the same `0x`-prefixed address or decimal-id form the API returns elsewhere. A `client_order_id` is unique only per sender, so combine `clientOrderIds` with `users` to single out one trader's order.
-
-Each data frame carries one block's matching events; only blocks with at least one matching event are delivered:
 
 ```json
-{"channel": "perpsEvents", "id": 1, "data": {
-  "blockHeight": 100001,
-  "createdAt": "2026-06-18T00:00:00Z",
-  "events": [
-    {
-      "idx": 0,
-      "eventType": "order_filled",
-      "user": "0x1234...abcd",
-      "pairId": "perp/btcusd",
-      "orderId": "100",
-      "clientOrderId": "42",
-      "data": { ... }
-    }
-  ]
-}}
+{"channel":"perpsEvents","id":1,"data":{"blockHeight":100001,"createdAt":"2026-06-18T00:00:00Z","events":[{"idx":0,"eventType":"order_filled","user":"0x1234…abcd","pairId":"perp/btcusd","orderId":"100","clientOrderId":"42","data":{ /* … */ }}]}}
 ```
 
-**`data` (PerpsEventsBatch) fields:**
+Each event carries its ordinal `idx`, its `eventType`, the indexed `user` / `pairId` / `orderId` / `clientOrderId` (when present), and the raw `data` payload (same shapes as the [Events reference](#7-events-reference)).
 
-| Field         | Type           | Description                       |
-| ------------- | -------------- | --------------------------------- |
-| `blockHeight` | `Int`          | Block height                      |
-| `createdAt`   | `String`       | Block timestamp (ISO 8601)        |
-| `events`      | `[PerpsEvent]` | The block's matching perps events |
+### 5.3 Standing-query channels
 
-**PerpsEvent fields:**
+A **standing query** re-runs a read once per block whose height is a multiple of `interval` (default 10; use `1` for every block), streaming `{blockHeight, response}` frames. The initial snapshot arrives immediately, then ticks align absolutely (`height % interval == 0`), so identical subscriptions share one execution per tick.
 
-| Field           | Type      | Description                                                 |
-| --------------- | --------- | ----------------------------------------------------------- |
-| `idx`           | `Int`     | Ordinal of this event within the block                      |
-| `eventType`     | `String`  | Event type name (see [§9](#9-events-reference))             |
-| `user`          | `String?` | The event's subject address, if it has a `user` field       |
-| `pairId`        | `String?` | The event's trading pair, if it has a `pair_id` field       |
-| `orderId`       | `String?` | The event's order, if it has an `order_id` field            |
-| `clientOrderId` | `String?` | The caller-assigned client order id, if it has one          |
-| `data`          | `JSON`    | Raw event payload (same shape as [§9](#9-events-reference)) |
-
-#### `blockInfo`
-
-Stream every finalized block's metadata — the `info` field of `Block` (`height`, `timestamp`, `hash`), one data frame per block. The lightest way to follow the chain tip.
+The generic form takes any grug `Query`:
 
 ```json
-{"method": "subscribe", "id": 2, "subscription": {"type": "blockInfo", "since": 100000}}
+{"method":"subscribe","id":5,"subscription":{"type":"query","query":{"wasm_smart":{"contract":"PERPS_CONTRACT","msg":{"user_state":{"user":"0x…"}}}},"interval":5}}
 ```
 
-| Field   | Type  | Description                                                            |
-| ------- | ----- | ---------------------------------------------------------------------- |
-| `since` | `Int` | Replay retained blocks from this height on connect; omit for live-only |
+Four **typed aliases** are the WebSocket twins of the `GET /perps/*` reads — same snake_case parameters, plus `interval`, with the contract address resolved server-side. Each frame's `response` is the raw contract response, exactly what the REST twin returns:
+
+| `type` / channel | REST twin |
+| ---------------- | --------- |
+| `perpsPairState` | `GET /perps/pair-state` |
+| `perpsUserState` | `GET /perps/user-state` |
+| `perpsOrdersByUser` | `GET /perps/order/by-user` |
+| `perpsLiquidityDepth` | `GET /perps/liquidity-depth` |
 
 ```json
-{"channel": "blockInfo", "id": 2, "data": {"height": 100001, "timestamp": "1781740800.000000000", "hash": "813A81B8C4CBAF71A73CEDD69F502C5A5FEE4CB7391EB92FC29AB4E1A2A5C2A0"}}
+{"method":"subscribe","id":6,"subscription":{"type":"perpsUserState","user":"0x…","include_all":true,"interval":1}}
 ```
-
-#### `block`
-
-Stream every finalized block as produced by the consensus engine — metadata (`info`) plus transactions (`txs`), without the execution outcome. The same `Block` shape the REST `/block/info/{height}` route returns, one data frame per block.
 
 ```json
-{"method": "subscribe", "id": 3, "subscription": {"type": "block", "since": 100000}}
+{"channel":"perpsUserState","id":6,"data":{"blockHeight":100005,"response":{ /* UserStateExtended */ }}}
 ```
 
-| Field   | Type  | Description                                                            |
-| ------- | ----- | ---------------------------------------------------------------------- |
-| `since` | `Int` | Replay retained blocks from this height on connect; omit for live-only |
+Standing queries are **live-only** — historical state cannot be re-queried, so there is no `since` replay; on reconnect, resubscribe and take the fresh snapshot. For incremental order updates prefer the push-based `perpsEvents` feed over polling `perpsOrdersByUser`.
+
+### 5.4 One-shot requests over WebSocket
+
+`broadcast` and `query` also ride the socket as one-shot request/response, so a client already holding a connection needn't open a separate HTTP request. Each is answered by a single frame on its own channel, tagged with the request `id`.
+
+**`query`** returns the raw `QueryResponse` (same shapes as `POST /query`). Success is a `data` frame; a failed query is an `error` frame with code `queryFailed` — `QueryResponse` is success-only, so any failure is an error (a failed one-shot query ends nothing and its `id` is free to reuse):
 
 ```json
-{"channel": "block", "id": 3, "data": {"info": { ... }, "txs": [ ... ]}}
+{"channel":"query","id":8,"data":{"balance":{"denom":"bridge/usdc","amount":"12345"}}}
 ```
 
-#### `fullBlock`
+**`broadcast`** returns the `BroadcastTxOutcome` (same shape as `POST /broadcast`). Note the asymmetry with `query`: a **mempool-rejected tx is still a `data` frame** (its rejection rides `check_tx.result`); only a transport failure to the consensus node is an `error` frame with code `broadcastFailed`.
 
-Stream every finalized block in full — the same `FullBlock` shape (`block` + `outcome`) the REST `/block/full/{height}` route returns, one data frame per block.
+### 5.5 Reconnect and errors
+
+The block-backed channels (`perpsEvents`, `blockInfo`, `block`, `fullBlock`) carry a block height on every frame. Track the last height you saw and, on reconnect, resubscribe with `since` set to that height plus one. Standing `query` subscriptions are live-only (resubscribe for a fresh snapshot). Subscriptions are not persisted across reconnects — resend your `subscribe` messages.
+
+A subscription-scoped error rides that subscription's own channel and `id`; a connection-level error uses the `error` channel. Error codes:
+
+| `code` | Meaning |
+| ------ | ------- |
+| `resync` | `since` predates the retained window, or the feed lagged past it. The subscription ends; reconnect with a newer `since` and backfill the gap from the Archive API or the `/block/*` REST routes. |
+| `queryFailed` | A standing or one-shot `query` failed (unknown contract, contract error, …). |
+| `broadcastFailed` | Transport failure to the consensus node on a `broadcast`. |
+| `tooManyRequests` | The server's subscription limit was reached. |
+| `badRequest` | The message could not be parsed, or the `id` is already in use. |
+| `unknownSubscription` | An `unsubscribe` referenced an `id` with no open subscription. |
 
 ```json
-{"method": "subscribe", "id": 4, "subscription": {"type": "fullBlock", "since": 100000}}
+{"channel":"perpsEvents","id":1,"error":{"code":"resync","message":"resync required: requested from block 100 but the oldest retained block is 900"}}
 ```
 
-| Field   | Type  | Description                                                            |
-| ------- | ----- | ---------------------------------------------------------------------- |
-| `since` | `Int` | Replay retained blocks from this height on connect; omit for live-only |
+## 6. Archive API — structured history
 
-```json
-{"channel": "fullBlock", "id": 4, "data": {"block": { ... }, "outcome": { ... }}}
-```
+The Archive API serves deep history from SQL databases populated by analyzing every finalized block. It is REST-only.
 
-#### `query`
+### 6.1 Feed model
 
-Run a one-time, read-only query against the latest finalized state — a **read** request/response (one request, one reply), not a subscription stream. The request and reply are the same raw grug `Query` / `QueryResponse` shapes as REST `POST /query` ([§11.1](#111-query)); this lets a client already holding a `/ws` connection query state without opening a separate HTTP request.
+Every feed is **newest-first** and **keyset-paginated** (`first` / `after` / `endCursor` — see [§2.3](#23-pagination)). A feed returns lightweight indexed columns plus, hydrated from the block store, the heavy payloads (a transaction's full `tx` / `outcome`, an event's decoded `data`). Because the archive ingests blocks after they finalize, its frontier trails the chain tip slightly; for the live tip, use the Live API.
 
-```json
-{"method": "query", "id": 6, "query": {"balance": {"address": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9", "denom": "hyp/all/btc"}}}
-```
+Feed **response schemas are fully documented in the Archive [interactive docs](#12-interactive-reference)** (the handlers return typed objects, so OpenAPI captures them); this section gives the routes and their meaning.
 
-| Field   | Type     | Description                                                     |
-| ------- | -------- | --------------------------------------------------------------- |
-| `id`    | `Int`    | Echoed on the reply frame                                       |
-| `query` | `Object` | The grug `Query` (same request payloads as [§11.1](#111-query)) |
+### 6.2 Blocks
 
-The reply rides the `query` channel. Success is a `data` frame holding the raw `QueryResponse`:
+| Route | Returns |
+| ----- | ------- |
+| `GET /blocks/{height}` | The full block at `height` as `{block, outcome}` (same shape as the Live API's `/block/full/{height}`); `404` if the store does not hold it |
+| `GET /blocks/latest` | The block at the store's **contiguous frontier** — the highest `H` with every height in `[1, H]` stored, i.e. the newest block servable together with all history below it |
 
-```json
-{"channel": "query", "id": 6, "data": {"balance": {"denom": "hyp/all/btc", "amount": "12345"}}}
-```
+During a backfill, `/blocks/latest` climbs from the bottom and trails the chain tip; once the store is gap-free, it _is_ the tip.
 
-A failed query — an unknown contract, a contract query that errors, and so on — is an `error` frame with code `queryFailed`, carrying the same error message the REST route would return as a `400`. Note the asymmetry with `broadcast`: a mempool-rejected tx is still a `data` frame there, because `BroadcastTxOutcome` carries its own rejection, while `QueryResponse` is success-only, so any failure is an `error` frame. A failed one-shot query ends nothing — the socket and its subscriptions are unaffected, and the `id` is free to reuse.
+### 6.3 Activity feeds
 
-```json
-{"channel": "query", "id": 6, "error": {"code": "queryFailed", "message": "..."}}
-```
+**Transactions:**
 
-**Subscribing to a query.** The same `query` payload can also be held open as a standing subscription: the server answers with an initial snapshot immediately, then re-runs the query once per block whose height is a multiple of `interval`, streaming the results on the `query` channel. The alignment is absolute — a tick fires when `height % interval == 0` — so every subscription with the same query and interval ticks at the same heights, and identical concurrent subscriptions are served from a single shared execution per tick.
+| Route | Returns |
+| ----- | ------- |
+| `GET /transactions/{hash}` | Every unit whose transaction bytes hash to `hash`, newest-first, un-paginated (the hash is **not** unique — byte-identical resubmissions can recur in later blocks) |
+| `GET /transactions/involving/{address}?role=&kind=` | Units the address **sent** or **participated in** (the union by default), newest-first, paginated. `role` (`sender` / `participant`) and `kind` (`transaction` / `cron`) narrow it |
 
-```json
-{"method": "subscribe", "id": 5, "subscription": {"type": "query", "query": {"app_config": {}}, "interval": 5}}
-```
+**Events:**
 
-| Field      | Type     | Description                                                     |
-| ---------- | -------- | --------------------------------------------------------------- |
-| `query`    | `Object` | The grug `Query` (same request payloads as [§11.1](#111-query)) |
-| `interval` | `Int`    | Re-run once per this many blocks; must be ≥ 1, defaults to 10   |
+| Route | Returns |
+| ----- | ------- |
+| `GET /events?type=&involved=` | Events filtered by `type` (a comma-separated list) and/or `involved` (a participant address). **At least one is required** — an unfiltered feed has no index anchor |
+| `GET /events/contract?contract=&user=&names=` | The contract events of one emitting `contract` (required), optionally narrowed to a participant `user` and/or a comma-separated `names` list |
+| `GET /events/perps?user=&names=` | Shortcut for `/events/contract` pre-bound to the deployment's perps address — the go-to feed for **deep perps history** (past fills, liquidations, order lifecycle). Same `user` / `names` filters |
 
-Unlike the one-shot reply, each subscription frame wraps the response with the block height it was served at:
+Use `/events/perps` to backfill the gap after a WebSocket `perpsEvents` `resync` (the two surface the same perps events; the WebSocket feed is the live window, this feed is the durable history). Event `data` payloads follow the [Events reference](#7-events-reference).
 
-```json
-{"channel": "query", "id": 5, "data": {"blockHeight": 100005, "response": {"app_config": { ... }}}}
-```
+### 6.4 Perps market history
 
-Each frame's `blockHeight` is strictly greater than the previous frame's; under executor lag a tick may be skipped when its result would duplicate the previous frame. The feed is live-only — there is no `since` replay, because historical state cannot be re-queried; on reconnect, simply resubscribe and take the fresh initial snapshot. A failed execution (including a failing initial snapshot, which arrives after the ack) ends the subscription with a single terminal `queryFailed` error frame; a feed that falls behind the retained window ends with the standard terminal `resync` frame.
+Candlestick (OHLCV) data, per-pair 24h statistics, recent trades, and fee/revenue aggregates are **not yet available** over REST or WebSocket. These historical analytics currently exist only on the deprecated GraphQL endpoint; where they will live (Live API vs. Archive API) and their exact shape are undecided, and they will be replaced by a future method. This note will be updated when that lands.
 
-#### `broadcast`
+## 7. Events reference
 
-Submit a signed transaction to the mempool — a **write** request/response (one request, one reply), not a subscription stream. The REST `POST /broadcast` ([§11.3](#113-broadcast)) is the default; this lets a client already holding a `/ws` connection broadcast without opening a separate HTTP request. Like REST, it returns a mempool receipt (`BroadcastTxOutcome`), **not** block inclusion.
+The perps contract emits the following events. Stream them live over the WebSocket `perpsEvents` channel ([§5.2](#52-streaming-channels)) or read their history from the Archive `/events/perps` feed ([§6.3](#63-activity-feeds)). Field names are the event's raw payload keys.
 
-```json
-{"method": "broadcast", "id": 1, "tx": { ... signed Tx ... }}
-```
+**Margin:**
 
-| Field | Type     | Description                                                    |
-| ----- | -------- | -------------------------------------------------------------- |
-| `id`  | `Int`    | Echoed on the reply frame                                      |
-| `tx`  | `Object` | The signed `Tx` (see [§2](#2-authentication-and-transactions)) |
+| Event | Fields | Description |
+| ----- | ------ | ----------- |
+| `deposited` | `user`, `amount` | Margin deposited |
+| `withdrew` | `user`, `amount` | Margin withdrawn |
 
-The reply rides the `broadcast` channel. Success — **including a mempool-rejected tx**, whose rejection is carried in `check_tx.result` — is a `data` frame holding the `BroadcastTxOutcome` (same shape as [§11.3](#113-broadcast)):
+**Vault:**
 
-```json
-{"channel": "broadcast", "id": 1, "data": {"tx_hash": "...", "check_tx": { ... }}}
-```
+| Event | Fields | Description |
+| ----- | ------ | ----------- |
+| `liquidity_added` | `user`, `amount`, `shares_minted` | Deposited to the vault |
+| `liquidity_unlocking` | `user`, `amount`, `shares_burned`, `end_time` | Withdrawal initiated (cooldown) |
+| `liquidity_released` | `user`, `amount` | Cooldown completed, funds released |
 
-Only a transport failure to the consensus node is an `error` frame:
+**Orders:**
 
-```json
-{"channel": "broadcast", "id": 1, "error": {"code": "broadcastFailed", "message": "..."}}
-```
+| Event | Fields | Description |
+| ----- | ------ | ----------- |
+| `order_filled` | `order_id`, `pair_id`, `user`, `fill_price`, `fill_size`, `closing_size`, `opening_size`, `realized_pnl`, `realized_funding?`, `fee`, `client_order_id?`, `fill_id?`, `is_maker?`, `remaining_order_size?`, `remaining_position_size?` | Order partially or fully filled |
+| `order_persisted` | `order_id`, `pair_id`, `user`, `limit_price`, `size`, `client_order_id?` | Limit order placed on the book |
+| `order_resized` | `order_id`, `pair_id`, `user`, `old_size`, `new_size`, `client_order_id?` | Reduce-only order shrunk in place |
+| `order_removed` | `order_id`, `pair_id`, `user`, `reason`, `client_order_id?` | Order removed from the book |
 
-### 12.3 Reconnect and errors
+**Conditional orders:**
 
-The four block-backed subscription channels (`perpsEvents`, `blockInfo`, `block`, `fullBlock`) are served from an in-memory window of recent blocks. Every data frame carries the block height (`blockHeight` for `perpsEvents`, `height` for `blockInfo`, `info.height` for `block`, `block.info.height` for `fullBlock`), so a client tracks the last height it saw and, on reconnect, resubscribes with `since` set to that height plus one. A `query` subscription is live-only — its frames carry a `blockHeight` too, but there is no `since` replay, because historical state cannot be re-queried; on reconnect, simply resubscribe and take the fresh initial snapshot. Subscriptions are not persisted across reconnects: a client that reconnects must resend its `subscribe` messages.
+| Event | Fields | Description |
+| ----- | ------ | ----------- |
+| `conditional_order_placed` | `pair_id`, `user`, `trigger_price`, `trigger_direction`, `size`, `max_slippage` | TP/SL created |
+| `conditional_order_triggered` | `pair_id`, `user`, `trigger_price`, `trigger_direction`, `oracle_price` | TP/SL triggered by a price move |
+| `conditional_order_removed` | `pair_id`, `user`, `trigger_direction`, `reason` | TP/SL removed |
 
-Problems are delivered as `error`-keyed frames. An error that concerns a specific subscription rides that subscription's own channel and `id` — an `error` sibling of the `data` frames it would otherwise send — so a client handles a feed's failure on the same channel it reads from. An error with no subscription to attribute it to (an unparseable message, or an `unsubscribe` for an unknown `id`) arrives on the dedicated `error` channel instead, carrying the offending `id` when there is one.
+**Liquidation:**
 
-| `code`                | Meaning                                                                                                                                                                                                                                                     |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `resync`              | `since` predates the retained window, or the feed lagged past it. The subscription ends; reconnect with a newer `since` and backfill the gap from the `perpsEvents` query ([§5.5](#55-trade-history)) or the `/block/info/*` / `/block/full/*` REST routes. |
-| `tooManyRequests`     | The server's subscription limit was reached.                                                                                                                                                                                                                |
-| `badRequest`          | The message could not be parsed, or the `id` is already in use.                                                                                                                                                                                             |
-| `unknownSubscription` | An `unsubscribe` referenced an `id` with no open subscription.                                                                                                                                                                                              |
+| Event | Fields | Description |
+| ----- | ------ | ----------- |
+| `liquidated` | `user`, `pair_id`, `adl_size`, `adl_price`, `adl_realized_pnl`, `adl_realized_funding?`, `remaining_position_size?` | Position liquidated in a pair |
+| `deleveraged` | `user`, `pair_id`, `closing_size`, `fill_price`, `realized_pnl`, `realized_funding?`, `remaining_position_size?` | Counter-party hit by ADL |
+| `bad_debt_covered` | `liquidated_user`, `amount`, `insurance_fund_remaining` | Insurance fund absorbed bad debt |
 
-A subscription-scoped error (here, a terminal `resync` on the `perpsEvents` feed opened with `id: 1`):
+**Referral:**
 
-```json
-{"channel": "perpsEvents", "id": 1, "error": {"code": "resync", "message": "resync required: requested from block 100 but the oldest retained block is 900"}}
-```
+| Event | Fields | Description |
+| ----- | ------ | ----------- |
+| `fee_distributed` | `payer`, `payer_addr`, `protocol_fee`, `vault_fee`, `commissions[]` | Trading fee split across protocol, vault, and the referral chain |
+| `referral_set` | `referrer`, `referee` | Referral relationship registered |
+
+**Notes on the order/liquidation fields.**
+
+- Fields marked `?` are optional and may be `null` on events emitted by older node versions (`realized_funding` before v0.17.0, `fill_id` before v0.15.0, `is_maker` before v0.16.0, `remaining_order_size` / `remaining_position_size` before v0.26.0). A consumer must tolerate their absence.
+- `fill_id` groups the two sides of one order-book match: a taker crossing a resting maker emits two `order_filled` events sharing one `fill_id`, one with `is_maker: true` and one with `is_maker: false`.
+- `realized_pnl` reports the closing PnL on the fill (price movement on the closed portion). Funding settled on the pre-existing position is reported separately as `realized_funding` (from v0.17.0). Trading fees are separate again, in `fee`; ADL and deleverage fills incur no fee.
+- `remaining_position_size` is the affected position's size **after** the event (positive long, negative short, zero if closed) — track a position's live size directly instead of accumulating `closing_size` / `opening_size` deltas. `remaining_order_size` is the order's unfilled remainder after the fill.
+- `order_removed.reason` is a `ReasonForOrderRemoval`: `filled`, `canceled`, `position_closed`, `self_trade_prevention`, `liquidated`, `deleveraged`, `slippage_exceeded`, `price_band_violation`, or `slippage_cap_tightened`.
+
+For liquidation and ADL mechanics, see [Liquidation & ADL](4-liquidation-and-adl.md); for fee splits, see [Order matching §8](2-order-matching.md#8-trading-fees) and [Referral](6-referral.md).
+
+## 8. Types reference
+
+The response objects of the perps [read shortcuts](#32-typed-read-shortcuts) mirror the contract types in [`dango/exchange/types/src/perps.rs`](https://github.com/left-curve/left-curve/blob/main/dango/exchange/types/src/perps.rs), the authoritative source. The consumer-facing fields are documented below; the global-parameter structs also carry vault-market-making and governance knobs, elided here and marked in the source.
+
+<a id="param"></a>**`Param`** (global parameters) — trading-relevant fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `max_open_orders` | `usize` | Max resting limit orders per user, across all pairs |
+| `max_action_batch_size` | `usize` | Max actions in one `batch_update_orders` |
+| `maker_fee_rates` / `taker_fee_rates` | `RateSchedule` | Volume-tiered fee rates (`{base, tiers}`; highest qualifying tier wins) |
+| `protocol_fee_rate` | `Dimensionless` | Fraction of each fee routed to the treasury |
+| `liquidation_fee_rate` | `Dimensionless` | Insurance-fund fee on liquidations |
+| `funding_period` | `Duration` | Interval between funding collections |
+| `vault_cooldown_period` | `Duration` | Vault-withdrawal cooldown |
+| `vault_deposit_cap` | `UsdValue \| null` | Max total vault margin (`null` = uncapped) |
+| `referral_active` | `bool` | Whether referral commissions are active |
+
+Plus `max_unlocks`, `liquidation_buffer_ratio`, `vault_total_weight`, `min_referrer_volume`, and `referrer_commission_rates` — see the source.
+
+<a id="pairparam"></a>**`PairParam`** (per-pair parameters) — trading-relevant fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `tick_size` | `UsdPrice` | Minimum price increment for limit orders |
+| `min_order_size` | `UsdValue` | Minimum notional (reduce-only exempt) |
+| `max_abs_oi` | `Quantity` | Max open interest per side |
+| `max_abs_funding_rate` | `FundingRate` | Daily funding-rate cap |
+| `initial_margin_ratio` | `Dimensionless` | Margin to open (e.g. `0.05` = 20× max leverage) |
+| `maintenance_margin_ratio` | `Dimensionless` | Margin to stay open (liquidation threshold) |
+| `max_limit_price_deviation` | `Dimensionless` | Max deviation of a limit price from oracle at submission |
+| `max_market_slippage` | `Dimensionless` | Max `max_slippage` on a market or TP/SL order |
+| `impact_size` | `UsdValue` | Notional used for impact-price computation |
+| `bucket_sizes` | `[UsdPrice]` | Valid granularities for `liquidity-depth` queries |
+
+Plus the vault market-making knobs (`vault_liquidity_weight`, `vault_half_spread`, `vault_max_quote_size`, the skew factors, `funding_rate_multiplier`) — see the source. For margin and leverage, see [Risk](7-risk.md).
+
+<a id="state"></a>**`State`** (global state):
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `last_funding_time` | `Timestamp` | Last funding collection |
+| `vault_share_supply` | `Uint128` | Total vault shares |
+| `insurance_fund` | `UsdValue` | Insurance fund balance (may be negative) |
+| `treasury` | `UsdValue` | Accumulated protocol fees |
+
+<a id="pairstate"></a>**`PairState`** (per-pair state):
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `long_oi` / `short_oi` | `Quantity` | Total long / short open interest |
+| `funding_per_unit` | `FundingPerUnit` | Cumulative funding accumulator |
+| `funding_rate` | `FundingRate` | Current per-day rate (positive = longs pay) |
+| `index_price` | `UsdPrice` | Reference price for margin, PnL, funding, liquidation |
+| `last_index_time` | `Timestamp` | When `index_price` was last updated |
+
+For funding, see [Funding](3-funding.md).
+
+<a id="userstate"></a>**`UserState`** / **`UserStateExtended`** (one user). The base fields (from `user-state` without any `include_*`):
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `margin` | `UsdValue` | Deposited margin |
+| `vault_shares` | `Uint128` | Vault shares owned |
+| `positions` | map of `PairId` → `Position` | Open positions |
+| `unlocks` | `[Unlock]` | Pending vault withdrawals (`{end_time, amount_to_release}`) |
+| `reserved_margin` | `UsdValue` | Margin reserved for resting limit orders |
+| `open_order_count` | `usize` | Number of resting limit orders |
+
+The `include_*` flags (`include_equity`, `include_available_margin`, `include_maintenance_margin`, `include_unrealized_pnl`, `include_unrealized_funding`, `include_liquidation_price`, or `include_all`) add computed fields — top-level `equity`, `available_margin`, `maintenance_margin`, and per-position `unrealized_pnl`, `unrealized_funding`, `liquidation_price`. Any field not requested is `null`.
+
+<a id="position"></a>**`Position`**:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `size` | `Quantity` | Positive = long, negative = short |
+| `entry_price` | `UsdPrice` | Average entry price |
+| `entry_funding_per_unit` | `FundingPerUnit` | Funding accumulator at last modification |
+| `conditional_order_above` | `ConditionalOrder \| null` | TP/SL triggering when oracle ≥ `trigger_price` |
+| `conditional_order_below` | `ConditionalOrder \| null` | TP/SL triggering when oracle ≤ `trigger_price` |
+
+A `ConditionalOrder` is `{order_id, size, trigger_price, max_slippage}`, with `size: null` meaning close the whole position.
+
+<a id="liquiditydepthresponse"></a>**`LiquidityDepthResponse`** — `{bids, asks}`, each a map of `UsdPrice` → `{size, notional}`; see the [worked example](#worked-example--order-book-depth).
+
+**Order responses** — the resting-limit-order reads (`order/*`) share the fields `pair_id`, `size`, `limit_price`, `reduce_only`, `reserved_margin`, `created_at`, and the optional `tp` / `sl` child orders. They differ at the edges: `order/{order_id}` also carries `user` and `client_order_id`; the `by-user` items carry `client_order_id` (and are already keyed by `order_id` in the map); the `by-client-order-id` response carries the resolved `order_id`.
+
+**Enums.** `OrderKind` is `{"market": {"max_slippage": "…"}}` or `{"limit": {"limit_price": "…", "time_in_force": "…", "client_order_id": "…"}}`. `TimeInForce` is `"GTC"` | `"IOC"` | `"POST"`. `TriggerDirection` is `"above"` | `"below"`. Key types are `{"secp256r1": "<base64>"}`, `{"secp256k1": "<base64>"}`, or `{"ethereum": "0x…"}`.

--- a/book/perps/9-constants.md
+++ b/book/perps/9-constants.md
@@ -4,12 +4,18 @@ This page collects the constants of Dango's mainnet and testnet deployments: API
 
 ## Endpoints
 
-| Network | HTTP                                     | WebSocket                              |
-| ------- | ---------------------------------------- | -------------------------------------- |
-| Mainnet | `https://api-mainnet.dango.zone/graphql` | `wss://api-mainnet.dango.zone/graphql` |
-| Testnet | `https://api-testnet.dango.zone/graphql` | `wss://api-testnet.dango.zone/graphql` |
+Each network runs two API servers: the **Live API** (consensus node — latest chain state, transaction broadcasting, real-time WebSocket) and the **Archive API** (archive node — structured historical data). See [the API reference](../perps/8-api.md) for which server serves what. Each server's interactive documentation (Swagger UI) is at `/docs/`, with the raw OpenAPI spec at `/openapi.json`.
 
-The testnet **faucet** is served separately at `https://faucet-testnet.dango.zone/mint` (see [§3.1.1 of the API reference](../perps/8-api.md#311-funding-a-new-account-via-the-faucet-testnet)). There is no faucet on mainnet.
+| API     | Network | HTTP                                     | WebSocket                         |
+| ------- | ------- | ---------------------------------------- | --------------------------------- |
+| Live    | Mainnet | `https://api-mainnet.dango.zone`         | `wss://api-mainnet.dango.zone/ws` |
+| Live    | Testnet | `https://api-testnet.dango.zone`         | `wss://api-testnet.dango.zone/ws` |
+| Archive | Mainnet | `https://api-archive-mainnet.dango.zone` | —                                 |
+| Archive | Testnet | `https://api-archive-testnet.dango.zone` | —                                 |
+
+The GraphQL endpoint previously served at `…/graphql` on the same hosts is **deprecated** (see the [API reference](../perps/8-api.md)); prefer the REST + WebSocket surface above.
+
+The testnet **faucet** is served separately at `https://faucet-testnet.dango.zone/mint` (see [the API reference](../perps/8-api.md#47-account-and-key-messages)). There is no faucet on mainnet.
 
 ## Chain IDs
 


### PR DESCRIPTION
Rewrite 8-api.md around the two-server model — Live API (consensus node: latest state, tx broadcasting, real-time WebSocket) and Archive API (archive node: structured history over SQL). Document the REST and WebSocket surfaces and drop the GraphQL-first material, keeping only a deprecation notice. The book now delegates the exhaustive endpoint reference to each server's auto-generated Swagger UI at /docs/ and owns what OpenAPI cannot express: the two-server model, transaction lifecycle and signing, the WebSocket protocol, the events catalog, and the response shapes of the opaque-JSON Live reads.

Update 9-constants.md endpoints to the per-server, per-transport layout (Live api-{mainnet,testnet}, Archive api-archive-{mainnet,testnet}). Fix a stale cross-link in 4-liquidation-and-adl.md (events reference moved sections).

Also correct several response-shape drifts found against the Rust types (PairState index_price/last_index_time, Param vault_deposit_cap, order-response tp/sl fields).