### PR TITLE
feat(gateway): emit deposited and withdrawn events

### DIFF
--- a/dango/exchange/gateway/src/execute.rs
+++ b/dango/exchange/gateway/src/execute.rs
@@ -9,8 +9,8 @@ use {
     dango_types::{
         bank,
         gateway::{
-            Addr32, ExecuteMsg, InstantiateMsg, NAMESPACE, Origin, PersonalQuota, RateLimit,
-            Remote, SetPersonalQuotaRequest, Traceable, WithdrawalFee,
+            Addr32, Deposited, ExecuteMsg, InstantiateMsg, NAMESPACE, Origin, PersonalQuota,
+            RateLimit, Remote, SetPersonalQuotaRequest, Traceable, WithdrawalFee, Withdrawn,
             bridge::{self, BridgeMsg},
         },
     },
@@ -270,7 +270,17 @@ fn receive_remote(
         } else {
             None
         })
-        .add_message(Message::transfer(recipient, coins! { denom => amount })?))
+        .add_message(Message::transfer(
+            recipient,
+            coins! { denom.clone() => amount },
+        )?)
+        .add_event(Deposited {
+            user: recipient,
+            bridge: ctx.sender,
+            remote,
+            denom,
+            amount,
+        })?)
 }
 
 fn transfer_remote(ctx: MutableCtx, remote: Remote, recipient: Addr32) -> anyhow::Result<Response> {
@@ -373,10 +383,22 @@ fn transfer_remote(ctx: MutableCtx, remote: Remote, recipient: Addr32) -> anyhow
             None
         })
         .may_add_message(if let Some(fee) = maybe_fee {
-            Some(Message::transfer(owner, coins! { coin.denom => fee })?)
+            Some(Message::transfer(
+                owner,
+                coins! { coin.denom.clone() => fee },
+            )?)
         } else {
             None
-        }))
+        })
+        .add_event(Withdrawn {
+            user: ctx.sender,
+            bridge,
+            remote,
+            recipient,
+            denom: coin.denom,
+            amount: coin.amount,
+            fee: maybe_fee.unwrap_or(Uint128::ZERO),
+        })?)
 }
 
 pub fn cron_execute(ctx: SudoCtx) -> StdResult<Response> {

--- a/dango/exchange/types/src/gateway.rs
+++ b/dango/exchange/types/src/gateway.rs
@@ -14,12 +14,14 @@
 //! - withdraw rate limit.
 
 pub mod bridge;
+mod events;
 mod msgs;
 mod origin;
 mod remote;
 
 pub use {
     dango_hyperlane_types::{Addr32, mailbox::Domain},
+    events::*,
     msgs::*,
     origin::*,
     remote::*,

--- a/dango/exchange/types/src/gateway/events.rs
+++ b/dango/exchange/types/src/gateway/events.rs
@@ -1,0 +1,41 @@
+use {
+    super::{Addr32, Remote},
+    dango_math::Uint128,
+    dango_primitives::{Addr, Denom},
+};
+
+/// Event indicating tokens have been received from a remote chain and
+/// credited to a Dango account (a deposit).
+#[dango_primitives::derive(Serde)]
+#[dango_primitives::event("deposited")]
+pub struct Deposited {
+    /// The Dango account that received the tokens.
+    pub user: Addr,
+    /// The bridge contract that relayed the transfer.
+    pub bridge: Addr,
+    /// The remote chain the tokens originated from.
+    pub remote: Remote,
+    pub denom: Denom,
+    pub amount: Uint128,
+}
+
+/// Event indicating tokens have been sent to a remote chain (a withdrawal).
+#[dango_primitives::derive(Serde)]
+#[dango_primitives::event("withdrawn")]
+pub struct Withdrawn {
+    /// The Dango account that initiated the withdrawal.
+    pub user: Addr,
+    /// The bridge contract that handles the transfer.
+    pub bridge: Addr,
+    /// The remote chain the tokens are sent to.
+    pub remote: Remote,
+    /// The recipient address on the remote chain.
+    pub recipient: Addr32,
+    pub denom: Denom,
+    /// The amount bridged to the remote chain, after deducting the
+    /// withdrawal fee.
+    pub amount: Uint128,
+    /// The withdrawal fee charged; zero if no fee is configured for the
+    /// route.
+    pub fee: Uint128,
+}

--- a/dango/testing/src/hyperlane.rs
+++ b/dango/testing/src/hyperlane.rs
@@ -6,7 +6,7 @@ use {
     dango_genesis::Contracts,
     dango_hyperlane_types::{Addr32, mailbox},
     dango_math::Uint128,
-    dango_primitives::{Addr, Addressable, Coins, Hash256, Signer},
+    dango_primitives::{Addr, Addressable, Coins, Hash256, Signer, TxOutcome},
     dango_types::{gateway::Domain, warp::TokenMessage},
     dango_vm_rust::RustVm,
     std::ops::{Deref, DerefMut},
@@ -87,6 +87,32 @@ where
         R: Addressable,
         A: Into<Uint128>,
     {
+        self.receive_warp_transfer_with_outcome(
+            relayer,
+            origin_domain,
+            origin_warp,
+            recipient,
+            amount,
+        )
+        .await
+        .map(|(message_id, _)| message_id)
+    }
+
+    /// Same as `receive_warp_transfer`, but also returns the outcome of the
+    /// mailbox `process` transaction, so callers can inspect the events it
+    /// emitted.
+    pub async fn receive_warp_transfer_with_outcome<R, A>(
+        &mut self,
+        relayer: &mut (dyn Signer + Send + Sync),
+        origin_domain: Domain,
+        origin_warp: Addr32,
+        recipient: &R,
+        amount: A,
+    ) -> anyhow::Result<(Hash256, TxOutcome)>
+    where
+        R: Addressable,
+        A: Into<Uint128>,
+    {
         // Mock validator set signs the message.
         let (message_id, raw_message, raw_metadata) = self
             .validator_sets
@@ -109,7 +135,8 @@ where
             );
 
         // Deliver the message to Dango mailbox.
-        self.suite
+        let outcome = self
+            .suite
             .execute(
                 relayer,
                 self.mailbox,
@@ -119,11 +146,13 @@ where
                 },
                 Coins::new(),
             )
-            .await
-            .result
-            .map_err(|err| anyhow!(err))?;
+            .await;
 
-        // Return the message ID.
-        Ok(message_id)
+        if let Err(err) = &outcome.result {
+            return Err(anyhow!(err.clone()));
+        }
+
+        // Return the message ID along with the transaction outcome.
+        Ok((message_id, outcome))
     }
 }

--- a/dango/testing/tests/gateway.rs
+++ b/dango/testing/tests/gateway.rs
@@ -2,8 +2,8 @@ use {
     dango_hyperlane_types::{Addr32, isms},
     dango_math::{MathError, NumberConst, Udec128, Uint128},
     dango_primitives::{
-        Addr, Addressable, Coin, Coins, Duration, Op, QuerierExt, ResultExt, btree_map, btree_set,
-        coins,
+        Addr, Addressable, CheckedContractEvent, Coin, Coins, Duration, JsonDeExt, Op, QuerierExt,
+        ResultExt, SearchEvent, btree_map, btree_set, coins,
     },
     dango_testing::{
         BalanceChange, HyperlaneTestSuite, MockValidatorSet, TestOption, TestSuite, mock_arbitrum,
@@ -535,6 +535,107 @@ async fn native_denom() {
     suite.balances().should_change(&accounts.user2, btree_map! {
         dango::DENOM.clone() => BalanceChange::Increased(100),
     });
+}
+
+#[tokio::test]
+async fn deposit_and_withdraw_events() {
+    let (suite, mut accounts, _, contracts, valset) = setup_test(TestOption {
+        bridge_ops: |_| vec![],
+        ..TestOption::default()
+    });
+
+    let mut suite = HyperlaneTestSuite::new(suite, valset, &contracts);
+
+    let remote = Remote::Warp {
+        domain: mock_arbitrum::DOMAIN,
+        contract: mock_arbitrum::USDC_WARP,
+    };
+
+    let mock_arbitrum_recipient: Addr32 = Addr::mock(201).into();
+
+    // Receiving a warp transfer should emit a `deposited` event from the
+    // gateway.
+    {
+        let (_, outcome) = suite
+            .receive_warp_transfer_with_outcome(
+                &mut accounts.user1,
+                mock_arbitrum::DOMAIN,
+                mock_arbitrum::USDC_WARP,
+                &accounts.user2,
+                100_000_000_u128,
+            )
+            .await
+            .unwrap();
+
+        let deposits = outcome
+            .events
+            .search_event::<CheckedContractEvent>()
+            .with_predicate(move |e| e.contract == contracts.gateway && e.ty == "deposited")
+            .take()
+            .all()
+            .into_iter()
+            .map(|e| {
+                e.event
+                    .data
+                    .deserialize_json::<gateway::Deposited>()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(deposits, vec![gateway::Deposited {
+            user: accounts.user2.address(),
+            bridge: contracts.warp,
+            remote,
+            denom: usdc::DENOM.clone(),
+            amount: Uint128::new(100_000_000),
+        }]);
+    }
+
+    // Sending a remote transfer should emit a `withdrawn` event from the
+    // gateway, reporting the bridged amount net of the withdrawal fee.
+    {
+        let events = suite
+            .execute(
+                &mut accounts.user2,
+                contracts.gateway,
+                &gateway::ExecuteMsg::TransferRemote {
+                    remote,
+                    recipient: mock_arbitrum_recipient,
+                },
+                Coin::new(
+                    usdc::DENOM.clone(),
+                    50_000_000 + ARBITRUM_USDC_WITHDRAWAL_FEE,
+                )
+                .unwrap(),
+            )
+            .await
+            .should_succeed()
+            .events;
+
+        let withdrawals = events
+            .search_event::<CheckedContractEvent>()
+            .with_predicate(move |e| e.contract == contracts.gateway && e.ty == "withdrawn")
+            .take()
+            .all()
+            .into_iter()
+            .map(|e| {
+                e.event
+                    .data
+                    .deserialize_json::<gateway::Withdrawn>()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(withdrawals, vec![gateway::Withdrawn {
+            user: accounts.user2.address(),
+            bridge: contracts.warp,
+            remote,
+            recipient: mock_arbitrum_recipient,
+            denom: usdc::DENOM.clone(),
+            amount: Uint128::new(50_000_000),
+            fee: Uint128::new(ARBITRUM_USDC_WITHDRAWAL_FEE),
+        }]);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The gateway contract previously emitted no events for bridge transfers, leaving indexers and clients without a way to track deposits and withdrawals. This PR adds two contract events, following the same `#[dango_primitives::event(...)]` pattern used by the bank and perps contracts:

- `Deposited` (`"deposited"`), emitted on `ExecuteMsg::ReceiveRemote`: the Dango recipient (`user`), the `bridge` contract that relayed the transfer, the `remote` chain, `denom`, and `amount`.
- `Withdrawn` (`"withdrawn"`), emitted on `ExecuteMsg::TransferRemote`: the withdrawing `user`, `bridge`, `remote`, the remote `recipient`, `denom`, the `amount` actually bridged (net of the withdrawal fee), and the `fee` charged (zero when no fee is configured for the route).

Also adds `receive_warp_transfer_with_outcome` to `HyperlaneTestSuite`, which returns the full `TxOutcome` alongside the message ID so tests can inspect the events emitted by inbound transfers. The existing `receive_warp_transfer` delegates to it, so its 38 call sites are unchanged.

## Validation

### Completed

- [x] New integration test `deposit_and_withdraw_events` asserts the exact payload of both events, including that `Withdrawn.amount` is net of the withdrawal fee
- [x] Full gateway test suite passes (22 tests)
- [x] Warp test suite passes (4 tests)
- [x] `just fmt` and `just lint` (clippy `-D warnings`) clean

### Remaining

- [ ] None

## Manual QA

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)