### PR TITLE
chore: upgrade cometbft to v0.39.3 and retune block time

### DIFF
--- a/.github/workflows/cometbft.yml
+++ b/.github/workflows/cometbft.yml
@@ -7,13 +7,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  COMETBFT_GIT_TAG: v0.38.21
+  COMETBFT_GIT_TAG: v0.39.3
 
 on:
   workflow_dispatch:
     inputs:
       cometbft_tag:
-        description: "Existing cometbft tag to sign (e.g. v0.38.21)"
+        description: "Existing cometbft tag to sign (e.g. v0.39.3)"
         required: false
       cometbft_digest:
         description: "Optional digest override (sha256:...) if you already know it"

--- a/deploy/NODE_MIGRATION.md
+++ b/deploy/NODE_MIGRATION.md
@@ -159,7 +159,7 @@ Creates a non-validator `priv_validator_key.json` + a fresh `priv_validator_stat
 ssh deploy@$TARGET_IP "mkdir -p $DATA_DIR/cometbft && \
   docker run --rm \
   -v $DATA_DIR/cometbft:/root/.cometbft \
-  ghcr.io/left-curve/left-curve/cometbft:v0.38.21 \
+  ghcr.io/left-curve/left-curve/cometbft:v0.39.3 \
   cometbft init --home /root/.cometbft"
 ```
 
@@ -308,8 +308,8 @@ If a rsync gets interrupted (network blip, server restart, etc.), re-run the sam
 2. Confirm the target's `node_key.json` matches source's. We use plain `docker run` (not `docker compose run`) because the compose service has an `entrypoint: sh -c '... cometbft start'` that ignores any appended command — `cometbft show-node-id` would silently turn into `cometbft start`. `docker run` against the image directly only inherits the image's `CMD` (which `cometbft show-node-id` cleanly overrides).
 
    ```bash
-   ssh deploy@$SOURCE_IP "docker run --rm -v $DATA_DIR/cometbft:/root/.cometbft ghcr.io/left-curve/left-curve/cometbft:v0.38.21 cometbft show-node-id --home /root/.cometbft"
-   ssh deploy@$TARGET_IP "docker run --rm -v $DATA_DIR/cometbft:/root/.cometbft ghcr.io/left-curve/left-curve/cometbft:v0.38.21 cometbft show-node-id --home /root/.cometbft"
+   ssh deploy@$SOURCE_IP "docker run --rm -v $DATA_DIR/cometbft:/root/.cometbft ghcr.io/left-curve/left-curve/cometbft:v0.39.3 cometbft show-node-id --home /root/.cometbft"
+   ssh deploy@$TARGET_IP "docker run --rm -v $DATA_DIR/cometbft:/root/.cometbft ghcr.io/left-curve/left-curve/cometbft:v0.39.3 cometbft show-node-id --home /root/.cometbft"
    ```
 
    Expected: same id printed by both.

--- a/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
+++ b/deploy/roles/full-app/templates/config/cometbft/config.toml.j2
@@ -8,7 +8,7 @@
 
 # The version of the CometBFT binary that created or
 # last modified the config file. Do not modify this.
-version = "1.0.0"
+version = "0.39.0"
 
 #######################################################################
 ###                   Main Base Config Options                      ###
@@ -21,29 +21,21 @@ proxy_app = "tcp://{{ dango_host }}:26658"
 # A custom human readable name for this node
 moniker = "dev"
 
-# Database backend: badgerdb | goleveldb | pebbledb | rocksdb | cleveldb | boltdb
-# * badgerdb (uses github.com/dgraph-io/badger)
-#   - stable
+# Database backend: goleveldb | cleveldb | rocksdb | badgerdb
+# * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
 #   - pure go
-#   - use badgerdb build tag (go build -tags badgerdb)
-# * goleveldb (github.com/syndtr/goleveldb)
-#   - UNMAINTAINED
 #   - stable
-#   - pure go
-# * pebbledb (uses github.com/cockroachdb/pebble)
-#   - stable
-#   - pure go
-# * rocksdb (uses github.com/linxGnu/grocksdb)
-#   - requires gcc
-#   - use rocksdb build tag (go build -tags rocksdb)
 # * cleveldb (uses levigo wrapper)
-#   - DEPRECATED
+#   - fast
 #   - requires gcc
 #   - use cleveldb build tag (go build -tags cleveldb)
-# * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
-#   - DEPRECATED
-#   - stable
-#   - use boltdb build tag (go build -tags boltdb)
+# * rocksdb (uses github.com/tecbot/gorocksdb)
+#   - EXPERIMENTAL
+#   - requires gcc
+#   - use rocksdb build tag (go build -tags rocksdb)
+# * badgerdb (uses github.com/dgraph-io/badger)
+#   - EXPERIMENTAL
+#   - use badgerdb build tag (go build -tags badgerdb)
 db_backend = "goleveldb"
 
 # Database directory
@@ -103,10 +95,24 @@ cors_allowed_methods = ["GET", "HEAD", "POST"]
 # A list of non simple headers the client is allowed to use with cross-domain requests
 cors_allowed_headers = ["Accept", "Content-Type", "Origin", "X-Requested-With", "X-Server-Time"]
 
+# TCP or UNIX socket address for the gRPC server to listen on
+# NOTE: This server only supports /broadcast_tx_commit
+grpc_laddr = ""
+
+# Maximum number of simultaneous connections.
+# Does not include RPC (HTTP&WebSocket) connections. See max_open_connections
+# If you want to accept a larger number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+# Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
+# 1024 - 40 - 10 - 50 = 924 = ~900
+grpc_max_open_connections = 900
+
 # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
 unsafe = false
 
 # Maximum number of simultaneous connections (including WebSocket).
+# Does not include gRPC connections. See grpc_max_open_connections
 # If you want to accept a larger number than the default, make sure
 # you increase your OS limits.
 # 0 - unlimited.
@@ -114,14 +120,14 @@ unsafe = false
 # 1024 - 40 - 10 - 50 = 924 = ~900
 max_open_connections = 5000
 
-# Maximum number of unique clientIDs that can /subscribe.
+# Maximum number of unique clientIDs that can /subscribe
 # If you're using /broadcast_tx_commit, set to the estimated maximum number
 # of broadcast_tx_commit calls per block.
 max_subscription_clients = 100
 
-# Maximum number of unique queries a given client can /subscribe to.
-# If you're using /broadcast_tx_commit, set to the estimated maximum number
-# of broadcast_tx_commit calls per block.
+# Maximum number of unique queries a given client can /subscribe to
+# If you're using GRPC (or Local RPC client) and /broadcast_tx_commit, set to
+# the estimated # maximum number of broadcast_tx_commit calls per block.
 max_subscriptions_per_client = 5
 
 # Experimental parameter to specify the maximum number of events a node will
@@ -179,72 +185,12 @@ tls_cert_file = ""
 
 # The path to a file containing matching private key that is used to create the HTTPS server.
 # Might be either absolute path or path related to CometBFT's config directory.
-# NOTE: both tls_cert_file and tls_key_file must be present for CometBFT to create HTTPS server.
+# NOTE: both tls-cert-file and tls-key-file must be present for CometBFT to create HTTPS server.
 # Otherwise, HTTP server is run.
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
 pprof_laddr = ""
-
-#######################################################
-###       gRPC Server Configuration Options         ###
-#######################################################
-
-#
-# Note that the gRPC server is exposed unauthenticated. It is critical that
-# this server not be exposed directly to the public internet. If this service
-# must be accessed via the public internet, please ensure that appropriate
-# precautions are taken (e.g. fronting with a reverse proxy like nginx with TLS
-# termination and authentication, using DDoS protection services like
-# CloudFlare, etc.).
-#
-
-[grpc]
-
-# TCP or UNIX socket address for the RPC server to listen on. If not specified,
-# the gRPC server will be disabled.
-laddr = ""
-
-#
-# Each gRPC service can be turned on/off, and in some cases configured,
-# individually. If the gRPC server is not enabled, all individual services'
-# configurations are ignored.
-#
-
-# The gRPC version service provides version information about the node and the
-# protocols it uses.
-[grpc.version_service]
-enabled = true
-
-# The gRPC block service returns block information
-[grpc.block_service]
-enabled = true
-
-# The gRPC block results service returns block results for a given height. If no height
-# is given, it will return the block results from the latest height.
-[grpc.block_results_service]
-enabled = true
-
-#
-# Configuration for privileged gRPC endpoints, which should **never** be exposed
-# to the public internet.
-#
-[grpc.privileged]
-# The host/port on which to expose privileged gRPC endpoints.
-laddr = ""
-
-#
-# Configuration specifically for the gRPC pruning service, which is considered a
-# privileged service.
-#
-[grpc.privileged.pruning_service]
-
-# Only controls whether the pruning service is accessible via the gRPC API - not
-# whether a previously set pruning service retain height is honored by the
-# node. See the [storage.pruning] section for control over pruning.
-#
-# Disabled by default.
-enabled = false
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -293,10 +239,15 @@ flush_throttle_timeout = "10ms"
 max_packet_msg_payload_size = 1024
 
 # Rate at which packets can be sent, in bytes/second
-send_rate = 5120000
+#
+# Raised from the 5.12 MB/s default so the p2p rate limiter never paces
+# block part delivery: at the default rate, a single 64 KiB block part
+# spends ~13 ms in the limiter alone, which compounds for multi-part
+# blocks.
+send_rate = 20971520
 
 # Rate at which packets can be received, in bytes/second
-recv_rate = 5120000
+recv_rate = 20971520
 
 # Set true to enable the peer-exchange reactor
 pex = true
@@ -317,8 +268,65 @@ allow_duplicate_ip = false
 dial_timeout      = "3s"
 handshake_timeout = "20s"
 
+# Experimental: configuration for go-libp2p
+[p2p.libp2p]
+
+# Enabled set true to use go-libp2p for networking instead of CometBFT's p2p.
+enabled = false
+
+# Bootstrap peers to connect to
+# format: { host, id, private (opt), persistent (opt), unconditional (opt) }
+bootstrap_peers = []
+
+# Options for scaling concurrent p2p message queues.
+# Tune workers to keep the system near the ideal operating point:
+# enough concurrency for throughput while keeping processing latency low.
+[p2p.libp2p.scaler]
+
+# Min and max concurrent worker range.
+min_workers = 4
+max_workers = 32
+
+# Target latency threshold:
+# scale up when observed latency is below this value, scale down when above it.
+threshold_latency = "100ms"
+
+# Override a specific reactor (case-insensitive), for example:
+# [[p2p.libp2p.scaler.overrides]]
+# reactor = "BLOCKSYNC"
+# min_workers = 2
+# max_workers = 16
+# threshold_latency = "250ms"
+#
+# By default, MEMPOOL reactor is overridden to have increased throughput
+# If you want to disable this, explicitly set override to an empty list:
+# overrides = []
+[[p2p.libp2p.scaler.overrides]]
+reactor = "MEMPOOL"
+min_workers = 8
+max_workers = 512
+threshold_latency = "500ms"
+
+# Configuration for resource limits
+[p2p.libp2p.limits]
+
+# Resource management modes:
+# - disabled: no resource limits. Use only in trusted environments (e.g. local dev, testing).
+#   Disabling limits can expose the node to resource exhaustion from malicious peers.
+# - default: libp2p's built-in limits. Memory is 1/8th of total system RAM, capped at 128MB min
+#   and 1GB max. Suitable for most production deployments.
+# - custom: disable limits for app protocols but enforce max_peers and max_peer_streams.
+#   Use when you need tighter control over peer count and stream concurrency.
+mode = "default"
+
+# Maximum number of peers (custom mode only)
+max_peers = 0
+
+# Maximum number of concurrent streams per peer (custom mode only)
+max_peer_streams = 0
+
 #######################################################
-###          Mempool Configuration Options          ###
+###          Mempool Configuration Option          ###
 #######################################################
 [mempool]
 
@@ -330,55 +338,67 @@ handshake_timeout = "20s"
 #  - "nop"   : nop-mempool (short for no operation; the ABCI app is responsible
 #  for storing, disseminating and proposing txs). "create_empty_blocks=false" is
 #  not supported.
+# - "app"    : app-side mempool (the ABCI app is responsible for mempool, comet only broadcasts txs).
+#
+# NOTE: must stay "flood" for Dango. The "app" type (added in v0.39.2) drives
+# the mempool through two new ABCI methods (InsertTx/ReapTxs) that our ABCI
+# server (tower-abci 0.19 / tendermint-rs 0.40, which implement the v0.38
+# protocol) does not recognize; enabling it kills the ABCI connection and
+# halts the node.
 type = "flood"
 
-# recheck (default: true) defines whether CometBFT should recheck the
+# Recheck (default: true) defines whether CometBFT should recheck the
 # validity for all remaining transaction in the mempool after a block.
 # Since a block affects the application state, some transactions in the
 # mempool may become invalid. If this does not apply to your application,
 # you can disable rechecking.
 #
-# Disabled for Dango. After every committed block, CometBFT reruns CheckTx over
-# EVERY remaining mempool tx, synchronously on the block-apply critical path.
-# With a full mempool (size = 5000) this costs ~1.2s per block -- far above our
-# ~350ms block time -- and on a node catching up via block-sync it throttles
-# apply below the chain's block production rate, so the node can never catch up
-# (observed on mainnet 2026-06-28: a restarted validator stuck at ~47 blk/min vs
-# ~170 produced). The only cost of disabling it is that txs invalidated by a
-# block are no longer evicted from the mempool eagerly; they linger until reaped
-# into a later block (where they execute, fail, and are then removed) or expire.
+# Disabled for Dango. Rechecking reruns CheckTx over EVERY remaining mempool
+# tx after each committed block; with a full mempool (size = 5000) that is
+# ~1.2s of CheckTx work per block -- far above our ~350ms block time. On
+# CometBFT <= 0.38 this ran synchronously on the block-apply critical path,
+# which throttled a block-syncing node below the chain's block production
+# rate, so it could never catch up (observed on mainnet 2026-06-28: a
+# restarted validator stuck at ~47 blk/min vs ~170 produced). CometBFT 0.39
+# moved the mempool update off the critical path (async after Commit), which
+# fixes the catch-up stall upstream, but the recheck work itself would still
+# compete with block processing for app time -- and it buys us nothing. The
+# only cost of disabling it is that txs invalidated by a block are no longer
+# evicted from the mempool eagerly; they linger until reaped into a later
+# block (where they execute, fail, and are then removed) or expire.
 recheck = false
 
 # recheck_timeout is the time the application has during the rechecking process
 # to return CheckTx responses, once all requests have been sent. Responses that
 # arrive after the timeout expires are discarded. It only applies to
 # non-local ABCI clients and when recheck is enabled.
+#
+# The ideal value will strongly depend on the application. It could roughly be estimated as the
+# average size of the mempool multiplied by the average time it takes the application to validate one
+# transaction. We consider that the ABCI application runs in the same location as the CometBFT binary
+# so that the recheck duration is not affected by network delays when making requests and receiving responses.
 recheck_timeout = "1s"
 
-# broadcast (default: true) defines whether the mempool should relay
+# Broadcast (default: true) defines whether the mempool should relay
 # transactions to other peers. Setting this to false will stop the mempool
 # from relaying transactions to other peers until they are included in a
 # block. In other words, if Broadcast is disabled, only the peer you send
 # the tx to will see it until it is included in a block.
 broadcast = true
 
-# wal_dir (default: "") configures the location of the Write Ahead Log
+# WalPath (default: "") configures the location of the Write Ahead Log
 # (WAL) for the mempool. The WAL is disabled by default. To enable, set
-# wal_dir to where you want the WAL to be written (e.g.
+# WalPath to where you want the WAL to be written (e.g.
 # "data/mempool.wal").
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
 size = 5000
 
-# Maximum size in bytes of a single transaction accepted into the mempool.
-max_tx_bytes = 1048576
-
-# The maximum size in bytes of all transactions stored in the mempool.
-# This is the raw, total transaction size. For example, given 1MB
-# transactions and a 5MB maximum mempool byte size, the mempool will
-# only accept five transactions.
-max_txs_bytes = 67108864
+# Limit the total size of all txs in the mempool.
+# This only accounts for raw transactions (e.g. given 1MB transactions and
+# max_txs_bytes=5MB, mempool will only accept 5 transactions).
+max_txs_bytes = 1073741824
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000
@@ -387,6 +407,15 @@ cache_size = 10000
 # Set to true if it's not possible for any invalid transaction to become valid
 # again in the future.
 keep-invalid-txs-in-cache = false
+
+# Maximum size of a single transaction.
+# NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
+max_tx_bytes = 1048576
+
+# Maximum size of a batch of transactions to send to a peer
+# Including space needed by encoding (one varint per transaction).
+# XXX: Unused due to https://github.com/tendermint/tendermint/issues/5796
+max_batch_bytes = 0
 
 # Experimental parameters to limit gossiping txs to up to the specified number of peers.
 # We use two independent upper values for persistent and non-persistent peers.
@@ -402,6 +431,17 @@ keep-invalid-txs-in-cache = false
 # performance results using the default P2P configuration.
 experimental_max_gossip_connections_to_non_persistent_peers = 0
 experimental_max_gossip_connections_to_persistent_peers     = 0
+
+# App mempool only: size of LRU cache for seen transactions (deduplication).
+seen_cache_size = 100000
+# App mempool only: max bytes passed to ReapTxs (0 = no limit).
+reap_max_bytes = 0
+# App mempool only: max gas passed to ReapTxs (0 = no limit).
+reap_max_gas = 0
+# App mempool only: interval between ReapTxs calls when streaming txs from app.
+reap_interval = "500ms"
+# App mempool only: delay after which a tx is forgotten for ABCI.CheckTx
+check_tx_retry_delay = "5s"
 
 #######################################################
 ###         State Sync Configuration Options        ###
@@ -439,6 +479,9 @@ chunk_request_timeout = "10s"
 # The number of concurrent chunk fetchers to run (default: 1).
 chunk_fetchers = "4"
 
+# Maximum number of chunks allowed in a snapshot (default: 100000).
+max_snapshot_chunks = 100000
+
 #######################################################
 ###       Block Sync Configuration Options          ###
 #######################################################
@@ -452,6 +495,11 @@ chunk_fetchers = "4"
 #   1) "v0" - the default block sync implementation
 version = "v0"
 
+# Experimental Adaptive sync (bool):
+#
+# Run both BLOCKSYNC and CONSENSUS for improved liveness, connectivity, and performance.
+adaptive_sync = false
+
 #######################################################
 ###         Consensus Configuration Options         ###
 #######################################################
@@ -460,7 +508,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "1s"
+timeout_propose = "500ms"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
@@ -474,11 +522,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-# Set to 0 if you want to make progress as soon as the node has all the precommits.
 timeout_commit = "50ms"
-
-# Deprecated: set `timeout_commit` to 0 instead.
-skip_timeout_commit = false
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart
@@ -486,14 +530,29 @@ skip_timeout_commit = false
 # So, validators should stop the state machine, wait for some blocks, and then restart the state machine to avoid panic.
 double_sign_check_height = 0
 
+# Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
+skip_timeout_commit = false
+
 # EmptyBlocks mode and possible interval between empty blocks
 create_empty_blocks          = true
 create_empty_blocks_interval = "0s"
 
 # Reactor sleep duration parameters
-peer_gossip_intraloop_sleep_duration = "0s"
-peer_gossip_sleep_duration           = "100ms"
-peer_query_maj23_sleep_duration      = "2s"
+#
+# peer_gossip_sleep_duration is lowered from the 100 ms default. Consensus
+# payloads (the proposal, block parts, votes) are delivered by per-peer
+# polling loops that sleep this long whenever they have nothing to send, so
+# each of the three gossip waves per block (proposal -> prevotes ->
+# precommits) incurs a mean delay of half this value per hop. At 100 ms that
+# was ~150 ms of pure poll latency per block -- the largest contributor to
+# the ~350 ms block times we measured; 10 ms targets a ~250 ms median. The
+# cost is busier poll loops (two goroutines per peer, ~100 wakeups/s each),
+# which is negligible CPU at our peer counts.
+peer_gossip_sleep_duration      = "10ms"
+peer_query_maj23_sleep_duration = "2s"
+
+# Maximum allowed difference between proposed block time and wall-clock time.
+block_time_tolerance = "1m0s"
 
 #######################################################
 ###         Storage Configuration Options           ###
@@ -505,60 +564,6 @@ peer_query_maj23_sleep_duration      = "2s"
 # persisted. ABCI responses are required for /block_results RPC queries, and to
 # reindex events in the command-line tool.
 discard_abci_responses = true
-
-# The representation of keys in the database.
-# The current representation of keys in Comet's stores is considered to be v1
-# Users can experiment with a different layout by setting this field to v2.
-# Note that this is an experimental feature and switching back from v2 to v1
-# is not supported by CometBFT.
-# If the database was initially created with v1, it is necessary to migrate the DB
-# before switching to v2. The migration is not done automatically.
-# v1 - the legacy layout existing in Comet prior to v1.
-# v2 - Order preserving representation ordering entries by height.
-experimental_db_key_layout = "v1"
-
-# If set to true, CometBFT will force compaction to happen for databases that support this feature.
-# and save on storage space. Setting this to true is most benefits when used in combination
-# with pruning as it will physically delete the entries marked for deletion.
-# false by default (forcing compaction is disabled).
-compact = false
-
-# To avoid forcing compaction every time, this parameter instructs CometBFT to wait
-# the given amount of blocks to be pruned before triggering compaction.
-# It should be tuned depending on the number of items. If your retain height is 1 block,
-# it is too much of an overhead to try compaction every block. But it should also not be a very
-# large multiple of your retain height as it might occur bigger overheads.
-compaction_interval = "1000"
-
-[storage.pruning]
-
-# The time period between automated background pruning operations.
-interval = "10s"
-
-#
-# Storage pruning configuration relating only to the data companion.
-#
-[storage.pruning.data_companion]
-
-# Whether automatic pruning respects values set by the data companion. Disabled
-# by default. All other parameters in this section are ignored when this is
-# disabled.
-#
-# If disabled, only the application retain height will influence block pruning
-# (but not block results pruning). Only enabling this at a later stage will
-# potentially mean that blocks below the application-set retain height at the
-# time will not be available to the data companion.
-enabled = false
-
-# The initial value for the data companion block retain height if the data
-# companion has not yet explicitly set one. If the data companion has already
-# set a block retain height, this is ignored.
-initial_block_retain_height = 0
-
-# The initial value for the data companion block results retain height if the
-# data companion has not yet explicitly set one. If the data companion has
-# already set a block results retain height, this is ignored.
-initial_block_results_retain_height = 0
 
 #######################################################
 ###   Transaction Indexer Configuration Options     ###

--- a/deploy/roles/full-app/vars/main.yml
+++ b/deploy/roles/full-app/vars/main.yml
@@ -12,7 +12,7 @@ cometbft_validator_public_key: ""
 cometbft_validator_private_key: ""
 dango_host: "dango"
 cometbft_host: "cometbft"
-cometbft_tag: "v0.38.21"
+cometbft_tag: "v0.39.3"
 cometbft_generate_keys: false
 deploy_env: "staging"
 chain_id: "dev-10"

--- a/docker/ci-stack/configs/cometbft/config/config.toml
+++ b/docker/ci-stack/configs/cometbft/config/config.toml
@@ -8,7 +8,7 @@
 
 # The version of the CometBFT binary that created or
 # last modified the config file. Do not modify this.
-version = "1.0.0"
+version = "0.39.0"
 
 #######################################################################
 ###                   Main Base Config Options                      ###
@@ -21,29 +21,21 @@ proxy_app = "tcp://dango:26658"
 # A custom human readable name for this node
 moniker = "dev"
 
-# Database backend: badgerdb | goleveldb | pebbledb | rocksdb | cleveldb | boltdb
-# * badgerdb (uses github.com/dgraph-io/badger)
-#   - stable
+# Database backend: goleveldb | cleveldb | rocksdb | badgerdb
+# * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
 #   - pure go
-#   - use badgerdb build tag (go build -tags badgerdb)
-# * goleveldb (github.com/syndtr/goleveldb)
-#   - UNMAINTAINED
 #   - stable
-#   - pure go
-# * pebbledb (uses github.com/cockroachdb/pebble)
-#   - stable
-#   - pure go
-# * rocksdb (uses github.com/linxGnu/grocksdb)
-#   - requires gcc
-#   - use rocksdb build tag (go build -tags rocksdb)
 # * cleveldb (uses levigo wrapper)
-#   - DEPRECATED
+#   - fast
 #   - requires gcc
 #   - use cleveldb build tag (go build -tags cleveldb)
-# * boltdb (uses etcd's fork of bolt - github.com/etcd-io/bbolt)
-#   - DEPRECATED
-#   - stable
-#   - use boltdb build tag (go build -tags boltdb)
+# * rocksdb (uses github.com/tecbot/gorocksdb)
+#   - EXPERIMENTAL
+#   - requires gcc
+#   - use rocksdb build tag (go build -tags rocksdb)
+# * badgerdb (uses github.com/dgraph-io/badger)
+#   - EXPERIMENTAL
+#   - use badgerdb build tag (go build -tags badgerdb)
 db_backend = "goleveldb"
 
 # Database directory
@@ -103,10 +95,24 @@ cors_allowed_methods = ["GET", "HEAD", "POST"]
 # A list of non simple headers the client is allowed to use with cross-domain requests
 cors_allowed_headers = ["Accept", "Content-Type", "Origin", "X-Requested-With", "X-Server-Time"]
 
+# TCP or UNIX socket address for the gRPC server to listen on
+# NOTE: This server only supports /broadcast_tx_commit
+grpc_laddr = ""
+
+# Maximum number of simultaneous connections.
+# Does not include RPC (HTTP&WebSocket) connections. See max_open_connections
+# If you want to accept a larger number than the default, make sure
+# you increase your OS limits.
+# 0 - unlimited.
+# Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
+# 1024 - 40 - 10 - 50 = 924 = ~900
+grpc_max_open_connections = 900
+
 # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
 unsafe = false
 
 # Maximum number of simultaneous connections (including WebSocket).
+# Does not include gRPC connections. See grpc_max_open_connections
 # If you want to accept a larger number than the default, make sure
 # you increase your OS limits.
 # 0 - unlimited.
@@ -114,14 +120,14 @@ unsafe = false
 # 1024 - 40 - 10 - 50 = 924 = ~900
 max_open_connections = 900
 
-# Maximum number of unique clientIDs that can /subscribe.
+# Maximum number of unique clientIDs that can /subscribe
 # If you're using /broadcast_tx_commit, set to the estimated maximum number
 # of broadcast_tx_commit calls per block.
 max_subscription_clients = 100
 
-# Maximum number of unique queries a given client can /subscribe to.
-# If you're using /broadcast_tx_commit, set to the estimated maximum number
-# of broadcast_tx_commit calls per block.
+# Maximum number of unique queries a given client can /subscribe to
+# If you're using GRPC (or Local RPC client) and /broadcast_tx_commit, set to
+# the estimated # maximum number of broadcast_tx_commit calls per block.
 max_subscriptions_per_client = 5
 
 # Experimental parameter to specify the maximum number of events a node will
@@ -179,72 +185,12 @@ tls_cert_file = ""
 
 # The path to a file containing matching private key that is used to create the HTTPS server.
 # Might be either absolute path or path related to CometBFT's config directory.
-# NOTE: both tls_cert_file and tls_key_file must be present for CometBFT to create HTTPS server.
+# NOTE: both tls-cert-file and tls-key-file must be present for CometBFT to create HTTPS server.
 # Otherwise, HTTP server is run.
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
 pprof_laddr = ""
-
-#######################################################
-###       gRPC Server Configuration Options         ###
-#######################################################
-
-#
-# Note that the gRPC server is exposed unauthenticated. It is critical that
-# this server not be exposed directly to the public internet. If this service
-# must be accessed via the public internet, please ensure that appropriate
-# precautions are taken (e.g. fronting with a reverse proxy like nginx with TLS
-# termination and authentication, using DDoS protection services like
-# CloudFlare, etc.).
-#
-
-[grpc]
-
-# TCP or UNIX socket address for the RPC server to listen on. If not specified,
-# the gRPC server will be disabled.
-laddr = ""
-
-#
-# Each gRPC service can be turned on/off, and in some cases configured,
-# individually. If the gRPC server is not enabled, all individual services'
-# configurations are ignored.
-#
-
-# The gRPC version service provides version information about the node and the
-# protocols it uses.
-[grpc.version_service]
-enabled = true
-
-# The gRPC block service returns block information
-[grpc.block_service]
-enabled = true
-
-# The gRPC block results service returns block results for a given height. If no height
-# is given, it will return the block results from the latest height.
-[grpc.block_results_service]
-enabled = true
-
-#
-# Configuration for privileged gRPC endpoints, which should **never** be exposed
-# to the public internet.
-#
-[grpc.privileged]
-# The host/port on which to expose privileged gRPC endpoints.
-laddr = ""
-
-#
-# Configuration specifically for the gRPC pruning service, which is considered a
-# privileged service.
-#
-[grpc.privileged.pruning_service]
-
-# Only controls whether the pruning service is accessible via the gRPC API - not
-# whether a previously set pruning service retain height is honored by the
-# node. See the [storage.pruning] section for control over pruning.
-#
-# Disabled by default.
-enabled = false
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -291,10 +237,15 @@ flush_throttle_timeout = "10ms"
 max_packet_msg_payload_size = 1024
 
 # Rate at which packets can be sent, in bytes/second
-send_rate = 5120000
+#
+# Raised from the 5.12 MB/s default so the p2p rate limiter never paces
+# block part delivery: at the default rate, a single 64 KiB block part
+# spends ~13 ms in the limiter alone, which compounds for multi-part
+# blocks.
+send_rate = 20971520
 
 # Rate at which packets can be received, in bytes/second
-recv_rate = 5120000
+recv_rate = 20971520
 
 # Set true to enable the peer-exchange reactor
 pex = true
@@ -315,8 +266,65 @@ allow_duplicate_ip = false
 dial_timeout      = "3s"
 handshake_timeout = "20s"
 
+# Experimental: configuration for go-libp2p
+[p2p.libp2p]
+
+# Enabled set true to use go-libp2p for networking instead of CometBFT's p2p.
+enabled = false
+
+# Bootstrap peers to connect to
+# format: { host, id, private (opt), persistent (opt), unconditional (opt) }
+bootstrap_peers = []
+
+# Options for scaling concurrent p2p message queues.
+# Tune workers to keep the system near the ideal operating point:
+# enough concurrency for throughput while keeping processing latency low.
+[p2p.libp2p.scaler]
+
+# Min and max concurrent worker range.
+min_workers = 4
+max_workers = 32
+
+# Target latency threshold:
+# scale up when observed latency is below this value, scale down when above it.
+threshold_latency = "100ms"
+
+# Override a specific reactor (case-insensitive), for example:
+# [[p2p.libp2p.scaler.overrides]]
+# reactor = "BLOCKSYNC"
+# min_workers = 2
+# max_workers = 16
+# threshold_latency = "250ms"
+#
+# By default, MEMPOOL reactor is overridden to have increased throughput
+# If you want to disable this, explicitly set override to an empty list:
+# overrides = []
+[[p2p.libp2p.scaler.overrides]]
+reactor = "MEMPOOL"
+min_workers = 8
+max_workers = 512
+threshold_latency = "500ms"
+
+# Configuration for resource limits
+[p2p.libp2p.limits]
+
+# Resource management modes:
+# - disabled: no resource limits. Use only in trusted environments (e.g. local dev, testing).
+#   Disabling limits can expose the node to resource exhaustion from malicious peers.
+# - default: libp2p's built-in limits. Memory is 1/8th of total system RAM, capped at 128MB min
+#   and 1GB max. Suitable for most production deployments.
+# - custom: disable limits for app protocols but enforce max_peers and max_peer_streams.
+#   Use when you need tighter control over peer count and stream concurrency.
+mode = "default"
+
+# Maximum number of peers (custom mode only)
+max_peers = 0
+
+# Maximum number of concurrent streams per peer (custom mode only)
+max_peer_streams = 0
+
 #######################################################
-###          Mempool Configuration Options          ###
+###          Mempool Configuration Option          ###
 #######################################################
 [mempool]
 
@@ -328,55 +336,67 @@ handshake_timeout = "20s"
 #  - "nop"   : nop-mempool (short for no operation; the ABCI app is responsible
 #  for storing, disseminating and proposing txs). "create_empty_blocks=false" is
 #  not supported.
+# - "app"    : app-side mempool (the ABCI app is responsible for mempool, comet only broadcasts txs).
+#
+# NOTE: must stay "flood" for Dango. The "app" type (added in v0.39.2) drives
+# the mempool through two new ABCI methods (InsertTx/ReapTxs) that our ABCI
+# server (tower-abci 0.19 / tendermint-rs 0.40, which implement the v0.38
+# protocol) does not recognize; enabling it kills the ABCI connection and
+# halts the node.
 type = "flood"
 
-# recheck (default: true) defines whether CometBFT should recheck the
+# Recheck (default: true) defines whether CometBFT should recheck the
 # validity for all remaining transaction in the mempool after a block.
 # Since a block affects the application state, some transactions in the
 # mempool may become invalid. If this does not apply to your application,
 # you can disable rechecking.
 #
-# Disabled for Dango. After every committed block, CometBFT reruns CheckTx over
-# EVERY remaining mempool tx, synchronously on the block-apply critical path.
-# With a full mempool (size = 5000) this costs ~1.2s per block -- far above our
-# ~350ms block time -- and on a node catching up via block-sync it throttles
-# apply below the chain's block production rate, so the node can never catch up
-# (observed on mainnet 2026-06-28: a restarted validator stuck at ~47 blk/min vs
-# ~170 produced). The only cost of disabling it is that txs invalidated by a
-# block are no longer evicted from the mempool eagerly; they linger until reaped
-# into a later block (where they execute, fail, and are then removed) or expire.
+# Disabled for Dango. Rechecking reruns CheckTx over EVERY remaining mempool
+# tx after each committed block; with a full mempool (size = 5000) that is
+# ~1.2s of CheckTx work per block -- far above our ~350ms block time. On
+# CometBFT <= 0.38 this ran synchronously on the block-apply critical path,
+# which throttled a block-syncing node below the chain's block production
+# rate, so it could never catch up (observed on mainnet 2026-06-28: a
+# restarted validator stuck at ~47 blk/min vs ~170 produced). CometBFT 0.39
+# moved the mempool update off the critical path (async after Commit), which
+# fixes the catch-up stall upstream, but the recheck work itself would still
+# compete with block processing for app time -- and it buys us nothing. The
+# only cost of disabling it is that txs invalidated by a block are no longer
+# evicted from the mempool eagerly; they linger until reaped into a later
+# block (where they execute, fail, and are then removed) or expire.
 recheck = false
 
 # recheck_timeout is the time the application has during the rechecking process
 # to return CheckTx responses, once all requests have been sent. Responses that
 # arrive after the timeout expires are discarded. It only applies to
 # non-local ABCI clients and when recheck is enabled.
+#
+# The ideal value will strongly depend on the application. It could roughly be estimated as the
+# average size of the mempool multiplied by the average time it takes the application to validate one
+# transaction. We consider that the ABCI application runs in the same location as the CometBFT binary
+# so that the recheck duration is not affected by network delays when making requests and receiving responses.
 recheck_timeout = "1s"
 
-# broadcast (default: true) defines whether the mempool should relay
+# Broadcast (default: true) defines whether the mempool should relay
 # transactions to other peers. Setting this to false will stop the mempool
 # from relaying transactions to other peers until they are included in a
 # block. In other words, if Broadcast is disabled, only the peer you send
 # the tx to will see it until it is included in a block.
 broadcast = true
 
-# wal_dir (default: "") configures the location of the Write Ahead Log
+# WalPath (default: "") configures the location of the Write Ahead Log
 # (WAL) for the mempool. The WAL is disabled by default. To enable, set
-# wal_dir to where you want the WAL to be written (e.g.
+# WalPath to where you want the WAL to be written (e.g.
 # "data/mempool.wal").
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
 size = 5000
 
-# Maximum size in bytes of a single transaction accepted into the mempool.
-max_tx_bytes = 1048576
-
-# The maximum size in bytes of all transactions stored in the mempool.
-# This is the raw, total transaction size. For example, given 1MB
-# transactions and a 5MB maximum mempool byte size, the mempool will
-# only accept five transactions.
-max_txs_bytes = 67108864
+# Limit the total size of all txs in the mempool.
+# This only accounts for raw transactions (e.g. given 1MB transactions and
+# max_txs_bytes=5MB, mempool will only accept 5 transactions).
+max_txs_bytes = 1073741824
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000
@@ -385,6 +405,15 @@ cache_size = 10000
 # Set to true if it's not possible for any invalid transaction to become valid
 # again in the future.
 keep-invalid-txs-in-cache = false
+
+# Maximum size of a single transaction.
+# NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
+max_tx_bytes = 1048576
+
+# Maximum size of a batch of transactions to send to a peer
+# Including space needed by encoding (one varint per transaction).
+# XXX: Unused due to https://github.com/tendermint/tendermint/issues/5796
+max_batch_bytes = 0
 
 # Experimental parameters to limit gossiping txs to up to the specified number of peers.
 # We use two independent upper values for persistent and non-persistent peers.
@@ -400,6 +429,17 @@ keep-invalid-txs-in-cache = false
 # performance results using the default P2P configuration.
 experimental_max_gossip_connections_to_non_persistent_peers = 0
 experimental_max_gossip_connections_to_persistent_peers     = 0
+
+# App mempool only: size of LRU cache for seen transactions (deduplication).
+seen_cache_size = 100000
+# App mempool only: max bytes passed to ReapTxs (0 = no limit).
+reap_max_bytes = 0
+# App mempool only: max gas passed to ReapTxs (0 = no limit).
+reap_max_gas = 0
+# App mempool only: interval between ReapTxs calls when streaming txs from app.
+reap_interval = "500ms"
+# App mempool only: delay after which a tx is forgotten for ABCI.CheckTx
+check_tx_retry_delay = "5s"
 
 #######################################################
 ###         State Sync Configuration Options        ###
@@ -437,6 +477,9 @@ chunk_request_timeout = "10s"
 # The number of concurrent chunk fetchers to run (default: 1).
 chunk_fetchers = "4"
 
+# Maximum number of chunks allowed in a snapshot (default: 100000).
+max_snapshot_chunks = 100000
+
 #######################################################
 ###       Block Sync Configuration Options          ###
 #######################################################
@@ -450,6 +493,11 @@ chunk_fetchers = "4"
 #   1) "v0" - the default block sync implementation
 version = "v0"
 
+# Experimental Adaptive sync (bool):
+#
+# Run both BLOCKSYNC and CONSENSUS for improved liveness, connectivity, and performance.
+adaptive_sync = false
+
 #######################################################
 ###         Consensus Configuration Options         ###
 #######################################################
@@ -458,7 +506,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "1s"
+timeout_propose = "500ms"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
@@ -472,11 +520,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-# Set to 0 if you want to make progress as soon as the node has all the precommits.
 timeout_commit = "50ms"
-
-# Deprecated: set `timeout_commit` to 0 instead.
-skip_timeout_commit = false
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart
@@ -484,14 +528,29 @@ skip_timeout_commit = false
 # So, validators should stop the state machine, wait for some blocks, and then restart the state machine to avoid panic.
 double_sign_check_height = 0
 
+# Make progress as soon as we have all the precommits (as if TimeoutCommit = 0)
+skip_timeout_commit = false
+
 # EmptyBlocks mode and possible interval between empty blocks
 create_empty_blocks          = true
 create_empty_blocks_interval = "0s"
 
 # Reactor sleep duration parameters
-peer_gossip_intraloop_sleep_duration = "0s"
-peer_gossip_sleep_duration           = "100ms"
-peer_query_maj23_sleep_duration      = "2s"
+#
+# peer_gossip_sleep_duration is lowered from the 100 ms default. Consensus
+# payloads (the proposal, block parts, votes) are delivered by per-peer
+# polling loops that sleep this long whenever they have nothing to send, so
+# each of the three gossip waves per block (proposal -> prevotes ->
+# precommits) incurs a mean delay of half this value per hop. At 100 ms that
+# was ~150 ms of pure poll latency per block -- the largest contributor to
+# the ~350 ms block times we measured; 10 ms targets a ~250 ms median. The
+# cost is busier poll loops (two goroutines per peer, ~100 wakeups/s each),
+# which is negligible CPU at our peer counts.
+peer_gossip_sleep_duration      = "10ms"
+peer_query_maj23_sleep_duration = "2s"
+
+# Maximum allowed difference between proposed block time and wall-clock time.
+block_time_tolerance = "1m0s"
 
 #######################################################
 ###         Storage Configuration Options           ###
@@ -503,60 +562,6 @@ peer_query_maj23_sleep_duration      = "2s"
 # persisted. ABCI responses are required for /block_results RPC queries, and to
 # reindex events in the command-line tool.
 discard_abci_responses = true
-
-# The representation of keys in the database.
-# The current representation of keys in Comet's stores is considered to be v1
-# Users can experiment with a different layout by setting this field to v2.
-# Note that this is an experimental feature and switching back from v2 to v1
-# is not supported by CometBFT.
-# If the database was initially created with v1, it is necessary to migrate the DB
-# before switching to v2. The migration is not done automatically.
-# v1 - the legacy layout existing in Comet prior to v1.
-# v2 - Order preserving representation ordering entries by height.
-experimental_db_key_layout = "v1"
-
-# If set to true, CometBFT will force compaction to happen for databases that support this feature.
-# and save on storage space. Setting this to true is most benefits when used in combination
-# with pruning as it will physically delete the entries marked for deletion.
-# false by default (forcing compaction is disabled).
-compact = false
-
-# To avoid forcing compaction every time, this parameter instructs CometBFT to wait
-# the given amount of blocks to be pruned before triggering compaction.
-# It should be tuned depending on the number of items. If your retain height is 1 block,
-# it is too much of an overhead to try compaction every block. But it should also not be a very
-# large multiple of your retain height as it might occur bigger overheads.
-compaction_interval = "1000"
-
-[storage.pruning]
-
-# The time period between automated background pruning operations.
-interval = "10s"
-
-#
-# Storage pruning configuration relating only to the data companion.
-#
-[storage.pruning.data_companion]
-
-# Whether automatic pruning respects values set by the data companion. Disabled
-# by default. All other parameters in this section are ignored when this is
-# disabled.
-#
-# If disabled, only the application retain height will influence block pruning
-# (but not block results pruning). Only enabling this at a later stage will
-# potentially mean that blocks below the application-set retain height at the
-# time will not be available to the data companion.
-enabled = false
-
-# The initial value for the data companion block retain height if the data
-# companion has not yet explicitly set one. If the data companion has already
-# set a block retain height, this is ignored.
-initial_block_retain_height = 0
-
-# The initial value for the data companion block results retain height if the
-# data companion has not yet explicitly set one. If the data companion has
-# already set a block results retain height, this is ignored.
-initial_block_results_retain_height = 0
 
 #######################################################
 ###   Transaction Indexer Configuration Options     ###

--- a/docker/ci-stack/docker-compose.yml
+++ b/docker/ci-stack/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       retries: 3
 
   cometbft:
-    image: ghcr.io/left-curve/left-curve/cometbft:${COMETBFT_TAG:-v0.38.21}
+    image: ghcr.io/left-curve/left-curve/cometbft:${COMETBFT_TAG:-v0.39.3}
     labels:
       <<: *common-labels
     ports:

--- a/docker/cometbft/Dockerfile
+++ b/docker/cometbft/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 LABEL org.opencontainers.image.description="CometBFT builder for Dango"
 LABEL org.opencontainers.image.source="https://github.com/left-curve/left-curve"
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/left-curve/left-curve"
 RUN apt update && apt install -y git make
 
 # Git tag of the cometbft repo.
-ARG COMETBFT_GIT_TAG="v0.38.21"
+ARG COMETBFT_GIT_TAG="v0.39.3"
 ENV COMETBFT_GIT_TAG=$COMETBFT_GIT_TAG
 
 # Download cometbft source code, build, then delete.

--- a/docker/cometbft/justfile
+++ b/docker/cometbft/justfile
@@ -1,4 +1,4 @@
-COMETBFT_VERSION := "0.38.21"
+COMETBFT_VERSION := "0.39.3"
 
 build:
   docker buildx build \


### PR DESCRIPTION
Bump CometBFT from v0.38.21 to v0.39.3 (the continuation of the 0.38 line with v1 features forward-ported; the v1.x line is retracted). Verified before upgrading:

- A rolling node-by-node upgrade is protocol-safe: BlockProtocol (11), P2PProtocol (8) and ABCISemVer (2.0.0) are unchanged between the two versions, and every proto change is additive and off the consensus gossip wire, so mixed 0.38/0.39 networks reach consensus. The on-disk database format is unchanged; nodes restart in place.
- tower-abci 0.19 / tendermint-rs 0.40 (v0.38 ABCI dialect) serve a v0.39.3 node unmodified, provided mempool.type stays "flood" and validator keys stay ed25519. Confirmed live against the ci-stack: clean ABCI handshake and sustained block production.

Regenerate both cometbft config files from the v0.39.3 `cometbft init` template (they were generated with the since-retracted v1.0.0), carrying over all customizations. v1-only keys ([grpc] tree, [storage.pruning] tree, storage.compact / compaction_interval / experimental_db_key_layout, peer_gossip_intraloop_sleep_duration) are dropped; new 0.39 keys keep upstream defaults, except mempool.max_txs_bytes which we bump to the new 1 GiB default.

Retune consensus latency, targeting a ~250 ms median block time (down from ~350 ms):

- peer_gossip_sleep_duration 100ms -> 10ms: consensus payloads (the proposal, block parts, votes) are delivered by per-peer polling loops that sleep this long when idle, so the three gossip waves per block picked up ~150 ms of mean poll latency at the default.
- send_rate / recv_rate 5.12 MB/s -> 20.97 MB/s: keeps the p2p rate limiter from pacing block-part delivery.
- timeout_propose 1s -> 500ms: failure-path only, no effect on the happy-path median.
- timeout_commit stays 50 ms and must remain uniform across validators; flush_throttle_timeout stays 10 ms as the reserve knob.

The cometbft builder image moves to golang 1.25, required by cometbft 0.39.
