### PR TITLE
chore: fix clippy lints for rust nightly 1.99

### DIFF
--- a/dango/hyperlane/types/src/isms/multisig.rs
+++ b/dango/hyperlane/types/src/isms/multisig.rs
@@ -48,8 +48,10 @@ impl Metadata {
         );
 
         let signatures = buf[68..]
-            .chunks_exact(65)
-            .map(|chunk| HexByteArray::from_inner(chunk.try_into().unwrap()))
+            .as_chunks::<65>()
+            .0
+            .iter()
+            .map(|chunk| HexByteArray::from_inner(*chunk))
             .collect();
 
         Ok(Self {

--- a/dango/indexer/clickhouse/src/indexer/perps_candles/cache.rs
+++ b/dango/indexer/clickhouse/src/indexer/perps_candles/cache.rs
@@ -175,26 +175,23 @@ impl PerpsCandleCache {
                 .unwrap_or(candles.len());
 
             let Some(pair_price) = pair_price else {
-                if let Some(previous_candle) = insert_pos
+                let previous_candle = insert_pos
                     .checked_sub(1)
                     .and_then(|idx| candles.get(idx))
-                    .cloned()
-                {
-                    let candle = PerpsCandle::new_with_previous_candle(
-                        &previous_candle,
-                        interval,
-                        time_start,
-                        block_height,
-                    );
+                    .cloned()?;
 
-                    candles.insert(insert_pos, candle.clone());
+                let candle = PerpsCandle::new_with_previous_candle(
+                    &previous_candle,
+                    interval,
+                    time_start,
+                    block_height,
+                );
 
-                    self.completed_candles.replace(previous_candle);
+                candles.insert(insert_pos, candle.clone());
 
-                    return Some(candle);
-                } else {
-                    return None;
-                }
+                self.completed_candles.replace(previous_candle);
+
+                return Some(candle);
             };
 
             let mut candle =

--- a/dango/indexer/httpd/src/routes/mock_app.rs
+++ b/dango/indexer/httpd/src/routes/mock_app.rs
@@ -117,6 +117,9 @@ impl QueryApp for MockApp {
             Query::AppConfig(_) => {
                 self.app_config_calls.fetch_add(1, Ordering::SeqCst);
 
+                // `fetch_update` is deprecated on nightly in favor of
+                // `try_update`, which is not yet available on stable.
+                #[allow(deprecated)]
                 if self
                     .app_config_failures
                     .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {

--- a/dango/pyth/client/src/client.rs
+++ b/dango/pyth/client/src/client.rs
@@ -215,7 +215,7 @@ impl PythClient {
 
                 // Reset all received data to false for each subscription ID, just to be sure that
                 // everything works fine.
-                for (_, value) in data_per_ids.iter_mut() {
+                for value in data_per_ids.values_mut() {
                     *value = false;
                 }
 


### PR DESCRIPTION
## Summary

CI runs clippy on the latest nightly, and the 2026-07-15 snapshot (`rustc 1.99.0-nightly (da80ed070 2026-07-14)`) introduced new lints and a deprecation that fail `clippy -D warnings`. This fixes all of them:

- **`chunks_exact_to_as_chunks`** (`dango/hyperlane/types/src/isms/multisig.rs`): replaced `.chunks_exact(65)` with `.as_chunks::<65>()` when decoding multisig ISM signatures; chunks are now `[u8; 65]` arrays, so the fallible `try_into().unwrap()` goes away.
- **`for_kv_map`** (`dango/pyth/client/src/client.rs`): iterate with `values_mut()` instead of destructuring `(_, value)` pairs.
- **`question_mark`** (`dango/indexer/clickhouse/src/indexer/perps_candles/cache.rs`): rewrote an `if let / else return None` block with the `?` operator.
- **deprecated `Atomic::fetch_update`** (`dango/indexer/httpd/src/routes/mock_app.rs`): kept `fetch_update` with a scoped `#[allow(deprecated)]` instead of renaming to `try_update`, because `try_update` is still feature-gated (`atomic_try_update`) on stable Rust — verified it fails to compile on 1.92 and 1.94. Can be renamed once it stabilizes.

## Validation

### Completed

- [x] `just lint` passes with zero warnings on `nightly-2026-07-15` (same rustc build as CI: `da80ed070 2026-07-14`)
- [x] `cargo +nightly-2026-07-15 fmt --all --check` clean
- [x] Verified `try_update` is unstable on stable 1.92/1.94, so the `#[allow(deprecated)]` keeps stable builds working

### Remaining

- [ ] CI green on this PR

## Manual QA

None — lint-only changes, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)