### PR TITLE
feat(deploy): add withdrawal-approver bot to full-app for testnet and mainnet

### DIFF
--- a/deploy/NODE_MIGRATION.md
+++ b/deploy/NODE_MIGRATION.md
@@ -93,7 +93,7 @@ The rest of the fleet is now on 3/4 validator quorum. Check Grafana: blocks stil
 
 Swap source out, target in. From here on, source is reached only by direct SSH; ansible no longer knows about it. The shell variables `$SOURCE_IP` and `$TARGET_IP` from your session refer to the actual IPs you'll be substituting in these files.
 
-1. Edit `inventory`: in every group that lists source, replace source's IP with target's IP. If target is already present in that group (e.g. `[full-app]`, since `NEW_SERVER_SETUP.md` adds the new host there during commissioning), just remove source's line. **Position matters in `[perp-liquidator-mainnet]`** — instance index is derived from list position, so insert target where source was.
+1. Edit `inventory`: in every group that lists source, replace source's IP with target's IP. If target is already present in that group (e.g. `[full-app]`, since `NEW_SERVER_SETUP.md` adds the new host there during commissioning), just remove source's line. **Position matters in `[perp-liquidator-mainnet]`** — instance index is derived from list position, so insert target where source was. **Don't skip `[withdrawal-approver-<network>]`** — it holds a single host, and a missed edit leaves the network with zero withdrawal guardians: no deploy step warns about it, user withdrawals just stop being approved. Also make sure source's stopped withdrawal-approver container is removed (step 11's wipe): it carries the guardian key and its `restart: always` policy revives it on a reboot of the source host.
 
 2. Create `host_vars/<target IP>.yml` (named after target's actual IP) with the mainnet flags (mirror `host_vars/<source IP>.yml`):
 

--- a/deploy/group_vars/all/vault.sops.json
+++ b/deploy/group_vars/all/vault.sops.json
@@ -89,6 +89,7 @@
 			}
 		]
 	},
+	"withdrawal_approver_private_key": "ENC[AES256_GCM,data:aFRV88S2BBR+8ltMmSGOOO9NPcSeOHVMMeFXpVNd80g6PkOchz2AFaQO03LrjSykGQzVjoxQ1A8jRNd2/Vwqyg==,iv:D4mmZsV3pcKjYw/JfM4+7n+PZAftgjYc0XpcF7CjmGc=,tag:RSjO32pRvXaPLVnxdVl1wA==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -120,8 +121,8 @@
 				"recipient": "age10xqeelr09uk292rrp48jw5fem7uepuf82ax6mpq6rjuv6m3aw9mqgjnfyh"
 			}
 		],
-		"lastmodified": "2026-07-06T10:09:55Z",
-		"mac": "ENC[AES256_GCM,data:IDayFmeZRkTb8ke8u+8WmuHi9MTmLFBtV2gxrULNc7ALFMDBLIaYKug5vRmVE3N/ljv4yUy/eb5jzqsJV+yGzBWiIXVl6Otg4dpfG4rGWycUoCLcCSzau75r+iMReeKUdGt65/bPh8MwD4nTrjmsnC1Iep+fL7DN6VB/2XV4Q8M=,iv:LH4ybCXySxtAvobi9Omxs2IbFM7t6PML/H4iZSx3aY8=,tag:fWotQrBGpSj2SmX2mUantw==,type:str]",
+		"lastmodified": "2026-07-16T15:09:00Z",
+		"mac": "ENC[AES256_GCM,data:FWFZG/6MKgAUt5qoAISj6DMSlYUbRbO7gB9CinUKNUP5+KyMsvhlsSliPOZ0BlbkIBt99XMHzHHy3YmDpdrDMgNBjWw8pFcQptzevxlGZH6z4Z8BRi0cFOOJoI4djVNq8TLFANvrMYM3L33P8bchxRQBaOeiLL7shg7+Ae4p8fg=,iv:Xr7AGHPqlbZD4WMLqd97jAsx3JVFgx9xh5lDQbACDo4=,tag:NOTRntf5mmYNc7IiD4xjuQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.13.2"
 	}

--- a/deploy/inventory
+++ b/deploy/inventory
@@ -193,6 +193,18 @@ perp-liquidator-devnet
 perp-liquidator-testnet
 perp-liquidator-mainnet
 
+# The withdrawal-approver must be a single instance per network (sole
+# responder to gateway withdrawal requests). No devnet group on purpose.
+[withdrawal-approver-testnet]
+100.90.163.19  # hetzner2
+
+[withdrawal-approver-mainnet]
+100.126.8.2    # hetzner1
+
+[withdrawal-approver:children]
+withdrawal-approver-testnet
+withdrawal-approver-mainnet
+
 [hyperlane]
 100.72.62.100  # hetzner5
 100.126.8.2    # hetzner1

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -386,6 +386,20 @@ restart-perp-liquidator network:
       --limit perp-liquidator-{{network}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-restart-perp-liquidator.log"
 
+# ---------------------------- Withdrawal approver -----------------------------
+
+# Redeploy only the withdrawal-approver container inside the current
+# deployment: re-render config/.env (key rotation), bump the tag, recreate.
+# The tag is mandatory: the guardian must always run a pinned image.
+# Usage: just deploy-withdrawal-approver testnet <bots-tag>
+deploy-withdrawal-approver network tag:
+  mkdir -p "{{justfile_directory()}}/logs" \
+    && uv run ansible-playbook redeploy-withdrawal-approver.yml \
+      -e dango_network={{network}} \
+      -e withdrawal_approver_tag={{tag}} \
+      --limit withdrawal-approver-{{network}} \
+      2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-withdrawal-approver.log"
+
 # ---------------------------------- Testnet -----------------------------------
 
 deploy-testnet dango_image_tag bots_image_tag:
@@ -394,9 +408,9 @@ deploy-testnet dango_image_tag bots_image_tag:
       -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "perps_bot_enabled": true, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-testnet-1", "dango_network": "testnet", "system_wide_directories": true, "deploy_env": "production"}' \
       -e dango_image_tag={{dango_image_tag}} \
       -e faucet_bot_tag={{bots_image_tag}} \
-      -e dex_bot_tag={{bots_image_tag}} \
       -e perps_bot_tag={{bots_image_tag}} \
       -e perp_liquidator_tag={{bots_image_tag}} \
+      -e withdrawal_approver_tag={{bots_image_tag}} \
       --limit {{hetzner2}},{{hetzner4}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-testnet.log"
 
@@ -436,6 +450,7 @@ pull-docker-images-testnet dango_image_tag bots_image_tag:
       -e faucet_bot_tag={{bots_image_tag}} \
       -e perps_bot_tag={{bots_image_tag}} \
       -e perp_liquidator_tag={{bots_image_tag}} \
+      -e withdrawal_approver_tag={{bots_image_tag}} \
       --limit {{hetzner2}},{{hetzner4}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-pull-docker-images-testnet.log"
 
@@ -450,9 +465,9 @@ deploy-mainnet dango_image_tag bots_image_tag:
       -e '{"traefik_enabled": true, "cometbft_generate_keys": true, "github_deployments_enabled": false, "expose_ports": false, "delete_postgres_database_at_merge": false, "delete_clickhouse_database_at_merge": false, "deploy_includes_postgres": false, "deploy_includes_clickhouse": false, "chain_id": "dango-1", "dango_network": "mainnet", "system_wide_directories": true, "deploy_env": "production"}' \
       -e dango_image_tag={{dango_image_tag}} \
       -e faucet_bot_tag={{bots_image_tag}} \
-      -e dex_bot_tag={{bots_image_tag}} \
       -e perps_bot_tag={{bots_image_tag}} \
       -e perp_liquidator_tag={{bots_image_tag}} \
+      -e withdrawal_approver_tag={{bots_image_tag}} \
       --limit {{hetzner5}},{{hetzner6}},{{hetzner1}},{{hetzner3}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet.log"
 
@@ -488,6 +503,7 @@ pull-docker-images-mainnet dango_image_tag bots_image_tag:
       -e faucet_bot_tag={{bots_image_tag}} \
       -e perps_bot_tag={{bots_image_tag}} \
       -e perp_liquidator_tag={{bots_image_tag}} \
+      -e withdrawal_approver_tag={{bots_image_tag}} \
       --limit {{hetzner5}},{{hetzner6}},{{hetzner1}},{{hetzner3}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-pull-docker-images-mainnet.log"
 

--- a/deploy/pull-docker-images.yml
+++ b/deploy/pull-docker-images.yml
@@ -54,6 +54,13 @@
           image: ghcr.io/left-curve/bots/perps-liquidator
           tag: "{{ perp_liquidator_tag }}"
           enabled: true
+        # withdrawal-approver only runs on its per-network host (static
+        # withdrawal-approver-<network> inventory groups) and only once the
+        # master switch is on — before that the image may not exist on GHCR.
+        - name: withdrawal-approver
+          image: ghcr.io/left-curve/bots/withdrawal-approver
+          tag: "{{ withdrawal_approver_tag }}"
+          enabled: "{{ withdrawal_approver_enabled | bool and inventory_hostname in withdrawal_approver_hosts }}"
       when: item.enabled | bool
       register: bot_pull
       retries: 3

--- a/deploy/redeploy-withdrawal-approver.yml
+++ b/deploy/redeploy-withdrawal-approver.yml
@@ -1,0 +1,101 @@
+---
+# Redeploy only the withdrawal-approver inside the CURRENT deployment:
+# re-render config.json and the secret .env (key rotation), bump the image
+# tag, and recreate just that container — without minting a new deployment
+# or touching dango/cometbft. Modeled on redeploy-perp-liquidator.yml.
+#
+# The current deployment's compose file must already contain the service
+# (i.e. it was deployed with withdrawal_approver_enabled on); otherwise the
+# compose recreate fails loudly with "no such service" — a full network
+# deploy is needed to add the service in that case.
+- hosts: full-app
+  remote_user: "{{ deploy_user }}"
+  gather_facts: yes
+  vars_files:
+    - roles/full-app/vars/main.yml
+    - roles/full-app/defaults/main.yml
+  pre_tasks:
+    - name: Get deploy user info
+      getent:
+        database: passwd
+        key: "{{ deploy_user }}"
+    - name: Set deploy_home fact
+      set_fact:
+        deploy_home: "{{ ansible_facts.getent_passwd[deploy_user][4] }}"
+  tasks:
+    - name: Skip hosts that do not run the withdrawal-approver
+      meta: end_host
+      when: inventory_hostname not in withdrawal_approver_hosts
+
+    - name: Check withdrawal-approver private key format
+      set_fact:
+        withdrawal_approver_key_ok: "{{ (withdrawal_approver_private_key | default('')) is match('^[0-9a-f]{64}$') }}"
+      no_log: true
+
+    - name: Validate withdrawal-approver deploy inputs
+      assert:
+        that:
+          - withdrawal_approver_key_ok | bool
+          - withdrawal_approver_tag != 'latest'
+        fail_msg: >-
+          withdrawal-approver preflight failed: withdrawal_approver_private_key
+          must be exactly 64 lowercase hex chars with no 0x prefix, and
+          withdrawal_approver_tag must be pinned (got
+          '{{ withdrawal_approver_tag }}').
+        quiet: true
+
+    - name: Read current deploy
+      include_role:
+        name: full-app
+        tasks_from: read_current_deploy.yml
+
+    - name: Set deployment facts
+      set_fact:
+        deployment_name: "{{ current_deployment }}"
+
+    - name: Create withdrawal-approver config directory
+      file:
+        path: "{{ deployment_dir }}/withdrawal-approver"
+        state: directory
+        mode: '0755'
+
+    - name: Copy withdrawal-approver config
+      copy:
+        src: "roles/full-app/files/withdrawal-approver/{{ dango_network }}/config.json"
+        dest: "{{ deployment_dir }}/withdrawal-approver/config.json"
+        mode: '0644'
+
+    # diff/no_log off: the rendered content is the guardian private key.
+    - name: Template withdrawal-approver .env
+      template:
+        src: roles/full-app/templates/withdrawal-approver.env.j2
+        dest: "{{ deployment_dir }}/withdrawal-approver/.env"
+        mode: '0600'
+      diff: false
+      no_log: true
+
+    - name: Update WITHDRAWAL_APPROVER_TAG in main .env
+      lineinfile:
+        path: "{{ deployment_dir }}/.env"
+        regexp: '^WITHDRAWAL_APPROVER_TAG='
+        line: "WITHDRAWAL_APPROVER_TAG={{ withdrawal_approver_tag }}"
+
+    - name: Login to GHCR
+      community.docker.docker_login:
+        registry: ghcr.io
+        username: "{{ ghcr_user }}"
+        password: "{{ ghcr_token }}"
+
+    # dependencies: false is essential: the service depends_on dango
+    # (service_healthy) and a bot-only redeploy must not restart the node
+    # (see redeploy-perp-liquidator.yml / #1785).
+    - name: Redeploy withdrawal-approver service
+      community.docker.docker_compose_v2:
+        project_name: "{{ current_deployment }}"
+        project_src: "{{ deployment_dir }}"
+        services:
+          - withdrawal-approver
+        pull: always
+        state: present
+        recreate: always
+        dependencies: false

--- a/deploy/releases/v0.27.1/justfile
+++ b/deploy/releases/v0.27.1/justfile
@@ -113,6 +113,7 @@ deploy-mainnet-hetzner1:
         -e dex_bot_tag={{ bots_image_tag }} \
         -e perps_bot_tag={{ bots_image_tag }} \
         -e perp_liquidator_tag={{ bots_image_tag }} \
+        -e withdrawal_approver_tag={{ bots_image_tag }} \
         -e cometbft_peers={{ hetzner3 }},{{ hetzner5 }},{{ hetzner6 }} \
         --limit {{ hetzner1 }} \
         2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner1.log
@@ -128,6 +129,7 @@ deploy-mainnet-hetzner3:
         -e dex_bot_tag={{ bots_image_tag }} \
         -e perps_bot_tag={{ bots_image_tag }} \
         -e perp_liquidator_tag={{ bots_image_tag }} \
+        -e withdrawal_approver_tag={{ bots_image_tag }} \
         -e cometbft_peers={{ hetzner1 }},{{ hetzner5 }},{{ hetzner6 }} \
         --limit {{ hetzner3 }} \
         2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner3.log
@@ -143,6 +145,7 @@ deploy-mainnet-hetzner5:
         -e dex_bot_tag={{ bots_image_tag }} \
         -e perps_bot_tag={{ bots_image_tag }} \
         -e perp_liquidator_tag={{ bots_image_tag }} \
+        -e withdrawal_approver_tag={{ bots_image_tag }} \
         -e cometbft_peers={{ hetzner1 }},{{ hetzner3 }},{{ hetzner6 }} \
         --limit {{ hetzner5 }} \
         2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner5.log
@@ -158,6 +161,7 @@ deploy-mainnet-hetzner6:
         -e dex_bot_tag={{ bots_image_tag }} \
         -e perps_bot_tag={{ bots_image_tag }} \
         -e perp_liquidator_tag={{ bots_image_tag }} \
+        -e withdrawal_approver_tag={{ bots_image_tag }} \
         -e cometbft_peers={{ hetzner1 }},{{ hetzner3 }},{{ hetzner5 }} \
         --limit {{ hetzner6 }} \
         2>&1 | tee logs/$(date -u +%Y%m%d%H%M%S)-deploy-mainnet-hetzner6.log

--- a/deploy/restart-services.yml
+++ b/deploy/restart-services.yml
@@ -7,6 +7,7 @@
       - dango
       - cometbft
       - perp-liquidator
+      - withdrawal-approver
     cometbft_rpc_port: 26657
   vars_files:
     - roles/full-app/vars/main.yml
@@ -58,11 +59,14 @@
     - name: Show services
       debug: var=compose_services.stdout_lines
 
+    # Intersect with the services actually present in this deployment's
+    # compose file: host-gated services (perp-liquidator, withdrawal-approver)
+    # don't exist on every host, and compose errors on unknown service names.
     - name: Start service and wait to be healthy
       community.docker.docker_compose_v2:
         project_name: "{{ current_deployment }}"
         project_src: "{{ deployment_dir }}"
-        services: "{{ services }}"
+        services: "{{ services | intersect(compose_services.stdout_lines) }}"
         state: present
         recreate: always
         wait: true

--- a/deploy/roles/full-app/files/withdrawal-approver/mainnet/config.json
+++ b/deploy/roles/full-app/files/withdrawal-approver/mainnet/config.json
@@ -1,0 +1,10 @@
+{
+  "app_settings": {
+    "fetch_sleep": "10s",
+    "review_sleep": "5s",
+    "page_limit": 30
+  },
+  "http_url": "http://dango:8080",
+  "log_level": "info",
+  "log_format": "text"
+}

--- a/deploy/roles/full-app/files/withdrawal-approver/testnet/config.json
+++ b/deploy/roles/full-app/files/withdrawal-approver/testnet/config.json
@@ -1,0 +1,10 @@
+{
+  "app_settings": {
+    "fetch_sleep": "10s",
+    "review_sleep": "5s",
+    "page_limit": 30
+  },
+  "http_url": "http://dango:8080",
+  "log_level": "info",
+  "log_format": "text"
+}

--- a/deploy/roles/full-app/tasks/deploy_standalone.yml
+++ b/deploy/roles/full-app/tasks/deploy_standalone.yml
@@ -5,6 +5,7 @@
       faucet-bot: "{{ faucet_bot_tag }}"
       perps-bot: "{{ perps_bot_tag }}"
       perp-liquidator: "{{ perp_liquidator_tag }}"
+      withdrawal-approver: "{{ withdrawal_approver_tag }}"
   run_once: true
 
 - name: Verify GHCR access for bot images
@@ -19,6 +20,9 @@
     - image: "ghcr.io/left-curve/bots/perps-liquidator:{{ perp_liquidator_tag }}"
       name: perp-liquidator
       enabled: "{{ inventory_hostname in (groups['perp-liquidator-' ~ dango_network] | default(groups['perp-liquidator-devnet'] | default([]))) }}"
+    - image: "ghcr.io/left-curve/bots/withdrawal-approver:{{ withdrawal_approver_tag }}"
+      name: withdrawal-approver
+      enabled: "{{ withdrawal_approver_host_enabled }}"
   when: item.enabled | bool
   register: ghcr_check
   ignore_errors: true

--- a/deploy/roles/full-app/tasks/main.yml
+++ b/deploy/roles/full-app/tasks/main.yml
@@ -25,6 +25,7 @@
 - import_tasks: perps_bot.yml
   when: perps_bot_enabled
 - import_tasks: perp_liquidator.yml
+- import_tasks: withdrawal_approver.yml
 - import_tasks: create_databases.yml
 - import_tasks: deploy_standalone.yml
 - import_tasks: update_traefik.yml

--- a/deploy/roles/full-app/tasks/withdrawal_approver.yml
+++ b/deploy/roles/full-app/tasks/withdrawal_approver.yml
@@ -1,0 +1,55 @@
+---
+# The withdrawal-approver answers gateway withdrawal requests as the guardian
+# and must run as a single instance per network. Placement comes from the
+# static `withdrawal-approver-<network>` inventory groups (not from the play
+# hosts) so rolling deploys with `--limit <one host>` keep it stable; the
+# `withdrawal_approver_host_enabled` gate (see vars/main.yml) additionally
+# requires the master switch and a system-wide deploy, keeping the bot out of
+# preview-style runs. No group exists for devnet: testnet and mainnet only.
+
+- name: Check withdrawal-approver private key format
+  set_fact:
+    withdrawal_approver_key_ok: "{{ (withdrawal_approver_private_key | default('')) is match('^[0-9a-f]{64}$') }}"
+  no_log: true
+  when: withdrawal_approver_host_enabled | bool
+
+- name: Validate withdrawal-approver deploy inputs
+  assert:
+    that:
+      - withdrawal_approver_key_ok | bool
+      - withdrawal_approver_tag != 'latest'
+    fail_msg: >-
+      withdrawal-approver preflight failed: withdrawal_approver_private_key
+      must be exactly 64 lowercase hex chars with no 0x prefix (the bot parses
+      it as strict HEXLOWER and crash-loops on anything else), and
+      withdrawal_approver_tag must be pinned to a release tag (got
+      '{{ withdrawal_approver_tag }}') — an unpinned guardian would silently
+      track bots main.
+    quiet: true
+  when: withdrawal_approver_host_enabled | bool
+
+- name: Create withdrawal-approver config directory
+  file:
+    path: "{{ deployment_dir }}/withdrawal-approver"
+    state: directory
+    mode: '0755'
+  when: withdrawal_approver_host_enabled | bool
+
+- name: Copy withdrawal-approver config
+  copy:
+    src: "withdrawal-approver/{{ dango_network }}/config.json"
+    dest: "{{ deployment_dir }}/withdrawal-approver/config.json"
+    mode: '0644'
+  when: withdrawal_approver_host_enabled | bool
+
+# diff/no_log off: in --diff (or ANSIBLE_DIFF_ALWAYS=1) runs the rendered
+# content — the guardian private key — would land on stdout and be tee'd
+# into deploy/logs/*.log by the justfile recipes.
+- name: Template withdrawal-approver .env
+  template:
+    src: withdrawal-approver.env.j2
+    dest: "{{ deployment_dir }}/withdrawal-approver/.env"
+    mode: '0600'
+  diff: false
+  no_log: true
+  when: withdrawal_approver_host_enabled | bool

--- a/deploy/roles/full-app/templates/docker-compose.yml
+++ b/deploy/roles/full-app/templates/docker-compose.yml
@@ -271,6 +271,23 @@ services:
       retries: 3
 {% endif %}
 
+{% if withdrawal_approver_host_enabled | bool %}
+  withdrawal-approver:
+    image: ghcr.io/left-curve/bots/withdrawal-approver:${WITHDRAWAL_APPROVER_TAG:-latest}
+    pull_policy: missing
+    labels:
+      <<: *common-labels
+      service_name: "withdrawal_approver"
+    depends_on:
+      dango:
+        condition: service_healthy
+    restart: always
+    env_file:
+      - ./withdrawal-approver/.env
+    volumes:
+      - ./withdrawal-approver/config.json:/root/.dango-withdrawal-approver/config.json
+{% endif %}
+
   cometbft:
     image: ghcr.io/left-curve/left-curve/cometbft:${COMETBFT_TAG:-latest}
     pull_policy: missing

--- a/deploy/roles/full-app/templates/env.j2
+++ b/deploy/roles/full-app/templates/env.j2
@@ -34,6 +34,7 @@ TRACE__ENABLED=true
 TRACE__ENDPOINT=http://ovh3:4317
 PERPS_BOT_TAG={{ perps_bot_tag }}
 PERP_LIQUIDATOR_TAG={{ perp_liquidator_tag }}
+WITHDRAWAL_APPROVER_TAG={{ withdrawal_approver_tag }}
 CHAIN_ID={{ chain_id }}
 COMETBFT_TAG={{ cometbft_tag }}
 DEPLOY_INCLUDES_POSTGRES={{ deploy_includes_postgres }}

--- a/deploy/roles/full-app/templates/withdrawal-approver.env.j2
+++ b/deploy/roles/full-app/templates/withdrawal-approver.env.j2
@@ -1,0 +1,7 @@
+# The withdrawal guardian's private key, from `withdrawal_approver_private_key`
+# in group_vars/all/vault.sops.json. The bot layers environment variables over
+# config.json (separator `__`), so the key stays out of the checked-in config.
+# `eip712` because the guardian account is registered with an Ethereum-wallet
+# key (Key::Ethereum): the bot derives the eth address from this raw key and
+# signs EIP-712, same setup as the standalone mainnet perps-bot.
+private_key__eip712={{ withdrawal_approver_private_key }}

--- a/deploy/roles/full-app/vars/main.yml
+++ b/deploy/roles/full-app/vars/main.yml
@@ -6,6 +6,21 @@ dango_image_digest: ""
 faucet_bot_tag: "latest"
 perps_bot_tag: "latest"
 perp_liquidator_tag: "latest"
+withdrawal_approver_tag: "latest"
+# Master switch for the withdrawal-approver. Keep false until the guarded
+# withdrawals gateway (left-curve#2247) is live on-chain AND the bot image
+# exists on GHCR for the chosen tag: with either prerequisite missing, an
+# enabled bot crash-loops and the post-deploy health gate takes the whole
+# stack down with it. Flip to true here when both are live — recipes need
+# no per-recipe flag.
+withdrawal_approver_enabled: false
+# Hosts running the withdrawal-approver for this network: static inventory
+# groups, single instance per network, no devnet group on purpose.
+withdrawal_approver_hosts: "{{ groups['withdrawal-approver-' ~ dango_network] | default([]) }}"
+# True on the one host where the bot deploys in this play. Gated on
+# system_wide_directories so preview-style manual runs (which skip
+# stop_previous) can never mint a second guardian instance.
+withdrawal_approver_host_enabled: "{{ withdrawal_approver_enabled | bool and system_wide_directories | bool and inventory_hostname in withdrawal_approver_hosts }}"
 cometbft_node_key: ""
 cometbft_validator_address: ""
 cometbft_validator_public_key: ""

--- a/deploy/roles/full-app/vars/main.yml
+++ b/deploy/roles/full-app/vars/main.yml
@@ -7,13 +7,13 @@ faucet_bot_tag: "latest"
 perps_bot_tag: "latest"
 perp_liquidator_tag: "latest"
 withdrawal_approver_tag: "latest"
-# Master switch for the withdrawal-approver. Keep false until the guarded
-# withdrawals gateway (left-curve#2247) is live on-chain AND the bot image
-# exists on GHCR for the chosen tag: with either prerequisite missing, an
-# enabled bot crash-loops and the post-deploy health gate takes the whole
-# stack down with it. Flip to true here when both are live — recipes need
-# no per-recipe flag.
-withdrawal_approver_enabled: false
+# Master switch for the withdrawal-approver. Ships enabled because this
+# change merges LAST, once the guarded-withdrawals gateway (left-curve#2247)
+# is live on-chain AND the bot image exists on GHCR for the pinned tag: with
+# either prerequisite missing, an enabled bot crash-loops and the post-deploy
+# health gate takes the whole stack down with it. Flip to false here to pull
+# the bot from the next deploy — recipes need no per-recipe flag.
+withdrawal_approver_enabled: true
 # Hosts running the withdrawal-approver for this network: static inventory
 # groups, single instance per network, no devnet group on purpose.
 withdrawal_approver_hosts: "{{ groups['withdrawal-approver-' ~ dango_network] | default([]) }}"


### PR DESCRIPTION
## Summary

Deploys the **withdrawal-approver** bot — the gateway's withdrawal guardian ([left-curve/bots#148](https://github.com/left-curve/bots/pull/148), contract side #2247) — inside the full-app role, for **testnet and mainnet only** (never devnet/PR previews).

> **Merge order: this PR merges LAST**, only after #2247's gateway is live on-chain, bots#148 is merged with its image published on GHCR, and the guardian account is set via `SetGuardian`. With either prerequisite missing, the enabled bot crash-loops at startup and the post-deploy health gate stops the whole stack on the guardian host.

- **Placement**: static `withdrawal-approver-{testnet,mainnet}` inventory groups (hetzner2 / hetzner1), single instance per network (the bot is the sole responder to withdrawal requests). Group-based gating — not `play_hosts | first` — so `--limit <one host>` rolling upgrades keep placement stable.
- **Secret handling**: per-network `config.json` files are checked in without the key; the guardian private key lives in the SOPS vault (`withdrawal_approver_private_key`, `group_vars/all`) and is rendered into a `0600` `.env` as `private_key__eip712=…`, which the bot layers over the config (same pattern as the standalone mainnet perps-bot). The `.env` template renders with `diff: false` + `no_log` so a `--diff` run can't tee the key into `deploy/logs/`.
- **Gating**: `withdrawal_approver_enabled` ships **true** (merge-last strategy) and remains the kill-switch — flip it to false to pull the bot from the next deploy. The gate additionally requires `system_wide_directories`, so preview-style manual runs (which skip `stop_previous`) can never mint a second guardian even with the flag on.
- **Preflight asserts** (before any file is touched): key must be exactly 64 lowercase hex, no `0x` (the bot parses strict HEXLOWER and would crash-loop, with the deploy rescue then stopping dango+cometbft on the host); image tag must be pinned (not `latest`).
- **Targeted lifecycle**: new `redeploy-withdrawal-approver.yml` + `just deploy-withdrawal-approver <network> <tag>` for key rotation / image bumps inside the current deployment (`dependencies: false`, so dango is never restarted).
- **Review hardening** (multi-agent review: 15 verified findings, 9 fixed here): `restart-services.yml` now intersects its services list with `docker compose config --services` (a stop→restart cycle no longer leaves host-gated services down — also fixes the latent perp-liquidator fragility); rolling-upgrade recipes in `releases/v0.27.1/justfile` pass the tag; `NODE_MIGRATION.md` covers the new groups; dead `-e dex_bot_tag` lines removed (vestige of #2064).
- **Known follow-ups** (deliberately not here): bot observability (needs an upstream `/health`+`/metrics` endpoint à la perps-liquidator; interim: Loki alert on log silence — logs already flow via promtail labels); `delete_old_deploy.yml` is not gated on `system_wide_directories` (pre-existing: a preview-style run against a production host destroys the tracked deployment); bot-registry refactor of the hand-maintained per-bot lists; the shared single key across both networks is an explicit decision — per-network split is one sops edit + a `[dango_network]` lookup if ever wanted.

## Validation

### Completed

- [x] yamllint (relaxed) clean on all changed YAML (line-length warnings only, consistent with the repo)
- [x] `ansible-playbook --syntax-check` on `full-app.yml`, `pull-docker-images.yml`, `restart-services.yml`, `redeploy-withdrawal-approver.yml`
- [x] Jinja render truth-table (8 scenarios): service renders only on hetzner2/testnet and hetzner1/mainnet with flag+system-wide on; never on devnet/previewnet/preview-style/flag-off; rendered YAML parses and service fields asserted
- [x] gate variable evaluated through the real Ansible templar (native bool, no string-truthiness) across flag combos — re-checked after shipping the flag enabled: preview-style defaults still render no bot
- [x] `just -n` dry-runs: tags threaded in all recipes, new recipe wired to the right playbook/`--limit`, dex vestige gone
- [x] bot runtime contract verified against bots#148 source: config field names/humantime/enum casing, env layering (`private_key__eip712`), HEXLOWER strictness, root/`/root` home, stateless-by-design restart safety
- [x] multi-agent review (11 finders + 14 verifiers + gap sweep) — 15 findings, 9 fixed in this PR

### Remaining

- [ ] merge #2247 + upgrade the gateway on-chain
- [ ] merge bots#148 (image published on GHCR for the pinned tag)
- [ ] create/fund the guardian account on both networks and `SetGuardian` with its **Dango** address
- [ ] **merge this PR last**, then deploy testnet → mainnet
- [ ] follow-ups listed above (observability, `delete_old_deploy` gating, bot registry)

## Manual QA

- Bot run locally against testnet with the vault key: config parse, env-layered key and guardian account lookup verified end-to-end (a devnet mis-target and an `eip_712` variant typo were diagnosed and corrected along the way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
