### PR TITLE
fix(ci): pin uv version in the zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+        with:
+          # Pin the uv version so setup-uv constructs the release download
+          # URL directly. Left unpinned, it resolves the latest release
+          # through a GitHub API call at runtime, and an API disruption
+          # then fails this job — taking the entire gated pipeline (lint,
+          # tests, image builds) down with it.
+          version: "0.11.29"
       - name: Run zizmor (SARIF)
         if: always()
         run: uvx zizmor --config .github/zizmor.yml --format=sarif .github/workflows/ > results.sarif


### PR DESCRIPTION
## Summary

Since ~22:26 UTC today, every push to `main` fails at `zizmor / Audit GitHub Actions`: `astral-sh/setup-uv`, left unpinned, resolves the latest uv release through a GitHub API call at runtime, and that call is currently getting intermittent 503s from GitHub's hosted runners (unlisted partial API degradation; reproduced outside CI with an authenticated request; rate limits not involved). Four re-runs over ~80 minutes failed identically. Because zizmor deliberately gates the self-hosted runner jobs, the entire pipeline — lint, tests, backend image builds, deploy — is skipped, which is currently blocking the v0.28.0 image builds.

This pins uv to the current stable release (`0.11.29`). With an exact version, setup-uv constructs the release download URL directly and performs no API lookup (verified in the action's source at the pinned SHA: `downloadVersionFromGithub` builds `releases/download/<version>/<artifact>` straight away). Plain github.com release downloads are unaffected by the degradation — checkout succeeded in all eight failed jobs.

## Validation

### Completed

- [x] Root cause confirmed from raw job logs of all four attempts (identical `setup-uv` "getting latest release" API failure with GitHub's 503 page).
- [x] Verified in setup-uv v7.2.0 source that an exact `version` input skips the failing API call.

### Remaining

- [ ] This PR's own `zizmor / Audit GitHub Actions` check goes green — it exercises the pinned code path, so it is the end-to-end validation.
- [ ] After merge: re-run the failed workflows on `53ee288` (or rely on this merge commit's own push run) so the v0.28.0 images get built.

## Manual QA

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C81PosoapD7uWCSZpo2BDM