### PR TITLE
style: switch rustfmt from the nightly to the stable toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Install toolchain
         if: env.BACKEND_CHANGED == 'true'
-        run: rustup toolchain install nightly --component rustfmt
+        run: rustup component add rustfmt
 
       # This ends up being 8GB and takes 60sec to pull, which is too slow just for formatting.
       # - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -193,7 +193,7 @@ jobs:
 
       - name: Run rustfmt checks
         if: env.BACKEND_CHANGED == 'true'
-        run: rustup run nightly cargo fmt --check --all
+        run: cargo fmt --check --all
 
   check-no-features:
     needs: [backend-test, changes]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,6 +54,5 @@
     "dotenv": false
   },
   "markdown.extension.toc.updateOnSave": false,
-  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Guidelines for contributing code to this repository.
 
 ## Formatter
 
-Use _nightly_ toolchain to format your code before pushing:
+Format your code before pushing:
 
 ```bash
-cargo +nightly fmt --all
+cargo fmt --all
 ```
 
 An easier way to do this is using the following [just](https://github.com/casey/just) command:
@@ -20,12 +20,11 @@ Also, add the following config to your VS Code settings, and enable format:
 
 ```json
 {
-  "editor.formatOnSave": true,
-  "rust-analyzer.rustfmt.extraArgs": ["+nightly"]
+  "editor.formatOnSave": true
 }
 ```
 
-We use [several rustfmt configurations](./rustfmt.toml) that are not yet available in the stable channel.
+Our [rustfmt configurations](./rustfmt.toml) work with the stable toolchain; no nightly is required.
 
 Make sure to format macros by hand - rustfmt won't format macros.
 

--- a/dango/archive/block-source/src/remote/fetcher/sentinel.rs
+++ b/dango/archive/block-source/src/remote/fetcher/sentinel.rs
@@ -353,11 +353,13 @@ mod tests {
         // so the loop must keep advancing via the committed frontier. With a
         // 10-block gap and `range_size` 20 every batch is a single stride, so a
         // short run resumes immediately (no misaligned follow-up stride).
-        let fetcher =
-            SentinelBlockFetcher::new(MockRangeClient { max_per_call: 3 }, SentinelFetcherConfig {
+        let fetcher = SentinelBlockFetcher::new(
+            MockRangeClient { max_per_call: 3 },
+            SentinelFetcherConfig {
                 range_size: 20,
                 ..SentinelFetcherConfig::default()
-            });
+            },
+        );
 
         let mut stream = fetcher.spawn(1, 10);
         assert_eq!(collect(&mut stream, 10).await, (1..=10).collect::<Vec<_>>());
@@ -367,12 +369,14 @@ mod tests {
     #[tokio::test]
     async fn serial_mode_is_the_degenerate_batch() {
         // `parallelism: 1` = one stride per batch: the pre-parallelism loop.
-        let fetcher =
-            SentinelBlockFetcher::new(MockRangeClient { max_per_call: 3 }, SentinelFetcherConfig {
+        let fetcher = SentinelBlockFetcher::new(
+            MockRangeClient { max_per_call: 3 },
+            SentinelFetcherConfig {
                 range_size: 20,
                 parallelism: 1,
                 ..SentinelFetcherConfig::default()
-            });
+            },
+        );
 
         let mut stream = fetcher.spawn(1, 10);
         assert_eq!(collect(&mut stream, 10).await, (1..=10).collect::<Vec<_>>());
@@ -386,13 +390,15 @@ mod tests {
         // fixed start no longer aligns with the committed frontier and the
         // walk must discard the batch tail and re-issue — never skipping or
         // reordering a height. Zero backoff keeps the test instant.
-        let fetcher =
-            SentinelBlockFetcher::new(MockRangeClient { max_per_call: 3 }, SentinelFetcherConfig {
+        let fetcher = SentinelBlockFetcher::new(
+            MockRangeClient { max_per_call: 3 },
+            SentinelFetcherConfig {
                 range_size: 5,
                 parallelism: 3,
                 retry_backoff: Duration::ZERO,
                 ..SentinelFetcherConfig::default()
-            });
+            },
+        );
 
         let mut stream = fetcher.spawn(1, 30);
         assert_eq!(collect(&mut stream, 30).await, (1..=30).collect::<Vec<_>>());

--- a/dango/archive/block-source/src/remote/store/disk.rs
+++ b/dango/archive/block-source/src/remote/store/disk.rs
@@ -64,10 +64,14 @@ impl RocksdbBlockStore {
         // The default CF carries only the tiny topology checkpoint, so it needs
         // no tuning; the blocks CF carries the large payloads and is tuned for
         // them — see `blocks_cf_options`.
-        let db = DB::open_cf_with_opts(&db_opts, path, [
-            (CF_DEFAULT, Options::default()),
-            (CF_BLOCKS, blocks_cf_options()),
-        ])?;
+        let db = DB::open_cf_with_opts(
+            &db_opts,
+            path,
+            [
+                (CF_DEFAULT, Options::default()),
+                (CF_BLOCKS, blocks_cf_options()),
+            ],
+        )?;
 
         let ranges = match db.get(TOPOLOGY_KEY)? {
             // A present checkpoint is the fast path. If it fails to decode
@@ -253,65 +257,92 @@ impl BlockStore for RocksdbBlockStore {
 /// property strings (stable RocksDB names); an unknown one just yields no value.
 #[cfg(feature = "metrics")]
 const ROCKSDB_GAUGES: &[(&str, &[(&str, &str)])] = &[
-    ("rocksdb_memtable_bytes", &[
-        ("rocksdb.cur-size-active-mem-table", "cur_size_active"),
-        ("rocksdb.cur-size-all-mem-tables", "cur_size_all"),
-        ("rocksdb.size-all-mem-tables", "size_all"),
-    ]),
-    ("rocksdb_sst_bytes", &[
-        ("rocksdb.live-sst-files-size", "live_sst_files_size"),
-        ("rocksdb.total-sst-files-size", "total_sst_files_size"),
-        ("rocksdb.estimate-live-data-size", "estimate_live_data_size"),
-    ]),
-    ("rocksdb_compaction_bytes", &[(
-        "rocksdb.estimate-pending-compaction-bytes",
-        "estimate_pending_compaction",
-    )]),
-    ("rocksdb_block_cache_bytes", &[
-        ("rocksdb.block-cache-capacity", "capacity"),
-        ("rocksdb.block-cache-usage", "usage"),
-        ("rocksdb.block-cache-pinned-usage", "pinned_usage"),
-    ]),
+    (
+        "rocksdb_memtable_bytes",
+        &[
+            ("rocksdb.cur-size-active-mem-table", "cur_size_active"),
+            ("rocksdb.cur-size-all-mem-tables", "cur_size_all"),
+            ("rocksdb.size-all-mem-tables", "size_all"),
+        ],
+    ),
+    (
+        "rocksdb_sst_bytes",
+        &[
+            ("rocksdb.live-sst-files-size", "live_sst_files_size"),
+            ("rocksdb.total-sst-files-size", "total_sst_files_size"),
+            ("rocksdb.estimate-live-data-size", "estimate_live_data_size"),
+        ],
+    ),
+    (
+        "rocksdb_compaction_bytes",
+        &[(
+            "rocksdb.estimate-pending-compaction-bytes",
+            "estimate_pending_compaction",
+        )],
+    ),
+    (
+        "rocksdb_block_cache_bytes",
+        &[
+            ("rocksdb.block-cache-capacity", "capacity"),
+            ("rocksdb.block-cache-usage", "usage"),
+            ("rocksdb.block-cache-pinned-usage", "pinned_usage"),
+        ],
+    ),
     // BlobDB payload files — the bulk of the on-disk bytes for this store.
-    ("rocksdb_blob_bytes", &[
-        ("rocksdb.total-blob-file-size", "total_blob_file_size"),
-        ("rocksdb.live-blob-file-size", "live_blob_file_size"),
-        (
-            "rocksdb.live-blob-file-garbage-size",
-            "live_blob_file_garbage_size",
-        ),
-    ]),
-    ("rocksdb_memtable_count", &[
-        ("rocksdb.num-entries-active-mem-table", "entries_active"),
-        ("rocksdb.num-entries-imm-mem-tables", "entries_imm"),
-        ("rocksdb.num-deletes-active-mem-table", "deletes_active"),
-        ("rocksdb.num-deletes-imm-mem-tables", "deletes_imm"),
-    ]),
-    ("rocksdb_compaction_count", &[
-        ("rocksdb.num-running-compactions", "running_compactions"),
-        ("rocksdb.num-running-flushes", "running_flushes"),
-    ]),
-    ("rocksdb_lsm_count", &[
-        ("rocksdb.num-live-versions", "live_versions"),
-        (
-            "rocksdb.current-super-version-number",
-            "super_version_number",
-        ),
-        ("rocksdb.num-blob-files", "num_blob_files"),
-    ]),
-    ("rocksdb_errors_count", &[(
-        "rocksdb.background-errors",
-        "background_errors",
-    )]),
-    ("rocksdb_flags", &[
-        ("rocksdb.compaction-pending", "compaction_pending"),
-        ("rocksdb.mem-table-flush-pending", "memtable_flush_pending"),
-        ("rocksdb.is-write-stopped", "is_write_stopped"),
-        (
-            "rocksdb.is-file-deletions-enabled",
-            "is_file_deletions_enabled",
-        ),
-    ]),
+    (
+        "rocksdb_blob_bytes",
+        &[
+            ("rocksdb.total-blob-file-size", "total_blob_file_size"),
+            ("rocksdb.live-blob-file-size", "live_blob_file_size"),
+            (
+                "rocksdb.live-blob-file-garbage-size",
+                "live_blob_file_garbage_size",
+            ),
+        ],
+    ),
+    (
+        "rocksdb_memtable_count",
+        &[
+            ("rocksdb.num-entries-active-mem-table", "entries_active"),
+            ("rocksdb.num-entries-imm-mem-tables", "entries_imm"),
+            ("rocksdb.num-deletes-active-mem-table", "deletes_active"),
+            ("rocksdb.num-deletes-imm-mem-tables", "deletes_imm"),
+        ],
+    ),
+    (
+        "rocksdb_compaction_count",
+        &[
+            ("rocksdb.num-running-compactions", "running_compactions"),
+            ("rocksdb.num-running-flushes", "running_flushes"),
+        ],
+    ),
+    (
+        "rocksdb_lsm_count",
+        &[
+            ("rocksdb.num-live-versions", "live_versions"),
+            (
+                "rocksdb.current-super-version-number",
+                "super_version_number",
+            ),
+            ("rocksdb.num-blob-files", "num_blob_files"),
+        ],
+    ),
+    (
+        "rocksdb_errors_count",
+        &[("rocksdb.background-errors", "background_errors")],
+    ),
+    (
+        "rocksdb_flags",
+        &[
+            ("rocksdb.compaction-pending", "compaction_pending"),
+            ("rocksdb.mem-table-flush-pending", "memtable_flush_pending"),
+            ("rocksdb.is-write-stopped", "is_write_stopped"),
+            (
+                "rocksdb.is-file-deletions-enabled",
+                "is_file_deletions_enabled",
+            ),
+        ],
+    ),
 ];
 
 /// Handle to the blocks CF — a cheap lookup; the CF always exists once opened.

--- a/dango/archive/cli/src/config.rs
+++ b/dango/archive/cli/src/config.rs
@@ -310,9 +310,12 @@ mod tests {
                 assert_eq!(remote.store_path, PathBuf::from("data/blocks"));
                 assert_eq!(remote.live_url, "http://node:8080");
                 // The TOML-integer path through `de_opt_usize`.
-                assert!(matches!(remote.fetcher, FetcherConfig::Sentinel {
-                    parallelism: Some(4)
-                }));
+                assert!(matches!(
+                    remote.fetcher,
+                    FetcherConfig::Sentinel {
+                        parallelism: Some(4)
+                    }
+                ));
             },
             other => panic!("expected a remote source, got {other:?}"),
         }
@@ -359,9 +362,12 @@ mod tests {
         match &overridden.block_source {
             BlockSourceConfig::Remote(remote) => {
                 assert_eq!(remote.live_url, "http://sentinel:9999");
-                assert!(matches!(remote.fetcher, FetcherConfig::Sentinel {
-                    parallelism: Some(6)
-                }));
+                assert!(matches!(
+                    remote.fetcher,
+                    FetcherConfig::Sentinel {
+                        parallelism: Some(6)
+                    }
+                ));
             },
             other => panic!("expected a remote source, got {other:?}"),
         }

--- a/dango/archive/projection/src/activity.rs
+++ b/dango/archive/projection/src/activity.rs
@@ -512,11 +512,10 @@ mod tests {
         assert_eq!(chunked(Vec::<u8>::new()).count(), 0);
 
         let batches: Vec<Vec<usize>> = chunked((0..INSERT_CHUNK * 2 + 1).collect()).collect();
-        assert_eq!(batches.iter().map(Vec::len).collect::<Vec<_>>(), vec![
-            INSERT_CHUNK,
-            INSERT_CHUNK,
-            1
-        ],);
+        assert_eq!(
+            batches.iter().map(Vec::len).collect::<Vec<_>>(),
+            vec![INSERT_CHUNK, INSERT_CHUNK, 1],
+        );
         // Order is preserved across the chunk boundary.
         assert_eq!(batches[1][0], INSERT_CHUNK);
         assert_eq!(batches[2][0], INSERT_CHUNK * 2);

--- a/dango/cli/src/main.rs
+++ b/dango/cli/src/main.rs
@@ -162,21 +162,24 @@ async fn main() -> anyhow::Result<()> {
 
     let mut _sentry_guard: Option<sentry::ClientInitGuard> = None;
     let sentry_layer = if cfg.sentry.enabled {
-        let guard = sentry::init((cfg.sentry.dsn, sentry::ClientOptions {
-            environment: Some(cfg.sentry.environment.clone().into()),
-            release: sentry::release_name!(),
-            enable_logs: cfg.sentry.enable_logs,
-            sample_rate: cfg.sentry.sample_rate,
-            traces_sample_rate: cfg.sentry.traces_sample_rate,
-            // Drop noisy exporter transport errors that surface as trace logs.
-            before_send: Some(Arc::new(|event| {
-                if event.logger.as_deref() == Some("opentelemetry_sdk") {
-                    return None;
-                }
-                Some(event)
-            })),
-            ..Default::default()
-        }));
+        let guard = sentry::init((
+            cfg.sentry.dsn,
+            sentry::ClientOptions {
+                environment: Some(cfg.sentry.environment.clone().into()),
+                release: sentry::release_name!(),
+                enable_logs: cfg.sentry.enable_logs,
+                sample_rate: cfg.sentry.sample_rate,
+                traces_sample_rate: cfg.sentry.traces_sample_rate,
+                // Drop noisy exporter transport errors that surface as trace logs.
+                before_send: Some(Arc::new(|event| {
+                    if event.logger.as_deref() == Some("opentelemetry_sdk") {
+                        return None;
+                    }
+                    Some(event)
+                })),
+                ..Default::default()
+            },
+        ));
         _sentry_guard = Some(guard);
 
         sentry::configure_scope(|scope| {

--- a/dango/core/app/src/execute/upload.rs
+++ b/dango/core/app/src/execute/upload.rs
@@ -69,12 +69,17 @@ fn _do_upload(
         return Err(AppError::code_exists(code_hash));
     }
 
-    CODES.save_with_gas(storage, gas_tracker, code_hash, &Code {
-        code: msg.code,
-        status: CodeStatus::Orphaned {
-            since: block.timestamp,
+    CODES.save_with_gas(
+        storage,
+        gas_tracker,
+        code_hash,
+        &Code {
+            code: msg.code,
+            status: CodeStatus::Orphaned {
+                since: block.timestamp,
+            },
         },
-    })?;
+    )?;
 
     Ok(())
 }

--- a/dango/core/app/src/macros.rs
+++ b/dango/core/app/src/macros.rs
@@ -23,7 +23,9 @@ macro_rules! catch_and_update_event {
             EventResult::Err { event, error } => {
                 $evt.$field = dango_primitives::EventStatus::Failed {
                     event,
-                    error: dango_backtrace::Backtraceable::into_generic_backtraced_error(error.clone()),
+                    error: dango_backtrace::Backtraceable::into_generic_backtraced_error(
+                        error.clone(),
+                    ),
                 };
 
                 return EventResult::NestedErr { event: $evt, error };
@@ -47,13 +49,16 @@ macro_rules! catch_and_push_event {
             EventResult::Err { event, error } => {
                 $evt.$field.push(dango_primitives::EventStatus::Failed {
                     event,
-                    error: dango_backtrace::Backtraceable::into_generic_backtraced_error(error.clone()),
+                    error: dango_backtrace::Backtraceable::into_generic_backtraced_error(
+                        error.clone(),
+                    ),
                 });
 
                 return EventResult::NestedErr { event: $evt, error };
             },
             EventResult::NestedErr { event, error } => {
-                $evt.$field.push(dango_primitives::EventStatus::NestedFailed(event));
+                $evt.$field
+                    .push(dango_primitives::EventStatus::NestedFailed(event));
 
                 return EventResult::NestedErr { event: $evt, error };
             },
@@ -66,18 +71,25 @@ macro_rules! catch_and_insert_event {
     ($result:expr, $evt:expr, $field:ident, key:$key:expr) => {
         match $result {
             EventResult::Ok(i) => {
-                $evt.$field.insert($key, dango_primitives::EventStatus::Ok(i));
+                $evt.$field
+                    .insert($key, dango_primitives::EventStatus::Ok(i));
             },
             EventResult::Err { event, error } => {
-                $evt.$field.insert($key, dango_primitives::EventStatus::Failed {
-                    event,
-                    error: dango_backtrace::Backtraceable::into_generic_backtraced_error(error.clone()),
-                });
+                $evt.$field.insert(
+                    $key,
+                    dango_primitives::EventStatus::Failed {
+                        event,
+                        error: dango_backtrace::Backtraceable::into_generic_backtraced_error(
+                            error.clone(),
+                        ),
+                    },
+                );
 
                 return EventResult::NestedErr { event: $evt, error };
             },
             EventResult::NestedErr { event, error } => {
-                $evt.$field.insert($key, dango_primitives::EventStatus::NestedFailed(event));
+                $evt.$field
+                    .insert($key, dango_primitives::EventStatus::NestedFailed(event));
 
                 return EventResult::NestedErr { event: $evt, error };
             },

--- a/dango/core/app/src/state.rs
+++ b/dango/core/app/src/state.rs
@@ -46,10 +46,12 @@ pub const NEXT_UPGRADE: Item<NextUpgrade> = Item::new(namespace("nxup"));
 pub const PAST_UPGRADES: Map<u64, PastUpgrade> = Map::new(namespace("pvup"));
 
 /// Wasm contract byte codes: code_hash => byte_code
-pub const CODES: IndexedMap<Hash256, Code, CodeIndexes> =
-    IndexedMap::new(namespace("code"), CodeIndexes {
+pub const CODES: IndexedMap<Hash256, Code, CodeIndexes> = IndexedMap::new(
+    namespace("code"),
+    CodeIndexes {
         status: MultiIndex::new(|_, c| c.status, namespace("code"), namespace("cdst")),
-    });
+    },
+);
 
 /// Contract metadata: address => contract_info
 pub const CONTRACTS: Map<Addr, ContractInfo> = Map::new(namespace("ctrt"));
@@ -86,35 +88,51 @@ mod tests {
         let mut storage = MockStorage::new();
 
         CODES
-            .save(&mut storage, Hash256::from_inner([0; 32]), &Code {
-                code: Binary::from_inner(vec![0; 32]),
-                status: CodeStatus::Orphaned {
-                    since: Duration::from_seconds(100),
+            .save(
+                &mut storage,
+                Hash256::from_inner([0; 32]),
+                &Code {
+                    code: Binary::from_inner(vec![0; 32]),
+                    status: CodeStatus::Orphaned {
+                        since: Duration::from_seconds(100),
+                    },
                 },
-            })
+            )
             .unwrap();
 
         CODES
-            .save(&mut storage, Hash256::from_inner([1; 32]), &Code {
-                code: Binary::from_inner(vec![1; 32]),
-                status: CodeStatus::Orphaned {
-                    since: Duration::from_seconds(20),
+            .save(
+                &mut storage,
+                Hash256::from_inner([1; 32]),
+                &Code {
+                    code: Binary::from_inner(vec![1; 32]),
+                    status: CodeStatus::Orphaned {
+                        since: Duration::from_seconds(20),
+                    },
                 },
-            })
+            )
             .unwrap();
 
         CODES
-            .save(&mut storage, Hash256::from_inner([2; 32]), &Code {
-                code: Binary::from_inner(vec![2; 32]),
-                status: CodeStatus::InUse { usage: 12345 },
-            })
+            .save(
+                &mut storage,
+                Hash256::from_inner([2; 32]),
+                &Code {
+                    code: Binary::from_inner(vec![2; 32]),
+                    status: CodeStatus::InUse { usage: 12345 },
+                },
+            )
             .unwrap();
 
         CODES
-            .save(&mut storage, Hash256::from_inner([3; 32]), &Code {
-                code: Binary::from_inner(vec![3; 32]),
-                status: CodeStatus::InUse { usage: 88888 },
-            })
+            .save(
+                &mut storage,
+                Hash256::from_inner([3; 32]),
+                &Code {
+                    code: Binary::from_inner(vec![3; 32]),
+                    status: CodeStatus::InUse { usage: 88888 },
+                },
+            )
             .unwrap();
 
         // Find _all_ codes, regardless of orphaned or in use.
@@ -126,30 +144,33 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(res, [
-                // Orphaned nodes are ordered by orphan time.
-                (
-                    CodeStatus::Orphaned {
-                        since: Timestamp::from_seconds(20),
-                    },
-                    Hash256::from_inner([1; 32]),
-                ),
-                (
-                    CodeStatus::Orphaned {
-                        since: Timestamp::from_seconds(100),
-                    },
-                    Hash256::from_inner([0; 32]),
-                ),
-                // In-use nodes are ordered by usage count.
-                (
-                    CodeStatus::InUse { usage: 12345 },
-                    Hash256::from_inner([2; 32]),
-                ),
-                (
-                    CodeStatus::InUse { usage: 88888 },
-                    Hash256::from_inner([3; 32]),
-                )
-            ]);
+            assert_eq!(
+                res,
+                [
+                    // Orphaned nodes are ordered by orphan time.
+                    (
+                        CodeStatus::Orphaned {
+                            since: Timestamp::from_seconds(20),
+                        },
+                        Hash256::from_inner([1; 32]),
+                    ),
+                    (
+                        CodeStatus::Orphaned {
+                            since: Timestamp::from_seconds(100),
+                        },
+                        Hash256::from_inner([0; 32]),
+                    ),
+                    // In-use nodes are ordered by usage count.
+                    (
+                        CodeStatus::InUse { usage: 12345 },
+                        Hash256::from_inner([2; 32]),
+                    ),
+                    (
+                        CodeStatus::InUse { usage: 88888 },
+                        Hash256::from_inner([3; 32]),
+                    )
+                ]
+            );
         }
 
         // Find all orphaned codes whose orphan time is earlier or equal to 100.
@@ -168,20 +189,23 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(res, [
-                (
-                    CodeStatus::Orphaned {
-                        since: Timestamp::from_seconds(20),
-                    },
-                    Hash256::from_inner([1; 32]),
-                ),
-                (
-                    CodeStatus::Orphaned {
-                        since: Timestamp::from_seconds(100),
-                    },
-                    Hash256::from_inner([0; 32]),
-                ),
-            ]);
+            assert_eq!(
+                res,
+                [
+                    (
+                        CodeStatus::Orphaned {
+                            since: Timestamp::from_seconds(20),
+                        },
+                        Hash256::from_inner([1; 32]),
+                    ),
+                    (
+                        CodeStatus::Orphaned {
+                            since: Timestamp::from_seconds(100),
+                        },
+                        Hash256::from_inner([0; 32]),
+                    ),
+                ]
+            );
         }
 
         // Find all orphaned codes whose orphan time is earlier or equal to 30.
@@ -200,12 +224,15 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(res, [(
-                CodeStatus::Orphaned {
-                    since: Timestamp::from_seconds(20),
-                },
-                Hash256::from_inner([1; 32]),
-            )]);
+            assert_eq!(
+                res,
+                [(
+                    CodeStatus::Orphaned {
+                        since: Timestamp::from_seconds(20),
+                    },
+                    Hash256::from_inner([1; 32]),
+                )]
+            );
         }
     }
 }

--- a/dango/core/db/disk/src/db.rs
+++ b/dango/core/db/disk/src/db.rs
@@ -147,12 +147,16 @@ impl<T> DiskDb<T> {
         let cf_opts = new_state_cf_options();
         let wasm_cf_opts = new_wasm_cf_options(cf_opts.clone());
         let storage_cf_opts = new_storage_cf_options(cf_opts.clone());
-        let db = DB::open_cf_with_opts(&opts, data_dir, [
-            (CF_NAME_DEFAULT, Options::default()),
-            (CF_NAME_STATE_STORAGE, storage_cf_opts),
-            (CF_NAME_STATE_COMMITMENT, cf_opts),
-            (CF_NAME_WASM_STORAGE, wasm_cf_opts),
-        ])?;
+        let db = DB::open_cf_with_opts(
+            &opts,
+            data_dir,
+            [
+                (CF_NAME_DEFAULT, Options::default()),
+                (CF_NAME_STATE_STORAGE, storage_cf_opts),
+                (CF_NAME_STATE_COMMITMENT, cf_opts),
+                (CF_NAME_WASM_STORAGE, wasm_cf_opts),
+            ],
+        )?;
 
         // If `priority_range` is specified, load the data in that range into memory.
         let priority_data = priority_range.map(|(min, max)| {
@@ -837,11 +841,14 @@ impl Storage for StateStorage {
 
             #[cfg(feature = "metrics")]
             {
-                let iter = iter.with_metrics(DISK_DB_LABEL, [
-                    ("operation", "next"),
-                    ("comment", self.comment),
-                    ("source", PRIORITY_DATA_LABEL),
-                ]);
+                let iter = iter.with_metrics(
+                    DISK_DB_LABEL,
+                    [
+                        ("operation", "next"),
+                        ("comment", self.comment),
+                        ("source", PRIORITY_DATA_LABEL),
+                    ],
+                );
 
                 metrics::histogram!(
                     DISK_DB_LABEL,
@@ -981,11 +988,14 @@ fn create_wasm_iter<'a>(
         });
 
     #[cfg(feature = "metrics")]
-    let iter = iter.with_metrics(DISK_DB_LABEL, [
-        ("operation", "next"),
-        ("comment", comment),
-        ("source", WASM_STORAGE_LABEL),
-    ]);
+    let iter = iter.with_metrics(
+        DISK_DB_LABEL,
+        [
+            ("operation", "next"),
+            ("comment", comment),
+            ("source", WASM_STORAGE_LABEL),
+        ],
+    );
 
     #[cfg(feature = "metrics")]
     {
@@ -1024,11 +1034,14 @@ fn create_state_iter<'a>(
         });
 
     #[cfg(feature = "metrics")]
-    let iter = iter.with_metrics(DISK_DB_LABEL, [
-        ("operation", "next"),
-        ("comment", comment),
-        ("source", STATE_STORAGE_LABEL),
-    ]);
+    let iter = iter.with_metrics(
+        DISK_DB_LABEL,
+        [
+            ("operation", "next"),
+            ("comment", comment),
+            ("source", STATE_STORAGE_LABEL),
+        ],
+    );
 
     #[cfg(feature = "metrics")]
     {
@@ -1928,10 +1941,10 @@ mod tests_simple {
 
         let buffer = Shared::new(Buffer::new_unnamed(MockStorage::new(), None));
 
-        let mut provider = StorageProvider::new(Box::new(buffer.clone()), &[
-            CONTRACT_NAMESPACE,
-            &Addr::mock(0),
-        ]);
+        let mut provider = StorageProvider::new(
+            Box::new(buffer.clone()),
+            &[CONTRACT_NAMESPACE, &Addr::mock(0)],
+        );
 
         MAP.save(&mut provider, "foo", &1).unwrap();
 
@@ -1984,10 +1997,10 @@ mod tests_simple {
     #[test]
     fn storage_provider_prefix_length_is_correct() {
         assert_eq!(
-            StorageProvider::new(Box::new(MockStorage::new()), &[
-                CONTRACT_NAMESPACE,
-                &Addr::mock(0),
-            ])
+            StorageProvider::new(
+                Box::new(MockStorage::new()),
+                &[CONTRACT_NAMESPACE, &Addr::mock(0),]
+            )
             .namespace()
             .len(),
             WASM_PREFIX_LEN,
@@ -2141,10 +2154,12 @@ mod test_deadlock {
         std::time::Duration,
     };
 
-    const PERSONS: IndexedMap<String, String, PersonIndexes> =
-        IndexedMap::new("person", PersonIndexes {
+    const PERSONS: IndexedMap<String, String, PersonIndexes> = IndexedMap::new(
+        "person",
+        PersonIndexes {
             race: MultiIndex::new(|_name, race| race.clone(), "person", "person__race"),
-        });
+        },
+    );
 
     struct PersonIndexes<'a> {
         pub race: MultiIndex<'a, String, String, String>,
@@ -2278,15 +2293,18 @@ mod test_deadlock {
                 })
                 .collect::<Vec<_>>();
 
-            assert_eq!(names, [
-                "Aela the Huntress",
-                "Astrid",
-                "Balimund",
-                "Brynjolf",
-                "Farengar Secret-Fire",
-                "Kodlak Whitemane",
-                "Ulfric Stormcloak",
-            ]);
+            assert_eq!(
+                names,
+                [
+                    "Aela the Huntress",
+                    "Astrid",
+                    "Balimund",
+                    "Brynjolf",
+                    "Farengar Secret-Fire",
+                    "Kodlak Whitemane",
+                    "Ulfric Stormcloak",
+                ]
+            );
         }
     }
 }

--- a/dango/core/db/disk/src/statistics.rs
+++ b/dango/core/db/disk/src/statistics.rs
@@ -18,64 +18,88 @@ use {
 pub const ROCKSDB_STATISTICS: [(&str, &[(&PropName, &str)]); 10] = [
     // ============= BYTES =============
     // Memtable (RAM)
-    ("rocksdb_memtable_bytes", &[
-        (CUR_SIZE_ACTIVE_MEM_TABLE, "cur_size_active"),
-        (CUR_SIZE_ALL_MEM_TABLES, "cur_size_all"),
-        (SIZE_ALL_MEM_TABLES, "size_all"),
-    ]),
+    (
+        "rocksdb_memtable_bytes",
+        &[
+            (CUR_SIZE_ACTIVE_MEM_TABLE, "cur_size_active"),
+            (CUR_SIZE_ALL_MEM_TABLES, "cur_size_all"),
+            (SIZE_ALL_MEM_TABLES, "size_all"),
+        ],
+    ),
     // SST / on-disk space
-    ("rocksdb_sst_bytes", &[
-        (LIVE_SST_FILES_SIZE, "live_sst_files_size"),
-        (TOTAL_SST_FILES_SIZE, "total_sst_files_size"),
-        (ESTIMATE_LIVE_DATA_SIZE, "estimate_live_data_size"),
-    ]),
+    (
+        "rocksdb_sst_bytes",
+        &[
+            (LIVE_SST_FILES_SIZE, "live_sst_files_size"),
+            (TOTAL_SST_FILES_SIZE, "total_sst_files_size"),
+            (ESTIMATE_LIVE_DATA_SIZE, "estimate_live_data_size"),
+        ],
+    ),
     // Compaction backlog (bytes to rewrite)
-    ("rocksdb_compaction_bytes", &[(
-        ESTIMATE_PENDING_COMPACTION_BYTES,
-        "estimate_pending_compaction",
-    )]),
+    (
+        "rocksdb_compaction_bytes",
+        &[(
+            ESTIMATE_PENDING_COMPACTION_BYTES,
+            "estimate_pending_compaction",
+        )],
+    ),
     // Block cache usage
-    ("rocksdb_block_cache_bytes", &[
-        (BLOCK_CACHE_CAPACITY, "capacity"),
-        (BLOCK_CACHE_USAGE, "usage"),
-        (BLOCK_CACHE_PINNED_USAGE, "pinned_usage"),
-    ]),
+    (
+        "rocksdb_block_cache_bytes",
+        &[
+            (BLOCK_CACHE_CAPACITY, "capacity"),
+            (BLOCK_CACHE_USAGE, "usage"),
+            (BLOCK_CACHE_PINNED_USAGE, "pinned_usage"),
+        ],
+    ),
     // ============= COUNTS =============
     // Memtable entries & deletes
-    ("rocksdb_memtable_count", &[
-        (NUM_ENTRIES_ACTIVE_MEM_TABLE, "entries_active"),
-        (NUM_ENTRIES_IMM_MEM_TABLES, "entries_imm"),
-        (NUM_DELETES_ACTIVE_MEM_TABLE, "deletes_active"),
-        (NUM_DELETES_IMM_MEM_TABLES, "deletes_imm"),
-    ]),
+    (
+        "rocksdb_memtable_count",
+        &[
+            (NUM_ENTRIES_ACTIVE_MEM_TABLE, "entries_active"),
+            (NUM_ENTRIES_IMM_MEM_TABLES, "entries_imm"),
+            (NUM_DELETES_ACTIVE_MEM_TABLE, "deletes_active"),
+            (NUM_DELETES_IMM_MEM_TABLES, "deletes_imm"),
+        ],
+    ),
     // Memtable state (immutables, flushes, etc.)
-    ("rocksdb_memtable_state_count", &[
-        (NUM_IMMUTABLE_MEM_TABLE, "immutable"),
-        (NUM_IMMUTABLE_MEM_TABLE_FLUSHED, "immutable_flushed"),
-        (NUM_RUNNING_FLUSHES, "running_flushes"),
-    ]),
+    (
+        "rocksdb_memtable_state_count",
+        &[
+            (NUM_IMMUTABLE_MEM_TABLE, "immutable"),
+            (NUM_IMMUTABLE_MEM_TABLE_FLUSHED, "immutable_flushed"),
+            (NUM_RUNNING_FLUSHES, "running_flushes"),
+        ],
+    ),
     // Active compactions
-    ("rocksdb_compaction_count", &[(
-        NUM_RUNNING_COMPACTIONS,
-        "running_compactions",
-    )]),
+    (
+        "rocksdb_compaction_count",
+        &[(NUM_RUNNING_COMPACTIONS, "running_compactions")],
+    ),
     // LSM structure info
-    ("rocksdb_lsm_count", &[
-        (NUM_LIVE_VERSIONS, "live_versions"),
-        (CURRENT_SUPER_VERSION_NUMBER, "super_version_number"),
-    ]),
+    (
+        "rocksdb_lsm_count",
+        &[
+            (NUM_LIVE_VERSIONS, "live_versions"),
+            (CURRENT_SUPER_VERSION_NUMBER, "super_version_number"),
+        ],
+    ),
     // Background errors
-    ("rocksdb_errors_count", &[(
-        BACKGROUND_ERRORS,
-        "background_errors",
-    )]),
+    (
+        "rocksdb_errors_count",
+        &[(BACKGROUND_ERRORS, "background_errors")],
+    ),
     // ============= FLAGS (0/1) =============
-    ("rocksdb_flags", &[
-        (COMPACTION_PENDING, "compaction_pending"),
-        (MEM_TABLE_FLUSH_PENDING, "memtable_flush_pending"),
-        (IS_WRITE_STOPPED, "is_write_stopped"),
-        (IS_FILE_DELETIONS_ENABLED, "is_file_deletions_enabled"),
-    ]),
+    (
+        "rocksdb_flags",
+        &[
+            (COMPACTION_PENDING, "compaction_pending"),
+            (MEM_TABLE_FLUSH_PENDING, "memtable_flush_pending"),
+            (IS_WRITE_STOPPED, "is_write_stopped"),
+            (IS_FILE_DELETIONS_ENABLED, "is_file_deletions_enabled"),
+        ],
+    ),
 ];
 
 pub(crate) struct StatisticsWorker {

--- a/dango/core/ffi/src/exports.rs
+++ b/dango/core/ffi/src/exports.rs
@@ -18,7 +18,9 @@ macro_rules! unwrap_into_generic_result {
         match $expr {
             Ok(val) => val,
             Err(err) => {
-                return GenericResult::Err(::dango_backtrace::BacktracedError::new(err.to_string()));
+                return GenericResult::Err(::dango_backtrace::BacktracedError::new(
+                    err.to_string(),
+                ));
             },
         }
     };

--- a/dango/core/storage/src/index/map.rs
+++ b/dango/core/storage/src/index/map.rs
@@ -377,15 +377,18 @@ mod tests {
         dango_primitives::{BorshSerExt, Bound, MockStorage, Order, StdResult},
     };
 
-    const FOOS: IndexedMap<(u64, u64), Foo, FooIndexes> = IndexedMap::new("foo", FooIndexes {
-        name: MultiIndex::new(|_, data| data.name.clone(), "foo", "foo__name"),
-        name_surname: MultiIndex::new(
-            |_, data| (data.name.clone(), data.surname.clone()),
-            "foo",
-            "foo__name_surname",
-        ),
-        id: UniqueIndex::new(|_, data| data.id, "foo", "foo__id"),
-    });
+    const FOOS: IndexedMap<(u64, u64), Foo, FooIndexes> = IndexedMap::new(
+        "foo",
+        FooIndexes {
+            name: MultiIndex::new(|_, data| data.name.clone(), "foo", "foo__name"),
+            name_surname: MultiIndex::new(
+                |_, data| (data.name.clone(), data.surname.clone()),
+                "foo",
+                "foo__name_surname",
+            ),
+            id: UniqueIndex::new(|_, data| data.id, "foo", "foo__id"),
+        },
+    );
 
     #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
     struct Foo {
@@ -460,13 +463,16 @@ mod tests {
                 .map(|val| val.unwrap())
                 .collect::<Vec<_>>();
 
-            assert_eq!(val, [
-                (101, Foo::new("bar", "s_bar", 101)),
-                (102, Foo::new("bar", "s_bar", 102)),
-                (103, Foo::new("bar", "s_bar", 103)),
-                (104, Foo::new("bar", "s_fooes", 104)),
-                (105, Foo::new("foo", "s_foo", 105))
-            ]);
+            assert_eq!(
+                val,
+                [
+                    (101, Foo::new("bar", "s_bar", 101)),
+                    (102, Foo::new("bar", "s_bar", 102)),
+                    (103, Foo::new("bar", "s_bar", 103)),
+                    (104, Foo::new("bar", "s_fooes", 104)),
+                    (105, Foo::new("foo", "s_foo", 105))
+                ]
+            );
         }
     }
 
@@ -484,13 +490,16 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ("bar".to_string(), (0, 1), Foo::new("bar", "s_bar", 101)),
-                ("bar".to_string(), (0, 2), Foo::new("bar", "s_bar", 102)),
-                ("bar".to_string(), (1, 1), Foo::new("bar", "s_bar", 103)),
-                ("bar".to_string(), (1, 2), Foo::new("bar", "s_fooes", 104)),
-                ("foo".to_string(), (1, 3), Foo::new("foo", "s_foo", 105)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ("bar".to_string(), (0, 1), Foo::new("bar", "s_bar", 101)),
+                    ("bar".to_string(), (0, 2), Foo::new("bar", "s_bar", 102)),
+                    ("bar".to_string(), (1, 1), Foo::new("bar", "s_bar", 103)),
+                    ("bar".to_string(), (1, 2), Foo::new("bar", "s_fooes", 104)),
+                    ("foo".to_string(), (1, 3), Foo::new("foo", "s_foo", 105)),
+                ]
+            );
         }
 
         // Given a specific index value, iterate records corresponding to it.
@@ -505,12 +514,15 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ((0, 1), Foo::new("bar", "s_bar", 101)),
-                ((0, 2), Foo::new("bar", "s_bar", 102)),
-                ((1, 1), Foo::new("bar", "s_bar", 103)),
-                ((1, 2), Foo::new("bar", "s_fooes", 104)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ((0, 1), Foo::new("bar", "s_bar", 101)),
+                    ((0, 2), Foo::new("bar", "s_bar", 102)),
+                    ((1, 1), Foo::new("bar", "s_bar", 103)),
+                    ((1, 2), Foo::new("bar", "s_fooes", 104)),
+                ]
+            );
         }
     }
 
@@ -542,11 +554,14 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ((0, 1), Foo::new("bar", "s_bar", 101)),
-                ((0, 2), Foo::new("bar", "s_bar", 102)),
-                ((1, 1), Foo::new("bar", "s_bar", 103)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ((0, 1), Foo::new("bar", "s_bar", 101)),
+                    ((0, 2), Foo::new("bar", "s_bar", 102)),
+                    ((1, 1), Foo::new("bar", "s_bar", 103)),
+                ]
+            );
         }
 
         // Given (A, B), iterate (C, D), with bounds.
@@ -566,10 +581,13 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ((0, 2), Foo::new("bar", "s_bar", 102)),
-                ((1, 1), Foo::new("bar", "s_bar", 103)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ((0, 2), Foo::new("bar", "s_bar", 102)),
+                    ((1, 1), Foo::new("bar", "s_bar", 103)),
+                ]
+            );
         }
 
         // Given A, iterate (B, C, D), without bounds.
@@ -584,12 +602,15 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ((0, 1), Foo::new("bar", "s_bar", 101)),
-                ((0, 2), Foo::new("bar", "s_bar", 102)),
-                ((1, 1), Foo::new("bar", "s_bar", 103)),
-                ((1, 2), Foo::new("bar", "s_fooes", 104)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ((0, 1), Foo::new("bar", "s_bar", 101)),
+                    ((0, 2), Foo::new("bar", "s_bar", 102)),
+                    ((1, 1), Foo::new("bar", "s_bar", 103)),
+                    ((1, 2), Foo::new("bar", "s_fooes", 104)),
+                ]
+            );
         }
 
         // Given A, iterate (B, C, D), with bounds.
@@ -610,11 +631,14 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ((0, 2), Foo::new("bar", "s_bar", 102)),
-                ((1, 1), Foo::new("bar", "s_bar", 103)),
-                ((1, 2), Foo::new("bar", "s_fooes", 104)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ((0, 2), Foo::new("bar", "s_bar", 102)),
+                    ((1, 1), Foo::new("bar", "s_bar", 103)),
+                    ((1, 2), Foo::new("bar", "s_fooes", 104)),
+                ]
+            );
         }
 
         // Given (A, B, C), iterate D, without bounds.
@@ -631,10 +655,13 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ((0, 1), Foo::new("bar", "s_bar", 101)),
-                ((0, 2), Foo::new("bar", "s_bar", 102)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ((0, 1), Foo::new("bar", "s_bar", 101)),
+                    ((0, 2), Foo::new("bar", "s_bar", 102)),
+                ]
+            );
         }
 
         // Given (A, B, C), iterate D, with bounds.
@@ -673,11 +700,14 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ((0, 1), Foo::new("bar", "s_bar", 101)),
-                ((0, 2), Foo::new("bar", "s_bar", 102)),
-                ((1, 1), Foo::new("bar", "s_bar", 103)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ((0, 1), Foo::new("bar", "s_bar", 101)),
+                    ((0, 2), Foo::new("bar", "s_bar", 102)),
+                    ((1, 1), Foo::new("bar", "s_bar", 103)),
+                ]
+            );
         }
 
         // Given A, iterate (B, C, D) using prefix_keys, without bounds only B.
@@ -695,11 +725,14 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                ("s_bar".to_string(), (0, 1)),
-                ("s_bar".to_string(), (0, 2)),
-                ("s_bar".to_string(), (1, 1)),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    ("s_bar".to_string(), (0, 1)),
+                    ("s_bar".to_string(), (0, 2)),
+                    ("s_bar".to_string(), (1, 1)),
+                ]
+            );
         }
 
         // Given A, iterate (B, C, D) usign prefix_values, without bounds only B.
@@ -717,11 +750,14 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                Foo::new("bar", "s_bar", 101),
-                Foo::new("bar", "s_bar", 102),
-                Foo::new("bar", "s_bar", 103),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    Foo::new("bar", "s_bar", 101),
+                    Foo::new("bar", "s_bar", 102),
+                    Foo::new("bar", "s_bar", 103),
+                ]
+            );
         }
 
         // Given A, iterate (B, C, D) using values, without bounds only B.
@@ -734,12 +770,15 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                Foo::new("bar", "s_bar", 101),
-                Foo::new("bar", "s_bar", 102),
-                Foo::new("bar", "s_bar", 103),
-                Foo::new("bar", "s_fooes", 104),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    Foo::new("bar", "s_bar", 101),
+                    Foo::new("bar", "s_bar", 102),
+                    Foo::new("bar", "s_bar", 103),
+                    Foo::new("bar", "s_fooes", 104),
+                ]
+            );
         }
 
         // Given A, iterate (B, C, D) using values_raw, without bounds only B.
@@ -752,12 +791,15 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                Foo::new("bar", "s_bar", 101).to_borsh_vec().unwrap(),
-                Foo::new("bar", "s_bar", 102).to_borsh_vec().unwrap(),
-                Foo::new("bar", "s_bar", 103).to_borsh_vec().unwrap(),
-                Foo::new("bar", "s_fooes", 104).to_borsh_vec().unwrap(),
-            ]);
+            assert_eq!(
+                val,
+                [
+                    Foo::new("bar", "s_bar", 101).to_borsh_vec().unwrap(),
+                    Foo::new("bar", "s_bar", 102).to_borsh_vec().unwrap(),
+                    Foo::new("bar", "s_bar", 103).to_borsh_vec().unwrap(),
+                    Foo::new("bar", "s_fooes", 104).to_borsh_vec().unwrap(),
+                ]
+            );
         }
     }
 }
@@ -816,15 +858,18 @@ mod cosmwasm_tests {
         }
     }
 
-    const DATA: IndexedMap<&str, Data, DataIndexes> = IndexedMap::new("data", DataIndexes {
-        name: MultiIndex::new(|_pk, d| d.name.to_string(), "data", "data__name"),
-        age: UniqueIndex::new(|_, d| d.age, "data", "data__age"),
-        name_lastname: UniqueIndex::new(
-            |_, d| index_string_tuple(&d.name, &d.last_name),
-            "data",
-            "data__name_lastname",
-        ),
-    });
+    const DATA: IndexedMap<&str, Data, DataIndexes> = IndexedMap::new(
+        "data",
+        DataIndexes {
+            name: MultiIndex::new(|_pk, d| d.name.to_string(), "data", "data__name"),
+            age: UniqueIndex::new(|_, d| d.age, "data", "data__age"),
+            name_lastname: UniqueIndex::new(
+                |_, d| index_string_tuple(&d.name, &d.last_name),
+                "data",
+                "data__name_lastname",
+            ),
+        },
+    );
 
     fn index_string(data: &str) -> Vec<u8> {
         data.as_bytes().to_vec()
@@ -1564,10 +1609,10 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect();
         let result = result.unwrap();
-        assert_eq!(result, [
-            ("5628".to_string(), data2),
-            ("5629".to_string(), data3),
-        ]);
+        assert_eq!(
+            result,
+            [("5628".to_string(), data2), ("5629".to_string(), data3),]
+        );
     }
 
     #[test]
@@ -1680,10 +1725,13 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(result, [
-            (("1".to_string(), "5627".to_string()), data1),
-            (("2".to_string(), "5628".to_string()), data2),
-        ]);
+        assert_eq!(
+            result,
+            [
+                (("1".to_string(), "5627".to_string()), data1),
+                (("2".to_string(), "5628".to_string()), data2),
+            ]
+        );
     }
 
     #[test]
@@ -1743,11 +1791,14 @@ mod cosmwasm_tests {
             )
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(result, [
-            (("2".to_string(), "5628".to_string()), data2.clone()),
-            (("2".to_string(), "5629".to_string()), data3.clone()),
-            (("3".to_string(), "5630".to_string()), data4)
-        ]);
+        assert_eq!(
+            result,
+            [
+                (("2".to_string(), "5628".to_string()), data2.clone()),
+                (("2".to_string(), "5629".to_string()), data3.clone()),
+                (("3".to_string(), "5630".to_string()), data4)
+            ]
+        );
 
         // let's try to iterate over a more restrictive prefix-range!
         let result = map
@@ -1759,10 +1810,13 @@ mod cosmwasm_tests {
             )
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(result, [
-            (("2".to_string(), "5628".to_string()), data2),
-            (("2".to_string(), "5629".to_string()), data3),
-        ]);
+        assert_eq!(
+            result,
+            [
+                (("2".to_string(), "5628".to_string()), data2),
+                (("2".to_string(), "5629".to_string()), data3),
+            ]
+        );
     }
 
     #[test]
@@ -1826,24 +1880,27 @@ mod cosmwasm_tests {
             )
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(result, [
-            (
-                ("1".to_string(), "1".to_string(), "5627".to_string()),
-                data1.clone()
-            ),
-            (
-                ("1".to_string(), "2".to_string(), "5628".to_string()),
-                data2.clone()
-            ),
-            (
-                ("2".to_string(), "1".to_string(), "5629".to_string()),
-                data3.clone()
-            ),
-            (
-                ("2".to_string(), "2".to_string(), "5630".to_string()),
-                data4
-            )
-        ]);
+        assert_eq!(
+            result,
+            [
+                (
+                    ("1".to_string(), "1".to_string(), "5627".to_string()),
+                    data1.clone()
+                ),
+                (
+                    ("1".to_string(), "2".to_string(), "5628".to_string()),
+                    data2.clone()
+                ),
+                (
+                    ("2".to_string(), "1".to_string(), "5629".to_string()),
+                    data3.clone()
+                ),
+                (
+                    ("2".to_string(), "2".to_string(), "5630".to_string()),
+                    data4
+                )
+            ]
+        );
 
         // let's prefix-range over inclusive bounds on both sides
         let result = map
@@ -1855,16 +1912,19 @@ mod cosmwasm_tests {
             )
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(result, [
-            (
-                ("1".to_string(), "1".to_string(), "5627".to_string()),
-                data1.clone()
-            ),
-            (
-                ("1".to_string(), "2".to_string(), "5628".to_string()),
-                data2.clone()
-            ),
-        ]);
+        assert_eq!(
+            result,
+            [
+                (
+                    ("1".to_string(), "1".to_string(), "5627".to_string()),
+                    data1.clone()
+                ),
+                (
+                    ("1".to_string(), "2".to_string(), "5628".to_string()),
+                    data2.clone()
+                ),
+            ]
+        );
     }
 
     mod bounds_unique_index {
@@ -1975,10 +2035,10 @@ mod cosmwasm_tests {
                 )
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
-            assert_eq!(items, [
-                (2, "two2".to_string(), 2),
-                (3, "three".to_string(), 3)
-            ]);
+            assert_eq!(
+                items,
+                [(2, "two2".to_string(), 2), (3, "three".to_string(), 3)]
+            );
         }
     }
 

--- a/dango/core/storage/src/map.rs
+++ b/dango/core/storage/src/map.rs
@@ -389,11 +389,14 @@ mod test {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(res, vec![
-                ((1_u64, "name_1".to_string()), "desc_1".to_string()),
-                ((2_u64, "name_2".to_string()), "desc_2".to_string()),
-                ((2_u64, "name_3".to_string()), "desc_3".to_string()),
-            ]);
+            assert_eq!(
+                res,
+                vec![
+                    ((1_u64, "name_1".to_string()), "desc_1".to_string()),
+                    ((2_u64, "name_2".to_string()), "desc_2".to_string()),
+                    ((2_u64, "name_3".to_string()), "desc_3".to_string()),
+                ]
+            );
         }
 
         // `prefix_range` with a min bound, ascending
@@ -408,11 +411,14 @@ mod test {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(res, vec![
-                ((3_u64, "name_4".to_string()), "desc_4".to_string()),
-                ((3_u64, "name_5".to_string()), "desc_5".to_string()),
-                ((4_u64, "name_6".to_string()), "desc_6".to_string()),
-            ]);
+            assert_eq!(
+                res,
+                vec![
+                    ((3_u64, "name_4".to_string()), "desc_4".to_string()),
+                    ((3_u64, "name_5".to_string()), "desc_5".to_string()),
+                    ((4_u64, "name_6".to_string()), "desc_6".to_string()),
+                ]
+            );
         }
 
         // `prefix_range` with a max bound, Descending
@@ -445,13 +451,16 @@ mod test {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(res, vec![
-                ((4_u64, "name_6".to_string()), "desc_6".to_string()),
-                ((3_u64, "name_5".to_string()), "desc_5".to_string()),
-                ((3_u64, "name_4".to_string()), "desc_4".to_string()),
-                ((2_u64, "name_3".to_string()), "desc_3".to_string()),
-                ((2_u64, "name_2".to_string()), "desc_2".to_string()),
-            ]);
+            assert_eq!(
+                res,
+                vec![
+                    ((4_u64, "name_6".to_string()), "desc_6".to_string()),
+                    ((3_u64, "name_5".to_string()), "desc_5".to_string()),
+                    ((3_u64, "name_4".to_string()), "desc_4".to_string()),
+                    ((2_u64, "name_3".to_string()), "desc_3".to_string()),
+                    ((2_u64, "name_2".to_string()), "desc_2".to_string()),
+                ]
+            );
         }
 
         // `prefix_range` with both min and max bounds, ascending
@@ -466,12 +475,15 @@ mod test {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(res, vec![
-                ((2_u64, "name_2".to_string()), "desc_2".to_string()),
-                ((2_u64, "name_3".to_string()), "desc_3".to_string()),
-                ((3_u64, "name_4".to_string()), "desc_4".to_string()),
-                ((3_u64, "name_5".to_string()), "desc_5".to_string()),
-            ]);
+            assert_eq!(
+                res,
+                vec![
+                    ((2_u64, "name_2".to_string()), "desc_2".to_string()),
+                    ((2_u64, "name_3".to_string()), "desc_3".to_string()),
+                    ((3_u64, "name_4".to_string()), "desc_4".to_string()),
+                    ((3_u64, "name_5".to_string()), "desc_5".to_string()),
+                ]
+            );
         }
     }
 }
@@ -663,10 +675,13 @@ mod cosmwasm_tests {
             .collect();
 
         assert_eq!(2, all.len());
-        assert_eq!(all, vec![
-            (b"jim".to_vec(), data_2_raw.clone()),
-            (b"john".to_vec(), data_1_raw.clone())
-        ]);
+        assert_eq!(
+            all,
+            vec![
+                (b"jim".to_vec(), data_2_raw.clone()),
+                (b"john".to_vec(), data_1_raw.clone())
+            ]
+        );
 
         // let's try to iterate over a range
         let all: Vec<_> = PEOPLE
@@ -678,10 +693,13 @@ mod cosmwasm_tests {
             )
             .collect();
         assert_eq!(2, all.len());
-        assert_eq!(all, vec![
-            (b"jim".to_vec(), data_2_raw),
-            (b"john".to_vec(), data_1_raw.clone())
-        ]);
+        assert_eq!(
+            all,
+            vec![
+                (b"jim".to_vec(), data_2_raw),
+                (b"john".to_vec(), data_1_raw.clone())
+            ]
+        );
 
         // let's try to iterate over a more restrictive range
         let all: Vec<_> = PEOPLE
@@ -724,11 +742,14 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            (b"ada".to_vec(), data3),
-            (b"jim".to_vec(), data2.clone()),
-            (b"john".to_vec(), data.clone())
-        ]);
+        assert_eq!(
+            all,
+            [
+                (b"ada".to_vec(), data3),
+                (b"jim".to_vec(), data2.clone()),
+                (b"john".to_vec(), data.clone())
+            ]
+        );
 
         // let's try to iterate over a range
         let all = PEOPLE
@@ -740,10 +761,10 @@ mod cosmwasm_tests {
             )
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            (b"jim".to_vec(), data2),
-            (b"john".to_vec(), data.clone())
-        ]);
+        assert_eq!(
+            all,
+            [(b"jim".to_vec(), data2), (b"john".to_vec(), data.clone())]
+        );
 
         // let's try to iterate over a more restrictive range
         let all = PEOPLE
@@ -786,11 +807,14 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            ("ada".to_string(), data3.clone()),
-            ("jim".to_string(), data2.clone()),
-            ("john".to_string(), data.clone())
-        ]);
+        assert_eq!(
+            all,
+            [
+                ("ada".to_string(), data3.clone()),
+                ("jim".to_string(), data2.clone()),
+                ("john".to_string(), data.clone())
+            ]
+        );
 
         // Manually add a broken key (invalid utf-8)
         storage.write(
@@ -819,23 +843,29 @@ mod cosmwasm_tests {
         let all: Vec<_> = PEOPLE_STR
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            (b"ada".to_vec(), data3.to_borsh_vec().unwrap()),
-            (b"jim".to_vec(), data2.to_borsh_vec().unwrap()),
-            (b"john".to_vec(), data.to_borsh_vec().unwrap()),
-            (b"\xddim".to_vec(), data2.to_borsh_vec().unwrap()),
-        ]);
+        assert_eq!(
+            all,
+            [
+                (b"ada".to_vec(), data3.to_borsh_vec().unwrap()),
+                (b"jim".to_vec(), data2.to_borsh_vec().unwrap()),
+                (b"john".to_vec(), data.to_borsh_vec().unwrap()),
+                (b"\xddim".to_vec(), data2.to_borsh_vec().unwrap()),
+            ]
+        );
 
         // And the same with keys_raw
         let all: Vec<_> = PEOPLE_STR
             .keys_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            b"ada".to_vec(),
-            b"jim".to_vec(),
-            b"john".to_vec(),
-            b"\xddim".to_vec(),
-        ]);
+        assert_eq!(
+            all,
+            [
+                b"ada".to_vec(),
+                b"jim".to_vec(),
+                b"john".to_vec(),
+                b"\xddim".to_vec(),
+            ]
+        );
     }
 
     #[test]
@@ -966,11 +996,10 @@ mod cosmwasm_tests {
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
         // order is correct
-        assert_eq!(all, [
-            (-1234, data),
-            (-56, data2.clone()),
-            (50, data3.clone())
-        ]);
+        assert_eq!(
+            all,
+            [(-1234, data), (-56, data2.clone()), (50, data3.clone())]
+        );
 
         // let's try to iterate over a range
         let all = SIGNED_ID
@@ -1026,11 +1055,10 @@ mod cosmwasm_tests {
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
         // order is correct
-        assert_eq!(all, [
-            (-1234, data),
-            (-56, data2.clone()),
-            (50, data3.clone())
-        ]);
+        assert_eq!(
+            all,
+            [(-1234, data), (-56, data2.clone()), (50, data3.clone())]
+        );
 
         // let's try to iterate over a range
         let all = SIGNED_ID
@@ -1076,30 +1104,36 @@ mod cosmwasm_tests {
         let all: Vec<_> = ALLOWANCE
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            (
-                (b"owner".to_vec(), b"spender".to_vec()).joined_key(),
-                1000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (b"owner".to_vec(), b"spender2".to_vec()).joined_key(),
-                3000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (b"owner2".to_vec(), b"spender".to_vec()).joined_key(),
-                5000_u64.to_borsh_vec().unwrap()
-            ),
-        ]);
+        assert_eq!(
+            all,
+            [
+                (
+                    (b"owner".to_vec(), b"spender".to_vec()).joined_key(),
+                    1000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (b"owner".to_vec(), b"spender2".to_vec()).joined_key(),
+                    3000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (b"owner2".to_vec(), b"spender".to_vec()).joined_key(),
+                    5000_u64.to_borsh_vec().unwrap()
+                ),
+            ]
+        );
 
         // let's try to iterate over a prefix
         let all: Vec<_> = ALLOWANCE
             .prefix(b"owner")
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            (b"spender".to_vec(), 1000_u64.to_borsh_vec().unwrap()),
-            (b"spender2".to_vec(), 3000_u64.to_borsh_vec().unwrap())
-        ]);
+        assert_eq!(
+            all,
+            [
+                (b"spender".to_vec(), 1000_u64.to_borsh_vec().unwrap()),
+                (b"spender2".to_vec(), 3000_u64.to_borsh_vec().unwrap())
+            ]
+        );
     }
 
     #[test]
@@ -1122,11 +1156,14 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            ((b"owner".to_vec(), b"spender".to_vec()), 1000),
-            ((b"owner".to_vec(), b"spender2".to_vec()), 3000),
-            ((b"owner2".to_vec(), b"spender".to_vec()), 5000)
-        ]);
+        assert_eq!(
+            all,
+            [
+                ((b"owner".to_vec(), b"spender".to_vec()), 1000),
+                ((b"owner".to_vec(), b"spender2".to_vec()), 3000),
+                ((b"owner2".to_vec(), b"spender".to_vec()), 5000)
+            ]
+        );
 
         // let's try to iterate over a prefix
         let all = ALLOWANCE
@@ -1134,10 +1171,10 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            (b"spender".to_vec(), 1000),
-            (b"spender2".to_vec(), 3000),
-        ]);
+        assert_eq!(
+            all,
+            [(b"spender".to_vec(), 1000), (b"spender2".to_vec(), 3000),]
+        );
 
         // let's try to iterate over a prefixed restricted inclusive range
         let all = ALLOWANCE
@@ -1150,10 +1187,10 @@ mod cosmwasm_tests {
             )
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            (b"spender".to_vec(), 1000),
-            (b"spender2".to_vec(), 3000),
-        ]);
+        assert_eq!(
+            all,
+            [(b"spender".to_vec(), 1000), (b"spender2".to_vec(), 3000),]
+        );
 
         // let's try to iterate over a prefixed restricted exclusive range
         let all = ALLOWANCE
@@ -1191,44 +1228,50 @@ mod cosmwasm_tests {
         let all: Vec<_> = TRIPLE
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            (
-                (b"owner".to_vec(), 9u8, b"recipient".to_vec()).joined_key(),
-                1000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (b"owner".to_vec(), 9u8, b"recipient2".to_vec()).joined_key(),
-                3000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (b"owner".to_vec(), 10u8, b"recipient3".to_vec()).joined_key(),
-                3000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (b"owner2".to_vec(), 9u8, b"recipient".to_vec()).joined_key(),
-                5000_u64.to_borsh_vec().unwrap()
-            )
-        ]);
+        assert_eq!(
+            all,
+            [
+                (
+                    (b"owner".to_vec(), 9u8, b"recipient".to_vec()).joined_key(),
+                    1000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (b"owner".to_vec(), 9u8, b"recipient2".to_vec()).joined_key(),
+                    3000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (b"owner".to_vec(), 10u8, b"recipient3".to_vec()).joined_key(),
+                    3000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (b"owner2".to_vec(), 9u8, b"recipient".to_vec()).joined_key(),
+                    5000_u64.to_borsh_vec().unwrap()
+                )
+            ]
+        );
 
         // let's iterate over a prefix
         let all: Vec<_> = TRIPLE
             .prefix(b"owner")
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            (
-                (9u8, b"recipient".to_vec()).joined_key(),
-                1000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (9u8, b"recipient2".to_vec()).joined_key(),
-                3000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (10u8, b"recipient3".to_vec()).joined_key(),
-                3000_u64.to_borsh_vec().unwrap()
-            )
-        ]);
+        assert_eq!(
+            all,
+            [
+                (
+                    (9u8, b"recipient".to_vec()).joined_key(),
+                    1000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (9u8, b"recipient2".to_vec()).joined_key(),
+                    3000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (10u8, b"recipient3".to_vec()).joined_key(),
+                    3000_u64.to_borsh_vec().unwrap()
+                )
+            ]
+        );
 
         // let's iterate over a sub prefix
         let all: Vec<_> = TRIPLE
@@ -1237,16 +1280,19 @@ mod cosmwasm_tests {
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
         // Use range() if you want key deserialization
-        assert_eq!(all, [
-            (
-                (b"recipient".to_vec()).joined_key(),
-                1000_u64.to_borsh_vec().unwrap()
-            ),
-            (
-                (b"recipient2".to_vec()).joined_key(),
-                3000_u64.to_borsh_vec().unwrap()
-            ),
-        ]);
+        assert_eq!(
+            all,
+            [
+                (
+                    (b"recipient".to_vec()).joined_key(),
+                    1000_u64.to_borsh_vec().unwrap()
+                ),
+                (
+                    (b"recipient2".to_vec()).joined_key(),
+                    3000_u64.to_borsh_vec().unwrap()
+                ),
+            ]
+        );
     }
 
     #[test]
@@ -1272,12 +1318,15 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            ((b"owner".to_vec(), 9, "recipient".to_string()), 1000),
-            ((b"owner".to_vec(), 9, "recipient2".to_string()), 3000),
-            ((b"owner".to_vec(), 10, "recipient3".to_string()), 3000),
-            ((b"owner2".to_vec(), 9, "recipient".to_string()), 5000)
-        ]);
+        assert_eq!(
+            all,
+            [
+                ((b"owner".to_vec(), 9, "recipient".to_string()), 1000),
+                ((b"owner".to_vec(), 9, "recipient2".to_string()), 3000),
+                ((b"owner".to_vec(), 10, "recipient3".to_string()), 3000),
+                ((b"owner2".to_vec(), 9, "recipient".to_string()), 5000)
+            ]
+        );
 
         // let's iterate over a sub_prefix
         let all = TRIPLE
@@ -1285,11 +1334,14 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            ((9, "recipient".to_string()), 1000),
-            ((9, "recipient2".to_string()), 3000),
-            ((10, "recipient3".to_string()), 3000),
-        ]);
+        assert_eq!(
+            all,
+            [
+                ((9, "recipient".to_string()), 1000),
+                ((9, "recipient2".to_string()), 3000),
+                ((10, "recipient3".to_string()), 3000),
+            ]
+        );
 
         // let's iterate over a prefix
         let all = TRIPLE
@@ -1298,10 +1350,13 @@ mod cosmwasm_tests {
             .range(&storage, None, None, Order::Ascending)
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            ("recipient".to_string(), 1000),
-            ("recipient2".to_string(), 3000),
-        ]);
+        assert_eq!(
+            all,
+            [
+                ("recipient".to_string(), 1000),
+                ("recipient2".to_string(), 3000),
+            ]
+        );
 
         // let's try to iterate over a prefixed restricted inclusive range
         let all = TRIPLE
@@ -1315,10 +1370,13 @@ mod cosmwasm_tests {
             )
             .collect::<StdResult<Vec<_>>>()
             .unwrap();
-        assert_eq!(all, [
-            ("recipient".to_string(), 1000),
-            ("recipient2".to_string(), 3000),
-        ]);
+        assert_eq!(
+            all,
+            [
+                ("recipient".to_string(), 1000),
+                ("recipient2".to_string(), 3000),
+            ]
+        );
 
         // let's try to iterate over a prefixed restricted exclusive range
         let all = TRIPLE
@@ -1504,10 +1562,13 @@ mod cosmwasm_tests {
         let all: Vec<_> = PEOPLE
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            (b"jim".to_vec(), data2.to_borsh_vec().unwrap()),
-            (b"john".to_vec(), data.to_borsh_vec().unwrap())
-        ]);
+        assert_eq!(
+            all,
+            [
+                (b"jim".to_vec(), data2.to_borsh_vec().unwrap()),
+                (b"john".to_vec(), data.to_borsh_vec().unwrap())
+            ]
+        );
 
         // or just show what is after jim
         let all: Vec<_> = PEOPLE
@@ -1536,10 +1597,13 @@ mod cosmwasm_tests {
             .prefix(b"owner")
             .range_raw(&storage, None, None, Order::Ascending)
             .collect();
-        assert_eq!(all, [
-            (b"spender".to_vec(), 1000_u64.to_borsh_vec().unwrap()),
-            (b"spender2".to_vec(), 3000_u64.to_borsh_vec().unwrap())
-        ]);
+        assert_eq!(
+            all,
+            [
+                (b"spender".to_vec(), 1000_u64.to_borsh_vec().unwrap()),
+                (b"spender2".to_vec(), 3000_u64.to_borsh_vec().unwrap())
+            ]
+        );
 
         // Or ranges between two items (even reverse)
         let all: Vec<_> = ALLOWANCE
@@ -1551,10 +1615,10 @@ mod cosmwasm_tests {
                 Order::Descending,
             )
             .collect();
-        assert_eq!(all, [(
-            b"spender2".to_vec(),
-            3000_u64.to_borsh_vec().unwrap()
-        )]);
+        assert_eq!(
+            all,
+            [(b"spender2".to_vec(), 3000_u64.to_borsh_vec().unwrap())]
+        );
     }
 
     #[test]
@@ -1578,10 +1642,13 @@ mod cosmwasm_tests {
             .prefix(5)
             .range_raw(&storage, None, None, Order::Ascending)
             .collect::<Vec<_>>();
-        assert_eq!(fives, [
-            (vec![7, 8, 9], 789_u64.to_borsh_vec().unwrap()),
-            (vec![9, 8, 7], 987_u64.to_borsh_vec().unwrap())
-        ]);
+        assert_eq!(
+            fives,
+            [
+                (vec![7, 8, 9], 789_u64.to_borsh_vec().unwrap()),
+                (vec![9, 8, 7], 987_u64.to_borsh_vec().unwrap())
+            ]
+        );
 
         // using inclusive bounds both sides
         let include = AGES

--- a/dango/core/storage/src/set.rs
+++ b/dango/core/storage/src/set.rs
@@ -499,14 +499,17 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                (Dec128::from_str("-1.5").unwrap(), "a".to_string()),
-                (Dec128::from_str("-1.5").unwrap(), "b".to_string()),
-                (Dec128::from_str("0").unwrap(), "abcb".to_string()),
-                (Dec128::from_str("1").unwrap(), "b".to_string()),
-                (Dec128::from_str("2").unwrap(), "a".to_string()),
-                (Dec128::from_str("2").unwrap(), "b".to_string())
-            ]);
+            assert_eq!(
+                val,
+                [
+                    (Dec128::from_str("-1.5").unwrap(), "a".to_string()),
+                    (Dec128::from_str("-1.5").unwrap(), "b".to_string()),
+                    (Dec128::from_str("0").unwrap(), "abcb".to_string()),
+                    (Dec128::from_str("1").unwrap(), "b".to_string()),
+                    (Dec128::from_str("2").unwrap(), "a".to_string()),
+                    (Dec128::from_str("2").unwrap(), "b".to_string())
+                ]
+            );
         }
 
         // Max
@@ -521,16 +524,19 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                (Dec128::from_str("-2").unwrap(), "a".to_string()),
-                (Dec128::from_str("-2").unwrap(), "b".to_string()),
-                (Dec128::from_str("-2").unwrap(), "c".to_string()),
-                (Dec128::from_str("-2").unwrap(), "d".to_string()),
-                (Dec128::from_str("-2").unwrap(), "e".to_string()),
-                (Dec128::from_str("-1.5").unwrap(), "a".to_string()),
-                (Dec128::from_str("-1.5").unwrap(), "b".to_string()),
-                (Dec128::from_str("0").unwrap(), "abcb".to_string())
-            ]);
+            assert_eq!(
+                val,
+                [
+                    (Dec128::from_str("-2").unwrap(), "a".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "b".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "c".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "d".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "e".to_string()),
+                    (Dec128::from_str("-1.5").unwrap(), "a".to_string()),
+                    (Dec128::from_str("-1.5").unwrap(), "b".to_string()),
+                    (Dec128::from_str("0").unwrap(), "abcb".to_string())
+                ]
+            );
         }
 
         // Max Min
@@ -545,15 +551,18 @@ mod tests {
                 .collect::<StdResult<Vec<_>>>()
                 .unwrap();
 
-            assert_eq!(val, [
-                (Dec128::from_str("-2").unwrap(), "a".to_string()),
-                (Dec128::from_str("-2").unwrap(), "b".to_string()),
-                (Dec128::from_str("-2").unwrap(), "c".to_string()),
-                (Dec128::from_str("-2").unwrap(), "d".to_string()),
-                (Dec128::from_str("-2").unwrap(), "e".to_string()),
-                (Dec128::from_str("-1.5").unwrap(), "a".to_string()),
-                (Dec128::from_str("-1.5").unwrap(), "b".to_string())
-            ]);
+            assert_eq!(
+                val,
+                [
+                    (Dec128::from_str("-2").unwrap(), "a".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "b".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "c".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "d".to_string()),
+                    (Dec128::from_str("-2").unwrap(), "e".to_string()),
+                    (Dec128::from_str("-1.5").unwrap(), "a".to_string()),
+                    (Dec128::from_str("-1.5").unwrap(), "b".to_string())
+                ]
+            );
         }
     }
 }

--- a/dango/core/storage/tests/index_list.rs
+++ b/dango/core/storage/tests/index_list.rs
@@ -13,10 +13,13 @@ struct TestIndexes<'a> {
     pub bar: UniqueIndex<'a, (u8, u64), i64, (i8, i64)>,
 }
 
-const TEST: IndexedMap<(u8, u64), (i8, i64), TestIndexes> = IndexedMap::new("test", TestIndexes {
-    foo: MultiIndex::new(|k, _v| k.0, "test", "test__foo"),
-    bar: UniqueIndex::new(|_k, v| v.1, "test", "test__bar"),
-});
+const TEST: IndexedMap<(u8, u64), (i8, i64), TestIndexes> = IndexedMap::new(
+    "test",
+    TestIndexes {
+        foo: MultiIndex::new(|k, _v| k.0, "test", "test__foo"),
+        bar: UniqueIndex::new(|_k, v| v.1, "test", "test__bar"),
+    },
+);
 
 #[test]
 fn index_list_macro_works() {

--- a/dango/core/vm/wasm/src/vm.rs
+++ b/dango/core/vm/wasm/src/vm.rs
@@ -268,11 +268,11 @@ impl Instance for WasmInstance {
             let param1_ptr = write_to_memory(env, store, param1.as_ref())?;
             let param2_ptr = write_to_memory(env, store, param2.as_ref())?;
             let res_ptr: u32 = env
-                .call_function1(store, name, &[
-                    ctx_ptr.into(),
-                    param1_ptr.into(),
-                    param2_ptr.into(),
-                ])?
+                .call_function1(
+                    store,
+                    name,
+                    &[ctx_ptr.into(), param1_ptr.into(), param2_ptr.into()],
+                )?
                 .try_into()
                 .map_err(VmError::return_type)?;
             let data = read_then_wipe(env, store, res_ptr)?;

--- a/dango/exchange/account-factory/src/query.rs
+++ b/dango/exchange/account-factory/src/query.rs
@@ -111,10 +111,13 @@ fn query_accounts(
         .map(|res| {
             let (addr, user_index, user) = res?;
             let (&index, _) = user.accounts.iter().find(|(_, a)| **a == addr).unwrap();
-            Ok((addr, Account {
-                index,
-                owner: user_index,
-            }))
+            Ok((
+                addr,
+                Account {
+                    index,
+                    owner: user_index,
+                },
+            ))
         })
         .collect()
 }

--- a/dango/exchange/account-factory/src/state.rs
+++ b/dango/exchange/account-factory/src/state.rs
@@ -10,19 +10,22 @@ pub const NEXT_USER_INDEX: Counter<UserIndex> = Counter::new("user_index", 0, 1)
 
 pub const NEXT_ACCOUNT_INDEX: Counter<AccountIndex> = Counter::new("account_index", 0, 1);
 
-pub const USERS: IndexedMap<UserIndex, User, UserIndexes> = IndexedMap::new("user", UserIndexes {
-    by_key: MultiIndex::new2(
-        |_, user| user.keys.keys().copied().collect(),
-        "user",
-        "user__key",
-    ),
-    by_account: UniqueIndex::new2(
-        |_, user| user.accounts.values().copied().collect(),
-        "user",
-        "user__account",
-    ),
-    by_name: UniqueIndex::new2(|_, user| vec![user.name.clone()], "user", "user__name"),
-});
+pub const USERS: IndexedMap<UserIndex, User, UserIndexes> = IndexedMap::new(
+    "user",
+    UserIndexes {
+        by_key: MultiIndex::new2(
+            |_, user| user.keys.keys().copied().collect(),
+            "user",
+            "user__key",
+        ),
+        by_account: UniqueIndex::new2(
+            |_, user| user.accounts.values().copied().collect(),
+            "user",
+            "user__account",
+        ),
+        by_name: UniqueIndex::new2(|_, user| vec![user.name.clone()], "user", "user__name"),
+    },
+);
 
 #[dango_storage::index_list(UserIndex, User)]
 pub struct UserIndexes<'a> {

--- a/dango/exchange/bank/src/state.rs
+++ b/dango/exchange/bank/src/state.rs
@@ -15,13 +15,16 @@ pub const BALANCES: Map<(&Addr, &Denom), Uint128> = Map::new("balance");
 
 // (sender, recipient) -> coins
 pub const ORPHANED_TRANSFERS: IndexedMap<(Addr, Addr), Coins, OrphanedTransferIndexes> =
-    IndexedMap::new("orphaned_transfer", OrphanedTransferIndexes {
-        recipient: MultiIndex::new(
-            |(_, recipient), _| *recipient,
-            "orphaned_transfer",
-            "orphaned_transfer__recipient",
-        ),
-    });
+    IndexedMap::new(
+        "orphaned_transfer",
+        OrphanedTransferIndexes {
+            recipient: MultiIndex::new(
+                |(_, recipient), _| *recipient,
+                "orphaned_transfer",
+                "orphaned_transfer__recipient",
+            ),
+        },
+    );
 
 #[dango_storage::index_list((Addr, Addr), Coins)]
 pub struct OrphanedTransferIndexes<'a> {

--- a/dango/exchange/gateway/src/execute.rs
+++ b/dango/exchange/gateway/src/execute.rs
@@ -239,12 +239,16 @@ fn set_personal_quota(
                 .map(|d| ctx.block.timestamp.checked_add(d))
                 .transpose()?;
 
-            PERSONAL_QUOTAS.save(ctx.storage, (user, &denom), &PersonalQuota {
-                amount,
-                expire_at,
-                granted_by: ctx.sender,
-                granted_at: ctx.block.timestamp,
-            })?;
+            PERSONAL_QUOTAS.save(
+                ctx.storage,
+                (user, &denom),
+                &PersonalQuota {
+                    amount,
+                    expire_at,
+                    granted_by: ctx.sender,
+                    granted_at: ctx.block.timestamp,
+                },
+            )?;
         },
         Op::Delete => {
             PERSONAL_QUOTAS.remove(ctx.storage, (user, &denom));
@@ -326,14 +330,18 @@ fn transfer_remote(ctx: MutableCtx, remote: Remote, recipient: Addr32) -> anyhow
     // guardian or the owner approves the request.
     let (id, _) = NEXT_WITHDRAWAL_REQUEST_ID.increment(ctx.storage)?;
 
-    WITHDRAWAL_REQUESTS.save(ctx.storage, id, &WithdrawalRequest {
-        user: ctx.sender,
-        remote,
-        recipient,
-        coin: coin.clone(),
-        status: WithdrawalStatus::Pending,
-        created_at: ctx.block.timestamp,
-    })?;
+    WITHDRAWAL_REQUESTS.save(
+        ctx.storage,
+        id,
+        &WithdrawalRequest {
+            user: ctx.sender,
+            remote,
+            recipient,
+            coin: coin.clone(),
+            status: WithdrawalStatus::Pending,
+            created_at: ctx.block.timestamp,
+        },
+    )?;
 
     Ok(Response::new().add_event(WithdrawalRequested {
         id,
@@ -430,10 +438,14 @@ fn respond_to_withdrawal(
 
             // Move the request out of the guardian's queue into the owner's.
             WITHDRAWAL_REQUESTS.remove(ctx.storage, id);
-            FROZEN_WITHDRAWAL_REQUESTS.save(ctx.storage, id, &WithdrawalRequest {
-                status: WithdrawalStatus::Frozen,
-                ..request.clone()
-            })?;
+            FROZEN_WITHDRAWAL_REQUESTS.save(
+                ctx.storage,
+                id,
+                &WithdrawalRequest {
+                    status: WithdrawalStatus::Frozen,
+                    ..request.clone()
+                },
+            )?;
 
             Ok(Response::new().add_event(WithdrawalFrozen {
                 id,

--- a/dango/exchange/gateway/src/rate_limit.rs
+++ b/dango/exchange/gateway/src/rate_limit.rs
@@ -240,11 +240,14 @@ pub fn query_rate_limit_statuses(
 
             let used_in_last_24h = rolling_window_sum(ctx.storage, &denom, ctx.block.timestamp)?;
 
-            Ok((denom, RateLimitStatus {
-                supply_snapshot: supply,
-                cap,
-                used_in_last_24h,
-            }))
+            Ok((
+                denom,
+                RateLimitStatus {
+                    supply_snapshot: supply,
+                    cap,
+                    used_in_last_24h,
+                },
+            ))
         })
         .collect()
 }

--- a/dango/exchange/genesis/src/builder.rs
+++ b/dango/exchange/genesis/src/builder.rs
@@ -168,9 +168,12 @@ where
         .zip(&addresses)
         .filter_map(|(user, address)| {
             if user.dango_balance.is_non_zero() {
-                Some((*address, coins! {
-                    dango::DENOM.clone() => user.dango_balance,
-                }))
+                Some((
+                    *address,
+                    coins! {
+                        dango::DENOM.clone() => user.dango_balance,
+                    },
+                ))
             } else {
                 None
             }

--- a/dango/exchange/perps/src/core/available_to_trade.rs
+++ b/dango/exchange/perps/src/core/available_to_trade.rs
@@ -182,23 +182,29 @@ mod tests {
     ) -> (UserState, NoCachePerpQuerier<'static>) {
         let mut positions = btree_map! {};
         if current_pos != 0 {
-            positions.insert(perp_eth::DENOM.clone(), Position {
-                size: Quantity::new_int(current_pos),
-                // entry_price = oracle so unrealized pnl is zero
-                entry_price: CURRENT_PRICE,
-                entry_funding_per_unit: FundingPerUnit::new_int(0),
-                conditional_order_above: None,
-                conditional_order_below: None,
-            });
+            positions.insert(
+                perp_eth::DENOM.clone(),
+                Position {
+                    size: Quantity::new_int(current_pos),
+                    // entry_price = oracle so unrealized pnl is zero
+                    entry_price: CURRENT_PRICE,
+                    entry_funding_per_unit: FundingPerUnit::new_int(0),
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            );
         }
         if other_pos != 0 {
-            positions.insert(perp_btc::DENOM.clone(), Position {
-                size: Quantity::new_int(other_pos),
-                entry_price: OTHER_PRICE,
-                entry_funding_per_unit: FundingPerUnit::new_int(0),
-                conditional_order_above: None,
-                conditional_order_below: None,
-            });
+            positions.insert(
+                perp_btc::DENOM.clone(),
+                Position {
+                    size: Quantity::new_int(other_pos),
+                    entry_price: OTHER_PRICE,
+                    entry_funding_per_unit: FundingPerUnit::new_int(0),
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            );
         }
 
         let reserved = if has_orders {

--- a/dango/exchange/perps/src/core/closure.rs
+++ b/dango/exchange/perps/src/core/closure.rs
@@ -1054,13 +1054,16 @@ mod tests {
         // bp = 46k - (-1k)/1 = 47k.
         let user_state = UserState {
             margin: UsdValue::new_int(3_000),
-            positions: BTreeMap::from([(pair_btc(), Position {
-                size: Quantity::new_int(1),
-                entry_price: UsdPrice::new_int(50_000),
-                entry_funding_per_unit: FundingPerUnit::ZERO,
-                conditional_order_above: None,
-                conditional_order_below: None,
-            })]),
+            positions: BTreeMap::from([(
+                pair_btc(),
+                Position {
+                    size: Quantity::new_int(1),
+                    entry_price: UsdPrice::new_int(50_000),
+                    entry_funding_per_unit: FundingPerUnit::ZERO,
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            )]),
             ..Default::default()
         };
 
@@ -1085,13 +1088,16 @@ mod tests {
         // bp = 54k + (-1k)/1 = 53k.
         let user_state = UserState {
             margin: UsdValue::new_int(3_000),
-            positions: BTreeMap::from([(pair_btc(), Position {
-                size: Quantity::new_int(-1),
-                entry_price: UsdPrice::new_int(50_000),
-                entry_funding_per_unit: FundingPerUnit::ZERO,
-                conditional_order_above: None,
-                conditional_order_below: None,
-            })]),
+            positions: BTreeMap::from([(
+                pair_btc(),
+                Position {
+                    size: Quantity::new_int(-1),
+                    entry_price: UsdPrice::new_int(50_000),
+                    entry_funding_per_unit: FundingPerUnit::ZERO,
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            )]),
             ..Default::default()
         };
 
@@ -1125,20 +1131,26 @@ mod tests {
         let user_state = UserState {
             margin: UsdValue::new_int(5_000),
             positions: BTreeMap::from([
-                (pair_btc(), Position {
-                    size: Quantity::new_int(1),
-                    entry_price: UsdPrice::new_int(50_000),
-                    entry_funding_per_unit: FundingPerUnit::ZERO,
-                    conditional_order_above: None,
-                    conditional_order_below: None,
-                }),
-                (pair_eth(), Position {
-                    size: Quantity::new_int(10),
-                    entry_price: UsdPrice::new_int(3_000),
-                    entry_funding_per_unit: FundingPerUnit::ZERO,
-                    conditional_order_above: None,
-                    conditional_order_below: None,
-                }),
+                (
+                    pair_btc(),
+                    Position {
+                        size: Quantity::new_int(1),
+                        entry_price: UsdPrice::new_int(50_000),
+                        entry_funding_per_unit: FundingPerUnit::ZERO,
+                        conditional_order_above: None,
+                        conditional_order_below: None,
+                    },
+                ),
+                (
+                    pair_eth(),
+                    Position {
+                        size: Quantity::new_int(10),
+                        entry_price: UsdPrice::new_int(3_000),
+                        entry_funding_per_unit: FundingPerUnit::ZERO,
+                        conditional_order_above: None,
+                        conditional_order_below: None,
+                    },
+                ),
             ]),
             ..Default::default()
         };
@@ -1187,13 +1199,16 @@ mod tests {
     fn bankruptcy_price_partial_close_long() {
         let user_state = UserState {
             margin: UsdValue::new_int(2_000),
-            positions: BTreeMap::from([(pair_btc(), Position {
-                size: Quantity::new_int(10),
-                entry_price: UsdPrice::new_int(2_000),
-                entry_funding_per_unit: FundingPerUnit::ZERO,
-                conditional_order_above: None,
-                conditional_order_below: None,
-            })]),
+            positions: BTreeMap::from([(
+                pair_btc(),
+                Position {
+                    size: Quantity::new_int(10),
+                    entry_price: UsdPrice::new_int(2_000),
+                    entry_funding_per_unit: FundingPerUnit::ZERO,
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            )]),
             ..Default::default()
         };
 
@@ -1225,13 +1240,16 @@ mod tests {
     fn bankruptcy_price_partial_close_short() {
         let user_state = UserState {
             margin: UsdValue::new_int(2_000),
-            positions: BTreeMap::from([(pair_btc(), Position {
-                size: Quantity::new_int(-10),
-                entry_price: UsdPrice::new_int(2_000),
-                entry_funding_per_unit: FundingPerUnit::ZERO,
-                conditional_order_above: None,
-                conditional_order_below: None,
-            })]),
+            positions: BTreeMap::from([(
+                pair_btc(),
+                Position {
+                    size: Quantity::new_int(-10),
+                    entry_price: UsdPrice::new_int(2_000),
+                    entry_funding_per_unit: FundingPerUnit::ZERO,
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            )]),
             ..Default::default()
         };
 

--- a/dango/exchange/perps/src/core/fill.rs
+++ b/dango/exchange/perps/src/core/fill.rs
@@ -135,13 +135,16 @@ fn apply_opening(
                 .checked_div(position.size.checked_abs()?)?;
         }
     } else {
-        user_state.positions.insert(pair_id.clone(), Position {
-            size: opening_size,
-            entry_price: fill_price,
-            entry_funding_per_unit: pair_state.funding_per_unit,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        user_state.positions.insert(
+            pair_id.clone(),
+            Position {
+                size: opening_size,
+                entry_price: fill_price,
+                entry_funding_per_unit: pair_state.funding_per_unit,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
     }
 
     Ok(())
@@ -216,13 +219,16 @@ mod tests {
 
     fn make_user_state(size: i128, entry_price: i128) -> UserState {
         let mut positions = BTreeMap::new();
-        positions.insert(pair_id(), Position {
-            size: Quantity::new_int(size),
-            entry_price: UsdPrice::new_int(entry_price),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(size),
+                entry_price: UsdPrice::new_int(entry_price),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         UserState {
             positions,
             ..Default::default()
@@ -446,13 +452,16 @@ mod tests {
         pair_state.long_oi = Quantity::new_int(10);
 
         let mut positions = BTreeMap::new();
-        positions.insert(pair_id(), Position {
-            size: Quantity::new_int(10),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO, // entered at 0
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(10),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO, // entered at 0
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         let mut user_state = UserState {
             positions,
             ..Default::default()
@@ -493,13 +502,16 @@ mod tests {
         pair_state.long_oi = Quantity::new_int(10);
 
         let mut positions = BTreeMap::new();
-        positions.insert(pair_id(), Position {
-            size: Quantity::new_int(10),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(10),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         let mut user_state = UserState {
             positions,
             ..Default::default()

--- a/dango/exchange/perps/src/core/margin.rs
+++ b/dango/exchange/perps/src/core/margin.rs
@@ -382,13 +382,16 @@ mod tests {
             },
             ..Default::default()
         };
-        let perp_querier = NoCachePerpQuerier::new_mock(Default::default(), hash_map! {
-            perp_eth::DENOM.clone() => PairState {
-                funding_per_unit: FundingPerUnit::new_int(0),
-                index_price: UsdPrice::new_percent(250_000),
-                ..Default::default()
-            }
-        });
+        let perp_querier = NoCachePerpQuerier::new_mock(
+            Default::default(),
+            hash_map! {
+                perp_eth::DENOM.clone() => PairState {
+                    funding_per_unit: FundingPerUnit::new_int(0),
+                    index_price: UsdPrice::new_percent(250_000),
+                    ..Default::default()
+                }
+            },
+        );
 
         assert_eq!(
             compute_user_equity(&perp_querier, &user_state).unwrap(),
@@ -415,13 +418,16 @@ mod tests {
             },
             ..Default::default()
         };
-        let perp_querier = NoCachePerpQuerier::new_mock(Default::default(), hash_map! {
-            perp_eth::DENOM.clone() => PairState {
-                funding_per_unit: FundingPerUnit::new_int(3),
-                index_price: UsdPrice::new_percent(250_000),
-                ..Default::default()
+        let perp_querier = NoCachePerpQuerier::new_mock(
+            Default::default(),
+            hash_map! {
+                perp_eth::DENOM.clone() => PairState {
+                    funding_per_unit: FundingPerUnit::new_int(3),
+                    index_price: UsdPrice::new_percent(250_000),
+                    ..Default::default()
+                },
             },
-        });
+        );
 
         assert_eq!(
             compute_user_equity(&perp_querier, &user_state).unwrap(),
@@ -457,18 +463,21 @@ mod tests {
             },
             ..Default::default()
         };
-        let perp_querier = NoCachePerpQuerier::new_mock(Default::default(), hash_map! {
-            perp_eth::DENOM.clone() => PairState {
-                funding_per_unit: FundingPerUnit::new_int(3),
-                index_price: UsdPrice::new_percent(250_000),
-                ..Default::default()
+        let perp_querier = NoCachePerpQuerier::new_mock(
+            Default::default(),
+            hash_map! {
+                perp_eth::DENOM.clone() => PairState {
+                    funding_per_unit: FundingPerUnit::new_int(3),
+                    index_price: UsdPrice::new_percent(250_000),
+                    ..Default::default()
+                },
+                perp_btc::DENOM.clone() => PairState {
+                    funding_per_unit: FundingPerUnit::new_int(0),
+                    index_price: UsdPrice::new_percent(4_800_000),
+                    ..Default::default()
+                },
             },
-            perp_btc::DENOM.clone() => PairState {
-                funding_per_unit: FundingPerUnit::new_int(0),
-                index_price: UsdPrice::new_percent(4_800_000),
-                ..Default::default()
-            },
-        });
+        );
 
         assert_eq!(
             compute_user_equity(&perp_querier, &user_state).unwrap(),
@@ -494,13 +503,16 @@ mod tests {
             },
             ..Default::default()
         };
-        let perp_querier = NoCachePerpQuerier::new_mock(Default::default(), hash_map! {
-            perp_eth::DENOM.clone() => PairState {
-                funding_per_unit: FundingPerUnit::new_int(0),
-                index_price: UsdPrice::new_percent(150_000),
-                ..Default::default()
+        let perp_querier = NoCachePerpQuerier::new_mock(
+            Default::default(),
+            hash_map! {
+                perp_eth::DENOM.clone() => PairState {
+                    funding_per_unit: FundingPerUnit::new_int(0),
+                    index_price: UsdPrice::new_percent(150_000),
+                    ..Default::default()
+                },
             },
-        });
+        );
 
         assert_eq!(
             compute_user_equity(&perp_querier, &user_state).unwrap(),

--- a/dango/exchange/perps/src/cron/process_funding.rs
+++ b/dango/exchange/perps/src/cron/process_funding.rs
@@ -157,18 +157,25 @@ mod tests {
     /// Returns: nothing.
     fn set_vault_position(storage: &mut dyn Storage, pair_id: &PairId, size: i128) {
         let mut positions = BTreeMap::new();
-        positions.insert(pair_id.clone(), Position {
-            size: Quantity::new_int(size),
-            entry_price: UsdPrice::ZERO,
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        positions.insert(
+            pair_id.clone(),
+            Position {
+                size: Quantity::new_int(size),
+                entry_price: UsdPrice::ZERO,
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         USER_STATES
-            .save(storage, CONTRACT, &UserState {
-                positions,
-                ..Default::default()
-            })
+            .save(
+                storage,
+                CONTRACT,
+                &UserState {
+                    positions,
+                    ..Default::default()
+                },
+            )
             .unwrap();
     }
 
@@ -186,16 +193,22 @@ mod tests {
         last_funding_time_secs: u128,
     ) {
         PARAM
-            .save(storage, &Param {
-                funding_period: Duration::from_seconds(funding_period_secs),
-                ..Default::default()
-            })
+            .save(
+                storage,
+                &Param {
+                    funding_period: Duration::from_seconds(funding_period_secs),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         STATE
-            .save(storage, &State {
-                last_funding_time: Timestamp::from_seconds(last_funding_time_secs),
-                ..Default::default()
-            })
+            .save(
+                storage,
+                &State {
+                    last_funding_time: Timestamp::from_seconds(last_funding_time_secs),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         PAIR_IDS
             .save(storage, &BTreeSet::from([pair_id.clone()]))
@@ -370,16 +383,22 @@ mod tests {
         let pair_param = default_funding_pair_param();
 
         PARAM
-            .save(&mut storage, &Param {
-                funding_period: Duration::from_seconds(3600),
-                ..Default::default()
-            })
+            .save(
+                &mut storage,
+                &Param {
+                    funding_period: Duration::from_seconds(3600),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         STATE
-            .save(&mut storage, &State {
-                last_funding_time: Timestamp::from_seconds(0),
-                ..Default::default()
-            })
+            .save(
+                &mut storage,
+                &State {
+                    last_funding_time: Timestamp::from_seconds(0),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         PAIR_IDS
             .save(&mut storage, &BTreeSet::from([btc.clone(), eth.clone()]))
@@ -387,39 +406,57 @@ mod tests {
         PAIR_PARAMS.save(&mut storage, &btc, &pair_param).unwrap();
         PAIR_PARAMS.save(&mut storage, &eth, &pair_param).unwrap();
         PAIR_STATES
-            .save(&mut storage, &btc, &PairState {
-                index_price: UsdPrice::new_percent(5_000_000), // $50,000
-                ..Default::default()
-            })
+            .save(
+                &mut storage,
+                &btc,
+                &PairState {
+                    index_price: UsdPrice::new_percent(5_000_000), // $50,000
+                    ..Default::default()
+                },
+            )
             .unwrap();
         PAIR_STATES
-            .save(&mut storage, &eth, &PairState {
-                index_price: UsdPrice::new_percent(300_000), // $3,000
-                ..Default::default()
-            })
+            .save(
+                &mut storage,
+                &eth,
+                &PairState {
+                    index_price: UsdPrice::new_percent(300_000), // $3,000
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         // Vault: long 50 BTC, short 50 ETH.
         let mut positions = BTreeMap::new();
-        positions.insert(btc.clone(), Position {
-            size: Quantity::new_int(50),
-            entry_price: UsdPrice::ZERO,
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
-        positions.insert(eth.clone(), Position {
-            size: Quantity::new_int(-50),
-            entry_price: UsdPrice::ZERO,
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        positions.insert(
+            btc.clone(),
+            Position {
+                size: Quantity::new_int(50),
+                entry_price: UsdPrice::ZERO,
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
+        positions.insert(
+            eth.clone(),
+            Position {
+                size: Quantity::new_int(-50),
+                entry_price: UsdPrice::ZERO,
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         USER_STATES
-            .save(&mut storage, CONTRACT, &UserState {
-                positions,
-                ..Default::default()
-            })
+            .save(
+                &mut storage,
+                CONTRACT,
+                &UserState {
+                    positions,
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         process_funding(&mut storage, Timestamp::from_seconds(3600), CONTRACT).unwrap();

--- a/dango/exchange/perps/src/cron/process_unlocks.rs
+++ b/dango/exchange/perps/src/cron/process_unlocks.rs
@@ -204,16 +204,24 @@ mod tests {
         let mut storage = MockStorage::new();
 
         USER_STATES
-            .save(&mut storage, USER_A, &UserState {
-                unlocks: unlocks_from(&[(500, 50)]),
-                ..Default::default()
-            })
+            .save(
+                &mut storage,
+                USER_A,
+                &UserState {
+                    unlocks: unlocks_from(&[(500, 50)]),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         USER_STATES
-            .save(&mut storage, USER_B, &UserState {
-                unlocks: unlocks_from(&[(700, 60)]),
-                ..Default::default()
-            })
+            .save(
+                &mut storage,
+                USER_B,
+                &UserState {
+                    unlocks: unlocks_from(&[(700, 60)]),
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         process_unlocks(

--- a/dango/exchange/perps/src/cron/vault_snapshot.rs
+++ b/dango/exchange/perps/src/cron/vault_snapshot.rs
@@ -48,10 +48,14 @@ pub fn take_vault_snapshot(
         },
     };
 
-    VAULT_SNAPSHOTS.save(storage, key, &VaultSnapshot {
-        equity,
-        share_supply: state.vault_share_supply,
-    })?;
+    VAULT_SNAPSHOTS.save(
+        storage,
+        key,
+        &VaultSnapshot {
+            equity,
+            share_supply: state.vault_share_supply,
+        },
+    )?;
 
     Ok(())
 }
@@ -82,28 +86,38 @@ mod tests {
     /// for BTC so the equity-computation lookup succeeds.
     fn init_storage(storage: &mut dyn Storage, share_supply: u128, position_size: i128) {
         STATE
-            .save(storage, &State {
-                vault_share_supply: Uint128::new(share_supply),
-                ..Default::default()
-            })
+            .save(
+                storage,
+                &State {
+                    vault_share_supply: Uint128::new(share_supply),
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         let mut positions = BTreeMap::new();
         if position_size != 0 {
-            positions.insert(btc_pair_id(), Position {
-                size: Quantity::new_int(position_size),
-                entry_price: UsdPrice::ZERO,
-                entry_funding_per_unit: FundingPerUnit::ZERO,
-                conditional_order_above: None,
-                conditional_order_below: None,
-            });
+            positions.insert(
+                btc_pair_id(),
+                Position {
+                    size: Quantity::new_int(position_size),
+                    entry_price: UsdPrice::ZERO,
+                    entry_funding_per_unit: FundingPerUnit::ZERO,
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            );
         }
 
         USER_STATES
-            .save(storage, CONTRACT, &UserState {
-                positions,
-                ..Default::default()
-            })
+            .save(
+                storage,
+                CONTRACT,
+                &UserState {
+                    positions,
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         PAIR_STATES
@@ -171,11 +185,14 @@ mod tests {
             .keys(&storage, None, None, Order::Ascending)
             .collect::<Result<_, _>>()
             .unwrap();
-        assert_eq!(keys, vec![
-            Timestamp::from_seconds(0),
-            Timestamp::from_seconds(ONE_DAY),
-            Timestamp::from_seconds(2 * ONE_DAY),
-        ]);
+        assert_eq!(
+            keys,
+            vec![
+                Timestamp::from_seconds(0),
+                Timestamp::from_seconds(ONE_DAY),
+                Timestamp::from_seconds(2 * ONE_DAY),
+            ]
+        );
     }
 
     #[test]

--- a/dango/exchange/perps/src/index_price.rs
+++ b/dango/exchange/perps/src/index_price.rs
@@ -195,16 +195,20 @@ mod tests {
     ) {
         let stored_price = may_invert_price(UsdPrice::new_int(price), true);
         let key: OrderKey = (pair_id.clone(), stored_price, Uint64::new(order_id));
-        BIDS.save(storage, key, &LimitOrder {
-            user: MAKER,
-            size: Quantity::new_int(size),
-            reduce_only: false,
-            reserved_margin: UsdValue::ZERO,
-            created_at: Timestamp::ZERO,
-            tp: None,
-            sl: None,
-            client_order_id: None,
-        })
+        BIDS.save(
+            storage,
+            key,
+            &LimitOrder {
+                user: MAKER,
+                size: Quantity::new_int(size),
+                reduce_only: false,
+                reserved_margin: UsdValue::ZERO,
+                created_at: Timestamp::ZERO,
+                tp: None,
+                sl: None,
+                client_order_id: None,
+            },
+        )
         .unwrap();
     }
 
@@ -220,16 +224,20 @@ mod tests {
             UsdPrice::new_int(price),
             Uint64::new(order_id),
         );
-        ASKS.save(storage, key, &LimitOrder {
-            user: MAKER,
-            size: Quantity::new_int(size),
-            reduce_only: false,
-            reserved_margin: UsdValue::ZERO,
-            created_at: Timestamp::ZERO,
-            tp: None,
-            sl: None,
-            client_order_id: None,
-        })
+        ASKS.save(
+            storage,
+            key,
+            &LimitOrder {
+                user: MAKER,
+                size: Quantity::new_int(size),
+                reduce_only: false,
+                reserved_margin: UsdValue::ZERO,
+                created_at: Timestamp::ZERO,
+                tp: None,
+                sl: None,
+                client_order_id: None,
+            },
+        )
         .unwrap();
     }
 

--- a/dango/exchange/perps/src/lib.rs
+++ b/dango/exchange/perps/src/lib.rs
@@ -80,10 +80,13 @@ fn account_factory(querier: impl DangoQuerier) -> Addr {
 }
 
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
-    STATE.save(ctx.storage, &State {
-        last_funding_time: ctx.block.timestamp,
-        ..Default::default()
-    })?;
+    STATE.save(
+        ctx.storage,
+        &State {
+            last_funding_time: ctx.block.timestamp,
+            ..Default::default()
+        },
+    )?;
 
     NEXT_ORDER_ID.save(ctx.storage, &OrderId::ONE)?;
     NEXT_FILL_ID.save(ctx.storage, &FillId::ONE)?;

--- a/dango/exchange/perps/src/maintain/liquidate.rs
+++ b/dango/exchange/perps/src/maintain/liquidate.rs
@@ -1067,13 +1067,16 @@ mod tests {
             .unwrap()
             .unwrap_or_default();
 
-        user_state.positions.insert(pair_id.clone(), Position {
-            size: Quantity::new_int(size),
-            entry_price: UsdPrice::new_int(entry_price),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        user_state.positions.insert(
+            pair_id.clone(),
+            Position {
+                size: Quantity::new_int(size),
+                entry_price: UsdPrice::new_int(entry_price),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
 
         USER_STATES.save(storage, user, &user_state).unwrap();
 
@@ -1149,11 +1152,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state,
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state)],
+        );
 
         // User has long 1 BTC at 50000, oracle at 50000.
         // Collateral = 10000 USD (well above MM = 50000 * 5% = 2500).
@@ -1163,10 +1166,13 @@ mod tests {
         pair_params.insert(pair_btc(), btc_pair_param());
 
         let mut pair_states = BTreeMap::new();
-        pair_states.insert(pair_btc(), PairState {
-            index_price: UsdPrice::new_int(50_000),
-            ..Default::default()
-        });
+        pair_states.insert(
+            pair_btc(),
+            PairState {
+                index_price: UsdPrice::new_int(50_000),
+                ..Default::default()
+            },
+        );
 
         let mut oracle_prices = BTreeMap::new();
         oracle_prices.insert(pair_btc(), UsdPrice::new_int(50_000));
@@ -1209,11 +1215,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // User has long 10 BTC at entry 50000. Oracle is now 47500.
         // equity < MM → liquidatable
@@ -1280,11 +1286,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // User long 10 BTC at 50000, oracle 47500 → liquidatable.
         save_position(&mut ctx.storage, USER, &pair_btc(), 10, 50_000);
@@ -1363,11 +1369,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // User long 1 BTC @ $50,000, margin $2,500, oracle $48,000.
         // Equity = $2,500 + ($48,000-$50,000) = $500.
@@ -1487,11 +1493,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // User long 1 BTC @ $50,000, margin $2,000, oracle $48,000.
         // Equity = $0, deficit = $2,400 → full position closed.
@@ -1631,11 +1637,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         save_position(&mut ctx.storage, USER, &pair_btc(), 1, 50_000);
 
@@ -1769,11 +1775,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // Vault (CONTRACT) long 1 BTC @ $50,000.
         save_position(&mut ctx.storage, CONTRACT, &pair_btc(), 1, 50_000);
@@ -1918,11 +1924,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // User long 1 BTC @ $50,000, margin $1,200, oracle $48,000.
         // Equity = -$800, deficit large → full position closed.
@@ -2037,11 +2043,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // User long 10 BTC @ $50,000, margin $2,400, oracle $47,500.
         // PnL = 10*(47500-50000) = -$25,000. Equity = $2,400 - $25,000 = -$22,600.
@@ -2137,11 +2143,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // Alice: long 10 BTC @ $2,000, oracle $2,200 (position in profit). Her
         // margin is set negative to model a prior withdrawal / loss realised
@@ -2233,11 +2239,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // USER has long 1 BTC at $50,000. Oracle at $47,500 → deeply underwater.
         // Equity = $100 + ($47,500-$50,000) = -$2,400.
@@ -2357,11 +2363,11 @@ mod tests {
             ..Default::default()
         };
 
-        setup_storage(&mut ctx.storage, &param, &[(
-            pair_btc(),
-            btc_pair_param(),
-            pair_state.clone(),
-        )]);
+        setup_storage(
+            &mut ctx.storage,
+            &param,
+            &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+        );
 
         // USER has long 10 BTC at entry $50k. Oracle drops to $47,500.
         // Equity < maintenance margin → liquidatable.
@@ -2496,11 +2502,11 @@ mod tests {
                 ..Default::default()
             };
 
-            setup_storage(&mut ctx.storage, &param, &[(
-                pair_btc(),
-                btc_pair_param(),
-                pair_state.clone(),
-            )]);
+            setup_storage(
+                &mut ctx.storage,
+                &param,
+                &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+            );
 
             save_position(&mut ctx.storage, USER, &pair_btc(), 10, 50_000);
 
@@ -2566,11 +2572,11 @@ mod tests {
                 ..Default::default()
             };
 
-            setup_storage(&mut ctx.storage, &param, &[(
-                pair_btc(),
-                btc_pair_param(),
-                pair_state.clone(),
-            )]);
+            setup_storage(
+                &mut ctx.storage,
+                &param,
+                &[(pair_btc(), btc_pair_param(), pair_state.clone())],
+            );
 
             save_position(&mut ctx.storage, USER, &pair_btc(), 10, 50_000);
 

--- a/dango/exchange/perps/src/maintain/set_fee_rate_override.rs
+++ b/dango/exchange/perps/src/maintain/set_fee_rate_override.rs
@@ -103,13 +103,16 @@ mod tests {
     /// invariant reduces to the override-level arithmetic alone.
     fn save_param(storage: &mut dyn Storage) {
         PARAM
-            .save(storage, &Param {
-                taker_fee_rates: RateSchedule {
-                    base: Dimensionless::ONE,
+            .save(
+                storage,
+                &Param {
+                    taker_fee_rates: RateSchedule {
+                        base: Dimensionless::ONE,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
-                ..Default::default()
-            })
+            )
             .unwrap();
     }
 
@@ -267,13 +270,16 @@ mod tests {
         // Use a param whose tier-schedule min taker rate is 1 so the
         // invariant is not tripped by the schedule itself.
         PARAM
-            .save(&mut ctx.storage, &Param {
-                taker_fee_rates: RateSchedule {
-                    base: Dimensionless::ONE,
+            .save(
+                &mut ctx.storage,
+                &Param {
+                    taker_fee_rates: RateSchedule {
+                        base: Dimensionless::ONE,
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
-                ..Default::default()
-            })
+            )
             .unwrap();
         let rates = (Dimensionless::new_int(-1), Dimensionless::ONE);
 
@@ -410,13 +416,16 @@ mod tests {
             .with_funds(Coins::default());
         // Schedule: taker 1%, maker 0 → invariant holds against bare schedule.
         PARAM
-            .save(&mut ctx.storage, &Param {
-                taker_fee_rates: RateSchedule {
-                    base: Dimensionless::new_permille(10),
+            .save(
+                &mut ctx.storage,
+                &Param {
+                    taker_fee_rates: RateSchedule {
+                        base: Dimensionless::new_permille(10),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
-                ..Default::default()
-            })
+            )
             .unwrap();
 
         // User A carries a -1% maker override — compatible with the schedule.

--- a/dango/exchange/perps/src/maintain/withdraw_treasury.rs
+++ b/dango/exchange/perps/src/maintain/withdraw_treasury.rs
@@ -78,10 +78,13 @@ mod tests {
     /// Seed `STATE` with the given treasury balance (all other fields default).
     fn seed_treasury(storage: &mut dyn Storage, treasury: UsdValue) {
         STATE
-            .save(storage, &State {
-                treasury,
-                ..Default::default()
-            })
+            .save(
+                storage,
+                &State {
+                    treasury,
+                    ..Default::default()
+                },
+            )
             .unwrap();
     }
 
@@ -141,12 +144,16 @@ mod tests {
             .with_funds(Coins::default());
         seed_treasury(&mut ctx.storage, UsdValue::new_int(1_000));
         USER_STATES
-            .save(&mut ctx.storage, OWNER, &UserState {
-                margin: UsdValue::new_int(500),
-                reserved_margin: UsdValue::new_int(100),
-                open_order_count: 2,
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                OWNER,
+                &UserState {
+                    margin: UsdValue::new_int(500),
+                    reserved_margin: UsdValue::new_int(100),
+                    open_order_count: 2,
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         withdraw_treasury(ctx.as_mutable()).should_succeed();

--- a/dango/exchange/perps/src/query.rs
+++ b/dango/exchange/perps/src/query.rs
@@ -135,16 +135,19 @@ pub fn query_user_state_extended(
                 None
             };
 
-            Ok((pair_id.clone(), PositionExtended {
-                size: position.size,
-                entry_price: position.entry_price,
-                entry_funding_per_unit: position.entry_funding_per_unit,
-                conditional_order_above: position.conditional_order_above.clone(),
-                conditional_order_below: position.conditional_order_below.clone(),
-                unrealized_pnl,
-                unrealized_funding,
-                liquidation_price,
-            }))
+            Ok((
+                pair_id.clone(),
+                PositionExtended {
+                    size: position.size,
+                    entry_price: position.entry_price,
+                    entry_funding_per_unit: position.entry_funding_per_unit,
+                    conditional_order_above: position.conditional_order_above.clone(),
+                    conditional_order_below: position.conditional_order_below.clone(),
+                    unrealized_pnl,
+                    unrealized_funding,
+                    liquidation_price,
+                },
+            ))
         })
         .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
 

--- a/dango/exchange/perps/src/referral.rs
+++ b/dango/exchange/perps/src/referral.rs
@@ -57,9 +57,10 @@ fn retrieve_user_index(
     }
 
     querier
-        .query_wasm_smart(account_factory, account_factory::QueryAccountRequest {
-            address: addr,
-        })
+        .query_wasm_smart(
+            account_factory,
+            account_factory::QueryAccountRequest { address: addr },
+        )
         .ok()
         .map(|account| account.owner)
 }

--- a/dango/exchange/perps/src/referral/set_fee_share_ratio.rs
+++ b/dango/exchange/perps/src/referral/set_fee_share_ratio.rs
@@ -40,11 +40,12 @@ pub fn set_fee_share_ratio(
     let account_factory = account_factory(ctx.querier);
 
     // TODO: refactor to raw query (query_wasm_path).
-    let account =
-        ctx.querier
-            .query_wasm_smart(account_factory, account_factory::QueryAccountRequest {
-                address: ctx.sender,
-            })?;
+    let account = ctx.querier.query_wasm_smart(
+        account_factory,
+        account_factory::QueryAccountRequest {
+            address: ctx.sender,
+        },
+    )?;
 
     let user_index = account.owner;
 

--- a/dango/exchange/perps/src/referral/set_referral.rs
+++ b/dango/exchange/perps/src/referral/set_referral.rs
@@ -50,9 +50,12 @@ pub fn set_referral(
             // TODO: refactor to raw query (query_wasm_path).
             let sender_user_index = ctx
                 .querier
-                .query_wasm_smart(account_factory, account_factory::QueryAccountRequest {
-                    address: ctx.sender,
-                })?
+                .query_wasm_smart(
+                    account_factory,
+                    account_factory::QueryAccountRequest {
+                        address: ctx.sender,
+                    },
+                )?
                 .owner;
             sender_user_index == referee
         },
@@ -85,10 +88,14 @@ pub fn set_referral(
     // active, and the old referrer's `referee_count` is not decremented so it
     // continues to read as "users that have been a direct referee of this
     // referrer at one point in time".
-    REFERRER_TO_REFEREE_STATISTICS.save(ctx.storage, (referrer, referee), &RefereeStats {
-        registered_at: ctx.block.timestamp,
-        ..Default::default()
-    })?;
+    REFERRER_TO_REFEREE_STATISTICS.save(
+        ctx.storage,
+        (referrer, referee),
+        &RefereeStats {
+            registered_at: ctx.block.timestamp,
+            ..Default::default()
+        },
+    )?;
 
     // Increment the referrer's referee count.
     {
@@ -324,10 +331,14 @@ mod tests {
             .save(&mut ctx.storage, REFEREE, &OUTSIDER)
             .unwrap();
         REFERRER_TO_REFEREE_STATISTICS
-            .save(&mut ctx.storage, (OUTSIDER, REFEREE), &RefereeStats {
-                registered_at: BLOCK_TIME,
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                (OUTSIDER, REFEREE),
+                &RefereeStats {
+                    registered_at: BLOCK_TIME,
+                    ..Default::default()
+                },
+            )
             .unwrap();
         USER_REFERRAL_DATA
             .save(

--- a/dango/exchange/perps/src/trade/resize_reduce_only.rs
+++ b/dango/exchange/perps/src/trade/resize_reduce_only.rs
@@ -380,13 +380,16 @@ mod tests {
     fn user_state_with(position: i128, reserved: i128, open_orders: usize) -> UserState {
         let mut positions = BTreeMap::new();
         if position != 0 {
-            positions.insert(pair(), Position {
-                size: Quantity::new_int(position),
-                entry_price: UsdPrice::new_int(2_000),
-                entry_funding_per_unit: FundingPerUnit::ZERO,
-                conditional_order_above: None,
-                conditional_order_below: None,
-            });
+            positions.insert(
+                pair(),
+                Position {
+                    size: Quantity::new_int(position),
+                    entry_price: UsdPrice::new_int(2_000),
+                    entry_funding_per_unit: FundingPerUnit::ZERO,
+                    conditional_order_above: None,
+                    conditional_order_below: None,
+                },
+            );
         }
         UserState {
             unlocks: VecDeque::new(),

--- a/dango/exchange/perps/src/trade/submit_order.rs
+++ b/dango/exchange/perps/src/trade/submit_order.rs
@@ -1467,10 +1467,13 @@ pub fn settle_pnls(
                 },
                 FeeBreakdown::ZERO,
             ),
-            (false, true) => (FeeBreakdown::ZERO, FeeBreakdown {
-                protocol_fee,
-                vault_fee,
-            }),
+            (false, true) => (
+                FeeBreakdown::ZERO,
+                FeeBreakdown {
+                    protocol_fee,
+                    vault_fee,
+                },
+            ),
             (false, false) => (FeeBreakdown::ZERO, FeeBreakdown::ZERO),
         };
 
@@ -1790,11 +1793,15 @@ mod tests {
             .save(storage, &pair_id(), &test_pair_param())
             .unwrap();
         PAIR_STATES
-            .save(storage, &pair_id(), &PairState {
-                index_price: UsdPrice::new_percent(5_000_000), // $50,000
-                oracle_price: UsdPrice::new_percent(5_000_000), // $50,000
-                ..Default::default()
-            })
+            .save(
+                storage,
+                &pair_id(),
+                &PairState {
+                    index_price: UsdPrice::new_percent(5_000_000), // $50,000
+                    oracle_price: UsdPrice::new_percent(5_000_000), // $50,000
+                    ..Default::default()
+                },
+            )
             .unwrap();
         NEXT_ORDER_ID.save(storage, &Uint64::new(1)).unwrap();
         NEXT_FILL_ID.save(storage, &FillId::ONE).unwrap();
@@ -2325,13 +2332,16 @@ mod tests {
             margin: LARGE_COLLATERAL,
             ..Default::default()
         };
-        taker_state.positions.insert(pair_id(), Position {
-            size: Quantity::new_int(5),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        taker_state.positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(5),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
 
         let SubmitOrderOutcome {
             pair_state: _,
@@ -3010,12 +3020,16 @@ mod tests {
         };
         ASKS.save(&mut ctx.storage, key, &ask).unwrap();
         USER_STATES
-            .save(&mut ctx.storage, MAKER_A, &UserState {
-                margin: LARGE_COLLATERAL,
-                open_order_count: 1,
-                reserved_margin: ask.reserved_margin,
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                MAKER_A,
+                &UserState {
+                    margin: LARGE_COLLATERAL,
+                    open_order_count: 1,
+                    reserved_margin: ask.reserved_margin,
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         let param = test_param();
@@ -3166,12 +3180,16 @@ mod tests {
         };
         ASKS.save(&mut ctx.storage, key, &ask).unwrap();
         USER_STATES
-            .save(&mut ctx.storage, MAKER_A, &UserState {
-                margin: LARGE_COLLATERAL,
-                open_order_count: 1,
-                reserved_margin: ask.reserved_margin,
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                MAKER_A,
+                &UserState {
+                    margin: LARGE_COLLATERAL,
+                    open_order_count: 1,
+                    reserved_margin: ask.reserved_margin,
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         // Partial fill consuming half the order.
@@ -3577,10 +3595,13 @@ mod tests {
     fn settle_pnls_empty() {
         let taker = TAKER;
         let mut taker_state = UserState::default();
-        let mut maker_states = BTreeMap::from([(CONTRACT, UserState {
-            margin: UsdValue::new_int(500),
-            ..Default::default()
-        })]);
+        let mut maker_states = BTreeMap::from([(
+            CONTRACT,
+            UserState {
+                margin: UsdValue::new_int(500),
+                ..Default::default()
+            },
+        )]);
         let mut state = State::default();
 
         // No fills — nothing to settle. Vault margin should be unchanged.
@@ -3635,10 +3656,13 @@ mod tests {
     fn settle_pnls_vault_pnl_adjusts_margin() {
         let taker = TAKER;
         let mut taker_state = UserState::default();
-        let mut maker_states = BTreeMap::from([(CONTRACT, UserState {
-            margin: UsdValue::new_int(1_000),
-            ..Default::default()
-        })]);
+        let mut maker_states = BTreeMap::from([(
+            CONTRACT,
+            UserState {
+                margin: UsdValue::new_int(1_000),
+                ..Default::default()
+            },
+        )]);
         let mut state = State::default();
 
         // Vault is the maker on this fill and realises +$500 PnL.
@@ -3663,10 +3687,13 @@ mod tests {
     fn settle_pnls_vault_loss_creates_bad_debt() {
         let taker = TAKER;
         let mut taker_state = UserState::default();
-        let mut maker_states = BTreeMap::from([(CONTRACT, UserState {
-            margin: UsdValue::new_int(100),
-            ..Default::default()
-        })]);
+        let mut maker_states = BTreeMap::from([(
+            CONTRACT,
+            UserState {
+                margin: UsdValue::new_int(100),
+                ..Default::default()
+            },
+        )]);
         let mut state = State::default();
 
         // Vault is the maker and realises −$500 PnL.
@@ -3691,10 +3718,13 @@ mod tests {
     fn settle_pnls_vault_profit_recovers_negative_margin() {
         let taker = TAKER;
         let mut taker_state = UserState::default();
-        let mut maker_states = BTreeMap::from([(CONTRACT, UserState {
-            margin: UsdValue::new_int(-300),
-            ..Default::default()
-        })]);
+        let mut maker_states = BTreeMap::from([(
+            CONTRACT,
+            UserState {
+                margin: UsdValue::new_int(-300),
+                ..Default::default()
+            },
+        )]);
         let mut state = State::default();
 
         // Vault maker with +$500 PnL on this fill.
@@ -3720,10 +3750,13 @@ mod tests {
     fn settle_pnls_vault_fees_skipped() {
         let taker = TAKER;
         let mut taker_state = UserState::default();
-        let mut maker_states = BTreeMap::from([(CONTRACT, UserState {
-            margin: UsdValue::new_int(1_000),
-            ..Default::default()
-        })]);
+        let mut maker_states = BTreeMap::from([(
+            CONTRACT,
+            UserState {
+                margin: UsdValue::new_int(1_000),
+                ..Default::default()
+            },
+        )]);
         let mut state = State::default();
 
         // Vault is the maker with no PnL and no fee — the upstream
@@ -4094,10 +4127,14 @@ mod tests {
             .save(&mut ctx.storage, &pair_id(), &test_pair_param())
             .unwrap();
         PAIR_STATES
-            .save(&mut ctx.storage, &pair_id(), &PairState {
-                oracle_price: UsdPrice::new_int(50_000),
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                &pair_id(),
+                &PairState {
+                    oracle_price: UsdPrice::new_int(50_000),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         NEXT_ORDER_ID
             .save(&mut ctx.storage, &Uint64::new(1))
@@ -4204,10 +4241,14 @@ mod tests {
             .save(&mut ctx.storage, &pair_id(), &test_pair_param())
             .unwrap();
         PAIR_STATES
-            .save(&mut ctx.storage, &pair_id(), &PairState {
-                oracle_price: UsdPrice::new_int(50_000),
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                &pair_id(),
+                &PairState {
+                    oracle_price: UsdPrice::new_int(50_000),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         NEXT_ORDER_ID
             .save(&mut ctx.storage, &Uint64::new(1))
@@ -4370,10 +4411,14 @@ mod tests {
             .save(&mut ctx.storage, &pair_id(), &test_pair_param())
             .unwrap();
         PAIR_STATES
-            .save(&mut ctx.storage, &pair_id(), &PairState {
-                oracle_price: UsdPrice::new_int(50_000),
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                &pair_id(),
+                &PairState {
+                    oracle_price: UsdPrice::new_int(50_000),
+                    ..Default::default()
+                },
+            )
             .unwrap();
         NEXT_ORDER_ID
             .save(&mut ctx.storage, &Uint64::new(1))
@@ -4820,13 +4865,16 @@ mod tests {
             margin: LARGE_COLLATERAL,
             ..Default::default()
         };
-        taker_state.positions.insert(pair_id(), Position {
-            size: Quantity::new_int(5),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        taker_state.positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(5),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
 
         let SubmitOrderOutcome {
             pair_state: _,
@@ -5191,10 +5239,14 @@ mod tests {
         // Vault (CONTRACT) is the maker. Give it enough margin to take
         // the other side of the taker's buy.
         USER_STATES
-            .save(&mut ctx.storage, CONTRACT, &UserState {
-                margin: LARGE_COLLATERAL,
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                CONTRACT,
+                &UserState {
+                    margin: LARGE_COLLATERAL,
+                    ..Default::default()
+                },
+            )
             .unwrap();
         // Vault ask at $50,000 — would be out-of-band at oracle=$30k.
         place_ask(&mut ctx.storage, CONTRACT, 50_000, 5, 100);
@@ -5565,13 +5617,16 @@ mod tests {
             margin: UsdValue::new_int(1_000),
             ..Default::default()
         };
-        vault_state.positions.insert(pair_id(), Position {
-            size: Quantity::new_int(-10),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        vault_state.positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(-10),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         USER_STATES
             .save(&mut ctx.storage, CONTRACT, &vault_state)
             .unwrap();
@@ -5913,13 +5968,16 @@ mod tests {
 
         // Give taker an existing long position.
         let mut ts = taker_state(&ctx.storage);
-        ts.positions.insert(pair_id(), Position {
-            size: Quantity::new_int(10),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        ts.positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(10),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         USER_STATES.save(&mut ctx.storage, TAKER, &ts).unwrap();
 
         // Place bid to absorb the sell.
@@ -6086,13 +6144,16 @@ mod tests {
 
         // Give taker an existing long with no conditional orders.
         let mut ts = taker_state(&ctx.storage);
-        ts.positions.insert(pair_id(), Position {
-            size: Quantity::new_int(5),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: None,
-            conditional_order_below: None,
-        });
+        ts.positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(5),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: None,
+                conditional_order_below: None,
+            },
+        );
         USER_STATES.save(&mut ctx.storage, TAKER, &ts).unwrap();
 
         // Place a buy limit at 49_000 — no asks below that so nothing fills.
@@ -6285,23 +6346,26 @@ mod tests {
 
         // Give taker a long position with existing TP/SL.
         let mut ts = taker_state(&ctx.storage);
-        ts.positions.insert(pair_id(), Position {
-            size: Quantity::new_int(5),
-            entry_price: UsdPrice::new_int(50_000),
-            entry_funding_per_unit: FundingPerUnit::ZERO,
-            conditional_order_above: Some(ConditionalOrder {
-                order_id: Uint64::new(99),
-                size: None,
-                trigger_price: UsdPrice::new_int(60_000),
-                max_slippage: Dimensionless::new_percent(1),
-            }),
-            conditional_order_below: Some(ConditionalOrder {
-                order_id: Uint64::new(98),
-                size: None,
-                trigger_price: UsdPrice::new_int(40_000),
-                max_slippage: Dimensionless::new_percent(2),
-            }),
-        });
+        ts.positions.insert(
+            pair_id(),
+            Position {
+                size: Quantity::new_int(5),
+                entry_price: UsdPrice::new_int(50_000),
+                entry_funding_per_unit: FundingPerUnit::ZERO,
+                conditional_order_above: Some(ConditionalOrder {
+                    order_id: Uint64::new(99),
+                    size: None,
+                    trigger_price: UsdPrice::new_int(60_000),
+                    max_slippage: Dimensionless::new_percent(1),
+                }),
+                conditional_order_below: Some(ConditionalOrder {
+                    order_id: Uint64::new(98),
+                    size: None,
+                    trigger_price: UsdPrice::new_int(40_000),
+                    max_slippage: Dimensionless::new_percent(2),
+                }),
+            },
+        );
         USER_STATES.save(&mut ctx.storage, TAKER, &ts).unwrap();
 
         // Buy more with different TP/SL.
@@ -6370,13 +6434,16 @@ mod tests {
             margin: LARGE_COLLATERAL,
             positions: {
                 let mut p = BTreeMap::new();
-                p.insert(pair_id(), Position {
-                    size: Quantity::new_int(-10),
-                    entry_price: UsdPrice::new_int(50_000),
-                    entry_funding_per_unit: FundingPerUnit::ZERO,
-                    conditional_order_above: None,
-                    conditional_order_below: None,
-                });
+                p.insert(
+                    pair_id(),
+                    Position {
+                        size: Quantity::new_int(-10),
+                        entry_price: UsdPrice::new_int(50_000),
+                        entry_funding_per_unit: FundingPerUnit::ZERO,
+                        conditional_order_above: None,
+                        conditional_order_below: None,
+                    },
+                );
                 p
             },
             ..Default::default()
@@ -6445,13 +6512,16 @@ mod tests {
             reserved_margin: UsdValue::new_int(12_500),
             positions: {
                 let mut p = BTreeMap::new();
-                p.insert(pair_id(), Position {
-                    size: Quantity::new_int(-10),
-                    entry_price: UsdPrice::new_int(50_000),
-                    entry_funding_per_unit: FundingPerUnit::ZERO,
-                    conditional_order_above: None,
-                    conditional_order_below: None,
-                });
+                p.insert(
+                    pair_id(),
+                    Position {
+                        size: Quantity::new_int(-10),
+                        entry_price: UsdPrice::new_int(50_000),
+                        entry_funding_per_unit: FundingPerUnit::ZERO,
+                        conditional_order_above: None,
+                        conditional_order_below: None,
+                    },
+                );
                 p
             },
             ..Default::default()
@@ -7301,12 +7371,16 @@ mod tests {
         )
         .unwrap();
         USER_STATES
-            .save(&mut ctx.storage, MAKER_A, &UserState {
-                margin: LARGE_COLLATERAL,
-                open_order_count: 1,
-                reserved_margin: UsdValue::new_int(25_000),
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                MAKER_A,
+                &UserState {
+                    margin: LARGE_COLLATERAL,
+                    open_order_count: 1,
+                    reserved_margin: UsdValue::new_int(25_000),
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         let param = test_param();
@@ -7393,12 +7467,16 @@ mod tests {
         ASKS.save(&mut ctx.storage, maker_key, &maker_order)
             .unwrap();
         USER_STATES
-            .save(&mut ctx.storage, MAKER_A, &UserState {
-                margin: LARGE_COLLATERAL,
-                open_order_count: 1,
-                reserved_margin: UsdValue::new_int(25_000),
-                ..Default::default()
-            })
+            .save(
+                &mut ctx.storage,
+                MAKER_A,
+                &UserState {
+                    margin: LARGE_COLLATERAL,
+                    open_order_count: 1,
+                    reserved_margin: UsdValue::new_int(25_000),
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
         // Sanity: the alias is reachable before the fill.

--- a/dango/exchange/proposal-preparer/src/maker_priority_handler.rs
+++ b/dango/exchange/proposal-preparer/src/maker_priority_handler.rs
@@ -185,10 +185,13 @@ fn classify_submit_or_cancel(req: &SubmitOrCancelOrderRequest) -> MsgClass {
 }
 
 fn is_post_only(kind: &OrderKind) -> bool {
-    matches!(kind, OrderKind::Limit {
-        time_in_force: TimeInForce::PostOnly,
-        ..
-    },)
+    matches!(
+        kind,
+        OrderKind::Limit {
+            time_in_force: TimeInForce::PostOnly,
+            ..
+        },
+    )
 }
 
 // ----------------------------------- tests -----------------------------------

--- a/dango/exchange/vesting/src/execute.rs
+++ b/dango/exchange/vesting/src/execute.rs
@@ -10,14 +10,17 @@ use {
 };
 
 pub fn instantiate(ctx: MutableCtx, msg: InstantiateMsg) -> anyhow::Result<Response> {
-    UNLOCKING_SCHEDULE.save(ctx.storage, &Schedule {
-        // Unlocking start time is defined as the token generation time.
-        // Since this contract is to be deployed at genesis, and the token is
-        // generated also at genesis, the start time is simply the block time.
-        start_time: ctx.block.timestamp,
-        cliff: msg.unlocking_cliff,
-        period: msg.unlocking_period,
-    })?;
+    UNLOCKING_SCHEDULE.save(
+        ctx.storage,
+        &Schedule {
+            // Unlocking start time is defined as the token generation time.
+            // Since this contract is to be deployed at genesis, and the token is
+            // generated also at genesis, the start time is simply the block time.
+            start_time: ctx.block.timestamp,
+            cliff: msg.unlocking_cliff,
+            period: msg.unlocking_period,
+        },
+    )?;
 
     Ok(Response::new())
 }
@@ -38,11 +41,15 @@ fn create(ctx: MutableCtx, user: Addr, schedule: Schedule) -> anyhow::Result<Res
 
     let coin = ctx.funds.into_one_coin_of_denom(&dango::DENOM)?;
 
-    POSITIONS.save(ctx.storage, user, &Position {
-        vesting_status: VestingStatus::Active(schedule),
-        total: coin.amount,
-        claimed: Uint128::ZERO,
-    })?;
+    POSITIONS.save(
+        ctx.storage,
+        user,
+        &Position {
+            vesting_status: VestingStatus::Active(schedule),
+            total: coin.amount,
+            claimed: Uint128::ZERO,
+        },
+    )?;
 
     Ok(Response::new())
 }

--- a/dango/exchange/vesting/src/query.rs
+++ b/dango/exchange/vesting/src/query.rs
@@ -47,10 +47,13 @@ fn query_positions(
             let (user, position) = res?;
             let claimable = position.compute_claimable(ctx.block.timestamp, &unlocking_schedule)?;
 
-            Ok((user, PositionResponse {
-                position,
-                claimable,
-            }))
+            Ok((
+                user,
+                PositionResponse {
+                    position,
+                    claimable,
+                },
+            ))
         })
         .collect()
 }

--- a/dango/hyperlane/isms/multisig/src/execute.rs
+++ b/dango/hyperlane/isms/multisig/src/execute.rs
@@ -60,10 +60,14 @@ fn set_validators(
         validators.len()
     );
 
-    VALIDATOR_SETS.save(ctx.storage, domain, &ValidatorSet {
-        threshold,
-        validators,
-    })?;
+    VALIDATOR_SETS.save(
+        ctx.storage,
+        domain,
+        &ValidatorSet {
+            threshold,
+            validators,
+        },
+    )?;
 
     Ok(Response::new())
 }
@@ -111,12 +115,18 @@ mod tests {
             .with_sender(Addr::mock(1))
             .with_funds(Coins::default());
 
-        instantiate(ctx.as_mutable(), InstantiateMsg {
-            validator_sets: BTreeMap::from([(0, ValidatorSet {
-                threshold: 0,
-                validators: BTreeSet::new(),
-            })]),
-        })
+        instantiate(
+            ctx.as_mutable(),
+            InstantiateMsg {
+                validator_sets: BTreeMap::from([(
+                    0,
+                    ValidatorSet {
+                        threshold: 0,
+                        validators: BTreeSet::new(),
+                    },
+                )]),
+            },
+        )
         .should_fail_with_error("threshold must be greater than zero for domain 0");
     }
 
@@ -126,12 +136,18 @@ mod tests {
             .with_sender(Addr::mock(1))
             .with_funds(Coins::default());
 
-        instantiate(ctx.as_mutable(), InstantiateMsg {
-            validator_sets: BTreeMap::from([(0, ValidatorSet {
-                threshold: 0,
-                validators: btree_set! { V1 },
-            })]),
-        })
+        instantiate(
+            ctx.as_mutable(),
+            InstantiateMsg {
+                validator_sets: BTreeMap::from([(
+                    0,
+                    ValidatorSet {
+                        threshold: 0,
+                        validators: btree_set! { V1 },
+                    },
+                )]),
+            },
+        )
         .should_fail_with_error("threshold must be greater than zero for domain 0");
     }
 
@@ -141,12 +157,18 @@ mod tests {
             .with_sender(Addr::mock(1))
             .with_funds(Coins::default());
 
-        instantiate(ctx.as_mutable(), InstantiateMsg {
-            validator_sets: BTreeMap::from([(0, ValidatorSet {
-                threshold: 2,
-                validators: btree_set! { V1 },
-            })]),
-        })
+        instantiate(
+            ctx.as_mutable(),
+            InstantiateMsg {
+                validator_sets: BTreeMap::from([(
+                    0,
+                    ValidatorSet {
+                        threshold: 2,
+                        validators: btree_set! { V1 },
+                    },
+                )]),
+            },
+        )
         .should_fail_with_error("not enough validators for domain 0");
     }
 
@@ -156,12 +178,18 @@ mod tests {
             .with_sender(Addr::mock(1))
             .with_funds(Coins::default());
 
-        instantiate(ctx.as_mutable(), InstantiateMsg {
-            validator_sets: BTreeMap::from([(0, ValidatorSet {
-                threshold: 1,
-                validators: btree_set! { V1 },
-            })]),
-        })
+        instantiate(
+            ctx.as_mutable(),
+            InstantiateMsg {
+                validator_sets: BTreeMap::from([(
+                    0,
+                    ValidatorSet {
+                        threshold: 1,
+                        validators: btree_set! { V1 },
+                    },
+                )]),
+            },
+        )
         .should_succeed();
     }
 

--- a/dango/hyperlane/isms/multisig/src/query.rs
+++ b/dango/hyperlane/isms/multisig/src/query.rs
@@ -189,10 +189,14 @@ mod tests {
         let mut message = Message::decode(&raw_message).unwrap();
 
         VALIDATOR_SETS
-            .save(&mut ctx.storage, message.origin_domain, &ValidatorSet {
-                threshold: 1,
-                validators,
-            })
+            .save(
+                &mut ctx.storage,
+                message.origin_domain,
+                &ValidatorSet {
+                    threshold: 1,
+                    validators,
+                },
+            )
             .unwrap();
 
         verify(ctx.as_immutable(), &raw_message, &raw_metadata).should_succeed();
@@ -277,10 +281,14 @@ mod tests {
 
         // Save the _only the first three_ validators with a threshold of 2.
         VALIDATOR_SETS
-            .save(&mut ctx.storage, message.origin_domain, &ValidatorSet {
-                threshold: 2,
-                validators: validator_set[..3].iter().copied().collect(),
-            })
+            .save(
+                &mut ctx.storage,
+                message.origin_domain,
+                &ValidatorSet {
+                    threshold: 2,
+                    validators: validator_set[..3].iter().copied().collect(),
+                },
+            )
             .unwrap();
 
         // ----------------------- 3. Verify signatures ------------------------
@@ -439,10 +447,14 @@ mod tests {
 
         // Save with threshold = 2 so a single signer shouldn't suffice.
         VALIDATOR_SETS
-            .save(&mut ctx.storage, message.origin_domain, &ValidatorSet {
-                threshold: 2,
-                validators: validator_set.iter().copied().collect(),
-            })
+            .save(
+                &mut ctx.storage,
+                message.origin_domain,
+                &ValidatorSet {
+                    threshold: 2,
+                    validators: validator_set.iter().copied().collect(),
+                },
+            )
             .unwrap();
 
         // -------------------- 3. Malleability must fail ----------------------

--- a/dango/indexer/httpd/src/routes/account.rs
+++ b/dango/indexer/httpd/src/routes/account.rs
@@ -102,9 +102,11 @@ pub async fn account(
     let address = path.into_inner();
     let factory = factory_address(&app_ctx).await?;
 
-    let response = query_wasm_smart(&app_ctx, factory, &account_factory::QueryMsg::Account {
-        address,
-    })
+    let response = query_wasm_smart(
+        &app_ctx,
+        factory,
+        &account_factory::QueryMsg::Account { address },
+    )
     .await?;
 
     Ok(HttpResponse::Ok().json(response))
@@ -141,13 +143,14 @@ pub async fn user(
     let factory = factory_address(&app_ctx).await?;
 
     // First resolve which user owns the account...
-    let account_info: account_factory::Account =
-        query_wasm_smart(&app_ctx, factory, &account_factory::QueryMsg::Account {
-            address,
-        })
-        .await?
-        .deserialize_json()
-        .map_err(ErrorInternalServerError)?;
+    let account_info: account_factory::Account = query_wasm_smart(
+        &app_ctx,
+        factory,
+        &account_factory::QueryMsg::Account { address },
+    )
+    .await?
+    .deserialize_json()
+    .map_err(ErrorInternalServerError)?;
 
     // ...then return that user, verbatim.
     let response = query_wasm_smart(
@@ -223,9 +226,11 @@ pub async fn session_seen_nonces(
     let address = path.into_inner();
     let SessionSeenNoncesQuery { session_key } = query.into_inner();
 
-    let response = query_wasm_smart(&app_ctx, address, &AccountQueryMsg::SessionSeenNonces {
-        session_key,
-    })
+    let response = query_wasm_smart(
+        &app_ctx,
+        address,
+        &AccountQueryMsg::SessionSeenNonces { session_key },
+    )
     .await?;
 
     Ok(HttpResponse::Ok().json(response))
@@ -350,22 +355,25 @@ mod tests {
 
         // Both queries went to the factory: first the account lookup, then
         // the user lookup with the owner index from the first response.
-        assert_eq!(app.wasm_smart_requests(), vec![
-            (
-                factory_addr(),
-                account_factory::QueryMsg::Account {
-                    address: user_addr(),
-                }
-                .to_json_value()
-                .unwrap(),
-            ),
-            (
-                factory_addr(),
-                account_factory::QueryMsg::User(account_factory::UserIndexOrName::Index(7))
+        assert_eq!(
+            app.wasm_smart_requests(),
+            vec![
+                (
+                    factory_addr(),
+                    account_factory::QueryMsg::Account {
+                        address: user_addr(),
+                    }
                     .to_json_value()
                     .unwrap(),
-            ),
-        ]);
+                ),
+                (
+                    factory_addr(),
+                    account_factory::QueryMsg::User(account_factory::UserIndexOrName::Index(7))
+                        .to_json_value()
+                        .unwrap(),
+                ),
+            ]
+        );
     }
 
     #[actix_web::test]
@@ -435,11 +443,14 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, coins.to_json_value().unwrap());
 
-        assert_eq!(app.last_balances_request(), QueryBalancesRequest {
-            address: user_addr(),
-            start_after: Some(usdc::DENOM.clone()),
-            limit: Some(5),
-        });
+        assert_eq!(
+            app.last_balances_request(),
+            QueryBalancesRequest {
+                address: user_addr(),
+                start_after: Some(usdc::DENOM.clone()),
+                limit: Some(5),
+            }
+        );
     }
 
     #[actix_web::test]

--- a/dango/indexer/httpd/src/routes/perps.rs
+++ b/dango/indexer/httpd/src/routes/perps.rs
@@ -176,10 +176,10 @@ pub async fn pair_params(
 ) -> Result<HttpResponse, Error> {
     let PairsPageQuery { start_after, limit } = query.into_inner();
 
-    let response = query_perps(&app_ctx, &perps::QueryMsg::PairParams {
-        start_after,
-        limit,
-    })
+    let response = query_perps(
+        &app_ctx,
+        &perps::QueryMsg::PairParams { start_after, limit },
+    )
     .await?;
 
     Ok(HttpResponse::Ok().json(response))
@@ -261,10 +261,10 @@ pub async fn pair_states(
 ) -> Result<HttpResponse, Error> {
     let PairsPageQuery { start_after, limit } = query.into_inner();
 
-    let response = query_perps(&app_ctx, &perps::QueryMsg::PairStates {
-        start_after,
-        limit,
-    })
+    let response = query_perps(
+        &app_ctx,
+        &perps::QueryMsg::PairStates { start_after, limit },
+    )
     .await?;
 
     Ok(HttpResponse::Ok().json(response))
@@ -398,10 +398,13 @@ pub async fn order_by_client_order_id(
         client_order_id,
     } = query.into_inner();
 
-    let response = query_perps(&app_ctx, &perps::QueryMsg::OrderByClientOrderId {
-        user,
-        client_order_id,
-    })
+    let response = query_perps(
+        &app_ctx,
+        &perps::QueryMsg::OrderByClientOrderId {
+            user,
+            client_order_id,
+        },
+    )
     .await?;
 
     json_or_not_found(

--- a/dango/indexer/httpd/src/routes/ws.rs
+++ b/dango/indexer/httpd/src/routes/ws.rs
@@ -898,12 +898,14 @@ fn standing_query_frame(
     projection: Projection,
 ) -> String {
     match (projection, &frame.response) {
-        (Projection::UnwrapWasmSmart, QueryResponse::WasmSmart(inner)) => {
-            data_frame(channel, id, &AliasQueryFrame {
+        (Projection::UnwrapWasmSmart, QueryResponse::WasmSmart(inner)) => data_frame(
+            channel,
+            id,
+            &AliasQueryFrame {
                 block_height: frame.block_height,
                 response: inner,
-            })
-        },
+            },
+        ),
         // A non-`wasm_smart` response is unreachable for desugared alias
         // queries; fall back to the verbatim envelope rather than dropping
         // the frame.
@@ -1141,9 +1143,10 @@ mod tests {
 
         assert_eq!(id, 3);
         assert_eq!(subscription.channel(), "blockInfo");
-        assert!(matches!(subscription, Subscription::BlockInfo {
-            since: Some(42)
-        }));
+        assert!(matches!(
+            subscription,
+            Subscription::BlockInfo { since: Some(42) }
+        ));
 
         // `block`, without `since` (live-only).
         let message: ClientMessage = serde_json::from_str(
@@ -1281,10 +1284,13 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(message, ClientMessage::Query {
-            id: 6,
-            query: Query::Balance(_)
-        }));
+        assert!(matches!(
+            message,
+            ClientMessage::Query {
+                id: 6,
+                query: Query::Balance(_)
+            }
+        ));
     }
 
     #[test]
@@ -1318,10 +1324,10 @@ mod tests {
             panic!("expected a subscribe message");
         };
 
-        assert!(matches!(subscription, Subscription::Query {
-            interval: 10,
-            ..
-        }));
+        assert!(matches!(
+            subscription,
+            Subscription::Query { interval: 10, .. }
+        ));
     }
 
     #[test]

--- a/dango/indexer/sql/src/indexer.rs
+++ b/dango/indexer/sql/src/indexer.rs
@@ -180,10 +180,13 @@ impl IndexerBuilder<Defined<String>> {
             base_url.starts_with("postgres://") || base_url.starts_with("postgresql://");
         if !is_postgres {
             // Return unchanged for non-Postgres databases
-            return (self, TestDatabaseGuard {
-                server_prefix: String::new(),
-                db_name: String::new(),
-            });
+            return (
+                self,
+                TestDatabaseGuard {
+                    server_prefix: String::new(),
+                    db_name: String::new(),
+                },
+            );
         }
 
         // Generate a unique database name

--- a/dango/indexer/stream/src/indexer.rs
+++ b/dango/indexer/stream/src/indexer.rs
@@ -142,14 +142,13 @@ impl dango_app::Indexer for Indexer {
         // perps feed has always worked (the perps address it needs only arrives
         // with `app_cfg` at `post_indexing`). The cold `reindex` path skips
         // `index_block`, so the rings stay live-only.
-        self.inner
-            .pending
-            .lock()
-            .unwrap()
-            .insert(block.info.height, FullBlock {
+        self.inner.pending.lock().unwrap().insert(
+            block.info.height,
+            FullBlock {
                 block: block.clone(),
                 outcome: block_outcome.clone(),
-            });
+            },
+        );
 
         Ok(())
     }

--- a/dango/indexer/stream/src/perps_events.rs
+++ b/dango/indexer/stream/src/perps_events.rs
@@ -357,9 +357,10 @@ mod tests {
     fn pair_filter() {
         let f = make_perps_filter(None, pairs(&["perp/btcusd"]), None, None, None);
         let out = f(&block()).unwrap();
-        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
-            0, 2
-        ]);
+        assert_eq!(
+            out.events.iter().map(|e| e.idx).collect::<Vec<_>>(),
+            vec![0, 2]
+        );
     }
 
     #[test]
@@ -367,9 +368,10 @@ mod tests {
         // mock(1) is the `user` of both the order_filled and order_persisted.
         let f = make_perps_filter(None, None, users(&[1]), None, None);
         let out = f(&block()).unwrap();
-        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
-            0, 2
-        ]);
+        assert_eq!(
+            out.events.iter().map(|e| e.idx).collect::<Vec<_>>(),
+            vec![0, 2]
+        );
 
         // mock(2) is not the `user` of any event here.
         let f = make_perps_filter(None, None, users(&[2]), None, None);
@@ -386,9 +388,10 @@ mod tests {
             None,
         );
         let out = f(&block()).unwrap();
-        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
-            2
-        ]);
+        assert_eq!(
+            out.events.iter().map(|e| e.idx).collect::<Vec<_>>(),
+            vec![2]
+        );
     }
 
     #[test]
@@ -396,16 +399,18 @@ mod tests {
         // order_id 100 belongs only to the order_filled (idx 0).
         let f = make_perps_filter(None, None, None, order_ids(&[100]), None);
         let out = f(&block()).unwrap();
-        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
-            0
-        ]);
+        assert_eq!(
+            out.events.iter().map(|e| e.idx).collect::<Vec<_>>(),
+            vec![0]
+        );
 
         // A set spanning both resting orders keeps both, in block order.
         let f = make_perps_filter(None, None, None, order_ids(&[100, 101]), None);
         let out = f(&block()).unwrap();
-        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
-            0, 2
-        ]);
+        assert_eq!(
+            out.events.iter().map(|e| e.idx).collect::<Vec<_>>(),
+            vec![0, 2]
+        );
 
         // The liquidated event (idx 1) carries no order_id, and no event has id
         // 999, so an order filter excludes everything.
@@ -418,9 +423,10 @@ mod tests {
         // Only the order_filled (idx 0) carries client_order_id 7.
         let f = make_perps_filter(None, None, None, None, client_order_ids(&[7]));
         let out = f(&block()).unwrap();
-        assert_eq!(out.events.iter().map(|e| e.idx).collect::<Vec<_>>(), vec![
-            0
-        ]);
+        assert_eq!(
+            out.events.iter().map(|e| e.idx).collect::<Vec<_>>(),
+            vec![0]
+        );
 
         // The liquidation and the cid-less resting order (idx 1, 2) cannot match
         // any client order filter.

--- a/dango/indexer/stream/src/recent_stream.rs
+++ b/dango/indexer/stream/src/recent_stream.rs
@@ -477,10 +477,13 @@ mod tests {
         }
         // Ring holds 3,4,5; asking from 2 cannot be served.
         let err = rs.subscribe(Some(2), id).err().unwrap();
-        assert_eq!(err, ResyncRequired {
-            requested_from: 2,
-            ring_floor: 3,
-        });
+        assert_eq!(
+            err,
+            ResyncRequired {
+                requested_from: 2,
+                ring_floor: 3,
+            }
+        );
     }
 
     #[tokio::test]

--- a/dango/pyth/client/tests/client.rs
+++ b/dango/pyth/client/tests/client.rs
@@ -40,10 +40,11 @@ const TOKEN: &str = "insert_lazer_token_here";
 async fn test_lazer_stream() {
     let client = PythClient::new(NonEmpty::new_unchecked(LAZER_ENDPOINTS_TEST), TOKEN).unwrap();
 
-    test_stream(client, vec![BTC_USD_ID, ETH_USD_ID], vec![
-        SOL_USD_ID,
-        HYPE_USD_ID,
-    ])
+    test_stream(
+        client,
+        vec![BTC_USD_ID, ETH_USD_ID],
+        vec![SOL_USD_ID, HYPE_USD_ID],
+    )
     .await;
 }
 

--- a/dango/pyth/client/tests/common_function.rs
+++ b/dango/pyth/client/tests/common_function.rs
@@ -20,14 +20,17 @@ impl VaasChecker {
     {
         let mut values = BTreeMap::new();
         for id in ids.into_iter() {
-            values.insert(id.id, btree_map! {
-                "price" => 0,
-                "publish_time" => 0,
-                // Set to -1 since the first iteration will increase the counter
-                // (price and publish time are 0).
-                "price_change" => -1,
-                "publish_time_change" => -1,
-            });
+            values.insert(
+                id.id,
+                btree_map! {
+                    "price" => 0,
+                    "publish_time" => 0,
+                    // Set to -1 since the first iteration will increase the counter
+                    // (price and publish time are 0).
+                    "price_change" => -1,
+                    "publish_time_change" => -1,
+                },
+            );
         }
         Self { values }
     }

--- a/dango/sdk/examples/perps_latency.rs
+++ b/dango/sdk/examples/perps_latency.rs
@@ -195,9 +195,12 @@ async fn index_price(
     pair_id: &dango_order_book::PairId,
 ) -> Result<UsdPrice> {
     let state: Option<PairState> = client
-        .query_wasm_smart(perps, perps::QueryPairStateRequest {
-            pair_id: pair_id.clone(),
-        })
+        .query_wasm_smart(
+            perps,
+            perps::QueryPairStateRequest {
+                pair_id: pair_id.clone(),
+            },
+        )
         .await?;
 
     Ok(state
@@ -212,9 +215,12 @@ async fn tick_size(
     pair_id: &dango_order_book::PairId,
 ) -> Result<UsdPrice> {
     let param: Option<PairParam> = client
-        .query_wasm_smart(perps, perps::QueryPairParamRequest {
-            pair_id: pair_id.clone(),
-        })
+        .query_wasm_smart(
+            perps,
+            perps::QueryPairParamRequest {
+                pair_id: pair_id.clone(),
+            },
+        )
         .await?;
 
     Ok(param

--- a/dango/sdk/examples/trade_history_csv.rs
+++ b/dango/sdk/examples/trade_history_csv.rs
@@ -66,12 +66,15 @@ async fn main() -> Result<()> {
             },
             |data| {
                 let pi = data.perps_events.page_info;
-                (data.perps_events.nodes, PageInfo {
-                    start_cursor: pi.start_cursor,
-                    end_cursor: pi.end_cursor,
-                    has_next_page: pi.has_next_page,
-                    has_previous_page: pi.has_previous_page,
-                })
+                (
+                    data.perps_events.nodes,
+                    PageInfo {
+                        start_cursor: pi.start_cursor,
+                        end_cursor: pi.end_cursor,
+                        has_next_page: pi.has_next_page,
+                        has_previous_page: pi.has_previous_page,
+                    },
+                )
             },
         )
         .await?;

--- a/dango/sdk/src/signer.rs
+++ b/dango/sdk/src/signer.rs
@@ -49,9 +49,12 @@ where
             .account_factory;
 
         Ok(client
-            .query_wasm_smart(account_factory, account_factory::QueryAccountRequest {
-                address: self.address,
-            })
+            .query_wasm_smart(
+                account_factory,
+                account_factory::QueryAccountRequest {
+                    address: self.address,
+                },
+            )
             .await?
             .owner)
     }
@@ -118,11 +121,14 @@ where
         let key_hash = secret.key_hash();
 
         let user_index = client
-            .query_wasm_smart(factory_addr, account_factory::QueryForgotUsernameRequest {
-                key_hash,
-                start_after: None,
-                limit: Some(1),
-            })
+            .query_wasm_smart(
+                factory_addr,
+                account_factory::QueryForgotUsernameRequest {
+                    key_hash,
+                    start_after: None,
+                    limit: Some(1),
+                },
+            )
             .await?
             .first()
             .ok_or_else(|| anyhow!("no user index found for key hash {key_hash}"))?

--- a/dango/testing/src/account.rs
+++ b/dango/testing/src/account.rs
@@ -153,9 +153,12 @@ impl TestAccount<Undefined<UserIndex>, Defined<Addr>> {
     ) -> TestAccount<Defined<UserIndex>, Defined<Addr>> {
         let account_factory = querier.query_account_factory().unwrap();
         let user_index = querier
-            .query_wasm_smart(account_factory, account_factory::QueryAccountRequest {
-                address: self.address.into_inner(),
-            })
+            .query_wasm_smart(
+                account_factory,
+                account_factory::QueryAccountRequest {
+                    address: self.address.into_inner(),
+                },
+            )
             .unwrap()
             .owner;
 

--- a/dango/testing/src/client.rs
+++ b/dango/testing/src/client.rs
@@ -264,13 +264,16 @@ async fn index(
         .zip(outcome.block_outcome.tx_outcomes.iter())
         .enumerate()
     {
-        index_txs.insert(*hash, SearchTxOutcome {
-            hash: *hash,
-            height: block_info.height,
-            index: index as u32,
-            tx: tx.clone(),
-            outcome: outcome.clone(),
-        });
+        index_txs.insert(
+            *hash,
+            SearchTxOutcome {
+                hash: *hash,
+                height: block_info.height,
+                index: index as u32,
+                tx: tx.clone(),
+                outcome: outcome.clone(),
+            },
+        );
     }
 
     let block = Block {

--- a/dango/testing/src/perps.rs
+++ b/dango/testing/src/perps.rs
@@ -31,16 +31,19 @@ pub async fn setup_perps_env(
     margin_per_user: u128,
 ) {
     suite
-        .seed_oracle_prices(&mut accounts.owner, btree_map! {
-            usdc::DENOM.clone() => OracleTestEntry {
-                pyth_id: 1,
-                humanized_price: UsdPrice::new_int(1),
+        .seed_oracle_prices(
+            &mut accounts.owner,
+            btree_map! {
+                usdc::DENOM.clone() => OracleTestEntry {
+                    pyth_id: 1,
+                    humanized_price: UsdPrice::new_int(1),
+                },
+                pair_id() => OracleTestEntry {
+                    pyth_id: 2,
+                    humanized_price: UsdPrice::new_int(eth_price as i128),
+                },
             },
-            pair_id() => OracleTestEntry {
-                pyth_id: 2,
-                humanized_price: UsdPrice::new_int(eth_price as i128),
-            },
-        })
+        )
         .await;
 
     for account in [&mut accounts.user1, &mut accounts.user2] {

--- a/dango/testing/tests/bank.rs
+++ b/dango/testing/tests/bank.rs
@@ -34,21 +34,24 @@ async fn batch_transfer() {
 
     // Owner makes a multi-send to users 1, 2, and the non-existent recipient.
     let events = suite
-        .batch_transfer(&mut accounts.owner, btree_map! {
-            accounts.user1.address() => coins! {
-                dango::DENOM.clone() => 100,
+        .batch_transfer(
+            &mut accounts.owner,
+            btree_map! {
+                accounts.user1.address() => coins! {
+                    dango::DENOM.clone() => 100,
+                },
+                accounts.user2.address() => coins! {
+                    dango::DENOM.clone() => 200,
+                    usdc::DENOM.clone() => 300,
+                },
+                dead1 => coins! {
+                    dango::DENOM.clone() => 400,
+                },
+                dead2 => coins! {
+                    usdc::DENOM.clone() => 500,
+                },
             },
-            accounts.user2.address() => coins! {
-                dango::DENOM.clone() => 200,
-                usdc::DENOM.clone() => 300,
-            },
-            dead1 => coins! {
-                dango::DENOM.clone() => 400,
-            },
-            dead2 => coins! {
-                usdc::DENOM.clone() => 500,
-            },
-        })
+        )
         .await
         .should_succeed()
         .events;
@@ -66,37 +69,40 @@ async fn batch_transfer() {
             .map(|e| e.event.data.deserialize_json::<Sent>().unwrap())
             .collect::<Vec<_>>();
 
-        assert!(vectors_have_same_elements(sends, vec![
-            Sent {
-                user: accounts.owner.address(),
-                to: accounts.user1.address(),
-                coins: coins! {
-                    dango::DENOM.clone() => 100,
+        assert!(vectors_have_same_elements(
+            sends,
+            vec![
+                Sent {
+                    user: accounts.owner.address(),
+                    to: accounts.user1.address(),
+                    coins: coins! {
+                        dango::DENOM.clone() => 100,
+                    },
                 },
-            },
-            Sent {
-                user: accounts.owner.address(),
-                to: accounts.user2.address(),
-                coins: coins! {
-                    dango::DENOM.clone() => 200,
-                    usdc::DENOM.clone() => 300,
+                Sent {
+                    user: accounts.owner.address(),
+                    to: accounts.user2.address(),
+                    coins: coins! {
+                        dango::DENOM.clone() => 200,
+                        usdc::DENOM.clone() => 300,
+                    },
                 },
-            },
-            Sent {
-                user: accounts.owner.address(),
-                to: contracts.bank, // The orphaned transfer goes to the bank.
-                coins: coins! {
-                    dango::DENOM.clone() => 400,
+                Sent {
+                    user: accounts.owner.address(),
+                    to: contracts.bank, // The orphaned transfer goes to the bank.
+                    coins: coins! {
+                        dango::DENOM.clone() => 400,
+                    },
                 },
-            },
-            Sent {
-                user: accounts.owner.address(),
-                to: contracts.bank, // The orphaned transfer goes to the bank.
-                coins: coins! {
-                    usdc::DENOM.clone() => 500,
+                Sent {
+                    user: accounts.owner.address(),
+                    to: contracts.bank, // The orphaned transfer goes to the bank.
+                    coins: coins! {
+                        usdc::DENOM.clone() => 500,
+                    },
                 },
-            },
-        ]));
+            ]
+        ));
     }
 
     // `received` events:
@@ -111,37 +117,40 @@ async fn batch_transfer() {
             .map(|e| e.event.data.deserialize_json::<Received>().unwrap())
             .collect::<Vec<_>>();
 
-        assert!(vectors_have_same_elements(receives, vec![
-            Received {
-                user: accounts.user1.address(),
-                from: accounts.owner.address(),
-                coins: coins! {
-                    dango::DENOM.clone() => 100,
+        assert!(vectors_have_same_elements(
+            receives,
+            vec![
+                Received {
+                    user: accounts.user1.address(),
+                    from: accounts.owner.address(),
+                    coins: coins! {
+                        dango::DENOM.clone() => 100,
+                    },
                 },
-            },
-            Received {
-                user: accounts.user2.address(),
-                from: accounts.owner.address(),
-                coins: coins! {
-                    dango::DENOM.clone() => 200,
-                    usdc::DENOM.clone() => 300,
+                Received {
+                    user: accounts.user2.address(),
+                    from: accounts.owner.address(),
+                    coins: coins! {
+                        dango::DENOM.clone() => 200,
+                        usdc::DENOM.clone() => 300,
+                    },
                 },
-            },
-            Received {
-                user: contracts.bank, // The orphaned transfer goes to the bank.
-                from: accounts.owner.address(),
-                coins: coins! {
-                    dango::DENOM.clone() => 400,
+                Received {
+                    user: contracts.bank, // The orphaned transfer goes to the bank.
+                    from: accounts.owner.address(),
+                    coins: coins! {
+                        dango::DENOM.clone() => 400,
+                    },
                 },
-            },
-            Received {
-                user: contracts.bank, // The orphaned transfer goes to the bank.
-                from: accounts.owner.address(),
-                coins: coins! {
-                    usdc::DENOM.clone() => 500,
+                Received {
+                    user: contracts.bank, // The orphaned transfer goes to the bank.
+                    from: accounts.owner.address(),
+                    coins: coins! {
+                        usdc::DENOM.clone() => 500,
+                    },
                 },
-            },
-        ]));
+            ]
+        ));
     }
 
     // `transfer_orphaned` events:
@@ -155,46 +164,61 @@ async fn batch_transfer() {
             .map(|e| e.event.data.deserialize_json::<TransferOrphaned>().unwrap())
             .collect::<Vec<_>>();
 
-        assert!(vectors_have_same_elements(orphans, vec![
-            TransferOrphaned {
-                from: accounts.owner.address(),
-                to: dead1,
-                coins: coins! {
-                    dango::DENOM.clone() => 400,
+        assert!(vectors_have_same_elements(
+            orphans,
+            vec![
+                TransferOrphaned {
+                    from: accounts.owner.address(),
+                    to: dead1,
+                    coins: coins! {
+                        dango::DENOM.clone() => 400,
+                    },
                 },
-            },
-            TransferOrphaned {
-                from: accounts.owner.address(),
-                to: dead2,
-                coins: coins! {
-                    usdc::DENOM.clone() => 500,
+                TransferOrphaned {
+                    from: accounts.owner.address(),
+                    to: dead2,
+                    coins: coins! {
+                        usdc::DENOM.clone() => 500,
+                    },
                 },
-            },
-        ]));
+            ]
+        ));
     }
 
     // Check the balance changes.
     {
-        suite.balances().should_change(&accounts.owner, btree_map! {
-            dango::DENOM.clone() => BalanceChange::Decreased(700),
-            usdc::DENOM.clone() => BalanceChange::Decreased(800),
-        });
+        suite.balances().should_change(
+            &accounts.owner,
+            btree_map! {
+                dango::DENOM.clone() => BalanceChange::Decreased(700),
+                usdc::DENOM.clone() => BalanceChange::Decreased(800),
+            },
+        );
 
-        suite.balances().should_change(&accounts.user1, btree_map! {
-            dango::DENOM.clone() => BalanceChange::Increased(100),
-        });
+        suite.balances().should_change(
+            &accounts.user1,
+            btree_map! {
+                dango::DENOM.clone() => BalanceChange::Increased(100),
+            },
+        );
 
-        suite.balances().should_change(&accounts.user2, btree_map! {
-            dango::DENOM.clone() => BalanceChange::Increased(200),
-            usdc::DENOM.clone() => BalanceChange::Increased(300),
-        });
+        suite.balances().should_change(
+            &accounts.user2,
+            btree_map! {
+                dango::DENOM.clone() => BalanceChange::Increased(200),
+                usdc::DENOM.clone() => BalanceChange::Increased(300),
+            },
+        );
 
         // The token that are supposed to go to the non-existing accounts should
         // have been withheld in the bank contract as orphaned transfers.
-        suite.balances().should_change(&contracts.bank, btree_map! {
-            dango::DENOM.clone() => BalanceChange::Increased(400),
-            usdc::DENOM.clone() => BalanceChange::Increased(500),
-        });
+        suite.balances().should_change(
+            &contracts.bank,
+            btree_map! {
+                dango::DENOM.clone() => BalanceChange::Increased(400),
+                usdc::DENOM.clone() => BalanceChange::Increased(500),
+            },
+        );
 
         // The non-existing accounts should have no balance.
         suite.balances().should_change(&dead1, btree_map! {});
@@ -204,10 +228,13 @@ async fn batch_transfer() {
     // The orphaned transfers should have been recorded.
     {
         suite
-            .query_wasm_smart(contracts.bank, QueryOrphanedTransfersRequest {
-                start_after: None,
-                limit: None,
-            })
+            .query_wasm_smart(
+                contracts.bank,
+                QueryOrphanedTransfersRequest {
+                    start_after: None,
+                    limit: None,
+                },
+            )
             .should_succeed_and_equal(vec![
                 OrphanedTransferResponseItem {
                     sender: accounts.owner.address(),
@@ -222,32 +249,41 @@ async fn batch_transfer() {
             ]);
 
         suite
-            .query_wasm_smart(contracts.bank, QueryOrphanedTransfersBySenderRequest {
-                sender: accounts.owner.address(),
-                start_after: None,
-                limit: None,
-            })
+            .query_wasm_smart(
+                contracts.bank,
+                QueryOrphanedTransfersBySenderRequest {
+                    sender: accounts.owner.address(),
+                    start_after: None,
+                    limit: None,
+                },
+            )
             .should_succeed_and_equal(btree_map! {
                 dead1 => coins! { dango::DENOM.clone() => 400 },
                 dead2 => coins! { usdc::DENOM.clone() => 500 },
             });
 
         suite
-            .query_wasm_smart(contracts.bank, QueryOrphanedTransfersByRecipientRequest {
-                recipient: dead1,
-                start_after: None,
-                limit: None,
-            })
+            .query_wasm_smart(
+                contracts.bank,
+                QueryOrphanedTransfersByRecipientRequest {
+                    recipient: dead1,
+                    start_after: None,
+                    limit: None,
+                },
+            )
             .should_succeed_and_equal(btree_map! {
                 accounts.owner.address() => coins! { dango::DENOM.clone() => 400 },
             });
 
         suite
-            .query_wasm_smart(contracts.bank, QueryOrphanedTransfersByRecipientRequest {
-                recipient: dead2,
-                start_after: None,
-                limit: None,
-            })
+            .query_wasm_smart(
+                contracts.bank,
+                QueryOrphanedTransfersByRecipientRequest {
+                    recipient: dead2,
+                    start_after: None,
+                    limit: None,
+                },
+            )
             .should_succeed_and_equal(btree_map! {
                 accounts.owner.address() => coins! { usdc::DENOM.clone() => 500 },
             });
@@ -375,9 +411,12 @@ async fn set_metadata_can_only_be_called_by_non_namespace_owner() {
 
     // Assert metadata is set correctly
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryMetadataRequest {
-            denom: Denom::new_unchecked(["testing", "test"]),
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryMetadataRequest {
+                denom: Denom::new_unchecked(["testing", "test"]),
+            },
+        )
         .should_succeed_and_equal(bank::Metadata {
             name: LengthBounded::new_unchecked("Very testy token".to_string()),
             symbol: LengthBounded::new_unchecked("TESTY".to_string()),
@@ -392,9 +431,12 @@ async fn set_namespace_owner_works() {
 
     // Query namespace owner of testing. Should fail because it's not set.
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryNamespaceOwnerRequest {
-            namespace: Part::new_unchecked("testing"),
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryNamespaceOwnerRequest {
+                namespace: Part::new_unchecked("testing"),
+            },
+        )
         .should_fail_with_error(
             "msg: data not found! type: dango_primitives::encoded_bytes::EncodedBytes",
         );
@@ -415,9 +457,12 @@ async fn set_namespace_owner_works() {
 
     // Query namespace owner of testing. Should succeed.
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryNamespaceOwnerRequest {
-            namespace: Part::new_unchecked("testing"),
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryNamespaceOwnerRequest {
+                namespace: Part::new_unchecked("testing"),
+            },
+        )
         .should_succeed_and_equal(accounts.user1.address());
 }
 
@@ -427,20 +472,26 @@ fn query_namespace_owners_works() {
 
     // Query namespace owners. Should succeed.
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryNamespaceOwnersRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryNamespaceOwnersRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and_equal(btree_map! {
             Part::new_unchecked("bridge") => contracts.gateway,
         });
 
     // Query namespace owners with limit. Should succeed.
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryNamespaceOwnersRequest {
-            start_after: None,
-            limit: Some(1),
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryNamespaceOwnersRequest {
+                start_after: None,
+                limit: Some(1),
+            },
+        )
         .should_succeed_and_equal(btree_map! {
             Part::new_unchecked("bridge") => contracts.gateway,
         });
@@ -451,10 +502,13 @@ fn query_metadatas_works() {
     let (suite, _, _, contracts, _) = setup_test_naive(Default::default());
 
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryMetadatasRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryMetadatasRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and(|metadatas| {
             metadatas.keys().collect::<BTreeSet<_>>()
                 == BTreeSet::from([
@@ -466,10 +520,13 @@ fn query_metadatas_works() {
 
     // Start after eth
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryMetadatasRequest {
-            start_after: Some(Denom::new_unchecked(["bridge", "eth"])),
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryMetadatasRequest {
+                start_after: Some(Denom::new_unchecked(["bridge", "eth"])),
+                limit: None,
+            },
+        )
         .should_succeed_and(|metadatas| {
             metadatas.keys().collect::<BTreeSet<_>>()
                 == BTreeSet::from([
@@ -480,10 +537,13 @@ fn query_metadatas_works() {
 
     // Limit 2
     suite
-        .query_wasm_smart(contracts.bank, bank::QueryMetadatasRequest {
-            start_after: None,
-            limit: Some(2),
-        })
+        .query_wasm_smart(
+            contracts.bank,
+            bank::QueryMetadatasRequest {
+                start_after: None,
+                limit: Some(2),
+            },
+        )
         .should_succeed_and(|metadatas| {
             metadatas.keys().collect::<BTreeSet<_>>()
                 == BTreeSet::from([

--- a/dango/testing/tests/factory.rs
+++ b/dango/testing/tests/factory.rs
@@ -29,13 +29,16 @@ use {
 #[tokio::test]
 async fn onboarding_without_deposit() {
     let (suite, mut accounts, codes, contracts, validator_sets) =
-        setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
-            account: AccountOption {
-                minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+        setup_test_naive_with_custom_genesis(
+            Default::default(),
+            GenesisOption {
+                account: AccountOption {
+                    minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+                    ..Preset::preset_test()
+                },
                 ..Preset::preset_test()
             },
-            ..Preset::preset_test()
-        });
+        );
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
     // Make an empty block to advance block height from 0 to 1.
@@ -157,14 +160,16 @@ async fn onboarding_without_deposit() {
 /// activate) an inactive account.
 #[tokio::test]
 async fn inactive_account_rejects_transfer_from_non_gateway() {
-    let (mut suite, mut accounts, codes, contracts, _) =
-        setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
+    let (mut suite, mut accounts, codes, contracts, _) = setup_test_naive_with_custom_genesis(
+        Default::default(),
+        GenesisOption {
             account: AccountOption {
                 minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
                 ..Preset::preset_test()
             },
             ..Preset::preset_test()
-        });
+        },
+    );
 
     let chain_id = suite.chain_id.clone();
 
@@ -230,13 +235,16 @@ async fn inactive_account_rejects_transfer_from_non_gateway() {
 #[tokio::test]
 async fn gateway_deposit_activates_account() {
     let (suite, mut accounts, codes, contracts, validator_sets) =
-        setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
-            account: AccountOption {
-                minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+        setup_test_naive_with_custom_genesis(
+            Default::default(),
+            GenesisOption {
+                account: AccountOption {
+                    minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+                    ..Preset::preset_test()
+                },
                 ..Preset::preset_test()
             },
-            ..Preset::preset_test()
-        });
+        );
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
     // Make an empty block so that subsequent transactions are processed at a
@@ -305,13 +313,16 @@ async fn gateway_deposit_activates_account() {
 #[tokio::test]
 async fn gateway_transfer_to_inactive_account_is_accepted() {
     let (suite, mut accounts, codes, contracts, validator_sets) =
-        setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
-            account: AccountOption {
-                minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+        setup_test_naive_with_custom_genesis(
+            Default::default(),
+            GenesisOption {
+                account: AccountOption {
+                    minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+                    ..Preset::preset_test()
+                },
                 ..Preset::preset_test()
             },
-            ..Preset::preset_test()
-        });
+        );
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
     suite.make_empty_block().await;
@@ -384,13 +395,16 @@ async fn gateway_transfer_to_inactive_account_is_accepted() {
 #[tokio::test]
 async fn gateway_deposits_accumulate_to_activate() {
     let (suite, mut accounts, codes, contracts, validator_sets) =
-        setup_test_naive_with_custom_genesis(Default::default(), GenesisOption {
-            account: AccountOption {
-                minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+        setup_test_naive_with_custom_genesis(
+            Default::default(),
+            GenesisOption {
+                account: AccountOption {
+                    minimum_deposit: coins! { usdc::DENOM.clone() => 10_000_000 },
+                    ..Preset::preset_test()
+                },
                 ..Preset::preset_test()
             },
-            ..Preset::preset_test()
-        });
+        );
     let mut suite = HyperlaneTestSuite::new(suite, validator_sets, &contracts);
 
     suite.make_empty_block().await;

--- a/dango/testing/tests/gas.rs
+++ b/dango/testing/tests/gas.rs
@@ -47,9 +47,12 @@ async fn gas_fee_rate_update_works() {
     let fee_old = Uint128::new(GAS as u128)
         .checked_mul_dec_ceil(OLD_FEE_RATE)
         .unwrap();
-    suite.balances().should_change(&accounts.user1, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(fee_old.into_inner()),
-    });
+    suite.balances().should_change(
+        &accounts.user1,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(fee_old.into_inner()),
+        },
+    );
 
     // The owner raises the rate to `NEW_FEE_RATE`.
     let mut new_cfg = suite.query_config().unwrap();
@@ -73,7 +76,10 @@ async fn gas_fee_rate_update_works() {
     let fee_new = Uint128::new(GAS as u128)
         .checked_mul_dec_ceil(NEW_FEE_RATE)
         .unwrap();
-    suite.balances().should_change(&accounts.user1, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(fee_new.into_inner()),
-    });
+    suite.balances().should_change(
+        &accounts.user1,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(fee_new.into_inner()),
+        },
+    );
 }

--- a/dango/testing/tests/gateway.rs
+++ b/dango/testing/tests/gateway.rs
@@ -59,9 +59,12 @@ async fn rate_limit() {
         }
 
         // Check balances.
-        suite.balances().should_change(receiver, btree_map! {
-            usdc::DENOM.clone() => BalanceChange::Increased(300_000_000),
-        });
+        suite.balances().should_change(
+            receiver,
+            btree_map! {
+                usdc::DENOM.clone() => BalanceChange::Increased(300_000_000),
+            },
+        );
     }
 
     suite
@@ -146,9 +149,12 @@ async fn rate_limit() {
             .query_supply(usdc::DENOM.clone())
             .should_succeed_and_equal(370_000_000.into());
 
-        suite.balances().should_change(receiver, btree_map! {
-            usdc::DENOM.clone() => BalanceChange::Increased(369_990_000),
-        });
+        suite.balances().should_change(
+            receiver,
+            btree_map! {
+                usdc::DENOM.clone() => BalanceChange::Increased(369_990_000),
+            },
+        );
     }
 
     // Quota was not bumped by the inbound transfer — sending even 1 token
@@ -190,10 +196,13 @@ async fn rate_limit() {
         ),
     ] {
         suite
-            .query_wasm_smart(contracts.gateway, gateway::QueryReserveRequest {
-                bridge: contracts.warp,
-                remote,
-            })
+            .query_wasm_smart(
+                contracts.gateway,
+                gateway::QueryReserveRequest {
+                    bridge: contracts.warp,
+                    remote,
+                },
+            )
             .should_succeed_and_equal(amount.into());
     }
 
@@ -522,13 +531,19 @@ async fn native_denom() {
     }
 
     // check the balances.
-    suite.balances().should_change(&accounts.user1, btree_map! {
-        dango::DENOM.clone() => BalanceChange::Decreased(100),
-    });
+    suite.balances().should_change(
+        &accounts.user1,
+        btree_map! {
+            dango::DENOM.clone() => BalanceChange::Decreased(100),
+        },
+    );
 
-    suite.balances().should_change(&accounts.user2, btree_map! {
-        dango::DENOM.clone() => BalanceChange::Increased(100),
-    });
+    suite.balances().should_change(
+        &accounts.user2,
+        btree_map! {
+            dango::DENOM.clone() => BalanceChange::Increased(100),
+        },
+    );
 }
 
 #[tokio::test]
@@ -576,13 +591,16 @@ async fn deposit_and_withdraw_events() {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(deposits, vec![gateway::Deposited {
-            user: accounts.user2.address(),
-            bridge: contracts.warp,
-            remote,
-            denom: usdc::DENOM.clone(),
-            amount: Uint128::new(100_000_000),
-        }]);
+        assert_eq!(
+            deposits,
+            vec![gateway::Deposited {
+                user: accounts.user2.address(),
+                bridge: contracts.warp,
+                remote,
+                denom: usdc::DENOM.clone(),
+                amount: Uint128::new(100_000_000),
+            }]
+        );
     }
 
     // Sending a remote transfer should emit a `withdrawn` event from the
@@ -619,16 +637,19 @@ async fn deposit_and_withdraw_events() {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(withdrawals, vec![gateway::Withdrawn {
-            id: 0,
-            user: accounts.user2.address(),
-            bridge: contracts.warp,
-            remote,
-            recipient: mock_arbitrum_recipient,
-            denom: usdc::DENOM.clone(),
-            amount: Uint128::new(50_000_000),
-            fee: Uint128::new(ARBITRUM_USDC_WITHDRAWAL_FEE),
-        }]);
+        assert_eq!(
+            withdrawals,
+            vec![gateway::Withdrawn {
+                id: 0,
+                user: accounts.user2.address(),
+                bridge: contracts.warp,
+                remote,
+                recipient: mock_arbitrum_recipient,
+                denom: usdc::DENOM.clone(),
+                amount: Uint128::new(50_000_000),
+                fee: Uint128::new(ARBITRUM_USDC_WITHDRAWAL_FEE),
+            }]
+        );
     }
 }
 
@@ -1125,10 +1146,13 @@ async fn personal_quota() {
         .should_succeed();
 
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
     assert_eq!(pq.amount, Uint128::new(50_000_000));
@@ -1160,10 +1184,13 @@ async fn personal_quota() {
         .should_succeed();
 
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
     assert_eq!(pq.amount, Uint128::new(10_000_000));
@@ -1196,10 +1223,13 @@ async fn personal_quota() {
 
     // Fully consumed personal quotas are removed from storage.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed_and_equal(None);
 
     // Global is now depleted. The error mentions the remainder after any
@@ -1261,10 +1291,13 @@ async fn personal_quota() {
     // The expired entry is left in storage; the handler doesn't scrub it. The
     // caller can still query it to reason about `expire_at`.
     let stored = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed();
     assert_eq!(
         stored.as_ref().map(|q| q.amount),
@@ -1274,10 +1307,13 @@ async fn personal_quota() {
 
     // ---- Pagination query ----
     let mut page = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotasRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotasRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed();
     assert_eq!(page.len(), 1);
     let entry = page.pop().unwrap();
@@ -1351,10 +1387,13 @@ async fn personal_quota_revoke_via_op_delete() {
         .should_succeed();
 
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
     assert_eq!(pq.amount, Uint128::new(50_000_000));
@@ -1378,10 +1417,13 @@ async fn personal_quota_revoke_via_op_delete() {
 
     // Entry is gone — not just zeroed.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed_and_equal(None);
 
     // Try to withdraw 20M — above the 10M global quota. Pre-revocation the
@@ -1491,10 +1533,13 @@ async fn zero_rate_limit_revokes_personal_quotas() {
 
     // Confirm the quota is in place.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver.address(),
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver.address(),
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed_and(|q| q.is_some());
 
     // Owner sets the USDC rate limit to 0 — a hard freeze.
@@ -1512,10 +1557,13 @@ async fn zero_rate_limit_revokes_personal_quotas() {
 
     // The personal quota must have been wiped by the freeze.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver.address(),
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver.address(),
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed_and_equal(None);
 
     // A 1-unit withdraw fails — no personal quota left and the global cap is 0.
@@ -1610,10 +1658,13 @@ async fn personal_quota_on_un_rate_limited_denom() {
         .should_succeed();
 
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
     assert_eq!(pq.amount, Uint128::new(20_000_000));
@@ -1644,10 +1695,13 @@ async fn personal_quota_on_un_rate_limited_denom() {
 
     // Personal quota is now fully consumed and removed from storage.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed_and_equal(None);
 
     // Without any personal or global restriction, a further transfer just
@@ -1759,10 +1813,13 @@ async fn personal_quota_mid_consumption_overwrite() {
         .should_succeed();
 
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
     assert_eq!(pq.amount, Uint128::new(60_000_000));
@@ -1790,10 +1847,13 @@ async fn personal_quota_mid_consumption_overwrite() {
         .should_succeed();
 
     let stored = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present after overwrite");
 
@@ -1852,20 +1912,26 @@ async fn personal_quotas_pagination() {
 
     // First page, limit 2.
     let page1 = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotasRequest {
-            start_after: None,
-            limit: Some(2),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotasRequest {
+                start_after: None,
+                limit: Some(2),
+            },
+        )
         .should_succeed();
     assert_eq!(page1.len(), 2);
 
     // Second page picks up after the last entry of page 1.
     let last = page1.last().expect("page 1 non-empty");
     let page2 = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotasRequest {
-            start_after: Some((last.user, last.denom.clone())),
-            limit: Some(2),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotasRequest {
+                start_after: Some((last.user, last.denom.clone())),
+                limit: Some(2),
+            },
+        )
         .should_succeed();
     assert_eq!(page2.len(), 2);
 
@@ -1908,10 +1974,13 @@ async fn personal_quotas_pagination() {
     // Querying beyond the end yields an empty page.
     let last_p2 = page2.last().unwrap();
     let page3 = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotasRequest {
-            start_after: Some((last_p2.user, last_p2.denom.clone())),
-            limit: Some(2),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotasRequest {
+                start_after: Some((last_p2.user, last_p2.denom.clone())),
+                limit: Some(2),
+            },
+        )
         .should_succeed();
     assert!(page3.is_empty());
 }
@@ -1993,10 +2062,13 @@ async fn personal_quota_expire_at_boundary() {
 
     // The active path consumed 1 token from the personal quota.
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry still present");
     assert_eq!(pq.amount, Uint128::new(9_999_999));
@@ -2043,10 +2115,13 @@ async fn personal_quota_expire_at_boundary() {
         .should_succeed();
 
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("expired entry is left in storage untouched");
     assert_eq!(pq.amount, Uint128::new(10_000_000));
@@ -2106,10 +2181,13 @@ async fn personal_quota_regrant_after_expiry() {
         .should_succeed();
 
     let pq_before = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
     let granted_at_before = pq_before.granted_at;
@@ -2138,10 +2216,13 @@ async fn personal_quota_regrant_after_expiry() {
         .should_succeed();
 
     let pq_after = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
 
@@ -2178,10 +2259,13 @@ async fn personal_quota_regrant_after_expiry() {
         .should_succeed();
 
     let pq_consumed = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
     assert_eq!(pq_consumed.amount, Uint128::new(19_000_000));
@@ -2253,10 +2337,13 @@ async fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
         .should_succeed();
 
     let pq_before_cron = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("entry present");
 
@@ -2265,10 +2352,13 @@ async fn personal_quota_cron_tick_does_not_scrub_expired_entry() {
     advance_to_next_day(&mut suite).await;
 
     let pq_after_cron = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: receiver_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: receiver_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("expired entry is preserved across cron");
 
@@ -2435,9 +2525,12 @@ async fn cap_is_snapshotted_at_cron_tick() {
         .should_succeed();
 
     let initial = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest {
+                denom: usdc_denom.clone(),
+            },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(initial.cap, Uint128::new(10_000_000));
@@ -2456,9 +2549,12 @@ async fn cap_is_snapshotted_at_cron_tick() {
         .should_succeed();
 
     let mid = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest {
+                denom: usdc_denom.clone(),
+            },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(mid.cap, Uint128::new(10_000_000));
@@ -2468,9 +2564,10 @@ async fn cap_is_snapshotted_at_cron_tick() {
     advance_to_next_day(&mut suite).await;
 
     let after_cron = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest { denom: usdc_denom },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(after_cron.cap, Uint128::new(20_000_000));
@@ -2562,9 +2659,10 @@ async fn personal_quota_does_not_consume_rolling_window() {
 
     // The trailing-window sum is still zero.
     let q = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest { denom: usdc_denom },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(q.used_in_last_24h, Uint128::ZERO);
@@ -2631,9 +2729,12 @@ async fn denom_removal_clears_withdraw_volumes() {
         .should_succeed();
 
     let after_drain = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest {
+                denom: usdc_denom.clone(),
+            },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(after_drain.used_in_last_24h, Uint128::new(5_000_000));
@@ -2651,9 +2752,12 @@ async fn denom_removal_clears_withdraw_volumes() {
         .should_succeed();
 
     let unlimited = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest {
+                denom: usdc_denom.clone(),
+            },
+        )
         .should_succeed();
     assert!(unlimited.is_none());
 
@@ -2671,9 +2775,10 @@ async fn denom_removal_clears_withdraw_volumes() {
         .should_succeed();
 
     let reseeded = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest { denom: usdc_denom },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(reseeded.cap, Uint128::new(19_000_000));
@@ -2701,9 +2806,12 @@ async fn query_rate_limit_status() {
 
     // Un-rate-limited denom returns None.
     let none = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest {
+                denom: usdc_denom.clone(),
+            },
+        )
         .should_succeed();
     assert!(none.is_none());
 
@@ -2748,9 +2856,12 @@ async fn query_rate_limit_status() {
 
     // Single-denom query.
     let single = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest {
+                denom: usdc_denom.clone(),
+            },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(single.supply_snapshot, Uint128::new(100_000_000));
@@ -2759,10 +2870,13 @@ async fn query_rate_limit_status() {
 
     // Paginated enumeration returns the same data.
     let page = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusesRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusesRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed();
     assert_eq!(page.len(), 1);
     let status = page.get(&usdc_denom).expect("usdc rate-limited");
@@ -2774,9 +2888,10 @@ async fn query_rate_limit_status() {
     advance_to_next_day(&mut suite).await;
 
     let aged = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRateLimitStatusRequest {
-            denom: usdc_denom,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRateLimitStatusRequest { denom: usdc_denom },
+        )
         .should_succeed()
         .expect("rate-limited");
     assert_eq!(aged.used_in_last_24h, Uint128::ZERO);
@@ -2853,10 +2968,13 @@ async fn remove_routes() {
         .should_succeed();
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRouteRequest {
-            bridge: contracts.warp,
-            remote: eth_eth,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRouteRequest {
+                bridge: contracts.warp,
+                remote: eth_eth,
+            },
+        )
         .should_succeed_and_equal(None);
 
     // Fund the arbitrum USDC route with 100M, plus the ethereum USDC route
@@ -2916,10 +3034,13 @@ async fn remove_routes() {
         .should_succeed();
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryReserveRequest {
-            bridge: contracts.warp,
-            remote: arb_usdc,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryReserveRequest {
+                bridge: contracts.warp,
+                remote: arb_usdc,
+            },
+        )
         .should_succeed_and_equal(Uint128::ZERO);
 
     // With the reserve drained to zero, the removal should now succeed.
@@ -2935,41 +3056,56 @@ async fn remove_routes() {
 
     // The route and its reverse mapping should be gone.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRouteRequest {
-            bridge: contracts.warp,
-            remote: arb_usdc,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRouteRequest {
+                bridge: contracts.warp,
+                remote: arb_usdc,
+            },
+        )
         .should_succeed_and_equal(None);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryReverseRouteRequest {
-            denom: usdc::DENOM.clone(),
-            remote: arb_usdc,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryReverseRouteRequest {
+                denom: usdc::DENOM.clone(),
+                remote: arb_usdc,
+            },
+        )
         .should_succeed_and_equal(None);
 
     // The zero-valued reserve entry should have been deleted as well.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryReserveRequest {
-            bridge: contracts.warp,
-            remote: arb_usdc,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryReserveRequest {
+                bridge: contracts.warp,
+                remote: arb_usdc,
+            },
+        )
         .should_fail_with_error("data not found");
 
     // The sibling ethereum USDC route — same alloyed denom, different remote
     // — should be unaffected.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRouteRequest {
-            bridge: contracts.warp,
-            remote: eth_usdc,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRouteRequest {
+                bridge: contracts.warp,
+                remote: eth_usdc,
+            },
+        )
         .should_succeed_and_equal(Some(usdc::DENOM.clone()));
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryReverseRouteRequest {
-            denom: usdc::DENOM.clone(),
-            remote: eth_usdc,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryReverseRouteRequest {
+                denom: usdc::DENOM.clone(),
+                remote: eth_usdc,
+            },
+        )
         .should_succeed_and_equal(Some(contracts.warp));
 
     // Inbound transfers through the removed route should fail.
@@ -3039,10 +3175,13 @@ async fn remove_routes() {
         .should_succeed();
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryReserveRequest {
-            bridge: contracts.warp,
-            remote: arb_usdc,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryReserveRequest {
+                bridge: contracts.warp,
+                remote: arb_usdc,
+            },
+        )
         .should_succeed_and_equal(Uint128::new(70_000));
 }
 
@@ -3127,17 +3266,23 @@ async fn remove_native_route() {
 
     // The route and its reverse mapping should be gone.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryRouteRequest {
-            bridge: contracts.warp,
-            remote: dango_remote,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryRouteRequest {
+                bridge: contracts.warp,
+                remote: dango_remote,
+            },
+        )
         .should_succeed_and_equal(None);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryReverseRouteRequest {
-            denom: dango::DENOM.clone(),
-            remote: dango_remote,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryReverseRouteRequest {
+                denom: dango::DENOM.clone(),
+                remote: dango_remote,
+            },
+        )
         .should_succeed_and_equal(None);
 
     // Receiving the tokens back now fails at the route lookup. (Contrast
@@ -3180,9 +3325,12 @@ async fn remove_native_route() {
         .await
         .should_succeed();
 
-    suite.balances().should_change(&accounts.user2, btree_map! {
-        dango::DENOM.clone() => BalanceChange::Increased(100),
-    });
+    suite.balances().should_change(
+        &accounts.user2,
+        btree_map! {
+            dango::DENOM.clone() => BalanceChange::Increased(100),
+        },
+    );
 }
 
 /// Only the chain owner can set or update the withdrawal guardian.
@@ -3600,25 +3748,32 @@ async fn withdrawal_approval_coin_accounting() {
         .deserialize_json::<gateway::WithdrawalRequested>()
         .unwrap();
 
-    assert_eq!(requested, gateway::WithdrawalRequested {
-        id: 0,
-        user: user_addr,
-        remote: WITHDRAW_REMOTE,
-        recipient: withdraw_recipient(),
-        denom: usdc::DENOM.clone(),
-        amount: Uint128::new(WITHDRAW),
-    });
+    assert_eq!(
+        requested,
+        gateway::WithdrawalRequested {
+            id: 0,
+            user: user_addr,
+            remote: WITHDRAW_REMOTE,
+            recipient: withdraw_recipient(),
+            denom: usdc::DENOM.clone(),
+            amount: Uint128::new(WITHDRAW),
+        }
+    );
 
     let id = requested.id;
 
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(WITHDRAW),
-    });
-    suite
-        .balances()
-        .should_change(&contracts.gateway, btree_map! {
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(WITHDRAW),
+        },
+    );
+    suite.balances().should_change(
+        &contracts.gateway,
+        btree_map! {
             usdc::DENOM.clone() => BalanceChange::Increased(WITHDRAW),
-        });
+        },
+    );
 
     // The gateway holds exactly the withdrawn amount.
     suite
@@ -3640,17 +3795,24 @@ async fn withdrawal_approval_coin_accounting() {
 
     // The bridged amount is burned and the fee goes to the owner; the user
     // gets nothing back.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
-    suite
-        .balances()
-        .should_change(&contracts.gateway, btree_map! {
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
+    suite.balances().should_change(
+        &contracts.gateway,
+        btree_map! {
             usdc::DENOM.clone() => BalanceChange::Decreased(WITHDRAW),
-        });
-    suite.balances().should_change(&owner_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Increased(ARBITRUM_USDC_WITHDRAWAL_FEE),
-    });
+        },
+    );
+    suite.balances().should_change(
+        &owner_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Increased(ARBITRUM_USDC_WITHDRAWAL_FEE),
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
@@ -3658,9 +3820,10 @@ async fn withdrawal_approval_coin_accounting() {
 
     // The approved request is deleted from storage.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and_equal(None);
 }
 
@@ -3708,27 +3871,37 @@ async fn withdrawal_rejection_coin_accounting() {
         .deserialize_json::<gateway::WithdrawalRejected>()
         .unwrap();
 
-    assert_eq!(rejected, gateway::WithdrawalRejected {
-        id,
-        user: user_addr,
-        denom: usdc::DENOM.clone(),
-        amount: Uint128::new(WITHDRAW),
-        rejected_by: accounts.user3.address(),
-    });
+    assert_eq!(
+        rejected,
+        gateway::WithdrawalRejected {
+            id,
+            user: user_addr,
+            denom: usdc::DENOM.clone(),
+            amount: Uint128::new(WITHDRAW),
+            rejected_by: accounts.user3.address(),
+        }
+    );
 
     // Across request + rejection the user is made whole — no fee is
     // charged on a rejected withdrawal — and the gateway keeps nothing.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
-    suite
-        .balances()
-        .should_change(&contracts.gateway, btree_map! {
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
             usdc::DENOM.clone() => BalanceChange::Unchanged,
-        });
-    suite.balances().should_change(&owner_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
+        },
+    );
+    suite.balances().should_change(
+        &contracts.gateway,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
+    suite.balances().should_change(
+        &owner_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
@@ -3736,9 +3909,10 @@ async fn withdrawal_rejection_coin_accounting() {
 
     // The rejected request is deleted from storage.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and_equal(None);
 }
 
@@ -3784,24 +3958,31 @@ async fn withdrawal_freeze_coin_accounting() {
         .deserialize_json::<gateway::WithdrawalFrozen>()
         .unwrap();
 
-    assert_eq!(frozen, gateway::WithdrawalFrozen {
-        id,
-        user: user_addr,
-        denom: usdc::DENOM.clone(),
-        amount: Uint128::new(WITHDRAW),
-        frozen_by: accounts.user3.address(),
-    });
+    assert_eq!(
+        frozen,
+        gateway::WithdrawalFrozen {
+            id,
+            user: user_addr,
+            denom: usdc::DENOM.clone(),
+            amount: Uint128::new(WITHDRAW),
+            frozen_by: accounts.user3.address(),
+        }
+    );
 
     // The funds left the user on request, and the freeze keeps them in the
     // gateway.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(WITHDRAW),
-    });
-    suite
-        .balances()
-        .should_change(&contracts.gateway, btree_map! {
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(WITHDRAW),
+        },
+    );
+    suite.balances().should_change(
+        &contracts.gateway,
+        btree_map! {
             usdc::DENOM.clone() => BalanceChange::Increased(WITHDRAW),
-        });
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
@@ -3810,9 +3991,10 @@ async fn withdrawal_freeze_coin_accounting() {
     // Unlike the terminal responses, freezing keeps the request in storage
     // — now in the frozen state — awaiting the owner's decision.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and(|req| {
             req.as_ref()
                 .is_some_and(|req| req.status == WithdrawalStatus::Frozen)
@@ -3877,24 +4059,34 @@ async fn withdrawal_confiscation_coin_accounting() {
         .deserialize_json::<gateway::WithdrawalConfiscated>()
         .unwrap();
 
-    assert_eq!(confiscated, gateway::WithdrawalConfiscated {
-        id,
-        user: user_addr,
-        denom: usdc::DENOM.clone(),
-        amount: Uint128::new(WITHDRAW),
-    });
+    assert_eq!(
+        confiscated,
+        gateway::WithdrawalConfiscated {
+            id,
+            user: user_addr,
+            denom: usdc::DENOM.clone(),
+            amount: Uint128::new(WITHDRAW),
+        }
+    );
 
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
-    suite
-        .balances()
-        .should_change(&contracts.gateway, btree_map! {
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
+    suite.balances().should_change(
+        &contracts.gateway,
+        btree_map! {
             usdc::DENOM.clone() => BalanceChange::Decreased(WITHDRAW),
-        });
-    suite.balances().should_change(&owner_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Increased(WITHDRAW),
-    });
+        },
+    );
+    suite.balances().should_change(
+        &owner_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Increased(WITHDRAW),
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
@@ -3902,9 +4094,10 @@ async fn withdrawal_confiscation_coin_accounting() {
 
     // The confiscated request is deleted from storage.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and_equal(None);
 }
 
@@ -3932,27 +4125,34 @@ async fn withdrawal_request_is_stored() {
     // block timestamp, which doesn't move here since the setup pins the
     // block time to zero.
     let request = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed()
         .expect("the request should be stored");
 
-    assert_eq!(request, gateway::WithdrawalRequest {
-        user: accounts.user2.address(),
-        remote: WITHDRAW_REMOTE,
-        recipient: withdraw_recipient(),
-        coin: Coin::new(usdc::DENOM.clone(), WITHDRAW).unwrap(),
-        status: WithdrawalStatus::Pending,
-        created_at: suite.block.timestamp,
-    });
+    assert_eq!(
+        request,
+        gateway::WithdrawalRequest {
+            user: accounts.user2.address(),
+            remote: WITHDRAW_REMOTE,
+            recipient: withdraw_recipient(),
+            coin: Coin::new(usdc::DENOM.clone(), WITHDRAW).unwrap(),
+            status: WithdrawalStatus::Pending,
+            created_at: suite.block.timestamp,
+        }
+    );
 
     // It is listed in the pending queue.
     let page = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed();
 
     assert_eq!(page.len(), 1);
@@ -3989,9 +4189,10 @@ async fn confiscation_requires_prior_freeze() {
     // The failed confiscation left the request untouched: still pending,
     // with the funds still in the gateway.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and(|req| {
             req.as_ref()
                 .is_some_and(|req| req.status == WithdrawalStatus::Pending)
@@ -4033,9 +4234,10 @@ async fn guardian_can_never_confiscate() {
     // The failed confiscation left the request untouched: still pending,
     // with the funds still in the gateway.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and(|req| {
             req.as_ref()
                 .is_some_and(|req| req.status == WithdrawalStatus::Pending)
@@ -4088,18 +4290,22 @@ async fn frozen_request_rejection_refunds_user() {
 
     // Across request + freeze + rejection the user is made whole, the
     // gateway keeps nothing, and the request is deleted.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
         .should_succeed_and_equal(Uint128::ZERO);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and_equal(None);
 }
 
@@ -4171,35 +4377,46 @@ async fn withdrawal_requests_pagination() {
 
     // First page, limit 2: the two lowest IDs, in ascending order.
     let page1 = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: Some(2),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: Some(2),
+            },
+        )
         .should_succeed();
 
-    assert_eq!(page1.iter().map(|item| item.id).collect::<Vec<_>>(), vec![
-        0, 1
-    ]);
+    assert_eq!(
+        page1.iter().map(|item| item.id).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
 
     // Second page resumes after the last ID of page 1 — `start_after` is
     // exclusive, so ID 1 doesn't repeat.
     let page2 = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: Some(page1.last().unwrap().id),
-            limit: Some(2),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: Some(page1.last().unwrap().id),
+                limit: Some(2),
+            },
+        )
         .should_succeed();
 
-    assert_eq!(page2.iter().map(|item| item.id).collect::<Vec<_>>(), vec![
-        2
-    ]);
+    assert_eq!(
+        page2.iter().map(|item| item.id).collect::<Vec<_>>(),
+        vec![2]
+    );
 
     // Querying beyond the end yields an empty page.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: Some(2),
-            limit: Some(2),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: Some(2),
+                limit: Some(2),
+            },
+        )
         .should_succeed_and(Vec::is_empty);
 }
 
@@ -4229,10 +4446,13 @@ async fn frozen_withdrawal_requests_enumeration() {
 
     // Both requests sit in the pending queue; the frozen queue is empty.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and(|page| page.iter().map(|item| item.id).collect::<Vec<_>>() == ids);
 
     suite
@@ -4258,10 +4478,13 @@ async fn frozen_withdrawal_requests_enumeration() {
 
     // The frozen request left the pending queue; the other remains.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and(|page| {
             page.iter().map(|item| item.id).collect::<Vec<_>>() == vec![ids[1]]
         });
@@ -4330,19 +4553,25 @@ async fn over_cap_request_fails_fast() {
         .should_fail_with_error("insufficient outbound quota! denom: bridge/usdc, requested: 11000000, residue after personal quota: 11000000");
 
     // Nothing was stored and nothing was escrowed.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
         .should_succeed_and_equal(Uint128::ZERO);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and(|page| page.is_empty());
 }
 
@@ -4439,9 +4668,12 @@ async fn racing_approvals_refund_second_request() {
 
     // The user paid for the first withdrawal only; the second escrow came
     // back. The gateway keeps nothing, and both requests are settled.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(AMOUNT),
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(AMOUNT),
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
@@ -4451,17 +4683,21 @@ async fn racing_approvals_refund_second_request() {
     // settled as the bridged one — and the pending queue is empty.
     for id in [first, second] {
         suite
-            .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-                id,
-            })
+            .query_wasm_smart(
+                contracts.gateway,
+                gateway::QueryWithdrawalRequestRequest { id },
+            )
             .should_succeed_and_equal(None);
     }
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and(|page| page.is_empty());
 }
 
@@ -4503,19 +4739,25 @@ async fn insufficient_reserve_request_fails_fast() {
         .should_fail_with_error("insufficient reserve!");
 
     // Nothing was stored and nothing was escrowed.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
         .should_succeed_and_equal(Uint128::ZERO);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and(|page| page.is_empty());
 }
 
@@ -4567,19 +4809,25 @@ async fn withdrawal_not_exceeding_fee_fails_fast() {
         ));
 
     // Nothing was stored and nothing was escrowed.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
         .should_succeed_and_equal(Uint128::ZERO);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestsRequest {
-            start_after: None,
-            limit: None,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestsRequest {
+                start_after: None,
+                limit: None,
+            },
+        )
         .should_succeed_and(|page| page.is_empty());
 }
 
@@ -4623,9 +4871,10 @@ async fn refreezing_frozen_request_fails() {
     // The failed refreeze left the request in the frozen state, with the
     // funds still escrowed.
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and(|req| {
             req.as_ref()
                 .is_some_and(|req| req.status == WithdrawalStatus::Frozen)
@@ -4789,9 +5038,12 @@ async fn reserve_drained_while_pending_refunds_on_approval() {
 
     // The user paid for the first withdrawal only; the second escrow came
     // back, and both requests are settled.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(AMOUNT),
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(AMOUNT),
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
@@ -4799,9 +5051,10 @@ async fn reserve_drained_while_pending_refunds_on_approval() {
 
     for id in [first, second] {
         suite
-            .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-                id,
-            })
+            .query_wasm_smart(
+                contracts.gateway,
+                gateway::QueryWithdrawalRequestRequest { id },
+            )
             .should_succeed_and_equal(None);
     }
 }
@@ -4872,18 +5125,22 @@ async fn fee_raised_while_pending_refunds_on_approval() {
     assert!(failed.reason.contains("not sufficient to cover fee"));
 
     // The escrow came back in full; the request is settled.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
         .should_succeed_and_equal(Uint128::ZERO);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and_equal(None);
 }
 
@@ -4974,18 +5231,22 @@ async fn route_removed_while_pending_refunds_on_approval() {
     assert_eq!(failed.denom, dango::DENOM.clone());
     assert!(failed.reason.contains("data not found"));
 
-    suite.balances().should_change(&user_addr, btree_map! {
-        dango::DENOM.clone() => BalanceChange::Unchanged,
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            dango::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, dango::DENOM.clone())
         .should_succeed_and_equal(Uint128::ZERO);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and_equal(None);
 }
 
@@ -5091,9 +5352,12 @@ async fn frozen_request_approval_failure_refunds() {
     assert!(failed.reason.contains("insufficient outbound quota"));
 
     // The user paid for the approved withdrawal only.
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(AMOUNT),
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(AMOUNT),
+        },
+    );
 
     suite
         .query_balance(&contracts.gateway, usdc::DENOM.clone())
@@ -5111,9 +5375,10 @@ async fn frozen_request_approval_failure_refunds() {
         .should_succeed_and(Vec::is_empty);
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id: frozen_id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id: frozen_id },
+        )
         .should_succeed_and_equal(None);
 }
 
@@ -5208,25 +5473,32 @@ async fn personal_quota_expired_between_request_and_approval() {
     assert_eq!(failed.user, user_addr);
     assert!(failed.reason.contains("insufficient outbound quota"));
 
-    suite.balances().should_change(&user_addr, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Unchanged,
-    });
+    suite.balances().should_change(
+        &user_addr,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Unchanged,
+        },
+    );
 
     // The expired entry is left in storage untouched — the failed
     // consumption never scrubbed it.
     let pq = suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryPersonalQuotaRequest {
-            user: user_addr,
-            denom: usdc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryPersonalQuotaRequest {
+                user: user_addr,
+                denom: usdc::DENOM.clone(),
+            },
+        )
         .should_succeed()
         .expect("expired entry is left in storage");
     assert_eq!(pq.amount, Uint128::new(10_000_000));
 
     suite
-        .query_wasm_smart(contracts.gateway, gateway::QueryWithdrawalRequestRequest {
-            id,
-        })
+        .query_wasm_smart(
+            contracts.gateway,
+            gateway::QueryWithdrawalRequestRequest { id },
+        )
         .should_succeed_and_equal(None);
 }
 

--- a/dango/testing/tests/httpd/ws.rs
+++ b/dango/testing/tests/httpd/ws.rs
@@ -755,9 +755,12 @@ async fn ws_perps_alias_subscriptions_stream_unwrapped_responses() -> anyhow::Re
         .query_wasm_smart(contracts.perps, perps::QueryParamRequest {})
         .should_succeed();
     let pair_param: Option<perps::PairParam> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryPairParamRequest {
-            pair_id: pair.clone(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryPairParamRequest {
+                pair_id: pair.clone(),
+            },
+        )
         .should_succeed();
 
     suite

--- a/dango/testing/tests/indexer_infra/api.rs
+++ b/dango/testing/tests/indexer_infra/api.rs
@@ -192,9 +192,10 @@ async fn perps_aliases_mirror_contract_queries() -> anyhow::Result<()> {
         .query_wasm_smart(contracts.perps, perps::QueryParamRequest {})
         .should_succeed();
     let pair_param: Option<perps::PairParam> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryPairParamRequest {
-            pair_id: pair_id(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryPairParamRequest { pair_id: pair_id() },
+        )
         .should_succeed();
 
     suite

--- a/dango/testing/tests/indexing/perps_candles.rs
+++ b/dango/testing/tests/indexing/perps_candles.rs
@@ -592,20 +592,23 @@ async fn index_perps_candles_multi_pair() -> anyhow::Result<()> {
 
     // Register oracle prices for both pairs.
     suite
-        .seed_oracle_prices(&mut accounts.owner, btree_map! {
-            usdc::DENOM.clone() => OracleTestEntry {
-                pyth_id: 1,
-                humanized_price: UsdPrice::new_int(1),
+        .seed_oracle_prices(
+            &mut accounts.owner,
+            btree_map! {
+                usdc::DENOM.clone() => OracleTestEntry {
+                    pyth_id: 1,
+                    humanized_price: UsdPrice::new_int(1),
+                },
+                eth_pair.clone() => OracleTestEntry {
+                    pyth_id: 2,
+                    humanized_price: UsdPrice::new_int(2_000),
+                },
+                btc_pair.clone() => OracleTestEntry {
+                    pyth_id: 3,
+                    humanized_price: UsdPrice::new_int(60_000),
+                },
             },
-            eth_pair.clone() => OracleTestEntry {
-                pyth_id: 2,
-                humanized_price: UsdPrice::new_int(2_000),
-            },
-            btc_pair.clone() => OracleTestEntry {
-                pyth_id: 3,
-                humanized_price: UsdPrice::new_int(60_000),
-            },
-        })
+        )
         .await;
 
     // Register the BTC pair via MaintainerMsg::Configure (ETH pair already

--- a/dango/testing/tests/oracle.rs
+++ b/dango/testing/tests/oracle.rs
@@ -103,10 +103,13 @@ async fn pyth_lazer() {
 
     // Query the trusted signers
     let trusted_signers = suite
-        .query_wasm_smart(oracle, QueryTrustedSignersRequest {
-            limit: None,
-            start_after: None,
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryTrustedSignersRequest {
+                limit: None,
+                start_after: None,
+            },
+        )
         .unwrap();
     assert_eq!(trusted_signers.len(), 1);
 
@@ -152,9 +155,12 @@ async fn pyth_lazer() {
 
     // Query the BTC price
     let price = suite
-        .query_wasm_smart(oracle, QueryPriceRequest {
-            denom: perp_btc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: perp_btc::DENOM.clone(),
+            },
+        )
         .unwrap();
 
     assert_eq!(
@@ -168,9 +174,12 @@ async fn pyth_lazer() {
 
     // Query the ETH price
     let price = suite
-        .query_wasm_smart(oracle, QueryPriceRequest {
-            denom: eth::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: eth::DENOM.clone(),
+            },
+        )
         .unwrap();
 
     assert_eq!(
@@ -226,9 +235,12 @@ async fn remove_price_sources() {
 
     // The price source should be unaffected by the failed removal.
     suite
-        .query_wasm_smart(oracle, QueryPriceSourceRequest {
-            denom: test_denom.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceSourceRequest {
+                denom: test_denom.clone(),
+            },
+        )
         .should_succeed();
 
     // Remove two price sources as the owner: one registered earlier in this
@@ -250,16 +262,22 @@ async fn remove_price_sources() {
     // the enumeration.
     for denom in [test_denom.clone(), eth::DENOM.clone()] {
         suite
-            .query_wasm_smart(oracle, QueryPriceSourceRequest {
-                denom: denom.clone(),
-            })
+            .query_wasm_smart(
+                oracle,
+                QueryPriceSourceRequest {
+                    denom: denom.clone(),
+                },
+            )
             .should_fail_with_error("data not found");
 
         suite
-            .query_wasm_smart(oracle, QueryPriceSourcesRequest {
-                start_after: None,
-                limit: Some(u32::MAX),
-            })
+            .query_wasm_smart(
+                oracle,
+                QueryPriceSourcesRequest {
+                    start_after: None,
+                    limit: Some(u32::MAX),
+                },
+            )
             .should_succeed_and(|sources| !sources.contains_key(&denom));
     }
 

--- a/dango/testing/tests/oracle_roll.rs
+++ b/dango/testing/tests/oracle_roll.rs
@@ -73,27 +73,36 @@ async fn roll_price_blends_over_the_schedule() {
 
     // Before the first fixing: 100% current = $100.
     let price = suite
-        .query_wasm_smart(oracle, QueryPriceRequest {
-            denom: denom.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: denom.clone(),
+            },
+        )
         .should_succeed();
     assert_eq!(price.humanized_price, UsdPrice::new_int(100));
 
     // Into the 40% window (~t0+152): 100*0.6 + 200*0.4 = $140.
     suite.increase_time(Duration::from_seconds(150)).await;
     let price = suite
-        .query_wasm_smart(oracle, QueryPriceRequest {
-            denom: denom.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: denom.clone(),
+            },
+        )
         .should_succeed();
     assert_eq!(price.humanized_price, UsdPrice::new_int(140));
 
     // After the last fixing (~t0+252): 100% next = $200.
     suite.increase_time(Duration::from_seconds(100)).await;
     let price = suite
-        .query_wasm_smart(oracle, QueryPriceRequest {
-            denom: denom.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: denom.clone(),
+            },
+        )
         .should_succeed();
     assert_eq!(price.humanized_price, UsdPrice::new_int(200));
 }

--- a/dango/testing/tests/perps/adl_bug_reproduction.rs
+++ b/dango/testing/tests/perps/adl_bug_reproduction.rs
@@ -176,9 +176,12 @@ async fn adl_bug_absurd_book_price() {
 
     // Verify positions.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -186,9 +189,12 @@ async fn adl_bug_absurd_book_price() {
     assert_eq!(state.positions[&pair].size, Quantity::new_int(-5));
 
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -309,9 +315,12 @@ async fn adl_bug_absurd_book_price() {
 
     // user1 (liquidated): should have no positions and ~$0 margin.
     let user1_state: Option<UserState> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -328,9 +337,12 @@ async fn adl_bug_absurd_book_price() {
     //   PnL = 5 × ($2,208 − $2,000) = +$1,040
     //   margin = $10,000 + $1,040 = $11,040
     let user3_state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -357,9 +369,12 @@ async fn adl_bug_absurd_book_price() {
     // After the fix: the bankruptcy price ($2,208) is used as target_price,
     // so the $100,000 ask is never matched. user2 should have no position.
     let user2_state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 

--- a/dango/testing/tests/perps/bankruptcy_bug_reproduction.rs
+++ b/dango/testing/tests/perps/bankruptcy_bug_reproduction.rs
@@ -171,9 +171,12 @@ async fn solvent_partial_close_adl_price() {
         .should_succeed();
 
     let alice: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(alice.margin, UsdValue::new_int(2_000));
@@ -290,9 +293,12 @@ async fn solvent_partial_close_adl_price() {
     // ------------------------------------------------------------------------
 
     let alice: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(alice.margin, UsdValue::new_int(1_600));
@@ -321,9 +327,12 @@ async fn solvent_partial_close_adl_price() {
     // ------------------------------------------------------------------------
 
     let bob: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(bob.margin, UsdValue::new_int(10_400));

--- a/dango/testing/tests/perps/batch_update_orders.rs
+++ b/dango/testing/tests/perps/batch_update_orders.rs
@@ -90,9 +90,12 @@ async fn batch_submit_then_cancel() {
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(orders.len(), 1, "only the ask should remain on the book");
     let (_, ask) = orders.iter().next().unwrap();
@@ -131,9 +134,12 @@ async fn batch_atomic_replace() {
     }
 
     let old_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(old_orders.len(), 3);
     let old_ids: Vec<OrderId> = old_orders.keys().copied().collect();
@@ -158,9 +164,12 @@ async fn batch_atomic_replace() {
         .should_succeed();
 
     let new_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(new_orders.len(), 3, "book should hold the 3 new bids");
     for id in old_ids {
@@ -227,9 +236,12 @@ async fn batch_reuse_client_order_id() {
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(orders.len(), 1);
     let (_, order) = orders.iter().next().unwrap();
@@ -255,15 +267,21 @@ async fn batch_atomicity_on_submit_failure() {
         .should_succeed();
 
     let state_before: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let orders_before: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     // Two submits with the same client_order_id. The first is accepted by the
@@ -286,15 +304,21 @@ async fn batch_atomicity_on_submit_failure() {
         .should_fail();
 
     let state_after: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let orders_after: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert_eq!(state_before, state_after, "UserState must be unchanged");
@@ -320,15 +344,21 @@ async fn batch_atomicity_on_cancel_failure() {
         .should_succeed();
 
     let state_before: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let orders_before: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     suite
@@ -350,15 +380,21 @@ async fn batch_atomicity_on_cancel_failure() {
         .should_fail_with_error("order not found");
 
     let state_after: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let orders_after: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert_eq!(state_before, state_after);
@@ -409,26 +445,38 @@ async fn batch_fill_reverts_on_later_failure() {
     // would leak taker mutations (position, reserved_margin, unrested bids)
     // past the rollback.
     let user1_state_before: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user1_orders_before: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     let user2_state_before: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user2_orders_before: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     // user2 submits a batch: market buy (crosses user1's ask) followed by a
@@ -465,26 +513,38 @@ async fn batch_fill_reverts_on_later_failure() {
     // a bid resting mid-batch under cid=99) are rolled back along with the
     // rest of the batch.
     let user1_state_after: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user1_orders_after: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     let user2_state_after: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user2_orders_after: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     assert_eq!(
@@ -540,9 +600,12 @@ async fn batch_single_action() {
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(orders.len(), 1);
 }
@@ -585,9 +648,12 @@ async fn batch_size_cap_enforced() {
         .should_succeed();
 
     let state_before: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -611,9 +677,12 @@ async fn batch_size_cap_enforced() {
         .should_fail_with_error("`max_action_batch_size` (3), found: 4");
 
     let state_after: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(state_before, state_after);
@@ -652,20 +721,23 @@ async fn batch_across_two_pairs() {
 
     // Register oracle prices for both pairs (plus USDC for settlement).
     suite
-        .seed_oracle_prices(&mut accounts.owner, btree_map! {
-            usdc::DENOM.clone() => OracleTestEntry {
-                pyth_id: 1,
-                humanized_price: UsdPrice::new_int(1),
+        .seed_oracle_prices(
+            &mut accounts.owner,
+            btree_map! {
+                usdc::DENOM.clone() => OracleTestEntry {
+                    pyth_id: 1,
+                    humanized_price: UsdPrice::new_int(1),
+                },
+                eth_pair.clone() => OracleTestEntry {
+                    pyth_id: 2,
+                    humanized_price: UsdPrice::new_int(2_000),
+                },
+                btc_pair.clone() => OracleTestEntry {
+                    pyth_id: 3,
+                    humanized_price: UsdPrice::new_int(60_000),
+                },
             },
-            eth_pair.clone() => OracleTestEntry {
-                pyth_id: 2,
-                humanized_price: UsdPrice::new_int(2_000),
-            },
-            btc_pair.clone() => OracleTestEntry {
-                pyth_id: 3,
-                humanized_price: UsdPrice::new_int(60_000),
-            },
-        })
+        )
         .await;
 
     // Add the BTC pair (the ETH pair is already configured at genesis;
@@ -742,9 +814,12 @@ async fn batch_across_two_pairs() {
     // Only the BTC bid remains; the ETH bid was cancelled by its
     // just-written cid.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(orders.len(), 1, "only the BTC bid should remain");
     let (_, order) = orders.iter().next().unwrap();
@@ -827,9 +902,12 @@ async fn batch_stp_fires_for_self_match() {
 
     // Post-batch: only the rested ask remains.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(orders.len(), 1, "only the rested ask should remain");
     let (_, order) = orders.iter().next().unwrap();
@@ -872,21 +950,30 @@ async fn batch_cancel_fails_for_filled_order() {
         .should_succeed();
 
     let user1_state_before: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user2_state_before: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user2_orders_before: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     let cid = 99u64;
@@ -927,21 +1014,30 @@ async fn batch_cancel_fails_for_filled_order() {
     // Full rollback: maker's resting ask and both users' states are
     // byte-identical to the snapshot.
     let user1_state_after: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user2_state_after: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let user2_orders_after: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     assert_eq!(user1_state_before, user1_state_after);
@@ -1016,16 +1112,22 @@ async fn batch_referral_commissions_rollback() {
     // Snapshot cumulative referral data for both referrer and referee
     // before the failing batch.
     let user1_data_before: UserReferralData = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferralDataRequest {
-            user: 1,
-            since: None,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferralDataRequest {
+                user: 1,
+                since: None,
+            },
+        )
         .should_succeed();
     let user2_data_before: UserReferralData = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferralDataRequest {
-            user: 2,
-            since: None,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferralDataRequest {
+                user: 2,
+                since: None,
+            },
+        )
         .should_succeed();
 
     let cid = 7u64;
@@ -1062,16 +1164,22 @@ async fn batch_referral_commissions_rollback() {
         .should_fail();
 
     let user1_data_after: UserReferralData = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferralDataRequest {
-            user: 1,
-            since: None,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferralDataRequest {
+                user: 1,
+                since: None,
+            },
+        )
         .should_succeed();
     let user2_data_after: UserReferralData = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferralDataRequest {
-            user: 2,
-            since: None,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferralDataRequest {
+                user: 2,
+                since: None,
+            },
+        )
         .should_succeed();
 
     assert_eq!(
@@ -1124,9 +1232,12 @@ async fn orders_by_user_returns_all_orders() {
     }
 
     let all: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(all.len(), 35);
 }

--- a/dango/testing/tests/perps/client_order_id.rs
+++ b/dango/testing/tests/perps/client_order_id.rs
@@ -62,9 +62,12 @@ async fn submit_cancel_resubmit_by_client_order_id() {
 
     // Sanity: exactly one resting order, carrying `cid`.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(orders.len(), 1);
 
@@ -84,9 +87,12 @@ async fn submit_cancel_resubmit_by_client_order_id() {
 
     // The order is gone.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert!(orders.is_empty(), "order should be removed after cancel");
 
@@ -115,9 +121,12 @@ async fn submit_cancel_resubmit_by_client_order_id() {
         .should_succeed();
 
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(
         orders.len(),
@@ -179,19 +188,25 @@ async fn query_order_by_client_order_id() {
 
     // Cross-check the system-assigned order IDs against the by-user query.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(orders.len(), 2);
 
     // The bid is found, with the correct system order ID and the un-inverted
     // limit price.
     let bid: QueryOrderByClientOrderIdResponse = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
-            user: accounts.user1.address(),
-            client_order_id: bid_cid,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrderByClientOrderIdRequest {
+                user: accounts.user1.address(),
+                client_order_id: bid_cid,
+            },
+        )
         .should_succeed()
         .expect("the bid should be found by its client order ID");
     let bid_item = orders
@@ -205,10 +220,13 @@ async fn query_order_by_client_order_id() {
 
     // The ask is found too — covers the `ASKS` branch of the lookup.
     let ask: QueryOrderByClientOrderIdResponse = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
-            user: accounts.user1.address(),
-            client_order_id: ask_cid,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrderByClientOrderIdRequest {
+                user: accounts.user1.address(),
+                client_order_id: ask_cid,
+            },
+        )
         .should_succeed()
         .expect("the ask should be found by its client order ID");
     assert_eq!(
@@ -223,19 +241,25 @@ async fn query_order_by_client_order_id() {
 
     // A client order ID the user never used: `None`.
     suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
-            user: accounts.user1.address(),
-            client_order_id: Uint64::new(99),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrderByClientOrderIdRequest {
+                user: accounts.user1.address(),
+                client_order_id: Uint64::new(99),
+            },
+        )
         .should_succeed_and(Option::is_none);
 
     // The index is scoped per sender: another user querying the same client
     // order ID gets `None`.
     suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
-            user: accounts.user2.address(),
-            client_order_id: bid_cid,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrderByClientOrderIdRequest {
+                user: accounts.user2.address(),
+                client_order_id: bid_cid,
+            },
+        )
         .should_succeed_and(Option::is_none);
 
     // After canceling the bid, the lookup returns `None`.
@@ -252,10 +276,13 @@ async fn query_order_by_client_order_id() {
         .should_succeed();
 
     suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrderByClientOrderIdRequest {
-            user: accounts.user1.address(),
-            client_order_id: bid_cid,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrderByClientOrderIdRequest {
+                user: accounts.user1.address(),
+                client_order_id: bid_cid,
+            },
+        )
         .should_succeed_and(Option::is_none);
 }
 

--- a/dango/testing/tests/perps/conditional_orders.rs
+++ b/dango/testing/tests/perps/conditional_orders.rs
@@ -91,9 +91,12 @@ async fn conditional_order_tp_triggers_on_price_rise() {
         .should_succeed();
 
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -122,9 +125,12 @@ async fn conditional_order_tp_triggers_on_price_rise() {
 
     // Step 5: Verify conditional order exists on the position.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let pos = state
@@ -166,9 +172,12 @@ async fn conditional_order_tp_triggers_on_price_rise() {
 
     // Step 9: Verify trader state — position closed.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -310,9 +319,12 @@ async fn conditional_order_sl_triggers_on_price_drop() {
 
     // Step 5: Verify trader state — position closed, PnL = 5*($1,800-$2,000) = -$1,000.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -567,9 +579,12 @@ async fn conditional_orders_follow_price_time_priority() {
     // -------------------------------------------------------------------------
 
     let state_user1: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -584,9 +599,12 @@ async fn conditional_orders_follow_price_time_priority() {
     );
 
     let state_user3: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -756,9 +774,12 @@ async fn conditional_order_failure_does_not_block_others() {
 
     // Verify positions: User1 = 5 long, User3 = 5 short.
     let state_user1: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(
@@ -768,9 +789,12 @@ async fn conditional_order_failure_does_not_block_others() {
     );
 
     let state_user3: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(
@@ -866,9 +890,12 @@ async fn conditional_order_failure_does_not_block_others() {
 
     // User1: position unchanged (sell failed), conditional order cancelled (not stuck).
     let state_user1: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -880,9 +907,12 @@ async fn conditional_order_failure_does_not_block_others() {
 
     // User3: position closed (short covered), conditional order consumed.
     let state_user3: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1021,9 +1051,12 @@ async fn conditional_order_self_trade_failure_preserves_user_state() {
 
     // Snapshot User1's state: should have 1 resting bid, reserved_margin > 0.
     let state_before: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(
@@ -1066,9 +1099,12 @@ async fn conditional_order_self_trade_failure_preserves_user_state() {
     // --- Post-trigger assertions ---
 
     let state_after: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1104,9 +1140,12 @@ async fn conditional_order_self_trade_failure_preserves_user_state() {
 
     // User1's resting bid must still be on the book.
     let orders: std::collections::BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(
         orders.len(),
@@ -1138,9 +1177,12 @@ async fn conditional_order_self_trade_failure_preserves_user_state() {
     // After the fill, User1's resting bid should be gone and
     // open_order_count == 0.
     let state_final: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(
@@ -1222,9 +1264,12 @@ async fn child_order_market_with_tp_triggers() {
 
     // Verify TP is on the position.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1262,9 +1307,12 @@ async fn child_order_market_with_tp_triggers() {
 
     // Verify position is closed.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1346,9 +1394,12 @@ async fn child_order_market_with_sl_triggers() {
 
     // Verify SL is on the position.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1384,9 +1435,12 @@ async fn child_order_market_with_sl_triggers() {
     suite.increase_time(Duration::from_minutes(2)).await;
 
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1511,9 +1565,12 @@ async fn child_order_ignored_when_position_closed() {
 
     // Position should be closed, no conditional orders.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1629,9 +1686,12 @@ async fn child_order_overwrites_existing() {
         .should_succeed();
 
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1751,9 +1811,12 @@ async fn conditional_order_overwrite_same_direction() {
         .should_succeed();
 
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1855,9 +1918,12 @@ async fn conditional_order_size_exceeds_position_allowed() {
 
     // Verify it was placed.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -2031,9 +2097,12 @@ async fn conditional_order_cancelled_when_slippage_cap_tightened() {
     // Position is still open (TP was not executed; order was cancelled
     // for cap tightening).
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 

--- a/dango/testing/tests/perps/index_price.rs
+++ b/dango/testing/tests/perps/index_price.rs
@@ -15,9 +15,10 @@ const ETH_PYTH_ID: u32 = 2;
 
 async fn query_index_price(suite: &TestSuiteNaive, perps_addr: Addr) -> UsdPrice {
     let pair_state: Option<PairState> = suite
-        .query_wasm_smart(perps_addr, perps::QueryPairStateRequest {
-            pair_id: pair_id(),
-        })
+        .query_wasm_smart(
+            perps_addr,
+            perps::QueryPairStateRequest { pair_id: pair_id() },
+        )
         .should_succeed();
 
     pair_state.unwrap().index_price

--- a/dango/testing/tests/perps/liquidation.rs
+++ b/dango/testing/tests/perps/liquidation.rs
@@ -166,9 +166,12 @@ async fn liquidation_on_order_book() {
 
     // Verify position: 5 ETH long @ $2,000, margin = $2,990.
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let pos = state
@@ -243,9 +246,12 @@ async fn liquidation_on_order_book() {
 
     // Capture vault margin before liquidation.
     let vault_state_before = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
     let vault_margin_before = vault_state_before.unwrap().margin;
 
@@ -294,9 +300,12 @@ async fn liquidation_on_order_book() {
 
     // Trader position should be reduced from 5 to ~3.310345 ETH (partial close).
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let pos = state
@@ -333,9 +342,12 @@ async fn liquidation_on_order_book() {
 
     // Vault margin should be unchanged (fee goes to insurance fund, not vault).
     let vault_state_after: Option<UserState> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
     let vault_margin_after = vault_state_after.unwrap().margin;
 
@@ -346,9 +358,12 @@ async fn liquidation_on_order_book() {
 
     // Bidder (user3) should have ~1.689655 ETH long @ $1,450.
     let bidder_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let bidder_pos = bidder_state
@@ -569,9 +584,12 @@ async fn liquidation_snaps_to_full_close_when_remainder_would_be_dust() {
     // Trader position fully closed (snap fired). USER_STATES entry may
     // survive with remaining margin, but the pair must not appear.
     let trader_state: Option<UserState> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     let state = trader_state.expect("trader user state should still exist with remaining margin");
     assert!(
@@ -600,9 +618,12 @@ async fn liquidation_snaps_to_full_close_when_remainder_would_be_dust() {
 
     // Bidder filled the full 5 ETH, not the ~1.69 ETH partial.
     let bidder_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let bidder_pos = bidder_state
@@ -741,9 +762,12 @@ async fn liquidation_with_adl() {
         .should_succeed();
 
     let state: Option<UserState> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert_eq!(state.unwrap().margin, UsdValue::new_int(1_090));
@@ -809,9 +833,12 @@ async fn liquidation_with_adl() {
         .should_succeed();
 
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -932,9 +959,12 @@ async fn liquidation_with_adl() {
 
     // Trader A should have no positions and $0 margin.
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     // User state is empty (margin=0, no positions) — may be pruned.
@@ -947,9 +977,12 @@ async fn liquidation_with_adl() {
     // Step 10: Verify Trader B's position was ADL'd.
     // -------------------------------------------------------------------------
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -968,9 +1001,12 @@ async fn liquidation_with_adl() {
 
     // Vault should be unaffected — no backstop, no bad debt.
     let vault_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1114,9 +1150,12 @@ async fn liquidation_cancels_conditional_orders() {
 
     // Verify both conditional orders were placed.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let pos = state.positions.get(&pair).expect("should have position");
@@ -1179,16 +1218,22 @@ async fn liquidation_cancels_conditional_orders() {
 
     // Step 7: Verify state after liquidation.
     let state: Option<UserState> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     // All limit orders should have been canceled during liquidation.
     let all_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -1319,9 +1364,12 @@ async fn vault_liquidation_on_order_book() {
         .should_succeed();
 
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     let vault_bid = vault_orders
@@ -1367,9 +1415,12 @@ async fn vault_liquidation_on_order_book() {
 
     // Verify vault is long.
     let vault_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1392,16 +1443,19 @@ async fn vault_liquidation_on_order_book() {
 
     // Sanity: verify vault is liquidatable (equity < MM).
     let vault_ext: perps::UserStateExtended = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
-            user: contracts.perps,
-            include_equity: true,
-            include_available_margin: false,
-            include_maintenance_margin: false,
-            include_unrealized_pnl: false,
-            include_unrealized_funding: false,
-            include_liquidation_price: false,
-            include_all: false,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateExtendedRequest {
+                user: contracts.perps,
+                include_equity: true,
+                include_available_margin: false,
+                include_maintenance_margin: false,
+                include_unrealized_pnl: false,
+                include_unrealized_funding: false,
+                include_liquidation_price: false,
+                include_all: false,
+            },
+        )
         .should_succeed();
 
     let equity = vault_ext.equity.unwrap();
@@ -1486,9 +1540,12 @@ async fn vault_liquidation_on_order_book() {
     // Vault position should be reduced (partial liquidation closes just enough
     // to restore equity above maintenance margin).
     let vault_state_after = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1515,16 +1572,19 @@ async fn vault_liquidation_on_order_book() {
     // This holds because liquidation_fee_rate = 0, so no fee erodes the
     // buffer created by the close schedule.
     let vault_ext_after: perps::UserStateExtended = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
-            user: contracts.perps,
-            include_equity: true,
-            include_available_margin: false,
-            include_maintenance_margin: false,
-            include_unrealized_pnl: false,
-            include_unrealized_funding: false,
-            include_liquidation_price: false,
-            include_all: false,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateExtendedRequest {
+                user: contracts.perps,
+                include_equity: true,
+                include_available_margin: false,
+                include_maintenance_margin: false,
+                include_unrealized_pnl: false,
+                include_unrealized_funding: false,
+                include_liquidation_price: false,
+                include_all: false,
+            },
+        )
         .should_succeed();
 
     let equity_after = vault_ext_after.equity.unwrap();
@@ -1557,9 +1617,12 @@ async fn vault_liquidation_on_order_book() {
 
     // Bidder (user3) should now have a long position from absorbing the vault's close.
     let user3_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 

--- a/dango/testing/tests/perps/liquidation_spec.rs
+++ b/dango/testing/tests/perps/liquidation_spec.rs
@@ -186,10 +186,13 @@ async fn seed_prices(
     };
 
     if let Some(btc_price) = btc_price {
-        entries.insert(btc_pair_id(), OracleTestEntry {
-            pyth_id: 3,
-            humanized_price: UsdPrice::new_int(btc_price),
-        });
+        entries.insert(
+            btc_pair_id(),
+            OracleTestEntry {
+                pyth_id: 3,
+                humanized_price: UsdPrice::new_int(btc_price),
+            },
+        );
     }
 
     suite.seed_oracle_prices(&mut accounts.owner, entries).await;

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -60,15 +60,18 @@ pub async fn register_oracle_prices(
     eth_price: u128,
 ) {
     suite
-        .seed_oracle_prices(&mut accounts.owner, btree_map! {
-            usdc::DENOM.clone() => OracleTestEntry {
-                pyth_id: 1,
-                humanized_price: UsdPrice::new_int(1),
+        .seed_oracle_prices(
+            &mut accounts.owner,
+            btree_map! {
+                usdc::DENOM.clone() => OracleTestEntry {
+                    pyth_id: 1,
+                    humanized_price: UsdPrice::new_int(1),
+                },
+                pair_id() => OracleTestEntry {
+                    pyth_id: 2,
+                    humanized_price: UsdPrice::new_int(eth_price as i128),
+                },
             },
-            pair_id() => OracleTestEntry {
-                pyth_id: 2,
-                humanized_price: UsdPrice::new_int(eth_price as i128),
-            },
-        })
+        )
         .await;
 }

--- a/dango/testing/tests/perps/price_band.rs
+++ b/dango/testing/tests/perps/price_band.rs
@@ -67,18 +67,20 @@ macro_rules! submit_limit {
             .execute(
                 &mut $accounts.user1,
                 $contracts.perps,
-                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(perps::SubmitOrderRequest {
-                    pair_id: $pair.clone(),
-                    size: Quantity::new_int($size),
-                    kind: OrderKind::Limit {
-                        limit_price: UsdPrice::new_int($price),
-                        time_in_force: $tif,
-                        client_order_id: None,
+                &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(
+                    perps::SubmitOrderRequest {
+                        pair_id: $pair.clone(),
+                        size: Quantity::new_int($size),
+                        kind: OrderKind::Limit {
+                            limit_price: UsdPrice::new_int($price),
+                            time_in_force: $tif,
+                            client_order_id: None,
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
                     },
-                    reduce_only: false,
-                    tp: None,
-                    sl: None,
-                })),
+                )),
                 Coins::new(),
             )
             .await
@@ -324,9 +326,12 @@ async fn banding_drift_maker_cancelled_at_match_time() {
 
     // user1's stale ask was cancelled by the match-time check.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert!(
         orders.is_empty(),
@@ -337,9 +342,12 @@ async fn banding_drift_maker_cancelled_at_match_time() {
     // was cancelled without filling, so user2's size-2 order is only
     // half-filled.
     let user2_state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let pos = user2_state

--- a/dango/testing/tests/perps/reduce_only.rs
+++ b/dango/testing/tests/perps/reduce_only.rs
@@ -191,9 +191,12 @@ fn order_at(
 /// OI, and after every fill the invariant `long_oi == short_oi` must hold.
 fn pair_state(suite: &TestSuiteNaive, contract: Addr, pair: &PairId) -> PairState {
     suite
-        .query_wasm_smart(contract, perps::QueryPairStateRequest {
-            pair_id: pair.clone(),
-        })
+        .query_wasm_smart(
+            contract,
+            perps::QueryPairStateRequest {
+                pair_id: pair.clone(),
+            },
+        )
         .should_succeed()
         .unwrap()
 }
@@ -1909,11 +1912,14 @@ async fn reduce_only_depth_correct_after_shrink() {
     // `None` if the book holds nothing there.
     let ask_depth_at = |suite: &TestSuiteNaive, price: i128| -> Option<Quantity> {
         suite
-            .query_wasm_smart(perps, perps::QueryLiquidityDepthRequest {
-                pair_id: pair.clone(),
-                bucket_size: UsdPrice::new_int(1),
-                limit: None,
-            })
+            .query_wasm_smart(
+                perps,
+                perps::QueryLiquidityDepthRequest {
+                    pair_id: pair.clone(),
+                    bucket_size: UsdPrice::new_int(1),
+                    limit: None,
+                },
+            )
             .should_succeed()
             .asks
             .get(&UsdPrice::new_int(price))

--- a/dango/testing/tests/perps/referral.rs
+++ b/dango/testing/tests/perps/referral.rs
@@ -94,9 +94,12 @@ async fn referral_during_user_register() {
     // The new user's referrer should be User1 (index 1).
     assert_eq!(
         suite
-            .query_wasm_smart(contracts.perps, perps::QueryReferrerRequest {
-                referee: user_index,
-            },)
+            .query_wasm_smart(
+                contracts.perps,
+                perps::QueryReferrerRequest {
+                    referee: user_index,
+                },
+            )
             .should_succeed(),
         Some(1),
     );
@@ -602,9 +605,12 @@ async fn referral_active_flag() {
 
     // Record initial margins.
     let user1_margin_before = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .map(|s: perps::UserState| s.margin)
         .unwrap();
@@ -622,9 +628,12 @@ async fn referral_active_flag() {
 
     // User1 (referrer) should NOT have received any commission.
     let user1_margin_after = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .map(|s: perps::UserState| s.margin)
         .unwrap();
@@ -660,9 +669,12 @@ async fn referral_active_flag() {
 
     // User1 (referrer) should now have received a commission.
     let user1_margin_final: UsdValue = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .map(|s: perps::UserState| s.margin)
         .unwrap();
@@ -854,14 +866,17 @@ async fn referrer_stats() {
 
     // Query stats sorted by volume descending.
     let stats: Vec<(Referee, perps::RefereeStats)> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferrerToRefereeStatsRequest {
-            referrer: 1,
-            order_by: ReferrerStatsOrderBy {
-                order: IterationOrder::Descending,
-                limit: None,
-                index: ReferrerStatsOrderIndex::Volume { start_after: None },
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferrerToRefereeStatsRequest {
+                referrer: 1,
+                order_by: ReferrerStatsOrderBy {
+                    order: IterationOrder::Descending,
+                    limit: None,
+                    index: ReferrerStatsOrderIndex::Volume { start_after: None },
+                },
             },
-        })
+        )
         .should_succeed();
 
     assert_eq!(stats.len(), 2);
@@ -871,14 +886,17 @@ async fn referrer_stats() {
 
     // Query ascending.
     let stats: Vec<(Referee, perps::RefereeStats)> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferrerToRefereeStatsRequest {
-            referrer: 1,
-            order_by: ReferrerStatsOrderBy {
-                order: IterationOrder::Ascending,
-                limit: None,
-                index: ReferrerStatsOrderIndex::Volume { start_after: None },
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferrerToRefereeStatsRequest {
+                referrer: 1,
+                order_by: ReferrerStatsOrderBy {
+                    order: IterationOrder::Ascending,
+                    limit: None,
+                    index: ReferrerStatsOrderIndex::Volume { start_after: None },
+                },
             },
-        })
+        )
         .should_succeed();
 
     assert_eq!(stats[0].0, 2);
@@ -889,16 +907,19 @@ async fn referrer_stats() {
 
     // start_after: skip user3's volume in descending order → only user2 remains.
     let stats: Vec<(Referee, perps::RefereeStats)> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferrerToRefereeStatsRequest {
-            referrer: 1,
-            order_by: ReferrerStatsOrderBy {
-                order: IterationOrder::Descending,
-                limit: None,
-                index: ReferrerStatsOrderIndex::Volume {
-                    start_after: Some(user3_volume),
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferrerToRefereeStatsRequest {
+                referrer: 1,
+                order_by: ReferrerStatsOrderBy {
+                    order: IterationOrder::Descending,
+                    limit: None,
+                    index: ReferrerStatsOrderIndex::Volume {
+                        start_after: Some(user3_volume),
+                    },
                 },
             },
-        })
+        )
         .should_succeed();
 
     assert_eq!(stats.len(), 1);
@@ -907,14 +928,17 @@ async fn referrer_stats() {
 
     // limit: only return 1 result in descending order → user3 (highest volume).
     let stats: Vec<(Referee, perps::RefereeStats)> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryReferrerToRefereeStatsRequest {
-            referrer: 1,
-            order_by: ReferrerStatsOrderBy {
-                order: IterationOrder::Descending,
-                limit: Some(1),
-                index: ReferrerStatsOrderIndex::Volume { start_after: None },
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryReferrerToRefereeStatsRequest {
+                referrer: 1,
+                order_by: ReferrerStatsOrderBy {
+                    order: IterationOrder::Descending,
+                    limit: Some(1),
+                    index: ReferrerStatsOrderIndex::Volume { start_after: None },
+                },
             },
-        })
+        )
         .should_succeed();
 
     assert_eq!(stats.len(), 1);
@@ -1027,9 +1051,10 @@ async fn commission_rate_margins() {
     .iter()
     .map(|addr| {
         suite
-            .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-                user: *addr,
-            })
+            .query_wasm_smart(
+                contracts.perps,
+                perps::QueryUserStateRequest { user: *addr },
+            )
             .should_succeed()
             .map(|s: perps::UserState| s.margin)
             .unwrap_or(UsdValue::ZERO)
@@ -1061,9 +1086,10 @@ async fn commission_rate_margins() {
     .iter()
     .map(|addr| {
         suite
-            .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-                user: *addr,
-            })
+            .query_wasm_smart(
+                contracts.perps,
+                perps::QueryUserStateRequest { user: *addr },
+            )
             .should_succeed()
             .map(|s: perps::UserState| s.margin)
             .unwrap_or(UsdValue::ZERO)
@@ -1493,9 +1519,10 @@ async fn negative_maker_fee_does_not_debit_referrers() {
         .iter()
         .map(|addr| {
             suite
-                .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-                    user: *addr,
-                })
+                .query_wasm_smart(
+                    contracts.perps,
+                    perps::QueryUserStateRequest { user: *addr },
+                )
                 .should_succeed()
                 .map(|s: perps::UserState| s.margin)
                 .unwrap_or(UsdValue::ZERO)
@@ -1527,9 +1554,10 @@ async fn negative_maker_fee_does_not_debit_referrers() {
         .iter()
         .map(|addr| {
             suite
-                .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-                    user: *addr,
-                })
+                .query_wasm_smart(
+                    contracts.perps,
+                    perps::QueryUserStateRequest { user: *addr },
+                )
                 .should_succeed()
                 .map(|s: perps::UserState| s.margin)
                 .unwrap_or(UsdValue::ZERO)
@@ -2156,11 +2184,10 @@ async fn cr_100_indirect_referrer_taker() {
         UsdValue::ZERO,
         "vault keeps nothing — entire vault_fee distributed to A and B",
     );
-    assert_eq!(trader_event.commissions, vec![
-        UsdValue::ZERO,
-        expected_b,
-        expected_a
-    ]);
+    assert_eq!(
+        trader_event.commissions,
+        vec![UsdValue::ZERO, expected_b, expected_a]
+    );
 }
 
 /// Direct chain A → trader. A.cr = 100%, A.sr = 0. Trader is the maker on a
@@ -2703,16 +2730,19 @@ async fn register_oracle_prices(
     eth_price: u128,
 ) {
     suite
-        .seed_oracle_prices(&mut accounts.owner, btree_map! {
-            usdc::DENOM.clone() => OracleTestEntry {
-                pyth_id: 1,
-                humanized_price: UsdPrice::new_int(1),
+        .seed_oracle_prices(
+            &mut accounts.owner,
+            btree_map! {
+                usdc::DENOM.clone() => OracleTestEntry {
+                    pyth_id: 1,
+                    humanized_price: UsdPrice::new_int(1),
+                },
+                pair_id() => OracleTestEntry {
+                    pyth_id: 2,
+                    humanized_price: UsdPrice::new_int(eth_price as i128),
+                },
             },
-            pair_id() => OracleTestEntry {
-                pyth_id: 2,
-                humanized_price: UsdPrice::new_int(eth_price as i128),
-            },
-        })
+        )
         .await;
 }
 

--- a/dango/testing/tests/perps/trading.rs
+++ b/dango/testing/tests/perps/trading.rs
@@ -52,9 +52,12 @@ async fn trading_lifecycle() {
 
     // Verify trader's margin = $10,000.
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -97,9 +100,12 @@ async fn trading_lifecycle() {
 
     // Verify ask exists on the book.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     assert_eq!(orders.len(), 1, "maker should have 1 ask");
@@ -130,9 +136,12 @@ async fn trading_lifecycle() {
 
     // Verify position and margin.
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let pos = state
@@ -150,9 +159,12 @@ async fn trading_lifecycle() {
 
     // Maker's ask should be removed.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -179,9 +191,12 @@ async fn trading_lifecycle() {
 
     // Verify margin = $9,980 - $7,000 = $2,980.
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -300,9 +315,12 @@ async fn limit_order_partial_fill_and_cancel() {
 
     // Verify position: 5 ETH long @ $2,000, margin = $9,990.
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let pos = state
@@ -330,9 +348,12 @@ async fn limit_order_partial_fill_and_cancel() {
 
     // Verify bid exists on the book.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert_eq!(orders.len(), 1, "trader should have 1 resting bid");
@@ -357,9 +378,12 @@ async fn limit_order_partial_fill_and_cancel() {
 
     // Verify reserved_margin = $0 and open_order_count = 0.
     let state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -372,9 +396,12 @@ async fn limit_order_partial_fill_and_cancel() {
 
     // Verify bid removed from book.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert!(orders.is_empty(), "orders should be empty after cancel");
@@ -442,11 +469,14 @@ async fn liquidity_depth_tracking() {
 
     let query_depth = |suite: &TestSuiteNaive| -> LiquidityDepthResponse {
         suite
-            .query_wasm_smart(contracts.perps, perps::QueryLiquidityDepthRequest {
-                pair_id: pair.clone(),
-                bucket_size: UsdPrice::new_int(100),
-                limit: None,
-            })
+            .query_wasm_smart(
+                contracts.perps,
+                perps::QueryLiquidityDepthRequest {
+                    pair_id: pair.clone(),
+                    bucket_size: UsdPrice::new_int(100),
+                    limit: None,
+                },
+            )
             .should_succeed()
     };
 
@@ -914,9 +944,12 @@ async fn negative_maker_fee_rebate_lifecycle() {
 
     // Taker: $100,000 - $30 fee = $99,970.
     let taker_state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -928,9 +961,12 @@ async fn negative_maker_fee_rebate_lifecycle() {
 
     // Maker: $100,000 + $10 rebate = $100,010.
     let maker_state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1056,9 +1092,12 @@ async fn ioc_limit_order_partial_fill() {
     // -------------------------------------------------------------------------
 
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -1085,9 +1124,12 @@ async fn ioc_limit_order_partial_fill() {
 
     // Verify no resting orders on book.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
 
     assert!(orders.is_empty(), "IOC taker should have no resting orders");
@@ -1741,9 +1783,12 @@ async fn order_filled_reports_maker_remainder_on_partial_fill() {
 
     // The event's remainder must equal the order actually left on the book.
     let maker_orders = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(
         maker_orders.len(),
@@ -1905,9 +1950,12 @@ async fn order_filled_taker_remainder_matches_persisted_order() {
     // Durable cross-check: the resting bid on the book carries the same size,
     // and the maker's book is empty.
     let taker_orders = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user3.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user3.address(),
+            },
+        )
         .should_succeed();
     assert_eq!(taker_orders.len(), 1);
     let resting = taker_orders.values().next().unwrap();
@@ -1915,9 +1963,12 @@ async fn order_filled_taker_remainder_matches_persisted_order() {
     assert_eq!(resting.limit_price, UsdPrice::new_int(2_000));
 
     let maker_orders = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed();
     assert!(
         maker_orders.is_empty(),
@@ -2024,9 +2075,12 @@ async fn sell_side_market_order_partial_fill() {
 
     // Verify taker has a 10 ETH short position from the 5 that filled.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -2043,9 +2097,12 @@ async fn sell_side_market_order_partial_fill() {
 
     // Maker's bid should be fully consumed.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -2144,9 +2201,12 @@ async fn buy_side_market_order_partial_fill() {
 
     // Verify taker has a 5 ETH long position from the partial fill.
     let state: UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -2163,9 +2223,12 @@ async fn buy_side_market_order_partial_fill() {
 
     // Maker's ask should be fully consumed.
     let orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: accounts.user2.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: accounts.user2.address(),
+            },
+        )
         .should_succeed();
 
     assert!(

--- a/dango/testing/tests/perps/vault.rs
+++ b/dango/testing/tests/perps/vault.rs
@@ -72,9 +72,12 @@ async fn vault_lp_lifecycle() {
         .should_succeed();
 
     let lp_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -87,9 +90,12 @@ async fn vault_lp_lifecycle() {
     let total_shares = lp_state.vault_shares;
 
     let vault_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -156,9 +162,12 @@ async fn vault_lp_lifecycle() {
 
     // Vault should have orders on the book.
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     let vault_bids: Vec<_> = vault_orders
@@ -219,9 +228,12 @@ async fn vault_lp_lifecycle() {
 
     // Vault should now have a long position.
     let vault_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
     let vault_pos = vault_state
@@ -292,9 +304,12 @@ async fn vault_lp_lifecycle() {
 
     // Vault should have realized PnL → margin increased above pre-trade level.
     let vault_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -322,9 +337,12 @@ async fn vault_lp_lifecycle() {
         .should_succeed();
 
     let lp_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let unlock1_amount = lp_state.unlocks.back().unwrap().amount_to_release;
@@ -355,9 +373,12 @@ async fn vault_lp_lifecycle() {
         .should_succeed();
 
     let lp_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -380,9 +401,12 @@ async fn vault_lp_lifecycle() {
     // -------------------------------------------------------------------------
 
     let lp_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -432,16 +456,19 @@ async fn oracle_triggers_on_oracle_update() {
     // -------------------------------------------------------------------------
 
     suite
-        .seed_oracle_prices(&mut accounts.owner, btree_map! {
-            usdc::DENOM.clone() => OracleTestEntry {
-                pyth_id: 1,
-                humanized_price: UsdPrice::new_int(1),
+        .seed_oracle_prices(
+            &mut accounts.owner,
+            btree_map! {
+                usdc::DENOM.clone() => OracleTestEntry {
+                    pyth_id: 1,
+                    humanized_price: UsdPrice::new_int(1),
+                },
+                pair.clone() => OracleTestEntry {
+                    pyth_id: 2,
+                    humanized_price: UsdPrice::new_int(1),
+                },
             },
-            pair.clone() => OracleTestEntry {
-                pyth_id: 2,
-                humanized_price: UsdPrice::new_int(1),
-            },
-        })
+        )
         .await;
 
     // -------------------------------------------------------------------------
@@ -500,9 +527,12 @@ async fn oracle_triggers_on_oracle_update() {
 
     // Vault should have no orders before any price is fed.
     let vault_orders_0: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -527,9 +557,12 @@ async fn oracle_triggers_on_oracle_update() {
 
     // Oracle price should be set for the perps pair.
     let price1 = suite
-        .query_wasm_smart(contracts.oracle, QueryPriceRequest {
-            denom: pair.clone(),
-        })
+        .query_wasm_smart(
+            contracts.oracle,
+            QueryPriceRequest {
+                denom: pair.clone(),
+            },
+        )
         .unwrap();
 
     assert!(
@@ -539,9 +572,12 @@ async fn oracle_triggers_on_oracle_update() {
 
     // Vault should have orders on the book (placed by OnOracleUpdate).
     let vault_orders_1: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     let vo1_bids: Vec<_> = vault_orders_1
@@ -616,9 +652,12 @@ async fn oracle_triggers_on_oracle_update() {
 
     // Oracle price should have been updated (new timestamp or value).
     let price2 = suite
-        .query_wasm_smart(contracts.oracle, QueryPriceRequest {
-            denom: pair.clone(),
-        })
+        .query_wasm_smart(
+            contracts.oracle,
+            QueryPriceRequest {
+                denom: pair.clone(),
+            },
+        )
         .unwrap();
 
     assert!(
@@ -630,9 +669,12 @@ async fn oracle_triggers_on_oracle_update() {
     // we tried, it would fail on the corrupted storage. Compare order IDs to
     // prove these are the exact same orders, not new ones at the same price.
     let vault_orders_2: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -715,9 +757,12 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
         .should_succeed();
 
     let vault_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -781,9 +826,12 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
         .should_succeed();
 
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     let vault_bid = vault_orders
@@ -831,9 +879,12 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
 
     // Verify vault has a long position.
     let vault_state = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
 
@@ -857,16 +908,19 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
 
     // Sanity check: vault should be healthy at this point.
     let vault_ext: perps::UserStateExtended = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
-            user: contracts.perps,
-            include_equity: true,
-            include_available_margin: true,
-            include_maintenance_margin: false,
-            include_unrealized_pnl: false,
-            include_unrealized_funding: false,
-            include_liquidation_price: false,
-            include_all: false,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateExtendedRequest {
+                user: contracts.perps,
+                include_equity: true,
+                include_available_margin: true,
+                include_maintenance_margin: false,
+                include_unrealized_pnl: false,
+                include_unrealized_funding: false,
+                include_liquidation_price: false,
+                include_all: false,
+            },
+        )
         .should_succeed();
 
     let equity_before = vault_ext.equity.unwrap();
@@ -929,9 +983,12 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
     //     .expect("vault should have a bid");
     // let round2_bid_size = vault_bid.size;
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -978,16 +1035,19 @@ async fn vault_overcommits_margin_after_position_and_price_drop() {
     // -------------------------------------------------------------------------
 
     let vault_ext: perps::UserStateExtended = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
-            user: contracts.perps,
-            include_equity: true,
-            include_available_margin: false,
-            include_maintenance_margin: false,
-            include_unrealized_pnl: false,
-            include_unrealized_funding: false,
-            include_liquidation_price: false,
-            include_all: false,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateExtendedRequest {
+                user: contracts.perps,
+                include_equity: true,
+                include_available_margin: false,
+                include_maintenance_margin: false,
+                include_unrealized_pnl: false,
+                include_unrealized_funding: false,
+                include_liquidation_price: false,
+                include_all: false,
+            },
+        )
         .should_succeed();
 
     let equity = vault_ext.equity.unwrap();

--- a/dango/testing/tests/perps/vault_snapshots.rs
+++ b/dango/testing/tests/perps/vault_snapshots.rs
@@ -52,10 +52,13 @@ async fn vault_snapshots_accrue_daily() {
         .should_succeed();
 
     let snapshots: BTreeMap<Timestamp, VaultSnapshot> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryVaultSnapshotsRequest {
-            min: None,
-            max: None,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryVaultSnapshotsRequest {
+                min: None,
+                max: None,
+            },
+        )
         .should_succeed();
 
     assert!(
@@ -72,10 +75,13 @@ async fn vault_snapshots_accrue_daily() {
     let day_1 = round_to_day(suite.block.timestamp);
 
     let snapshots: BTreeMap<Timestamp, VaultSnapshot> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryVaultSnapshotsRequest {
-            min: None,
-            max: None,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryVaultSnapshotsRequest {
+                min: None,
+                max: None,
+            },
+        )
         .should_succeed();
 
     assert_eq!(snapshots.len(), 1);
@@ -108,10 +114,13 @@ async fn vault_snapshots_accrue_daily() {
     assert_eq!(day_3, day_2 + Duration::from_days(1));
 
     let snapshots: BTreeMap<Timestamp, VaultSnapshot> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryVaultSnapshotsRequest {
-            min: None,
-            max: None,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryVaultSnapshotsRequest {
+                min: None,
+                max: None,
+            },
+        )
         .should_succeed();
     let keys: Vec<_> = snapshots.keys().copied().collect();
     assert_eq!(keys, vec![day_1, day_2, day_3]);
@@ -122,20 +131,26 @@ async fn vault_snapshots_accrue_daily() {
 
     // `min == max == day_2` → one entry.
     let snapshots: BTreeMap<Timestamp, VaultSnapshot> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryVaultSnapshotsRequest {
-            min: Some(day_2),
-            max: Some(day_2),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryVaultSnapshotsRequest {
+                min: Some(day_2),
+                max: Some(day_2),
+            },
+        )
         .should_succeed();
     assert_eq!(snapshots.len(), 1);
     assert!(snapshots.contains_key(&day_2));
 
     // Range covering day_2..=day_3 → two entries.
     let snapshots: BTreeMap<Timestamp, VaultSnapshot> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryVaultSnapshotsRequest {
-            min: Some(day_2),
-            max: Some(day_3),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryVaultSnapshotsRequest {
+                min: Some(day_2),
+                max: Some(day_3),
+            },
+        )
         .should_succeed();
     assert_eq!(snapshots.len(), 2);
     assert!(snapshots.contains_key(&day_2));

--- a/dango/testing/tests/perps/vault_withdrawal_health.rs
+++ b/dango/testing/tests/perps/vault_withdrawal_health.rs
@@ -72,9 +72,12 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
         .should_succeed();
 
     let lp_state: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: accounts.user1.address(),
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
         .should_succeed()
         .unwrap();
     let lp_shares = lp_state.vault_shares;
@@ -133,9 +136,12 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
         .should_succeed();
 
     let vault_orders: BTreeMap<OrderId, QueryOrdersByUserResponseItem> = suite
-        .query_wasm_smart(contracts.perps, perps::QueryOrdersByUserRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryOrdersByUserRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed();
 
     let vault_bids: Vec<_> = vault_orders
@@ -191,9 +197,12 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
 
     // Verify vault has a long position.
     let vault_state: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
     let vault_pos = vault_state
@@ -215,16 +224,19 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
     register_oracle_prices(&mut suite, &mut accounts, 1_900).await;
 
     let vault_ext: perps::UserStateExtended = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateExtendedRequest {
-            user: contracts.perps,
-            include_equity: true,
-            include_maintenance_margin: true,
-            include_available_margin: false,
-            include_unrealized_pnl: true,
-            include_unrealized_funding: false,
-            include_liquidation_price: false,
-            include_all: false,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateExtendedRequest {
+                user: contracts.perps,
+                include_equity: true,
+                include_maintenance_margin: true,
+                include_available_margin: false,
+                include_unrealized_pnl: true,
+                include_unrealized_funding: false,
+                include_liquidation_price: false,
+                include_all: false,
+            },
+        )
         .should_succeed();
 
     let equity_before = vault_ext.equity.unwrap();
@@ -235,9 +247,12 @@ async fn vault_withdrawal_at_breakeven_makes_vault_liquidatable() {
     );
     // Confirm breakeven: equity ≈ margin (no unrealized PnL).
     let vault_state_bev: perps::UserState = suite
-        .query_wasm_smart(contracts.perps, perps::QueryUserStateRequest {
-            user: contracts.perps,
-        })
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: contracts.perps,
+            },
+        )
         .should_succeed()
         .unwrap();
     assert_eq!(

--- a/dango/testing/tests/proposal_preparer.rs
+++ b/dango/testing/tests/proposal_preparer.rs
@@ -42,10 +42,13 @@ async fn proposal_pyth() {
 
         // Retrieve all PythIds from the oracle.
         let mut pyth_ids = suite
-            .query_wasm_smart(contracts.oracle, QueryPriceSourcesRequest {
-                start_after: None,
-                limit: None,
-            })
+            .query_wasm_smart(
+                contracts.oracle,
+                QueryPriceSourcesRequest {
+                    start_after: None,
+                    limit: None,
+                },
+            )
             .should_succeed()
             .into_values()
             .flat_map(|config| config.feeds())
@@ -101,9 +104,12 @@ async fn proposal_pyth() {
 
     // Retrieve the prices and sequences.
     let prices1 = suite
-        .query_wasm_smart(oracle, QueryPriceRequest {
-            denom: perp_btc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: perp_btc::DENOM.clone(),
+            },
+        )
         .should_succeed();
 
     // Await some time and assert that the timestamps are updated.
@@ -112,9 +118,12 @@ async fn proposal_pyth() {
     suite.make_empty_block().await;
 
     let prices2 = suite
-        .query_wasm_smart(oracle, QueryPriceRequest {
-            denom: perp_btc::DENOM.clone(),
-        })
+        .query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: perp_btc::DENOM.clone(),
+            },
+        )
         .should_succeed();
 
     // Assert that the prices have been updated.
@@ -133,17 +142,23 @@ async fn proposal_pyth() {
 
         // Verify the denom does not exist in the oracle.
         suite
-            .query_wasm_smart(contracts.oracle, QueryPriceRequest {
-                denom: test_denom.clone(),
-            })
+            .query_wasm_smart(
+                contracts.oracle,
+                QueryPriceRequest {
+                    denom: test_denom.clone(),
+                },
+            )
             .should_fail_with_error("data not found");
 
         // Verify the NOT_USED_ID is not in the oracle.
         suite
-            .query_wasm_smart(contracts.oracle, QueryPriceSourcesRequest {
-                start_after: None,
-                limit: Some(u32::MAX),
-            })
+            .query_wasm_smart(
+                contracts.oracle,
+                QueryPriceSourcesRequest {
+                    start_after: None,
+                    limit: Some(u32::MAX),
+                },
+            )
             .should_succeed()
             .values()
             .flat_map(|config| config.feeds())
@@ -194,9 +209,12 @@ async fn assert_price_exists<P>(
             tx.should_succeed();
         }
 
-        if let Ok(p) = suite.query_wasm_smart(oracle, QueryPriceRequest {
-            denom: denom.clone(),
-        }) {
+        if let Ok(p) = suite.query_wasm_smart(
+            oracle,
+            QueryPriceRequest {
+                denom: denom.clone(),
+            },
+        ) {
             price = Some(p);
             break;
         }

--- a/dango/testing/tests/sdk/smoke.rs
+++ b/dango/testing/tests/sdk/smoke.rs
@@ -94,30 +94,38 @@ macro_rules! query_smoke_test {
     };
 }
 
-query_smoke_test!(test_query_app, QueryApp, query_app::Variables {
-    request: json!({"config":{}}),
-    height: None,
-});
+query_smoke_test!(
+    test_query_app,
+    QueryApp,
+    query_app::Variables {
+        request: json!({"config":{}}),
+        height: None,
+    }
+);
 
-query_smoke_test!(test_simulate, Simulate, simulate::Variables {
-    tx: json!({
-        "data": {
-            "chain_id": "dev-1",
-            "nonce": 1,
-            "username": "owner"
-        },
-        "msgs": [
-            {
-                "transfer": {
-                    "0x01bba610cbbfe9df0c99b8862f3ad41b2f646553": {
-                        "hyp/all/btc": "100"
+query_smoke_test!(
+    test_simulate,
+    Simulate,
+    simulate::Variables {
+        tx: json!({
+            "data": {
+                "chain_id": "dev-1",
+                "nonce": 1,
+                "username": "owner"
+            },
+            "msgs": [
+                {
+                    "transfer": {
+                        "0x01bba610cbbfe9df0c99b8862f3ad41b2f646553": {
+                            "hyp/all/btc": "100"
+                        }
                     }
                 }
-            }
-        ],
-        "sender": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9"
-    }),
-});
+            ],
+            "sender": "0x33361de42571d6aa20c37daa6da4b5ab67bfaad9"
+        }),
+    }
+);
 
 // -----------------------------------------------------------------------------
 // Subscription smoke tests

--- a/dango/testing/tests/vesting.rs
+++ b/dango/testing/tests/vesting.rs
@@ -204,9 +204,12 @@ async fn before_unlocking_starting_time() {
 
         // Check if the position is updated
         suite
-            .query_wasm_smart(vesting_addr, vesting::QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                vesting::QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| res.position.claimed == res.position.total);
     }
 }
@@ -337,9 +340,12 @@ async fn after_unlocking_starting_time() {
 
         // Check if the position is updated
         suite
-            .query_wasm_smart(vesting_addr, vesting::QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                vesting::QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| res.position.claimed == res.position.total);
     }
 }
@@ -394,9 +400,12 @@ async fn terminate_before_unlocking_starting_time_never_claimed() {
 
         // Check the status of the position after terminate
         suite
-            .query_wasm_smart(vesting_addr, QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| {
                 res.position.vesting_status == VestingStatus::Terminated(Uint128::new(40))
                     && res.claimable == Uint128::new(37)
@@ -436,9 +445,12 @@ async fn terminate_before_unlocking_starting_time_never_claimed() {
 
         // Check if the position is removed
         suite
-            .query_wasm_smart(vesting_addr, vesting::QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                vesting::QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| {
                 res.position.vesting_status == VestingStatus::Terminated(Uint128::new(40))
                     && res.position.claimed == Uint128::new(40)
@@ -527,9 +539,12 @@ async fn terminate_before_unlocking_starting_time_with_claimed() {
 
         // Check the status of the position after terminate
         suite
-            .query_wasm_smart(vesting_addr, QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| {
                 res.position.vesting_status == VestingStatus::Terminated(Uint128::new(44))
                     && res.position.claimed == Uint128::new(37)
@@ -553,9 +568,12 @@ async fn terminate_before_unlocking_starting_time_with_claimed() {
 
         // Check if the position is removed
         suite
-            .query_wasm_smart(vesting_addr, vesting::QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                vesting::QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| {
                 res.position.vesting_status == VestingStatus::Terminated(Uint128::new(44))
                     && res.position.claimed == Uint128::new(44)
@@ -616,9 +634,12 @@ async fn terminate_after_unlocking_starting_time() {
 
         // Check the status of the position after terminate
         suite
-            .query_wasm_smart(vesting_addr, QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| {
                 res.position.vesting_status == VestingStatus::Terminated(Uint128::new(37))
                     && res.claimable == Uint128::new(37)
@@ -639,9 +660,12 @@ async fn terminate_after_unlocking_starting_time() {
 
         // Check if the position is removed
         suite
-            .query_wasm_smart(vesting_addr, vesting::QueryPositionRequest {
-                user: accounts.user1.address(),
-            })
+            .query_wasm_smart(
+                vesting_addr,
+                vesting::QueryPositionRequest {
+                    user: accounts.user1.address(),
+                },
+            )
             .should_succeed_and(|res| {
                 res.position.vesting_status == VestingStatus::Terminated(Uint128::new(37))
                     && res.position.claimed == Uint128::new(37)

--- a/dango/testing/tests/vm/hybrid.rs
+++ b/dango/testing/tests/vm/hybrid.rs
@@ -80,12 +80,18 @@ async fn do_backtrace_test() {
     let (suite, _, wasm_tester, rust_tester) = setup_test().await;
 
     let res = suite
-        .query_wasm_smart(wasm_tester, QueryBacktraceRequest {
-            query: Query::wasm_smart(rust_tester, &QueryMsg::FailingQuery {
-                msg: "boom".to_string(),
-            })
-            .unwrap(),
-        })
+        .query_wasm_smart(
+            wasm_tester,
+            QueryBacktraceRequest {
+                query: Query::wasm_smart(
+                    rust_tester,
+                    &QueryMsg::FailingQuery {
+                        msg: "boom".to_string(),
+                    },
+                )
+                .unwrap(),
+            },
+        )
         .should_succeed();
 
     if let BacktraceQueryResponse::Err(err) = res {
@@ -99,9 +105,12 @@ async fn do_backtrace_test() {
     }
 
     let backtrace = suite
-        .query_wasm_smart(wasm_tester, QueryFailingQueryRequest {
-            msg: "boom wasm".to_string(),
-        })
+        .query_wasm_smart(
+            wasm_tester,
+            QueryFailingQueryRequest {
+                msg: "boom wasm".to_string(),
+            },
+        )
         .unwrap_err()
         .into_generic_backtraced_error()
         .backtrace
@@ -111,9 +120,12 @@ async fn do_backtrace_test() {
     assert!(!backtrace.contains("dango_tester::query::failing_query"));
 
     let backtrace = suite
-        .query_wasm_smart(rust_tester, QueryFailingQueryRequest {
-            msg: "boom rust".to_string(),
-        })
+        .query_wasm_smart(
+            rust_tester,
+            QueryFailingQueryRequest {
+                msg: "boom rust".to_string(),
+            },
+        )
         .unwrap_err()
         .into_generic_backtraced_error()
         .backtrace

--- a/dango/testing/tests/vm/wasm.rs
+++ b/dango/testing/tests/vm/wasm.rs
@@ -91,10 +91,13 @@ async fn immutable_state() {
     // This tests how the VM handles state mutability while serving the `Query`
     // ABCI request.
     suite
-        .query_wasm_smart(tester, dango_tester::QueryForceWriteRequest {
-            key: "larry".to_string(),
-            value: "engineer".to_string(),
-        })
+        .query_wasm_smart(
+            tester,
+            dango_tester::QueryForceWriteRequest {
+                key: "larry".to_string(),
+                value: "engineer".to_string(),
+            },
+        )
         .should_fail_with_error(VmError::immutable_state());
 
     // Execute the tester contract.
@@ -331,12 +334,15 @@ async fn recovering_secp256k1_pubkey() {
         let msg_hash = sha2_256(MSG);
         let (sig, recovery_id) = sk.sign_prehash_recoverable(&msg_hash);
 
-        (vk, QueryRecoverSecp256k1Request {
-            sig: sig.to_vec().into(),
-            msg_hash: msg_hash.to_vec().into(),
-            recovery_id: recovery_id.to_byte(),
-            compressed: true,
-        })
+        (
+            vk,
+            QueryRecoverSecp256k1Request {
+                sig: sig.to_vec().into(),
+                msg_hash: msg_hash.to_vec().into(),
+                recovery_id: recovery_id.to_byte(),
+                compressed: true,
+            },
+        )
     };
 
     // Ok

--- a/dango/testing/tests/warp.rs
+++ b/dango/testing/tests/warp.rs
@@ -117,14 +117,20 @@ async fn sending_remote() {
         });
 
     // Sender should have been deducted balance.
-    suite.balances().should_change(&accounts.user1, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Decreased(SEND_AMOUNT),
-    });
+    suite.balances().should_change(
+        &accounts.user1,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Decreased(SEND_AMOUNT),
+        },
+    );
 
     // The chain owner should have received the fee.
-    suite.balances().should_change(&accounts.owner, btree_map! {
-        usdc::DENOM.clone() => BalanceChange::Increased(ETHEREUM_USDC_WITHDRAWAL_FEE),
-    });
+    suite.balances().should_change(
+        &accounts.owner,
+        btree_map! {
+            usdc::DENOM.clone() => BalanceChange::Increased(ETHEREUM_USDC_WITHDRAWAL_FEE),
+        },
+    );
 
     // Gateway contract should not hold any of the synth token (should be burned).
     suite

--- a/justfile
+++ b/justfile
@@ -71,7 +71,7 @@ lint-without-features:
 
 # Perform formatting
 fmt:
-  cargo +nightly fmt --all
+  cargo fmt --all
 
 # Build schema
 build-graphql-schema:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,16 +1,21 @@
 # https://rust-lang.github.io/rustfmt/
-condense_wildcard_suffixes     = true
-format_macro_bodies            = false
-format_macro_matchers          = false
-group_imports                  = "Preserve"
-imports_granularity            = "One"
 match_block_trailing_comma     = true
-normalize_comments             = true
-normalize_doc_attributes       = true
-overflow_delimited_expr        = true
-reorder_impl_items             = true
 single_line_if_else_max_width  = 0
 single_line_let_else_max_width = 0
 style_edition                  = "2024"
 use_field_init_shorthand       = true
 use_try_shorthand              = true
+
+# The following options are nightly-only. They are commented out because we
+# format with the stable toolchain; uncomment when any one of them becomes
+# available in stable.
+
+# condense_wildcard_suffixes = true
+# format_macro_bodies        = false
+# format_macro_matchers      = false
+# group_imports              = "Preserve"
+# imports_granularity        = "One"
+# normalize_comments         = true
+# normalize_doc_attributes   = true
+# overflow_delimited_expr    = true
+# reorder_impl_items         = true


### PR DESCRIPTION
Comment out the nine nightly-only options in rustfmt.toml (rather than deleting them, so they are easy to reinstate) and reformat the workspace with stable rustfmt; the diff consists almost entirely of trailing delimited expressions no longer overflowing (overflow_delimited_expr). The fmt CI job, the justfile recipe, the recommended VSCode settings, and the contributing guide no longer require a nightly toolchain.