### PR TITLE
chore(deploy): add no_log to ansible tasks handling key material

### DIFF
--- a/deploy/roles/full-app/tasks/cometbft_keys.yml
+++ b/deploy/roles/full-app/tasks/cometbft_keys.yml
@@ -41,6 +41,9 @@
     cometbft show-validator --home {{ cometbft_container_dir }}
   register: cometbft_validator_public_key_result
 
+# The registered result contains the raw private key, so `no_log` is required:
+# without it, a task failure or a `-v` run would print the key into the
+# terminal and the tee'd log under `deploy/logs/`.
 - name: Get validator private key
   command: >
     docker run --rm
@@ -48,19 +51,25 @@
     ghcr.io/left-curve/left-curve/cometbft:{{ cometbft_tag }}
     cat {{ cometbft_container_dir }}/config/priv_validator_key.json
   register: cometbft_priv_validator_key_result
+  no_log: true
 
 - name: Calculate validator address
   shell: >
     echo "{{ (cometbft_validator_public_key_result.stdout | from_json).value }}" | base64 -d | sha256sum | head -c 40 | tr '[:lower:]' '[:upper:]'
   register: validator_address_calc
 
+# `no_log` because the facts include the validator private key, which verbose
+# runs would otherwise print. The public facts set here are still shown by the
+# "Debug keys" task below.
 - name: Set validator facts
   set_fact:
     cometbft_validator_public_key: "{{ (cometbft_validator_public_key_result.stdout | from_json).value }}"
     cometbft_validator_address: "{{ validator_address_calc.stdout }}"
     cometbft_validator_private_key: "{{ (cometbft_priv_validator_key_result.stdout | from_json).priv_key.value }}"
     cometbft_node_id: "{{ cometbft_node_id_result.stdout }}"
+  no_log: true
 
+# Same as the validator key above: the result holds the node's private key.
 - name: Read and parse node_key.json
   command: >
     docker run --rm
@@ -68,10 +77,12 @@
     ghcr.io/left-curve/left-curve/cometbft:{{ cometbft_tag }}
     cat {{ cometbft_container_dir }}/config/node_key.json
   register: cometbft_node_key_result
+  no_log: true
 
 - name: Extract node key value
   set_fact:
     cometbft_node_key: "{{ (cometbft_node_key_result.stdout | from_json).priv_key.value }}"
+  no_log: true
 
 - name: Debug keys
   debug:

--- a/deploy/roles/full-app/tasks/deploy_configs.yml
+++ b/deploy/roles/full-app/tasks/deploy_configs.yml
@@ -31,13 +31,27 @@
         mode: "{{ item.mode | default('0600') }}"
       loop:
         - { src: "config/cometbft/config.toml.j2", dest: "{{ cometbft_directory }}/config/config.toml" }
-        - { src: "config/cometbft/node_key.json", dest: "{{ cometbft_directory }}/config/node_key.json" }
-        - { src: "config/cometbft/priv_validator_key.json", dest: "{{ cometbft_directory }}/config/priv_validator_key.json" }
         - { src: "config/dango/app.toml", dest: "{{ dango_directory }}/config/app.toml" }
         - { src: "docker-compose.yml", dest: "{{ deployment_dir }}/docker-compose.yml" }
-        - { src: "env.j2", dest: "{{ deployment_dir }}/.env" }
         - { src: "envrc.j2", dest: "{{ deployment_dir }}/.envrc" }
         - { src: "Makefile", dest: "{{ deployment_dir }}/Makefile", mode: "0644" }
+
+    # These templates render secrets (CometBFT private keys, database
+    # passwords, API tokens). They are deployed in a separate task with
+    # `no_log` so the rendered contents never reach ansible output or the
+    # tee'd logs under `deploy/logs/` — in particular via `--diff` mode,
+    # which would otherwise print the full file contents on any change.
+    # Don't merge them back into the loop above.
+    - name: Deploy secret configuration files
+      template:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: "0600"
+      loop:
+        - { src: "config/cometbft/node_key.json", dest: "{{ cometbft_directory }}/config/node_key.json" }
+        - { src: "config/cometbft/priv_validator_key.json", dest: "{{ cometbft_directory }}/config/priv_validator_key.json" }
+        - { src: "env.j2", dest: "{{ deployment_dir }}/.env" }
+      no_log: true
 
 - name: Check if network-specific genesis exists
   stat:


### PR DESCRIPTION
## Summary

Ansible tasks in the `full-app` role that register, set, or template key material and other secret values now run with `no_log: true`, keeping their contents out of ansible output and the tee'd logs under `deploy/logs/`, including in `--diff` runs. The secret-bearing templates (`node_key.json`, `priv_validator_key.json`, `.env`) are deployed by a dedicated task, separate from the diff-able config templates.

## Validation

### Completed

- [x] `uvx yamllint -d relaxed` clean on both changed files
- [x] Static ansible syntax check (`import_role` of both task files) passes
- [x] Independent agent review of the diff
- [x] Confirmed existing `deploy/logs/` contain only public values

### Remaining

- [ ] One `full-app.yml` run against a testnet host to confirm deploy output and behavior are unchanged

## Manual QA

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRT4fTidXkz7fxPDPGgVt1
