### PR TITLE
feat(sdk): add a client for the Archive API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3846,6 +3846,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "dango-primitives",
+ "serde",
+ "serde_json",
+ "utoipa",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4489,6 +4489,7 @@ dependencies = [
  "bip32",
  "csv",
  "dango-account-factory",
+ "dango-archive-types",
  "dango-auth",
  "dango-backtrace",
  "dango-eth-utils",

--- a/dango/archive/httpd/Cargo.toml
+++ b/dango/archive/httpd/Cargo.toml
@@ -22,7 +22,7 @@ actix-cors                 = { workspace = true }
 actix-web                  = { workspace = true }
 anyhow                     = { workspace = true }
 dango-archive-block-source = { workspace = true }
-dango-archive-types        = { workspace = true }
+dango-archive-types        = { workspace = true, features = ["utoipa"] }
 futures                    = { workspace = true }
 hex                        = { workspace = true }
 metrics                    = { workspace = true, optional = true }

--- a/dango/archive/httpd/src/lib.rs
+++ b/dango/archive/httpd/src/lib.rs
@@ -35,7 +35,11 @@ mod server;
 pub use {
     crate::metrics::init_metrics,
     config::HttpdConfig,
+    // Re-exported from the shared types crate (they moved there so clients can
+    // deserialize the same envelope the handlers serialize); the projections
+    // keep importing them from here.
+    dango_archive_types::{Page, PageInfo},
     error::ApiError,
-    read::{Binder, Page, PageInfo, decode_after, page_limit, paginate},
+    read::{Binder, decode_after, page_limit, paginate},
     server::{Configurator, serve},
 };

--- a/dango/archive/httpd/src/read.rs
+++ b/dango/archive/httpd/src/read.rs
@@ -15,9 +15,9 @@
 
 use {
     crate::error::ApiError,
+    dango_archive_types::{Page, PageInfo},
     sea_orm::Value,
     serde::{Serialize, de::DeserializeOwned},
-    utoipa::ToSchema,
 };
 
 /// Page size when a feed is queried without an explicit `first`.
@@ -97,24 +97,6 @@ impl Binder {
 }
 
 // ---- page assembly ----
-
-/// A page of a feed's results: the items plus the cursor of the last one.
-#[derive(Serialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct Page<N> {
-    pub items: Vec<N>,
-    pub page_info: PageInfo,
-}
-
-/// Forward-pagination metadata. `hasNextPage` comes from the surplus
-/// `limit + 1`-th row; `endCursor` is the cursor of the last returned item (the
-/// `after` for the next page), `null` when the page is empty.
-#[derive(Serialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct PageInfo {
-    pub has_next_page: bool,
-    pub end_cursor: Option<String>,
-}
 
 /// Turn up to `limit + 1` rows (newest-first) into a [`Page`]: the surplus row,
 /// if any, sets `hasNextPage` and is dropped; the last kept row's keyset becomes

--- a/dango/archive/projection/Cargo.toml
+++ b/dango/archive/projection/Cargo.toml
@@ -24,7 +24,7 @@ borsh                      = { workspace = true }
 clickhouse                 = { workspace = true }
 dango-archive-block-source = { workspace = true }
 dango-archive-httpd        = { workspace = true }
-dango-archive-types        = { workspace = true }
+dango-archive-types        = { workspace = true, features = ["utoipa"] }
 dango-primitives           = { workspace = true, features = ["chrono"] }
 futures                    = { workspace = true }
 metrics                    = { workspace = true, optional = true }

--- a/dango/archive/projection/src/activity/event_type.rs
+++ b/dango/archive/projection/src/activity/event_type.rs
@@ -1,95 +1,10 @@
-use {
-    dango_primitives::{Addr, FlatEvent},
-    serde::{Deserialize, Serialize},
-};
-
-/// Compact discriminant for a [`FlatEvent`], stored in `activity_events.event_type`
-/// and used to key the projection's priority / involvement configuration.
-///
-/// Mirrors `FlatEvent`'s variants one-to-one. The `#[repr(i16)]` values are the
-/// **stored codes**: they are part of the on-disk schema, so existing codes must
-/// never be renumbered (append-only). [`From<&FlatEvent>`] is exhaustive, so a
-/// new upstream variant is a compile error here until it is given a code.
-///
-/// Serialized snake_case (`transfer`, `contract_event`, …): the spelling the
-/// read API accepts to filter the activity feeds by type and surfaces as an
-/// event's `type`.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, utoipa::ToSchema)]
-#[serde(rename_all = "snake_case")]
-#[repr(i16)]
-pub enum EventType {
-    Configure = 0,
-    Upgrade = 1,
-    Transfer = 2,
-    Upload = 3,
-    Instantiate = 4,
-    Execute = 5,
-    Migrate = 6,
-    Reply = 7,
-    Authenticate = 8,
-    Backrun = 9,
-    Withhold = 10,
-    Finalize = 11,
-    Cron = 12,
-    Guest = 13,
-    ContractEvent = 14,
-}
-
-impl EventType {
-    /// The stored discriminant (the value written to `event_type`).
-    #[must_use]
-    pub fn code(self) -> i16 {
-        self as i16
-    }
-
-    /// The variant for a stored discriminant, or `None` if `code` is unknown —
-    /// the inverse of [`code`](Self::code), used to surface `event_type` in the
-    /// read API. Spelled out (not `transmute`) so an out-of-range value read
-    /// from the database is a clean `None`, never undefined behaviour.
-    #[must_use]
-    pub fn from_code(code: i16) -> Option<Self> {
-        Some(match code {
-            0 => Self::Configure,
-            1 => Self::Upgrade,
-            2 => Self::Transfer,
-            3 => Self::Upload,
-            4 => Self::Instantiate,
-            5 => Self::Execute,
-            6 => Self::Migrate,
-            7 => Self::Reply,
-            8 => Self::Authenticate,
-            9 => Self::Backrun,
-            10 => Self::Withhold,
-            11 => Self::Finalize,
-            12 => Self::Cron,
-            13 => Self::Guest,
-            14 => Self::ContractEvent,
-            _ => return None,
-        })
-    }
-}
-
-impl From<&FlatEvent> for EventType {
-    fn from(event: &FlatEvent) -> Self {
-        match event {
-            FlatEvent::Configure(_) => Self::Configure,
-            FlatEvent::Upgrade(_) => Self::Upgrade,
-            FlatEvent::Transfer(_) => Self::Transfer,
-            FlatEvent::Upload(_) => Self::Upload,
-            FlatEvent::Instantiate(_) => Self::Instantiate,
-            FlatEvent::Execute(_) => Self::Execute,
-            FlatEvent::Migrate(_) => Self::Migrate,
-            FlatEvent::Reply(_) => Self::Reply,
-            FlatEvent::Authenticate(_) => Self::Authenticate,
-            FlatEvent::Backrun(_) => Self::Backrun,
-            FlatEvent::Withhold(_) => Self::Withhold,
-            FlatEvent::Finalize(_) => Self::Finalize,
-            FlatEvent::Cron(_) => Self::Cron,
-            FlatEvent::Guest(_) => Self::Guest,
-            FlatEvent::ContractEvent(_) => Self::ContractEvent,
-        }
-    }
-}
+/// The compact [`FlatEvent`] discriminant, moved to [`dango_archive_types`] so
+/// clients (e.g. the SDK's `ArchiveClient`) share the exact spellings and
+/// stored codes; re-exported here for the projection's many internal users.
+/// What stays below is the projection-only taxonomy: which columns a
+/// `FlatEvent` populates.
+pub use dango_archive_types::EventType;
+use dango_primitives::{Addr, FlatEvent};
 
 // ---- per-event taxonomy used by the `events` table columns ----
 

--- a/dango/archive/projection/src/activity/http/feeds.rs
+++ b/dango/archive/projection/src/activity/http/feeds.rs
@@ -27,7 +27,9 @@
 //! so the SQL shape can never regress unnoticed.
 
 use {
-    super::types::{AddressRole, Event, EventRow, Transaction, UnitKind, event_from_row},
+    super::types::{
+        AddressRole, Event, EventRow, Transaction, UnitKind, event_from_row, transaction_from_model,
+    },
     crate::{
         activity::{entity::transactions, event_type::EventType},
         metrics::timed_query,
@@ -96,7 +98,7 @@ pub(crate) async fn transactions_by_hash(
     )
     .await?;
     txn.commit().await?;
-    rows.into_iter().map(Transaction::try_from).collect()
+    rows.into_iter().map(transaction_from_model).collect()
 }
 
 /// Query 1 — transactions (and cronjobs) **involving** an address: by default
@@ -213,7 +215,7 @@ pub(crate) async fn transactions_involving(
             kind: m.kind,
             idx: m.idx,
         },
-        Transaction::try_from,
+        transaction_from_model,
     )
 }
 

--- a/dango/archive/projection/src/activity/http/types.rs
+++ b/dango/archive/projection/src/activity/http/types.rs
@@ -1,13 +1,12 @@
-//! The activity read API's **type surface**: the `UnitKind` / `AddressRole`
-//! enums used as arguments, and the `Transaction` / `Event` JSON objects the
-//! handlers return.
+//! The activity read API's **storage glue**: decoding stored rows into the
+//! shared wire types.
 //!
-//! Addresses and hashes are grug's own `Addr` / `Hash256`: their serde already
-//! speaks the canonical text dialect — an address is lowercase `0x`-prefixed, a
-//! hash bare uppercase — both on input (`web::Path<Addr>` parses the hex, like
-//! `web::Path<Uuid>`) and output (serialized as that same string), so the read
-//! API needs no wrapper newtype. Stored as raw bytes (`BYTEA`), they are decoded
-//! back with `Addr::try_from` / `Hash256::try_from`.
+//! The wire types themselves — the `UnitKind` / `AddressRole` argument enums
+//! and the `Transaction` / `Event` JSON objects — live in
+//! [`dango_archive_types`], shared with clients (e.g. the SDK's
+//! `ArchiveClient`) so the wire format cannot drift; they are re-exported here
+//! for the handlers and feeds. This module keeps what only the server needs:
+//! the sea-orm row structs and the stored-code / stored-bytes decoders.
 //!
 //! The heavy detail — a unit's full `tx` / `outcome`, an event's decoded `data`
 //! — is **always** hydrated eagerly from the unit's block (see [`super::hydrate`])
@@ -15,12 +14,13 @@
 //! [`super::feeds`] leave them `None` and the handler fills them before
 //! responding.
 
+pub(crate) use dango_archive_types::{AddressRole, Event, Transaction, UnitKind};
 use {
     crate::activity::{decompress_event, entity::transactions, event_type::EventType},
     dango_archive_httpd::ApiError,
     dango_primitives::{Addr, Hash256, Timestamp},
     sea_orm::FromQueryResult,
-    serde::{Deserialize, Serialize},
+    serde::Serialize,
 };
 
 // ---- stored-bytes decoders ----
@@ -38,48 +38,11 @@ fn hash_from_bytes(bytes: Vec<u8>) -> Result<Hash256, ApiError> {
         .map_err(|err| ApiError::Internal(format!("invalid stored hash: {err}")))
 }
 
-// ---- enums ----
-
-/// How an `address` argument must relate to a unit in the
-/// `transactionsInvolving` feed. Omitted ⇒ **either** — the address sent the
-/// unit *or* was a party to one of its events (their union).
-#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq, utoipa::ToSchema)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum AddressRole {
-    /// The address sent the unit (`transactions.sender`). Cron units have no
-    /// sender, so this never matches a cronjob.
-    Sender,
-    /// The address is a party to one of the unit's events (the participation
-    /// rows in `events`).
-    Participant,
-}
-
-/// The kind of an executed unit — mirrors [`dango_primitives::FlatCategory`].
-/// Serialized / parsed as `"cron"` / `"transaction"`.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, utoipa::ToSchema)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum UnitKind {
-    Cron,
-    Transaction,
-}
-
-impl UnitKind {
-    /// The stored discriminant for this kind (the value in `transactions.kind`
-    /// / `events.category`).
-    pub(crate) fn code(self) -> i16 {
-        match self {
-            Self::Cron => dango_primitives::FlatCategory::Cron as i16,
-            Self::Transaction => dango_primitives::FlatCategory::Tx as i16,
-        }
-    }
-
-    fn from_code(code: i16) -> Result<Self, ApiError> {
-        match code {
-            c if c == dango_primitives::FlatCategory::Cron as i16 => Ok(Self::Cron),
-            c if c == dango_primitives::FlatCategory::Tx as i16 => Ok(Self::Transaction),
-            other => Err(ApiError::Internal(format!("unknown unit kind: {other}"))),
-        }
-    }
+/// `UnitKind` from its stored discriminant — an unknown code is a
+/// data-integrity error surfaced as a 500.
+fn unit_kind_from_code(code: i16) -> Result<UnitKind, ApiError> {
+    UnitKind::from_code(code)
+        .ok_or_else(|| ApiError::Internal(format!("unknown unit kind: {code}")))
 }
 
 // ---- event rows + output ----
@@ -100,40 +63,6 @@ pub(crate) struct EventRow {
     pub data: Option<Vec<u8>>,
 }
 
-/// An indexed event, identified by its position. The participant set is **not**
-/// a field — the address feeds return one row per (event × address) and the
-/// attribute feeds collapse to the event. `contract` / `name` are present only
-/// for contract events; `data` is the decoded payload, hydrated eagerly (from
-/// the `event_data` blob for priority types, otherwise from the unit's block),
-/// `null` only if the source no longer holds the block.
-#[derive(Serialize, Clone, Debug, utoipa::ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct Event {
-    /// Height of the block the event was emitted in.
-    pub block_height: u64,
-    /// Kind of the enclosing unit (a transaction or a cronjob).
-    pub category: UnitKind,
-    /// Index of the enclosing unit within the block.
-    pub category_index: u32,
-    /// The event's 0-based position within its unit.
-    pub event_index: u32,
-    /// The event's type.
-    #[serde(rename = "type")]
-    pub ty: EventType,
-    /// Emitting contract — present only for contract events.
-    #[schema(value_type = Option<String>)]
-    pub contract: Option<Addr>,
-    /// The contract-event name (`order_filled`, …) — present only for contract
-    /// events.
-    pub name: Option<String>,
-    /// The decoded payload as JSON — a `FlatEvent`. Set by [`event_from_row`]
-    /// for priority types (decompressed from the joined blob) and by
-    /// [`super::hydrate`] from the block for the rest; `null` when the block is
-    /// unavailable.
-    #[schema(value_type = Option<Object>)]
-    pub data: Option<serde_json::Value>,
-}
-
 /// Build an [`Event`] from a feed row, decoding the priority payload that rode
 /// along in the `event_data` join. Non-priority rows (no joined blob) leave
 /// `data` `None` for [`super::hydrate`] to fill from the block.
@@ -144,7 +73,7 @@ pub(crate) fn event_from_row(row: EventRow) -> Result<Event, ApiError> {
     };
     Ok(Event {
         block_height: row.block_height as u64,
-        category: UnitKind::from_code(row.category)?,
+        category: unit_kind_from_code(row.category)?,
         category_index: row.category_index as u32,
         event_index: row.event_index as u32,
         ty: EventType::from_code(row.event_type)
@@ -155,58 +84,24 @@ pub(crate) fn event_from_row(row: EventRow) -> Result<Event, ApiError> {
     })
 }
 
-/// An executed unit — a transaction (`kind = "transaction"`) or a cronjob
-/// (`kind = "cron"`). `hash` and `sender` are absent for cron units. The indexed
-/// columns are cheap; the full submitted `tx` and the execution `outcome` are
-/// hydrated eagerly from the unit's block (see [`super::hydrate`]) — `tx` is
-/// `null` for cron units, both are `null` if the block is unavailable.
-#[derive(Serialize, Clone, Debug, utoipa::ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct Transaction {
-    /// Height of the block the unit executed in.
-    pub block_height: u64,
-    /// Index of the unit within the block (per kind).
-    pub idx: u32,
-    /// Whether this is a transaction or a cronjob.
-    pub kind: UnitKind,
-    /// Content hash — absent for cron units.
-    #[schema(value_type = Option<String>)]
-    pub hash: Option<Hash256>,
-    /// Account or contract that sent the unit — absent for cron units.
-    #[schema(value_type = Option<String>)]
-    pub sender: Option<Addr>,
-    /// Whether the unit's outcome was `Ok`.
-    pub success: bool,
-    /// Block time, RFC 3339 / ISO 8601 (UTC). A string, not an integer, so the
-    /// nanosecond value never loses precision in 64-bit-lossy clients.
-    pub timestamp: String,
-    /// The full transaction as submitted on-chain (the `Tx` JSON the node
-    /// serializes) — `null` for cron units. Hydrated from the block.
-    #[schema(value_type = Option<Object>)]
-    pub tx: Option<serde_json::Value>,
-    /// The unit's execution outcome as JSON — externally tagged
-    /// `{"transaction": …}` / `{"cron": …}` (see [`UnitOutcome`]). Hydrated from
-    /// the block.
-    #[schema(value_type = Option<Object>)]
-    pub outcome: Option<serde_json::Value>,
-}
-
-impl TryFrom<transactions::Model> for Transaction {
-    type Error = ApiError;
-
-    fn try_from(model: transactions::Model) -> Result<Self, Self::Error> {
-        Ok(Self {
-            block_height: model.block_height as u64,
-            idx: model.idx as u32,
-            kind: UnitKind::from_code(model.kind)?,
-            hash: model.hash.map(hash_from_bytes).transpose()?,
-            sender: model.sender.map(addr_from_bytes).transpose()?,
-            success: model.success,
-            timestamp: Timestamp::from_nanos(model.timestamp as u128).to_rfc3339_string(),
-            tx: None,
-            outcome: None,
-        })
-    }
+/// Build a [`Transaction`] from its stored row, leaving `tx` / `outcome` `None`
+/// for [`super::hydrate`] to fill from the block.
+///
+/// A free function, not `TryFrom`: with [`Transaction`] living in
+/// [`dango_archive_types`], `impl TryFrom<transactions::Model> for Transaction`
+/// would be an orphan impl.
+pub(crate) fn transaction_from_model(model: transactions::Model) -> Result<Transaction, ApiError> {
+    Ok(Transaction {
+        block_height: model.block_height as u64,
+        idx: model.idx as u32,
+        kind: unit_kind_from_code(model.kind)?,
+        hash: model.hash.map(hash_from_bytes).transpose()?,
+        sender: model.sender.map(addr_from_bytes).transpose()?,
+        success: model.success,
+        timestamp: Timestamp::from_nanos(model.timestamp as u128).to_rfc3339_string(),
+        tx: None,
+        outcome: None,
+    })
 }
 
 /// A unit's execution outcome, as carried in its block: a [`TxOutcome`] for a

--- a/dango/archive/testing/src/lib.rs
+++ b/dango/archive/testing/src/lib.rs
@@ -414,6 +414,13 @@ impl Env {
     /// contiguously, so once a block's tx is visible every block below it has
     /// been ingested too. Returns the list of matching units. Tolerates the read
     /// API's startup window (a not-yet-bound server reads as "not indexed").
+    /// Base URL of the in-process REST read API — for driving it with an
+    /// external client (e.g. the SDK's `ArchiveClient`) instead of the raw
+    /// helpers below.
+    pub fn read_url(&self) -> &str {
+        &self.read_url
+    }
+
     pub async fn wait_for_tx_indexed(
         &self,
         hash: &str,

--- a/dango/archive/testing/tests/archive_client.rs
+++ b/dango/archive/testing/tests/archive_client.rs
@@ -1,0 +1,231 @@
+//! Drives every `ArchiveClient` method against the real archive stack (mock
+//! node → block source → committer → projection → REST read API) — the drift
+//! guard for the typed client: it must deserialize exactly what the server
+//! serializes.
+//!
+//! Fixture arithmetic (see `backfill.rs`): the mock chain runs with a zero
+//! gas-fee rate, so each transfer produces exactly one `Transfer` event and two
+//! bank contract-events (`sent` / `received`), and each broadcast drives
+//! exactly one block. The test env anchors the `/events/perps` shortcut on the
+//! **bank** contract, so the shortcut serves the same events as
+//! `/events/contract?contract={bank}`.
+
+use {
+    dango_archive_testing::{Env, broadcast_transfer},
+    dango_primitives::BlockClient,
+    dango_sdk::{
+        ArchiveClient,
+        archive::{AddressRole, EventType, UnitKind},
+    },
+    std::time::Duration,
+};
+
+/// How many transfers the test broadcasts (one block each).
+const TRANSFERS: usize = 3;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn archive_client_covers_every_route() {
+    let mut env = Env::setup().await.expect("set up the e2e environment");
+    let archive = ArchiveClient::new(env.read_url()).expect("build the archive client");
+
+    let sender = *env.accounts.user1.address.inner();
+    let recipient = *env.accounts.user2.address.inner();
+
+    // Broadcast the transfers, then bridge the async ingest pipeline by
+    // waiting for the last one to be indexed (ingest is in block order, so the
+    // earlier ones are then indexed too).
+    let mut hashes = vec![];
+    for i in 0..TRANSFERS {
+        let hash = broadcast_transfer(
+            &env.client,
+            &mut env.accounts.user1,
+            recipient,
+            100 + i as u128,
+        )
+        .await
+        .expect("broadcast a transfer");
+        hashes.push(hash);
+    }
+    env.wait_for_tx_indexed(&hashes.last().unwrap().to_string(), Duration::from_secs(30))
+        .await
+        .expect("the last transfer to be indexed");
+
+    // ---- /up ----
+
+    archive.up().await.expect("the liveness probe answers");
+
+    // ---- blocks ----
+
+    let latest = archive
+        .latest_block()
+        .await
+        .expect("query the latest block")
+        .expect("the archive holds blocks");
+    let tip = latest.block.info.height;
+    assert!(
+        tip >= TRANSFERS as u64,
+        "the frontier covers the broadcast blocks"
+    );
+
+    let by_height = archive
+        .block(tip)
+        .await
+        .expect("query the block by height")
+        .expect("the frontier block is held");
+    assert_eq!(by_height.block.info.height, tip);
+    assert_eq!(by_height.block.info.hash, latest.block.info.hash);
+    assert_eq!(by_height.outcome.height, tip);
+
+    // An absent height is `None`, not an error.
+    assert!(
+        archive
+            .block(tip + 1_000_000)
+            .await
+            .expect("query an absent height")
+            .is_none()
+    );
+
+    // The `BlockClient` impl serves the same data, erroring on absence.
+    let block = archive
+        .query_block(Some(tip))
+        .await
+        .expect("BlockClient::query_block");
+    assert_eq!(block.info.height, tip);
+    let outcome = archive
+        .query_block_outcome(None)
+        .await
+        .expect("BlockClient::query_block_outcome");
+    assert_eq!(outcome.height, tip);
+    assert!(archive.query_block(Some(tip + 1_000_000)).await.is_err());
+
+    // ---- /transactions/{hash} ----
+
+    let units = archive
+        .transactions_by_hash(hashes[0])
+        .await
+        .expect("look up the first transfer by hash");
+    assert_eq!(units.len(), 1, "the hash resolves to exactly one unit");
+    let unit = &units[0];
+    assert_eq!(unit.hash, Some(hashes[0]));
+    assert_eq!(unit.sender, Some(sender));
+    assert_eq!(unit.kind, UnitKind::Transaction);
+    assert!(unit.success);
+    assert!(unit.tx.is_some(), "the submitted tx is hydrated");
+    assert!(unit.outcome.is_some(), "the execution outcome is hydrated");
+
+    // ---- /transactions/involving/{address} ----
+
+    let page = archive
+        .transactions_involving(sender, Some(AddressRole::Sender), None, None, None)
+        .await
+        .expect("the sender's transactions");
+    assert_eq!(page.items.len(), TRANSFERS);
+    assert!(
+        page.items
+            .windows(2)
+            .all(|w| w[0].block_height >= w[1].block_height),
+        "the feed is newest-first"
+    );
+    assert!(!page.page_info.has_next_page);
+
+    // Narrowing to cron units matches nothing (only transactions ran).
+    let crons = archive
+        .transactions_involving(sender, None, Some(UnitKind::Cron), None, None)
+        .await
+        .expect("the sender's cron units");
+    assert!(crons.items.is_empty());
+
+    // A `first: 1` cursor walk reassembles the same feed.
+    let walked = archive
+        .paginate_transactions_involving(sender, Some(AddressRole::Sender), None, Some(1))
+        .await
+        .expect("paginate the sender's transactions");
+    assert_eq!(walked, page.items);
+
+    // ---- /events ----
+
+    let transfers = archive
+        .events(&[EventType::Transfer], None, None, None)
+        .await
+        .expect("the transfer events");
+    assert_eq!(
+        transfers.items.len(),
+        TRANSFERS,
+        "exactly one Transfer event per transfer"
+    );
+    assert!(
+        transfers
+            .items
+            .iter()
+            .all(|event| event.ty == EventType::Transfer && event.data.is_some())
+    );
+
+    let involving_recipient = archive
+        .events(&[], Some(recipient), None, None)
+        .await
+        .expect("the recipient's events");
+    assert!(
+        !involving_recipient.items.is_empty(),
+        "the recipient participates in the transfers' events"
+    );
+
+    // Neither `types` nor `involved`: the server refuses (no index anchor).
+    assert!(archive.events(&[], None, None, None).await.is_err());
+
+    // ---- /events/contract and the /events/perps shortcut ----
+
+    let bank = env.contracts.bank;
+    let bank_events = archive
+        .contract_events(bank, None, &[], None, None)
+        .await
+        .expect("the bank's contract events");
+    assert_eq!(
+        bank_events.items.len(),
+        2 * TRANSFERS,
+        "a `sent` and a `received` per transfer"
+    );
+    assert!(bank_events.items.iter().all(|event| {
+        event.ty == EventType::ContractEvent
+            && event.contract == Some(bank)
+            && matches!(event.name.as_deref(), Some("sent" | "received"))
+    }));
+
+    let sent = archive
+        .contract_events(bank, None, &["sent"], None, None)
+        .await
+        .expect("the bank's `sent` events");
+    assert_eq!(sent.items.len(), TRANSFERS);
+    assert!(
+        sent.items
+            .iter()
+            .all(|event| event.name.as_deref() == Some("sent"))
+    );
+
+    // The test env anchors the perps shortcut on the bank, so the shortcut
+    // must serve the very same events.
+    let via_shortcut = archive
+        .perps_events(None, &["sent"], None, None)
+        .await
+        .expect("the `sent` events via the perps shortcut");
+    assert_eq!(via_shortcut.items, sent.items);
+
+    // A `first: 1` cursor walk reassembles the same feed.
+    let walked = archive
+        .paginate_contract_events(bank, None, &[], Some(1))
+        .await
+        .expect("paginate the bank's contract events");
+    assert_eq!(walked, bank_events.items);
+
+    let walked = archive
+        .paginate_perps_events(None, &["sent"], Some(1))
+        .await
+        .expect("paginate via the perps shortcut");
+    assert_eq!(walked, sent.items);
+
+    // And the generic events walk.
+    let walked = archive
+        .paginate_events(&[EventType::Transfer], None, Some(1))
+        .await
+        .expect("paginate the transfer events");
+    assert_eq!(walked, transfers.items);
+}

--- a/dango/archive/types/Cargo.toml
+++ b/dango/archive/types/Cargo.toml
@@ -12,6 +12,15 @@ version       = { workspace = true }
 [lib]
 path = "src/lib.rs"
 
+[features]
+# Derives `utoipa::ToSchema` on the wire types, for the crates that serve them
+# over HTTP and document them via OpenAPI (the httpd and the projections).
+# Clients (e.g. dango-sdk) leave it off so they never pull utoipa.
+utoipa = ["dep:utoipa"]
+
 [dependencies]
 anyhow           = { workspace = true }
 dango-primitives = { workspace = true }
+serde            = { workspace = true, features = ["derive"] }
+serde_json       = { workspace = true }
+utoipa           = { workspace = true, optional = true }

--- a/dango/archive/types/src/activity.rs
+++ b/dango/archive/types/src/activity.rs
@@ -1,0 +1,272 @@
+//! The activity read API's **wire types**: the `UnitKind` / `AddressRole` /
+//! `EventType` enums used as feed arguments, and the `Transaction` / `Event`
+//! JSON objects the feeds return.
+//!
+//! These are shared verbatim between the server side (the activity projection's
+//! handlers, which serialize them) and clients (e.g. the SDK's `ArchiveClient`,
+//! which deserializes them), so the wire format cannot drift between the two.
+//! The projection's storage glue — row structs, column-code decoding into these
+//! types, hydration — stays in the projection.
+//!
+//! Addresses and hashes are grug's own `Addr` / `Hash256`: their serde already
+//! speaks the canonical text dialect — an address is lowercase `0x`-prefixed, a
+//! hash bare uppercase — so the read API needs no wrapper newtype.
+
+use {
+    dango_primitives::{Addr, FlatEvent, Hash256},
+    serde::{Deserialize, Serialize},
+};
+
+// ---- argument enums ----
+
+/// How an `address` argument must relate to a unit in the
+/// `transactionsInvolving` feed. Omitted ⇒ **either** — the address sent the
+/// unit *or* was a party to one of its events (their union).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum AddressRole {
+    /// The address sent the unit (`transactions.sender`). Cron units have no
+    /// sender, so this never matches a cronjob.
+    Sender,
+    /// The address is a party to one of the unit's events (the participation
+    /// rows in `events`).
+    Participant,
+}
+
+/// The kind of an executed unit — mirrors [`dango_primitives::FlatCategory`].
+/// Serialized / parsed as `"cron"` / `"transaction"`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum UnitKind {
+    Cron,
+    Transaction,
+}
+
+impl UnitKind {
+    /// The stored discriminant for this kind (the value in `transactions.kind`
+    /// / `events.category`).
+    #[must_use]
+    pub fn code(self) -> i16 {
+        match self {
+            Self::Cron => dango_primitives::FlatCategory::Cron as i16,
+            Self::Transaction => dango_primitives::FlatCategory::Tx as i16,
+        }
+    }
+
+    /// The variant for a stored discriminant, or `None` if `code` is unknown —
+    /// the inverse of [`code`](Self::code).
+    #[must_use]
+    pub fn from_code(code: i16) -> Option<Self> {
+        match code {
+            c if c == dango_primitives::FlatCategory::Cron as i16 => Some(Self::Cron),
+            c if c == dango_primitives::FlatCategory::Tx as i16 => Some(Self::Transaction),
+            _ => None,
+        }
+    }
+}
+
+/// Compact discriminant for a [`FlatEvent`], stored in `activity_events.event_type`
+/// and used to key the projection's priority / involvement configuration.
+///
+/// Mirrors `FlatEvent`'s variants one-to-one. The `#[repr(i16)]` values are the
+/// **stored codes**: they are part of the on-disk schema, so existing codes must
+/// never be renumbered (append-only). [`From<&FlatEvent>`] is exhaustive, so a
+/// new upstream variant is a compile error here until it is given a code.
+///
+/// Serialized snake_case (`transfer`, `contract_event`, …): the spelling the
+/// read API accepts to filter the activity feeds by type and surfaces as an
+/// event's `type`.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+#[repr(i16)]
+pub enum EventType {
+    Configure = 0,
+    Upgrade = 1,
+    Transfer = 2,
+    Upload = 3,
+    Instantiate = 4,
+    Execute = 5,
+    Migrate = 6,
+    Reply = 7,
+    Authenticate = 8,
+    Backrun = 9,
+    Withhold = 10,
+    Finalize = 11,
+    Cron = 12,
+    Guest = 13,
+    ContractEvent = 14,
+}
+
+impl EventType {
+    /// The stored discriminant (the value written to `event_type`).
+    #[must_use]
+    pub fn code(self) -> i16 {
+        self as i16
+    }
+
+    /// The variant for a stored discriminant, or `None` if `code` is unknown —
+    /// the inverse of [`code`](Self::code), used to surface `event_type` in the
+    /// read API. Spelled out (not `transmute`) so an out-of-range value read
+    /// from the database is a clean `None`, never undefined behaviour.
+    #[must_use]
+    pub fn from_code(code: i16) -> Option<Self> {
+        Some(match code {
+            0 => Self::Configure,
+            1 => Self::Upgrade,
+            2 => Self::Transfer,
+            3 => Self::Upload,
+            4 => Self::Instantiate,
+            5 => Self::Execute,
+            6 => Self::Migrate,
+            7 => Self::Reply,
+            8 => Self::Authenticate,
+            9 => Self::Backrun,
+            10 => Self::Withhold,
+            11 => Self::Finalize,
+            12 => Self::Cron,
+            13 => Self::Guest,
+            14 => Self::ContractEvent,
+            _ => return None,
+        })
+    }
+}
+
+impl From<&FlatEvent> for EventType {
+    fn from(event: &FlatEvent) -> Self {
+        match event {
+            FlatEvent::Configure(_) => Self::Configure,
+            FlatEvent::Upgrade(_) => Self::Upgrade,
+            FlatEvent::Transfer(_) => Self::Transfer,
+            FlatEvent::Upload(_) => Self::Upload,
+            FlatEvent::Instantiate(_) => Self::Instantiate,
+            FlatEvent::Execute(_) => Self::Execute,
+            FlatEvent::Migrate(_) => Self::Migrate,
+            FlatEvent::Reply(_) => Self::Reply,
+            FlatEvent::Authenticate(_) => Self::Authenticate,
+            FlatEvent::Backrun(_) => Self::Backrun,
+            FlatEvent::Withhold(_) => Self::Withhold,
+            FlatEvent::Finalize(_) => Self::Finalize,
+            FlatEvent::Cron(_) => Self::Cron,
+            FlatEvent::Guest(_) => Self::Guest,
+            FlatEvent::ContractEvent(_) => Self::ContractEvent,
+        }
+    }
+}
+
+// ---- feed objects ----
+
+/// An indexed event, identified by its position. The participant set is **not**
+/// a field — the address feeds return one row per (event × address) and the
+/// attribute feeds collapse to the event. `contract` / `name` are present only
+/// for contract events; `data` is the decoded payload, hydrated eagerly by the
+/// server, `null` only if the source no longer holds the block.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct Event {
+    /// Height of the block the event was emitted in.
+    pub block_height: u64,
+    /// Kind of the enclosing unit (a transaction or a cronjob).
+    pub category: UnitKind,
+    /// Index of the enclosing unit within the block.
+    pub category_index: u32,
+    /// The event's 0-based position within its unit.
+    pub event_index: u32,
+    /// The event's type.
+    #[serde(rename = "type")]
+    pub ty: EventType,
+    /// Emitting contract — present only for contract events.
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
+    pub contract: Option<Addr>,
+    /// The contract-event name (`order_filled`, …) — present only for contract
+    /// events.
+    pub name: Option<String>,
+    /// The decoded payload as JSON — a `FlatEvent`. Hydrated by the server;
+    /// `null` when the block is unavailable.
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<Object>))]
+    pub data: Option<serde_json::Value>,
+}
+
+/// An executed unit — a transaction (`kind = "transaction"`) or a cronjob
+/// (`kind = "cron"`). `hash` and `sender` are absent for cron units. The indexed
+/// columns are cheap; the full submitted `tx` and the execution `outcome` are
+/// hydrated eagerly by the server from the unit's block — `tx` is `null` for
+/// cron units, both are `null` if the block is unavailable.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct Transaction {
+    /// Height of the block the unit executed in.
+    pub block_height: u64,
+    /// Index of the unit within the block (per kind).
+    pub idx: u32,
+    /// Whether this is a transaction or a cronjob.
+    pub kind: UnitKind,
+    /// Content hash — absent for cron units.
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
+    pub hash: Option<Hash256>,
+    /// Account or contract that sent the unit — absent for cron units.
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<String>))]
+    pub sender: Option<Addr>,
+    /// Whether the unit's outcome was `Ok`.
+    pub success: bool,
+    /// Block time, RFC 3339 / ISO 8601 (UTC). A string, not an integer, so the
+    /// nanosecond value never loses precision in 64-bit-lossy clients.
+    pub timestamp: String,
+    /// The full transaction as submitted on-chain (the `Tx` JSON the node
+    /// serializes) — `null` for cron units. Hydrated from the block.
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<Object>))]
+    pub tx: Option<serde_json::Value>,
+    /// The unit's execution outcome as JSON — externally tagged
+    /// `{"transaction": …}` / `{"cron": …}`. Hydrated from the block.
+    #[cfg_attr(feature = "utoipa", schema(value_type = Option<Object>))]
+    pub outcome: Option<serde_json::Value>,
+}
+
+// ---- tests ----
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The snake_case spellings are the wire format the read API accepts in
+    /// `type` filters and surfaces in an event's `type` — pinned here so a
+    /// rename cannot slip through unnoticed.
+    #[test]
+    fn event_type_serializes_snake_case() {
+        for (ty, spelling) in [
+            (EventType::Transfer, "\"transfer\""),
+            (EventType::ContractEvent, "\"contract_event\""),
+            (EventType::Cron, "\"cron\""),
+        ] {
+            assert_eq!(serde_json::to_string(&ty).unwrap(), spelling);
+            assert_eq!(
+                serde_json::from_str::<EventType>(spelling).unwrap(),
+                ty,
+                "the spelling must round-trip",
+            );
+        }
+    }
+
+    /// Every stored code round-trips through `from_code`, and codes are stable.
+    #[test]
+    fn event_type_codes_round_trip() {
+        for code in 0..=14 {
+            let ty = EventType::from_code(code).expect("known code");
+            assert_eq!(ty.code(), code);
+        }
+        assert_eq!(EventType::from_code(15), None);
+        assert_eq!(EventType::Transfer.code(), 2);
+        assert_eq!(EventType::ContractEvent.code(), 14);
+    }
+
+    #[test]
+    fn unit_kind_codes_round_trip() {
+        for kind in [UnitKind::Cron, UnitKind::Transaction] {
+            assert_eq!(UnitKind::from_code(kind.code()), Some(kind));
+        }
+    }
+}

--- a/dango/archive/types/src/lib.rs
+++ b/dango/archive/types/src/lib.rs
@@ -3,9 +3,15 @@
 //! This crate has no dependencies on other `dango-archive-*` crates and
 //! contains items shared between the block source and the projections.
 
+mod activity;
 mod block_data;
+mod page;
 
-pub use block_data::{BlockData, BlockDataExt};
+pub use {
+    activity::{AddressRole, Event, EventType, Transaction, UnitKind},
+    block_data::{BlockData, BlockDataExt},
+    page::{Page, PageInfo},
+};
 
 /// Convenience alias for `anyhow::Result<T>` used across all archive
 /// crates.

--- a/dango/archive/types/src/page.rs
+++ b/dango/archive/types/src/page.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+/// A page of a feed's results: the items plus the cursor of the last one.
+///
+/// This is the envelope every keyset-paginated read-API feed answers with —
+/// serialized by the httpd's handlers, deserialized by clients (e.g. the SDK's
+/// `ArchiveClient`), so the wire shape lives here, shared by both sides.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct Page<N> {
+    pub items: Vec<N>,
+    pub page_info: PageInfo,
+}
+
+/// Forward-pagination metadata. `hasNextPage` comes from the surplus
+/// `limit + 1`-th row; `endCursor` is the cursor of the last returned item (the
+/// `after` for the next page), `null` when the page is empty.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct PageInfo {
+    pub has_next_page: bool,
+    pub end_cursor: Option<String>,
+}

--- a/dango/sdk/Cargo.toml
+++ b/dango/sdk/Cargo.toml
@@ -19,6 +19,7 @@ alloy                       = { workspace = true }
 anyhow                      = { workspace = true }
 async-trait                 = { workspace = true }
 bip32                       = { workspace = true }
+dango-archive-types         = { workspace = true }
 dango-auth                  = { workspace = true }
 dango-backtrace             = { workspace = true }
 dango-eth-utils             = { workspace = true }
@@ -29,7 +30,7 @@ futures                     = { workspace = true }
 graphql_client              = { workspace = true }
 k256                        = { workspace = true }
 pbkdf2                      = { workspace = true }
-reqwest                     = { workspace = true, features = ["json"] }
+reqwest                     = { workspace = true, features = ["json", "query"] }
 serde                       = { workspace = true }
 serde_json                  = { workspace = true }
 sha2                        = { workspace = true }

--- a/dango/sdk/src/archive.rs
+++ b/dango/sdk/src/archive.rs
@@ -1,0 +1,324 @@
+//! Client for the **Archive API** — the archive node's REST read surface
+//! (structured history: raw blocks, transaction and event feeds), the
+//! counterpart of [`HttpClient`](crate::HttpClient) which talks to the Live
+//! API.
+//!
+//! One method per route. The feed responses deserialize into the same
+//! [`dango_archive_types`] structs the server serializes, so the wire format
+//! cannot drift between the two sides. Every feed is newest-first and
+//! keyset-paginated (`first` / `after`); the `paginate_*` conveniences walk a
+//! feed to exhaustion by rolling each page's `endCursor` back in as the next
+//! `after`.
+
+pub use dango_archive_types::{
+    AddressRole, BlockData, Event, EventType, Page, PageInfo, Transaction, UnitKind,
+};
+use {
+    crate::client::error_for_status,
+    anyhow::{anyhow, bail},
+    async_trait::async_trait,
+    dango_primitives::{Addr, Block, BlockClient, BlockOutcome, Hash256},
+    reqwest::{IntoUrl, StatusCode},
+    serde::{Serialize, de::DeserializeOwned},
+    std::future::Future,
+    url::Url,
+};
+
+#[derive(Debug, Clone)]
+pub struct ArchiveClient {
+    inner: reqwest::Client,
+    url: Url,
+}
+
+impl ArchiveClient {
+    pub fn new<U>(url: U) -> anyhow::Result<Self>
+    where
+        U: IntoUrl,
+    {
+        Ok(Self {
+            inner: reqwest::Client::new(),
+            url: url.into_url()?,
+        })
+    }
+
+    /// GET `path` with the given query pairs, deserializing the JSON response.
+    async fn get<T>(&self, path: &str, query: &[(&str, String)]) -> anyhow::Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let mut request = self.inner.get(self.url.join(path)?);
+        if !query.is_empty() {
+            request = request.query(query);
+        }
+        Ok(error_for_status(request.send().await?)
+            .await?
+            .json()
+            .await?)
+    }
+
+    /// GET `path`, mapping a 404 to `None` — for the block reads, where an
+    /// absent height is an expected state (below the backfill floor, or a cold
+    /// archive), not an error.
+    async fn get_opt<T>(&self, path: &str) -> anyhow::Result<Option<T>>
+    where
+        T: DeserializeOwned,
+    {
+        let response = self.inner.get(self.url.join(path)?).send().await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        Ok(Some(error_for_status(response).await?.json().await?))
+    }
+
+    // ---- blocks ----
+
+    /// `GET /up` — the liveness probe. `Ok` when the service answers.
+    pub async fn up(&self) -> anyhow::Result<()> {
+        error_for_status(self.inner.get(self.url.join("up")?).send().await?).await?;
+        Ok(())
+    }
+
+    /// `GET /blocks/{height}` — the full block at `height` (`{block, outcome}`),
+    /// or `None` when the archive does not hold it.
+    pub async fn block(&self, height: u64) -> anyhow::Result<Option<BlockData>> {
+        self.get_opt(&format!("blocks/{height}")).await
+    }
+
+    /// `GET /blocks/latest` — the block at the archive's **contiguous
+    /// frontier**: the newest block servable together with all the history
+    /// below it. `None` while the archive is cold (no contiguous prefix yet).
+    pub async fn latest_block(&self) -> anyhow::Result<Option<BlockData>> {
+        self.get_opt("blocks/latest").await
+    }
+
+    // ---- transactions ----
+
+    /// `GET /transactions/{hash}` — every unit whose transaction bytes hash to
+    /// `hash`, newest-first, un-paginated (the hash is not unique:
+    /// byte-identical re-submissions can recur in later blocks).
+    pub async fn transactions_by_hash(&self, hash: Hash256) -> anyhow::Result<Vec<Transaction>> {
+        self.get(&format!("transactions/{hash}"), &[]).await
+    }
+
+    /// `GET /transactions/involving/{address}` — one page of the units the
+    /// address **sent** or **participated in** (the union by default), narrowed
+    /// with `role` / `kind`. Newest-first.
+    pub async fn transactions_involving(
+        &self,
+        address: Addr,
+        role: Option<AddressRole>,
+        kind: Option<UnitKind>,
+        first: Option<u32>,
+        after: Option<String>,
+    ) -> anyhow::Result<Page<Transaction>> {
+        let mut query = Vec::new();
+        if let Some(role) = role {
+            query.push(("role", snake(&role)?));
+        }
+        if let Some(kind) = kind {
+            query.push(("kind", snake(&kind)?));
+        }
+        push_page_args(&mut query, first, after);
+        self.get(&format!("transactions/involving/{address}"), &query)
+            .await
+    }
+
+    /// Walk [`transactions_involving`](Self::transactions_involving) to
+    /// exhaustion, collecting all items across pages.
+    pub async fn paginate_transactions_involving(
+        &self,
+        address: Addr,
+        role: Option<AddressRole>,
+        kind: Option<UnitKind>,
+        page_size: Option<u32>,
+    ) -> anyhow::Result<Vec<Transaction>> {
+        collect_pages(|after| self.transactions_involving(address, role, kind, page_size, after))
+            .await
+    }
+
+    // ---- events ----
+
+    /// `GET /events` — one page of events filtered by `types` and/or
+    /// `involved` (a participant address). The server requires **at least one**
+    /// of the two (an unfiltered feed has no index anchor); an empty `types`
+    /// slice omits the `type` argument. Newest-first.
+    pub async fn events(
+        &self,
+        types: &[EventType],
+        involved: Option<Addr>,
+        first: Option<u32>,
+        after: Option<String>,
+    ) -> anyhow::Result<Page<Event>> {
+        let mut query = Vec::new();
+        if !types.is_empty() {
+            let list = types.iter().map(snake).collect::<Result<Vec<_>, _>>()?;
+            query.push(("type", list.join(",")));
+        }
+        if let Some(address) = involved {
+            query.push(("involved", address.to_string()));
+        }
+        push_page_args(&mut query, first, after);
+        self.get("events", &query).await
+    }
+
+    /// Walk [`events`](Self::events) to exhaustion, collecting all items
+    /// across pages.
+    pub async fn paginate_events(
+        &self,
+        types: &[EventType],
+        involved: Option<Addr>,
+        page_size: Option<u32>,
+    ) -> anyhow::Result<Vec<Event>> {
+        collect_pages(|after| self.events(types, involved, page_size, after)).await
+    }
+
+    /// `GET /events/contract` — one page of the contract events of one
+    /// emitting `contract`, optionally narrowed to a participant `user` and/or
+    /// a set of event `names` (an empty slice omits the argument).
+    /// Newest-first.
+    pub async fn contract_events(
+        &self,
+        contract: Addr,
+        user: Option<Addr>,
+        names: &[&str],
+        first: Option<u32>,
+        after: Option<String>,
+    ) -> anyhow::Result<Page<Event>> {
+        let mut query = vec![("contract", contract.to_string())];
+        push_event_filters(&mut query, user, names);
+        push_page_args(&mut query, first, after);
+        self.get("events/contract", &query).await
+    }
+
+    /// Walk [`contract_events`](Self::contract_events) to exhaustion,
+    /// collecting all items across pages.
+    pub async fn paginate_contract_events(
+        &self,
+        contract: Addr,
+        user: Option<Addr>,
+        names: &[&str],
+        page_size: Option<u32>,
+    ) -> anyhow::Result<Vec<Event>> {
+        collect_pages(|after| self.contract_events(contract, user, names, page_size, after)).await
+    }
+
+    /// `GET /events/perps` — shortcut for
+    /// [`contract_events`](Self::contract_events) with the contract pre-bound
+    /// server-side to the deployment's perps address. Same `user` / `names`
+    /// narrowing.
+    pub async fn perps_events(
+        &self,
+        user: Option<Addr>,
+        names: &[&str],
+        first: Option<u32>,
+        after: Option<String>,
+    ) -> anyhow::Result<Page<Event>> {
+        let mut query = Vec::new();
+        push_event_filters(&mut query, user, names);
+        push_page_args(&mut query, first, after);
+        self.get("events/perps", &query).await
+    }
+
+    /// Walk [`perps_events`](Self::perps_events) to exhaustion, collecting all
+    /// items across pages.
+    pub async fn paginate_perps_events(
+        &self,
+        user: Option<Addr>,
+        names: &[&str],
+        page_size: Option<u32>,
+    ) -> anyhow::Result<Vec<Event>> {
+        collect_pages(|after| self.perps_events(user, names, page_size, after)).await
+    }
+
+    /// The block at `height`, or the frontier block when `None` — erroring on
+    /// absence, for the [`BlockClient`] impl.
+    async fn block_data(&self, height: Option<u64>) -> anyhow::Result<BlockData> {
+        match height {
+            Some(height) => self
+                .block(height)
+                .await?
+                .ok_or_else(|| anyhow!("block {height} is not held by the archive")),
+            None => self
+                .latest_block()
+                .await?
+                .ok_or_else(|| anyhow!("the archive holds no blocks yet")),
+        }
+    }
+}
+
+/// The archive can back anything that reads blocks through the [`BlockClient`]
+/// trait; `None` resolves to the archive's contiguous frontier rather than the
+/// chain tip.
+#[async_trait]
+impl BlockClient for ArchiveClient {
+    type Error = anyhow::Error;
+
+    async fn query_block(&self, height: Option<u64>) -> Result<Block, Self::Error> {
+        Ok(self.block_data(height).await?.block)
+    }
+
+    async fn query_block_outcome(&self, height: Option<u64>) -> Result<BlockOutcome, Self::Error> {
+        Ok(self.block_data(height).await?.outcome)
+    }
+}
+
+// ---- query-string helpers ----
+
+/// An argument enum's wire spelling, taken from its serde serialization — so
+/// the query string can never drift from the spelling the server parses.
+fn snake<T>(value: &T) -> anyhow::Result<String>
+where
+    T: Serialize,
+{
+    match serde_json::to_value(value)? {
+        serde_json::Value::String(text) => Ok(text),
+        other => bail!("expected a string serialization, got: {other}"),
+    }
+}
+
+/// Append the shared `first` / `after` pagination arguments.
+fn push_page_args(query: &mut Vec<(&str, String)>, first: Option<u32>, after: Option<String>) {
+    if let Some(first) = first {
+        query.push(("first", first.to_string()));
+    }
+    if let Some(after) = after {
+        query.push(("after", after));
+    }
+}
+
+/// Append the `user` / `names` narrowing shared by the contract-event feeds.
+fn push_event_filters(query: &mut Vec<(&str, String)>, user: Option<Addr>, names: &[&str]) {
+    if let Some(user) = user {
+        query.push(("user", user.to_string()));
+    }
+    if !names.is_empty() {
+        query.push(("names", names.join(",")));
+    }
+}
+
+/// Walk a keyset-paginated feed to exhaustion: fetch with `after = None`, roll
+/// each page's `endCursor` back in until `hasNextPage` is false, and collect
+/// all items.
+async fn collect_pages<N, F, Fut>(fetch: F) -> anyhow::Result<Vec<N>>
+where
+    F: Fn(Option<String>) -> Fut,
+    Fut: Future<Output = anyhow::Result<Page<N>>>,
+{
+    let mut all_items = Vec::new();
+    let mut after = None;
+
+    loop {
+        let page = fetch(after.clone()).await?;
+        all_items.extend(page.items);
+
+        if !page.page_info.has_next_page {
+            break;
+        }
+        after = page.page_info.end_cursor;
+        if after.is_none() {
+            break;
+        }
+    }
+
+    Ok(all_items)
+}

--- a/dango/sdk/src/client.rs
+++ b/dango/sdk/src/client.rs
@@ -383,7 +383,9 @@ impl SearchTxClient for HttpClient {
     }
 }
 
-async fn error_for_status(response: reqwest::Response) -> anyhow::Result<reqwest::Response> {
+pub(crate) async fn error_for_status(
+    response: reqwest::Response,
+) -> anyhow::Result<reqwest::Response> {
     if let Err(e) = response.error_for_status_ref() {
         bail!("{}: {}", e, response.text().await?)
     } else {

--- a/dango/sdk/src/lib.rs
+++ b/dango/sdk/src/lib.rs
@@ -1,3 +1,7 @@
+// A named module, not flattened into the root: its wire types re-exported from
+// `dango_archive_types` (e.g. `PageInfo`) would collide with the GraphQL types
+// glob below.
+pub mod archive;
 mod client;
 mod keystore;
 mod secret;
@@ -6,6 +10,6 @@ mod subscription;
 mod ws;
 
 pub use {
-    client::*, dango_indexer_graphql_types::*, keystore::*, secret::*, signer::*, subscription::*,
-    ws::*,
+    archive::ArchiveClient, client::*, dango_indexer_graphql_types::*, keystore::*, secret::*,
+    signer::*, subscription::*, ws::*,
 };


### PR DESCRIPTION
## Summary

Adds `ArchiveClient` to `dango-sdk` — the Archive API counterpart of the Live API's `HttpClient` — so bots (first consumer: the monitor bot's event-driven checks) can read structured history through a typed Rust client instead of the deprecated GraphQL surface.

- **Commit 1** moves the activity wire types (`Page`/`PageInfo`, `Event`, `Transaction`, `AddressRole`, `UnitKind`, `EventType`) from the httpd/projection into the shared `dango-archive-types` crate with `Deserialize` added, so server and client share the exact same structs and the wire format cannot drift. utoipa derives are feature-gated (`utoipa`), enabled only by the serving crates; the httpd re-exports `Page`/`PageInfo` so downstream imports are unchanged. No behavior change.
- **Commit 2** adds the client: one method per REST route (`/up`, `/blocks/{height}`, `/blocks/latest`, `/transactions/{hash}`, `/transactions/involving/{address}`, `/events`, `/events/contract`, `/events/perps`), 404 → `None` on the block reads, `paginate_*` conveniences that walk a keyset-paginated feed to exhaustion, and a `BlockClient` impl. Exposed as `dango_sdk::archive` (the crate root's GraphQL `PageInfo` glob would collide).

## Validation

### Completed

- [x] New serde round-trip unit tests in `dango-archive-types` pin the snake_case spellings and stored codes
- [x] New e2e test (`dango/archive/testing/tests/archive_client.rs`) drives every client method against the real stack: exact fixture counts, `first: 1` cursor walks reassembling full feeds, `/events/perps` answering identically to `/events/contract`, 404 semantics, and the `/events` required-filter 400
- [x] Full archive e2e suite (`backfill`, `e2e`, `db`, `live_ws`) green against a local Postgres 17
- [x] `just lint` (clippy `-D warnings`) and `just fmt` clean

### Remaining

- [ ] CI green on this PR

## Manual QA

None — all validation is automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjCp5dPhF97GEaRPLM1LF7