### PR TITLE
feat(deploy): add playbook and recipes for the monitor bot

### DIFF
--- a/deploy/group_vars/all/vault.sops.json
+++ b/deploy/group_vars/all/vault.sops.json
@@ -18,6 +18,7 @@
 	"tailscale_authkey": "ENC[AES256_GCM,data:B1oVe75/xsMBWD3tlAJcTGIOUrFdlQrrQNzua/TTwWvNb+zGTyTydn+nuyfFAbrvX8poNIXy0hy2k6u5Kg==,iv:4Iv2f/0HFNeycP6MHOX9Kq4hhhfQNfS8BsLPz/Q5dVk=,tag:hMr6RkqV0CL+mspn5t8Jtw==,type:str]",
 	"status_discord_webhook": "ENC[AES256_GCM,data:SdQLB8/m711oGTP3rliSmbnqTl2jdehbYZqk91joK4OldI7ppvvJGTXSrbC1GbAsRJS6L2JdFiS6mGNjqsPmvVFmgIH0mvYz9Vvq3uNbQ/3rpkh+YuqqcjTXG9ztL1gcuZjFXBlgNnfpXuDj+yJO8Wo2QgI0Y9lT1w==,iv:G6qTHUNpLCIeaTYZm5aGFLZLGQlu0EMoEG3GNkeAUGg=,tag:+BoAHxeuT+RgND6DIC26fQ==,type:str]",
 	"logs_discord_webhook": "ENC[AES256_GCM,data:gz/YfW383Q/RyAtyOojeOkmJtY2jfE/e7mfJgRMEH7skCmBgm8db8pxpDdHpr2UWixgi9OlDoyyygjAkufo54u5CE5k10dgjBu09b9x4jxG6AcVN/FoKU0HjEpPp/yWUkSWXrsU7S2WztXSJthjD+FUAqXhb6wkRsw==,iv:ss+OA7pYXQ4TKfS3ucHmn/+NUp5F9SzJxmgvKOv+8nQ=,tag:lsJn9SdDBiTuRxi396zL/Q==,type:str]",
+	"monitor_bot_discord_webhook": "ENC[AES256_GCM,data:Eo3gOakcF+k9+x7v1o1AV2oQraNnXqZ3qb26KSR865elPy1MpHMtM7aioBAXkK8XSdnmo7hWZetwSuXoyy9hVMFq30QQfJFaqXi+ojPx565GLoQbQB9sqocUhnCZNUY9DgzbUUewpd2JdGSpq7JY9tzLYp6T7a1u2Q==,iv:FpG0NLB5s+k1RGubQMbHgEKXDinUTgi2Wrk1zivmpNI=,tag:DjySVd4GubP2fzdNMZy3/g==,type:str]",
 	"gf_rendering_renderer_token": "ENC[AES256_GCM,data:kA44OS2CB2nODmkL/eQviw==,iv:CTWbtpfCDiKW/9gX1xe9zfSVSLclclvsdaZqKOWs9gY=,tag:JiI6rQG1/ltGoxKUaptyQA==,type:str]",
 	"cloudflare_api_token": "ENC[AES256_GCM,data:059jS/OHvDgZnQr01t+2YEGoypO6c+ULL+03yWmpLsSlTrHKYsgmQmNWuqSNiuLFdIV4Obk=,iv:+LlrYGkb3b1DOvTn3/kbj/V44+Udb7UshHYEqmcUTBE=,tag:/7PEbG2QI2EQXLsvd+qf3A==,type:str]",
 	"cloudflare_account_id": "ENC[AES256_GCM,data:eGfs3FDDXocH9JTWI+lrIBpbTbXuVMVg1fMAPrqg+a4=,iv:aqdyR3wzkg+yn3NYVeTKwOT582z/tviHP/V0EMJXjL4=,tag:6lz+eRClGMa+uxviamo73Q==,type:str]",
@@ -121,8 +122,8 @@
 				"recipient": "age10xqeelr09uk292rrp48jw5fem7uepuf82ax6mpq6rjuv6m3aw9mqgjnfyh"
 			}
 		],
-		"lastmodified": "2026-07-16T15:09:00Z",
-		"mac": "ENC[AES256_GCM,data:FWFZG/6MKgAUt5qoAISj6DMSlYUbRbO7gB9CinUKNUP5+KyMsvhlsSliPOZ0BlbkIBt99XMHzHHy3YmDpdrDMgNBjWw8pFcQptzevxlGZH6z4Z8BRi0cFOOJoI4djVNq8TLFANvrMYM3L33P8bchxRQBaOeiLL7shg7+Ae4p8fg=,iv:Xr7AGHPqlbZD4WMLqd97jAsx3JVFgx9xh5lDQbACDo4=,tag:NOTRntf5mmYNc7IiD4xjuQ==,type:str]",
+		"lastmodified": "2026-07-19T14:18:45Z",
+		"mac": "ENC[AES256_GCM,data:f783/y6UTX4BwUUjNjspRnHQ5OoO9TtnS1zGDS91z6U+UcKWKjmnmF35kEko6bobHGJiedLEnq0Z5lfpaFfTldK8tvJUdFM8ymyDaUhJnJQ+xVk5krkOBKD9YaFE+OYw12SjmjxKH6nLe1ZQOlXGPq0mJEBQ3jhGlc0Uy83ANkE=,iv:1FsRWk/Rt9VRlCNF6N6uJDYpQulN8fpLhpm+gz9WbUM=,tag:gAIFAVSrnN/AzoB8d2FeMg==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.13.2"
 	}

--- a/deploy/inventory
+++ b/deploy/inventory
@@ -205,6 +205,21 @@ perp-liquidator-mainnet
 withdrawal-approver-testnet
 withdrawal-approver-mainnet
 
+# The monitor bot runs on ovh3 (the monitoring host), deliberately separated
+# from the nodes it watches. Only mainnet is deployed for now; the testnet
+# group is pre-declared so a future rollout is a single
+# `just deploy-monitor-bot testnet`. No devnet group on purpose: devnet has no
+# archive instance, which the bot's fill_price check requires.
+[monitor-bot-testnet]
+100.122.37.57  # ovh3
+
+[monitor-bot-mainnet]
+100.122.37.57  # ovh3
+
+[monitor-bot:children]
+monitor-bot-testnet
+monitor-bot-mainnet
+
 [hyperlane]
 100.72.62.100  # hetzner5
 100.126.8.2    # hetzner1

--- a/deploy/justfile
+++ b/deploy/justfile
@@ -400,6 +400,27 @@ deploy-withdrawal-approver network tag:
       --limit withdrawal-approver-{{network}} \
       2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-withdrawal-approver.log"
 
+# ------------------------------- Monitor Bot ----------------------------------
+
+# Deploy the monitor bot for a network. All instances run on ovh3 (the
+# monitoring host), separated from the nodes they watch. The Discord webhook
+# it alerts through comes from `monitor_bot_discord_webhook` in the vault.
+# Usage: just deploy-monitor-bot mainnet
+#        just deploy-monitor-bot mainnet v0.28.0
+deploy-monitor-bot network tag="latest":
+  mkdir -p "{{justfile_directory()}}/logs" \
+    && uv run ansible-playbook monitor-bot.yml \
+      -e '{"monitor_bot_networks": ["{{network}}"], "monitor_bot_tag": "{{tag}}"}' \
+      --limit monitor-bot-{{network}} \
+      2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-deploy-monitor-bot.log"
+
+stop-monitor-bot network:
+  mkdir -p "{{justfile_directory()}}/logs" \
+    && uv run ansible-playbook stop-monitor-bot.yml \
+      -e '{"monitor_bot_networks": ["{{network}}"]}' \
+      --limit monitor-bot-{{network}} \
+      2>&1 | tee "{{justfile_directory()}}/logs/$(date -u +%Y%m%d%H%M%S)-stop-monitor-bot.log"
+
 # ---------------------------------- Testnet -----------------------------------
 
 deploy-testnet dango_image_tag bots_image_tag:

--- a/deploy/monitor-bot.yml
+++ b/deploy/monitor-bot.yml
@@ -1,0 +1,17 @@
+---
+- hosts: monitor-bot
+  become: true
+  become_user: "{{ deploy_user }}"
+  remote_user: deploy
+  collections:
+    - community.docker
+  pre_tasks:
+    - name: Get deploy user info
+      getent:
+        database: passwd
+        key: "{{ deploy_user }}"
+    - name: Set deploy_home fact
+      set_fact:
+        deploy_home: "{{ ansible_facts.getent_passwd[deploy_user][4] }}"
+  roles:
+    - monitor-bot

--- a/deploy/roles/monitor-bot/defaults/main.yml
+++ b/deploy/roles/monitor-bot/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+monitor_bot_dir: "{{ deploy_home }}/monitor-bot"
+monitor_bot_image: "ghcr.io/left-curve/bots/monitor"
+monitor_bot_tag: "latest"
+monitor_bot_networks: []
+# Host ports for the bot's HTTP /health, /status, /metrics server, bound to
+# the wireguard IP (Prometheus on ovh3 resolves scrape hostnames to wireguard
+# IPs) and the tailscale IP (laptop debugging). Follows the bot port blocks
+# 9300s (points-bot), 9310 (perp-liquidator), 9320 (batch-block-backup).
+monitor_bot_http_ports:
+  devnet: 9330
+  testnet: 9331
+  mainnet: 9332
+# Optional "hostname:ip" entries rendered into the container's extra_hosts —
+# the archive role's trick of resolving an api-*.dango.zone hostname to a
+# node's wireguard IP so traffic hits that node's traefik directly, bypassing
+# Cloudflare. Off by default on purpose: the monitor should watch the same
+# public path users take, so that Cloudflare/load-balancer outages are
+# detected too. Only set this if Cloudflare's bot management starts blocking
+# the bot's requests and a WAF exception is not an option.
+monitor_bot_host_overrides: []

--- a/deploy/roles/monitor-bot/tasks/deploy-instance.yml
+++ b/deploy/roles/monitor-bot/tasks/deploy-instance.yml
@@ -1,0 +1,50 @@
+---
+- name: "{{ network }} - Create directories"
+  file:
+    path: "{{ monitor_bot_dir }}/{{ network }}/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - ""
+    - "data"
+
+- name: "{{ network }} - Template config.json"
+  template:
+    src: config.json.j2
+    dest: "{{ monitor_bot_dir }}/{{ network }}/config.json"
+    mode: "0644"
+
+# diff/no_log off: the rendered content is the Discord webhook URL, which is
+# a post-to-channel credential.
+- name: "{{ network }} - Template .env"
+  template:
+    src: env.j2
+    dest: "{{ monitor_bot_dir }}/{{ network }}/.env"
+    mode: "0600"
+  diff: false
+  no_log: true
+
+- name: "{{ network }} - Template docker-compose.yml"
+  template:
+    src: docker-compose.yml.j2
+    dest: "{{ monitor_bot_dir }}/{{ network }}/docker-compose.yml"
+    mode: "0644"
+
+- name: "{{ network }} - Login to GHCR"
+  community.docker.docker_login:
+    registry: ghcr.io
+    username: "{{ ghcr_user }}"
+    password: "{{ ghcr_token }}"
+  no_log: true
+
+- name: "{{ network }} - Launch stack"
+  community.docker.docker_compose_v2:
+    project_src: "{{ monitor_bot_dir }}/{{ network }}"
+    pull: always
+    state: present
+    recreate: always
+
+- name: "{{ network }} - Logout from GHCR"
+  community.docker.docker_login:
+    registry: ghcr.io
+    state: absent

--- a/deploy/roles/monitor-bot/tasks/main.yml
+++ b/deploy/roles/monitor-bot/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Deploy monitor-bot instances
+  include_tasks: deploy-instance.yml
+  loop: "{{ monitor_bot_networks }}"
+  loop_control:
+    loop_var: network

--- a/deploy/roles/monitor-bot/tasks/stop-instance.yml
+++ b/deploy/roles/monitor-bot/tasks/stop-instance.yml
@@ -1,0 +1,6 @@
+---
+- name: "{{ network }} - Stop stack"
+  community.docker.docker_compose_v2:
+    project_src: "{{ monitor_bot_dir }}/{{ network }}"
+    state: stopped
+    pull: never

--- a/deploy/roles/monitor-bot/templates/config.json.j2
+++ b/deploy/roles/monitor-bot/templates/config.json.j2
@@ -1,0 +1,5 @@
+{
+  "live_url": "https://api-{{ network }}.dango.zone",
+  "archive_url": "https://api-archive-{{ network }}.dango.zone",
+  "name": "{{ network }}"
+}

--- a/deploy/roles/monitor-bot/templates/docker-compose.yml.j2
+++ b/deploy/roles/monitor-bot/templates/docker-compose.yml.j2
@@ -1,0 +1,40 @@
+# Explicit project name so this stack doesn't collide with other bots that
+# share a "<bot>/{{ network }}" directory layout (Compose otherwise derives the
+# project name from the parent dir, "{{ network }}", and treats their
+# containers as orphans of each other).
+name: monitor-bot-{{ network }}
+
+services:
+  monitor:
+    image: {{ monitor_bot_image }}:{{ monitor_bot_tag }}
+    pull_policy: always
+    container_name: monitor-bot-{{ network }}
+    restart: always
+    # Docker labels promtail turns into Loki labels (docker_sd relabeling) —
+    # same keys the full-app stack uses.
+    labels:
+      service_name: "monitor_bot"
+      dango_network: "{{ network }}"
+      environment: "production"
+    env_file:
+      - .env
+{% if monitor_bot_host_overrides | length > 0 %}
+    # Resolve API hostnames to internal IPs (see monitor_bot_host_overrides in
+    # the role defaults for why this is off by default).
+    extra_hosts:
+{% for entry in monitor_bot_host_overrides %}
+      - "{{ entry }}"
+{% endfor %}
+{% endif %}
+    volumes:
+      - ./config.json:/root/.dango-monitor/config.json
+      # The bot's persistent store (RocksDB), holding the checks' scan
+      # checkpoints — must survive container recreates so e.g. the fill_price
+      # check resumes where it left off instead of re-deriving a start height.
+      - ./data:/root/.dango-monitor/data
+    ports:
+      # Health/status/metrics on the wireguard IP for the Prometheus scrape
+      # (ovh3 resolves hosts to wireguard IPs) and on the tailscale IP for
+      # laptop debugging — same dual binding as the archive role.
+      - "{{ wireguard_ip }}:{{ monitor_bot_http_ports[network] }}:8080"
+      - "{{ tailscale_ip }}:{{ monitor_bot_http_ports[network] }}:8080"

--- a/deploy/roles/monitor-bot/templates/env.j2
+++ b/deploy/roles/monitor-bot/templates/env.j2
@@ -1,0 +1,7 @@
+# Managed by Ansible (roles/monitor-bot) — do not edit by hand.
+
+# The Discord incoming webhook the alerts are posted to, from
+# `monitor_bot_discord_webhook` in group_vars/all/vault.sops.json. The bot
+# layers environment variables over config.json (separator `__`), so the
+# webhook stays out of the world-readable config.json.
+DISCORD_WEBHOOK_URL={{ monitor_bot_discord_webhook }}

--- a/deploy/roles/prometheus/files/alert-rules.yml
+++ b/deploy/roles/prometheus/files/alert-rules.yml
@@ -68,6 +68,18 @@ groups:
       summary: "High error rate detected"
       description: "Error rate is above 10% for more than 5 minutes."
 
+  # The monitor bot watches the exchange's invariants; this rule watches the
+  # monitor bot, so its own death is alerted through alertmanager -> Discord
+  # rather than only through its heartbeat going silent.
+  - alert: MonitorBotDown
+    expr: up{job="monitor-bot"} == 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Monitor bot is down ({{ $labels.dango_network }})"
+      description: "Prometheus has not been able to scrape the monitor bot on {{ $labels.instance }} for more than 5 minutes. Its exchange checks and Discord alerts are not running."
+
 - name: cloudflare-alerts
   rules:
   - alert: CloudflaredDown

--- a/deploy/roles/prometheus/templates/prometheus.yml
+++ b/deploy/roles/prometheus/templates/prometheus.yml
@@ -360,10 +360,12 @@ scrape_configs:
           dango_network: 'system'
 # Archive hosts (from the [archive] group): their host-level postgres holds
 # the projection tables, so it is labeled with the host's real network — the
-# archive dashboard filters pg_database_size by dango_network.
+# archive dashboard filters pg_database_size by dango_network. The network is
+# derived from archive_instances (like the 'archive' job below): since #2222
+# these hosts run no dango node and their dango_networks is empty.
 {% for host in groups['archive'] | default([]) %}
 {%   set hn = hostvars[host].hostname | default(host) %}
-{%   set net = (hostvars[host].dango_networks | default(['system'])) | first %}
+{%   set net = hostvars[host].archive_instances | default([]) | map(attribute='name') | first | default('system') %}
       - targets: ['{{ hn }}:9187']
         labels:
           service: 'postgres'

--- a/deploy/roles/prometheus/templates/prometheus.yml
+++ b/deploy/roles/prometheus/templates/prometheus.yml
@@ -502,6 +502,17 @@ scrape_configs:
           network: 'mainnet'
           dango_network: 'mainnet'
 
+  # The monitor bot runs on ovh3 itself (see [monitor-bot] in the inventory);
+  # the target still goes through the wireguard hostname like every other one.
+  - job_name: 'monitor-bot'
+    static_configs:
+      - targets: ['ovh3:9332']
+        labels:
+          service: 'monitor-bot'
+          environment: 'production'
+          network: 'mainnet'
+          dango_network: 'mainnet'
+
   - job_name: 'points-bot'
     static_configs:
       - targets: ['ovh2:9300']

--- a/deploy/stop-monitor-bot.yml
+++ b/deploy/stop-monitor-bot.yml
@@ -1,0 +1,23 @@
+---
+- hosts: monitor-bot
+  become: true
+  become_user: "{{ deploy_user }}"
+  remote_user: deploy
+  collections:
+    - community.docker
+  pre_tasks:
+    - name: Get deploy user info
+      getent:
+        database: passwd
+        key: "{{ deploy_user }}"
+    - name: Set deploy_home fact
+      set_fact:
+        deploy_home: "{{ ansible_facts.getent_passwd[deploy_user][4] }}"
+  tasks:
+    - name: Stop monitor-bot instances
+      include_role:
+        name: monitor-bot
+        tasks_from: stop-instance
+      loop: "{{ monitor_bot_networks }}"
+      loop_control:
+        loop_var: network


### PR DESCRIPTION
## Summary

Deploy the bots repo's new `monitor` bot (left-curve/bots#150) as a standalone per-network compose stack on ovh3, the monitoring host — deliberately separated from the nodes and archive it watches, and reaching the APIs through the same Cloudflare-fronted path users take.

- New `roles/monitor-bot` following the points-bot shape (per-network instance dirs, templated `config.json` + `docker-compose.yml`), with batch-block-backup-style secret handling: the Discord webhook is rendered into a 0600 `.env` (`no_log`) and layered over the config by the bot's env-override parser, so it stays out of the world-readable `config.json`.
- The compose template mounts `./data:/root/.dango-monitor/data` — the bot's RocksDB scan checkpoints survive container recreates (the dev compose in the bots repo lacks this volume). HTTP `/health`/`/status`/`/metrics` is published on the wireguard IP (for the local Prometheus scrape) + tailscale IP (for laptop debugging), ports 9330–9332 following the existing bot port blocks.
- `monitor-bot.yml` / `stop-monitor-bot.yml` playbooks and `deploy-monitor-bot` / `stop-monitor-bot` just recipes.
- Inventory groups `[monitor-bot-mainnet]` / `[monitor-bot-testnet]` (both ovh3). Only mainnet is deployed initially; the testnet group is pre-declared for a one-command rollout later. No devnet group: devnet has no archive instance, which the fill_price check requires.
- Prometheus: a `monitor-bot` scrape job and a `MonitorBotDown` critical alert (`up == 0` for 5m), so the watcher's own death is reported through alertmanager → Discord rather than only through its heartbeat going silent.
- Vault: new `monitor_bot_discord_webhook` secret in `group_vars/all/vault.sops.json` (same home as the existing `status_discord_webhook` / `logs_discord_webhook`).
- An off-by-default `monitor_bot_host_overrides` var can pin API hostnames to a node's wireguard IP (the archive role's Cloudflare-bypass trick), kept as a documented fallback should Cloudflare's bot management ever block the bot.

## Validation

### Completed

- [x] yamllint clean on all new/modified files (`just lint` as a whole fails identically on untouched `main` — pre-existing Jinja-in-`.yml` template errors in other roles)
- [x] `ansible-playbook --syntax-check` passes for both playbooks (run against a sandbox inventory, since the sops vars plugin requires a YubiKey to load `group_vars/all`)
- [x] All three templates rendered with test variables and parse-verified (JSON/YAML), including both `extra_hosts` modes and the exact port bindings

### Remaining

- [ ] `just deploy-monitor-bot mainnet` — container healthy, `/status` on `100.122.37.57:9332` shows all three checks passing
- [ ] Startup + heartbeat messages arrive in the new Discord channel
- [ ] `just deploy-monitoring` — new scrape target `up` in Prometheus, `MonitorBotDown` rule loaded
- [ ] Watch for Cloudflare 403s on the checks (fallback ladder: WAF skip-rule for ovh3's egress IP → `monitor_bot_host_overrides`)

## Manual QA

1. `just add-deploy-key`, then `just deploy-monitor-bot mainnet`.
2. `curl http://100.122.37.57:9332/health` and `/status` over tailscale; confirm the latest block is advancing and no check is erroring.
3. Confirm the startup message and a heartbeat in the Discord channel; `just stop-monitor-bot mainnet` and confirm silence + redeploy resumes from the checkpoint.
4. `just deploy-monitoring`, then check `http://100.122.37.57:9090/targets` shows `monitor-bot` up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8VAVszeZSUAK6rVrs9tDC