### PR TITLE
feat(explorer): show involved address transactions

### DIFF
--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -269,6 +269,11 @@
       "events": "Events",
       "txHash": "Tx hash",
       "sender": "Sender",
+      "role": "Role",
+      "roles": {
+        "sender": "Sender",
+        "participant": "Participant"
+      },
       "time": "Time",
       "block": "Block",
       "index": "Index",

--- a/ui/portal/app/src/components/explorer/ExplorerCommon.tsx
+++ b/ui/portal/app/src/components/explorer/ExplorerCommon.tsx
@@ -1,7 +1,7 @@
 import { m } from "@left-curve/foundation/paraglide/messages.js";
 import { formatUnits } from "@left-curve/utils";
 import { useApp } from "@left-curve/foundation";
-import { useConfig, usePrices } from "@left-curve/store";
+import { getExplorerTransactionKey, useConfig, usePrices } from "@left-curve/store";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, View } from "react-native";
 import { AddressVisualizer } from "~/components/foundation/AddressVisualizer";
@@ -15,7 +15,18 @@ import {
 } from "~/components/foundation";
 
 import type { Address, Coins, IndexedTransaction } from "@left-curve/types";
+import type { ExplorerTransactionRole } from "@left-curve/store";
 import type React from "react";
+
+type ExplorerTransactionRow = IndexedTransaction & {
+  involvement?: ExplorerTransactionRole[];
+};
+
+function getRoleLabel(role: ExplorerTransactionRole): string {
+  return role === "sender"
+    ? m["explorer.txs.roles.sender"]()
+    : m["explorer.txs.roles.participant"]();
+}
 
 export const ExplorerScreen: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
@@ -150,7 +161,7 @@ export const ExplorerAssetsList: React.FC<{ balances: Coins }> = ({ balances }) 
 };
 
 type TransactionsListProps = {
-  transactions: IndexedTransaction[];
+  transactions: ExplorerTransactionRow[];
   onOpenTx: (hash: string) => void;
   onOpenBlock: (height: number) => void;
   onOpenAddress: (url: string) => void;
@@ -175,14 +186,21 @@ export const ExplorerTransactionsList: React.FC<TransactionsListProps> = ({
   return (
     <ExplorerSectionCard title={m["explorer.txs.title"]()}>
       {transactions.map((tx) => (
-        <View key={tx.hash} className="rounded-md border border-outline-secondary-gray p-3 gap-2">
+        <View
+          key={getExplorerTransactionKey(tx)}
+          className="rounded-md border border-outline-secondary-gray p-3 gap-2"
+        >
           <ExplorerKeyValueRow label="Hash">
-            <Pressable className="flex-row items-center gap-1" onPress={() => onOpenTx(tx.hash)}>
-              <GlobalText className="diatype-sm-bold text-ink-secondary-blue">
-                {tx.hash.slice(0, 18)}...
-              </GlobalText>
-              <IconLink className="w-4 h-4 text-ink-secondary-blue" />
-            </Pressable>
+            {tx.hash ? (
+              <Pressable className="flex-row items-center gap-1" onPress={() => onOpenTx(tx.hash)}>
+                <GlobalText className="diatype-sm-bold text-ink-secondary-blue">
+                  {tx.hash.slice(0, 18)}...
+                </GlobalText>
+                <IconLink className="w-4 h-4 text-ink-secondary-blue" />
+              </Pressable>
+            ) : (
+              <GlobalText>—</GlobalText>
+            )}
           </ExplorerKeyValueRow>
 
           <ExplorerKeyValueRow label={m["explorer.txs.block"]()}>
@@ -198,13 +216,29 @@ export const ExplorerTransactionsList: React.FC<TransactionsListProps> = ({
           </ExplorerKeyValueRow>
 
           <ExplorerKeyValueRow label={m["explorer.txs.sender"]()}>
-            <AddressVisualizer
-              withIcon
-              address={tx.sender as Address}
-              classNames={{ text: "diatype-sm-bold" }}
-              onClick={onOpenAddress}
-            />
+            {tx.sender ? (
+              <AddressVisualizer
+                withIcon
+                address={tx.sender as Address}
+                classNames={{ text: "diatype-sm-bold" }}
+                onClick={onOpenAddress}
+              />
+            ) : (
+              <GlobalText>—</GlobalText>
+            )}
           </ExplorerKeyValueRow>
+
+          {tx.involvement ? (
+            <ExplorerKeyValueRow label={m["explorer.txs.role"]()} valueClassName="flex-row gap-1">
+              {tx.involvement.map((role) => (
+                <Badge
+                  key={role}
+                  color={role === "sender" ? "blue" : "rice"}
+                  text={getRoleLabel(role)}
+                />
+              ))}
+            </ExplorerKeyValueRow>
+          ) : null}
 
           <ExplorerKeyValueRow label={m["explorer.txs.result"]({ result: "" })}>
             <Badge

--- a/ui/portal/app/src/components/foundation/Badge.tsx
+++ b/ui/portal/app/src/components/foundation/Badge.tsx
@@ -42,6 +42,10 @@ const badgeVariants = tv(
           base: "bg-surface-tertiary-green border-surface-primary-green",
           text: "text-fg-primary-green",
         },
+        rice: {
+          base: "bg-surface-quaternary-rice border-outline-secondary-rice",
+          text: "text-fg-primary-rice",
+        },
       },
       size: {
         s: {

--- a/ui/portal/app/src/screens/(app)/account/[address].tsx
+++ b/ui/portal/app/src/screens/(app)/account/[address].tsx
@@ -1,11 +1,7 @@
 import { m } from "@left-curve/foundation/paraglide/messages.js";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useApp } from "@left-curve/foundation";
-import {
-  useExplorerAccount,
-  useExplorerTransactionsBySender,
-  usePrices,
-} from "@left-curve/store";
+import { useExplorerAccount, useExplorerTransactionsByAddress, usePrices } from "@left-curve/store";
 
 import { AddressVisualizer } from "~/components/foundation/AddressVisualizer";
 import { Badge, GlobalText, MobileTitle, Skeleton } from "~/components/foundation";
@@ -26,10 +22,11 @@ export default function AccountExplorerScreen() {
   const { settings } = useApp();
   const { calculateBalance } = usePrices();
 
-  const { data: txData, pagination, isLoading: txsLoading } = useExplorerTransactionsBySender(
-    account?.address as `0x${string}`,
-    !!account,
-  );
+  const {
+    data: txData,
+    pagination,
+    isLoading: txsLoading,
+  } = useExplorerTransactionsByAddress(account?.address as `0x${string}`, !!account);
 
   const totalCoins = account ? Object.values(account.balances).length : 0;
   const totalBalance = account
@@ -56,7 +53,8 @@ export default function AccountExplorerScreen() {
           title={m["explorer.accounts.notFound.title"]()}
           description={
             <>
-              {m["explorer.accounts.notFound.pre"]()} <GlobalText className="underline">{address}</GlobalText>{" "}
+              {m["explorer.accounts.notFound.pre"]()}{" "}
+              <GlobalText className="underline">{address}</GlobalText>{" "}
               {m["explorer.accounts.notFound.description"]()}
             </>
           }

--- a/ui/portal/app/src/screens/(app)/contract/[address].tsx
+++ b/ui/portal/app/src/screens/(app)/contract/[address].tsx
@@ -3,7 +3,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useApp } from "@left-curve/foundation";
 import {
   useExplorerContract,
-  useExplorerTransactionsBySender,
+  useExplorerTransactionsByAddress,
   usePrices,
 } from "@left-curve/store";
 
@@ -26,10 +26,11 @@ export default function ContractExplorerScreen() {
   const { settings } = useApp();
   const { calculateBalance } = usePrices();
 
-  const { data: txData, pagination, isLoading: txsLoading } = useExplorerTransactionsBySender(
-    address as `0x${string}`,
-    !!contract,
-  );
+  const {
+    data: txData,
+    pagination,
+    isLoading: txsLoading,
+  } = useExplorerTransactionsByAddress(address as `0x${string}`, !!contract);
 
   const totalCoins = contract ? Object.values(contract.balances).length : 0;
   const totalBalance = contract
@@ -56,7 +57,8 @@ export default function ContractExplorerScreen() {
           title={m["explorer.contracts.notFound.title"]()}
           description={
             <>
-              {m["explorer.contracts.notFound.pre"]()} <GlobalText className="underline">{address}</GlobalText>{" "}
+              {m["explorer.contracts.notFound.pre"]()}{" "}
+              <GlobalText className="underline">{address}</GlobalText>{" "}
               {m["explorer.contracts.notFound.description"]()}
             </>
           }

--- a/ui/portal/web/src/components/explorer/AccountExplorer.tsx
+++ b/ui/portal/web/src/components/explorer/AccountExplorer.tsx
@@ -2,7 +2,7 @@ import { AddressVisualizer, useApp } from "@left-curve/applets-kit";
 import {
   type ExplorerAccount,
   useExplorerAccount,
-  useExplorerTransactionsBySender,
+  useExplorerTransactionsByAddress,
   usePrices,
 } from "@left-curve/store";
 import type { UseQueryResult } from "@tanstack/react-query";
@@ -144,7 +144,7 @@ const Assets: React.FC = () => {
 const Transactions: React.FC = () => {
   const { isLoading, data: account } = useAccountExplorer();
 
-  const { data, pagination, ...transactions } = useExplorerTransactionsBySender(
+  const { data, pagination, ...transactions } = useExplorerTransactionsByAddress(
     account?.address as Address,
     !!account,
   );

--- a/ui/portal/web/src/components/explorer/ContractExplorer.tsx
+++ b/ui/portal/web/src/components/explorer/ContractExplorer.tsx
@@ -1,6 +1,6 @@
 import {
   useExplorerContract,
-  useExplorerTransactionsBySender,
+  useExplorerTransactionsByAddress,
   usePrices,
 } from "@left-curve/store";
 import { createContext, useContext } from "react";
@@ -129,7 +129,7 @@ const Assets: React.FC = () => {
 
 const Transactions: React.FC = () => {
   const { isLoading, data: contract, address } = useContractExplorer();
-  const { data, pagination, ...transactions } = useExplorerTransactionsBySender(
+  const { data, pagination, ...transactions } = useExplorerTransactionsByAddress(
     address,
     !!contract,
   );

--- a/ui/portal/web/src/components/explorer/TransactionsTable.tsx
+++ b/ui/portal/web/src/components/explorer/TransactionsTable.tsx
@@ -1,14 +1,25 @@
 import { useNavigate } from "@tanstack/react-router";
 
 import { m } from "@left-curve/foundation/paraglide/messages.js";
+import { getExplorerTransactionKey, type ExplorerTransactionRole } from "@left-curve/store";
 
-import { Cell, CursorPagination, Table } from "@left-curve/applets-kit";
+import { Badge, Cell, CursorPagination, Table } from "@left-curve/applets-kit";
 
 import type { TableClassNames, TableColumn } from "@left-curve/applets-kit";
 import type { IndexedTransaction } from "@left-curve/types";
 
+type TransactionRow = IndexedTransaction & {
+  involvement?: ExplorerTransactionRole[];
+};
+
+function getRoleLabel(role: ExplorerTransactionRole): string {
+  return role === "sender"
+    ? m["explorer.txs.roles.sender"]()
+    : m["explorer.txs.roles.participant"]();
+}
+
 type TransactionsTableProps = {
-  transactions?: IndexedTransaction[];
+  transactions?: TransactionRow[];
   pagination?: {
     isLoading: boolean;
     goNext: () => void;
@@ -25,17 +36,23 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
   classNames,
 }) => {
   const navigate = useNavigate();
+  const showRole = transactions?.some((transaction) => transaction.involvement !== undefined);
 
-  const columns: TableColumn<IndexedTransaction> = [
+  const columns: TableColumn<TransactionRow> = [
     {
       header: "Hash",
-      cell: ({ row }) => (
-        <Cell.TxHash
-          hash={row.original.hash}
-          href={`/tx/${row.original.hash}`}
-          navigate={() => navigate({ to: `/tx/${row.original.hash}` })}
-        />
-      ),
+      cell: ({ row }) => {
+        const { hash } = row.original;
+        if (!hash) return <span>—</span>;
+
+        return (
+          <Cell.TxHash
+            hash={hash}
+            href={`/tx/${hash}`}
+            navigate={() => navigate({ to: `/tx/${hash}` })}
+          />
+        );
+      },
     },
     {
       header: "Block",
@@ -53,13 +70,36 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
     },
     {
       header: "Sender",
-      cell: ({ row }) => (
-        <Cell.Sender sender={row.original.sender} navigate={(url) => navigate({ to: url })} />
-      ),
+      cell: ({ row }) => {
+        if (!row.original.sender) return <span>—</span>;
+
+        return (
+          <Cell.Sender sender={row.original.sender} navigate={(url) => navigate({ to: url })} />
+        );
+      },
     },
+    ...(showRole
+      ? ([
+          {
+            header: m["explorer.txs.role"](),
+            cell: ({ row }) => (
+              <div className="flex items-center gap-1">
+                {row.original.involvement?.map((role) => (
+                  <Badge
+                    key={role}
+                    color={role === "sender" ? "blue" : "rice"}
+                    text={getRoleLabel(role)}
+                  />
+                ))}
+              </div>
+            ),
+          },
+        ] satisfies TableColumn<TransactionRow>)
+      : []),
     {
       header: "Actions",
-      cell: ({ row }) => <Cell.TxMessages messages={row.original.messages} />,
+      cell: ({ row }) =>
+        row.original.messages.length ? <Cell.TxMessages messages={row.original.messages} /> : "—",
     },
     {
       header: "Result",
@@ -84,6 +124,7 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
     <Table
       data={transactions}
       columns={columns}
+      getRowId={getExplorerTransactionKey}
       classNames={classNames}
       bottomContent={
         pagination ? (

--- a/ui/portal/web/src/components/explorer/UserExplorer.tsx
+++ b/ui/portal/web/src/components/explorer/UserExplorer.tsx
@@ -5,6 +5,7 @@ import {
   useExplorerUser,
   useExplorerUserTransactions,
   type AccountWithDetails,
+  type ExplorerTransaction,
   type ExplorerUserData,
 } from "@left-curve/store";
 import { useNavigate } from "@tanstack/react-router";
@@ -14,7 +15,7 @@ import { AssetsTable } from "./AssetsTable";
 import { HeaderExplorer } from "./HeaderExplorer";
 import { TransactionsTable } from "./TransactionsTable";
 
-import type { Address, IndexedTransaction } from "@left-curve/types";
+import type { Address } from "@left-curve/types";
 import type React from "react";
 import type { PropsWithChildren } from "react";
 import { Image } from "~/components/foundation/Image";
@@ -22,7 +23,7 @@ import { Image } from "~/components/foundation/Image";
 type UserExplorerContextType = {
   username: string;
   userData: ExplorerUserData | null;
-  transactions: IndexedTransaction[];
+  transactions: ExplorerTransaction[];
   transactionsPagination: {
     isLoading: boolean;
     goNext: () => void;

--- a/ui/portal/web/tests/explorer-account-contract-screens.test.tsx
+++ b/ui/portal/web/tests/explorer-account-contract-screens.test.tsx
@@ -19,7 +19,7 @@ const explorerScreenMocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   useExplorerAccount: vi.fn(),
   useExplorerContract: vi.fn(),
-  useExplorerTransactionsBySender: vi.fn(),
+  useExplorerTransactionsByAddress: vi.fn(),
 }));
 
 vi.mock("@left-curve/store", () => ({
@@ -42,7 +42,7 @@ vi.mock("@left-curve/store", () => ({
   }),
   useExplorerAccount: explorerScreenMocks.useExplorerAccount,
   useExplorerContract: explorerScreenMocks.useExplorerContract,
-  useExplorerTransactionsBySender: explorerScreenMocks.useExplorerTransactionsBySender,
+  useExplorerTransactionsByAddress: explorerScreenMocks.useExplorerTransactionsByAddress,
   usePrices: () => ({
     calculateBalance: explorerScreenMocks.calculateBalance,
   }),
@@ -263,7 +263,7 @@ describe("account and contract explorer screens", () => {
       return null;
     });
     explorerScreenMocks.getContractInfo.mockResolvedValue(null);
-    explorerScreenMocks.useExplorerTransactionsBySender.mockReturnValue(transactionsResponse);
+    explorerScreenMocks.useExplorerTransactionsByAddress.mockReturnValue(transactionsResponse);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: {
@@ -314,7 +314,7 @@ describe("account and contract explorer screens", () => {
     );
 
     expect(screen.getByText("assets-table:bridge/usdc:1250000|uatom:2000000:")).toBeInTheDocument();
-    expect(explorerScreenMocks.useExplorerTransactionsBySender).toHaveBeenCalledWith(
+    expect(explorerScreenMocks.useExplorerTransactionsByAddress).toHaveBeenCalledWith(
       accountAddress,
       true,
     );
@@ -525,7 +525,7 @@ describe("account and contract explorer screens", () => {
     expect(screen.getByText("None")).toBeInTheDocument();
     expect(screen.getByText("$45.00 (2 Assets)")).toHaveClass("bg-surface-tertiary-green");
     expect(screen.getByText("assets-table:bridge/usdc:1250000|uatom:2000000:")).toBeInTheDocument();
-    expect(explorerScreenMocks.useExplorerTransactionsBySender).toHaveBeenCalledWith(
+    expect(explorerScreenMocks.useExplorerTransactionsByAddress).toHaveBeenCalledWith(
       contractAddress,
       true,
     );
@@ -533,7 +533,7 @@ describe("account and contract explorer screens", () => {
 
     cleanup();
     vi.clearAllMocks();
-    explorerScreenMocks.useExplorerTransactionsBySender.mockReturnValue(transactionsResponse);
+    explorerScreenMocks.useExplorerTransactionsByAddress.mockReturnValue(transactionsResponse);
     renderContractExplorer(<ContractExplorer.NotFound />, null);
 
     expect(screen.getByText(m["explorer.contracts.notFound.title"]())).toBeInTheDocument();
@@ -547,7 +547,7 @@ describe("account and contract explorer screens", () => {
     };
 
     explorerScreenMocks.calculateBalance.mockReturnValueOnce("$0.00");
-    explorerScreenMocks.useExplorerTransactionsBySender.mockReturnValue({
+    explorerScreenMocks.useExplorerTransactionsByAddress.mockReturnValue({
       ...transactionsResponse,
       data: {
         nodes: [],
@@ -582,7 +582,7 @@ describe("account and contract explorer screens", () => {
     });
     expect(screen.getByText("$0.00 (2 Assets)")).toHaveClass("bg-surface-tertiary-green");
     expect(screen.getByText("assets-table:bridge/usdc:0|uatom:0:")).toBeInTheDocument();
-    expect(explorerScreenMocks.useExplorerTransactionsBySender).toHaveBeenCalledWith(
+    expect(explorerScreenMocks.useExplorerTransactionsByAddress).toHaveBeenCalledWith(
       contractAddress,
       true,
     );

--- a/ui/portal/web/tests/explorer-hooks.test.tsx
+++ b/ui/portal/web/tests/explorer-hooks.test.tsx
@@ -5,6 +5,7 @@ import { useExplorerAccount } from "../../../store/src/hooks/explorer/useExplore
 import { useExplorerBlock } from "../../../store/src/hooks/explorer/useExplorerBlock";
 import { useExplorerContract } from "../../../store/src/hooks/explorer/useExplorerContract";
 import { useExplorerTransaction } from "../../../store/src/hooks/explorer/useExplorerTransaction";
+import { useExplorerTransactionsByAddress } from "../../../store/src/hooks/explorer/useExplorerTransactionsByAddress";
 import { useExplorerTransactionsBySender } from "../../../store/src/hooks/explorer/useExplorerTransactionsBySender";
 import { useExplorerUser } from "../../../store/src/hooks/explorer/useExplorerUser";
 import { useExplorerUserTransactions } from "../../../store/src/hooks/explorer/useExplorerUserTransactions";
@@ -655,6 +656,143 @@ describe("explorer hooks", () => {
     expect(fetchMock.mock.calls.some(([url]) => (url as URL).searchParams.has("before"))).toBe(
       false,
     );
+    expect(
+      fetchMock.mock.calls.every(([url]) => (url as URL).searchParams.get("role") === "sender"),
+    ).toBe(true);
+  });
+
+  it("queries archive transactions involving an address and infers sender and participant roles", async () => {
+    publicClient.chain = { id: "dango-1" };
+    const address = "0x6164647265737300000000000000000000000000";
+    const otherSender = "0x6f74686572000000000000000000000000000000";
+    const page = {
+      items: [
+        {
+          blockHeight: 12,
+          idx: 0,
+          kind: "transaction",
+          hash: "sender-transaction",
+          sender: address,
+          success: true,
+          timestamp: "2026-06-08T12:00:02Z",
+          tx: { sender: address, gas_limit: 2, msgs: [] },
+          outcome: { transaction: { gas_limit: 2, gas_used: 1, result: { ok: null }, events: [] } },
+        },
+        {
+          blockHeight: 11,
+          idx: 0,
+          kind: "transaction",
+          hash: "participant-transaction",
+          sender: otherSender,
+          success: true,
+          timestamp: "2026-06-08T12:00:01Z",
+          tx: { sender: otherSender, gas_limit: 2, msgs: [] },
+          outcome: { transaction: { gas_limit: 2, gas_used: 1, result: { ok: null }, events: [] } },
+        },
+        {
+          blockHeight: 10,
+          idx: 1,
+          kind: "cron",
+          hash: null,
+          sender: null,
+          success: true,
+          timestamp: "2026-06-08T12:00:00Z",
+          tx: null,
+          outcome: { cron: { gas_used: 1, result: { ok: null }, events: [] } },
+        },
+      ],
+      pageInfo: { hasNextPage: true, endCursor: "page-end" },
+    };
+    const nextPage = {
+      items: [
+        {
+          blockHeight: 9,
+          idx: 0,
+          kind: "transaction",
+          hash: "next-page-transaction",
+          sender: otherSender,
+          success: true,
+          timestamp: "2026-06-08T11:59:59Z",
+          tx: { sender: otherSender, gas_limit: 2, msgs: [] },
+          outcome: { transaction: { gas_limit: 2, gas_used: 1, result: { ok: null }, events: [] } },
+        },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: "next-page-end" },
+    };
+    const fetchMock = vi.fn((input: URL) =>
+      Promise.resolve(
+        jsonResponse(input.searchParams.get("after") === "page-end" ? nextPage : page),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useExplorerTransactionsByAddress(address), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.nodes).toHaveLength(3));
+
+    expect(result.current.data?.nodes.map((transaction) => transaction.involvement)).toEqual([
+      ["sender"],
+      ["participant"],
+      ["participant"],
+    ]);
+    expect(result.current.data?.nodes[2]).toMatchObject({
+      hash: "",
+      sender: "",
+      transactionType: "CRON",
+    });
+
+    const [requestUrl] = fetchMock.mock.calls[0] as unknown as [URL];
+    expect(requestUrl.pathname).toBe(`/transactions/involving/${address}`);
+    expect(requestUrl.searchParams.get("first")).toBe("10");
+    expect(requestUrl.searchParams.has("role")).toBe(false);
+    expect(requestUrl.searchParams.has("kind")).toBe(false);
+    expect(publicClient.searchTxs).not.toHaveBeenCalled();
+
+    act(() => result.current.pagination.goNext());
+
+    await waitFor(() => expect(result.current.data?.nodes[0]?.hash).toBe("next-page-transaction"));
+    expect((fetchMock.mock.calls[1]?.[0] as URL).searchParams.get("after")).toBe("page-end");
+    expect(
+      fetchMock.mock.calls.every(
+        ([url]) => !(url as URL).searchParams.has("role") && !(url as URL).searchParams.has("kind"),
+      ),
+    ).toBe(true);
+  });
+
+  it("labels non-archive address history as sender-only", async () => {
+    const address = "0x6164647265737300000000000000000000000000";
+    publicClient.searchTxs.mockResolvedValue({
+      nodes: [
+        {
+          blockHeight: 1,
+          createdAt: "2026-06-08T12:00:00Z",
+          hash: "public-transaction",
+          sender: address,
+          transactionIdx: 0,
+          transactionType: "TX",
+        },
+      ],
+      edge: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+
+    const { result } = renderHook(() => useExplorerTransactionsByAddress(address), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data?.nodes).toHaveLength(1));
+
+    expect(result.current.data?.nodes[0]?.involvement).toEqual(["sender"]);
+    expect(publicClient.searchTxs).toHaveBeenCalledWith({
+      after: undefined,
+      before: undefined,
+      first: 10,
+      last: undefined,
+      senderAddress: address,
+      sortBy: "BLOCK_HEIGHT_DESC",
+    });
   });
 
   it("does not query sender transactions when disabled", () => {
@@ -1248,27 +1386,32 @@ describe("explorer hooks", () => {
   });
 
   it("sorts and paginates user transactions across all account addresses", async () => {
+    const firstAddress = "0x6669727374000000000000000000000000000000";
     const newestTxs = Array.from({ length: 11 }, (_, index) => ({
+      blockHeight: index + 10,
       hash: `new-${index}`,
       createdAt: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+      sender: firstAddress,
+      transactionIdx: 0,
+      transactionType: "TX",
     }));
     const oldestTx = {
+      blockHeight: 1,
       hash: "oldest",
       createdAt: new Date(Date.UTC(2025, 0, 1)).toISOString(),
+      sender: "0x7365636f6e640000000000000000000000000000",
+      transactionIdx: 0,
+      transactionType: "TX",
     };
     publicClient.searchTxs.mockImplementation(({ senderAddress }: { senderAddress: string }) =>
       Promise.resolve({
-        nodes:
-          senderAddress === "0x6669727374000000000000000000000000000000" ? newestTxs : [oldestTx],
+        nodes: senderAddress === firstAddress ? newestTxs : [oldestTx],
       }),
     );
 
     const { result } = renderHook(
       () =>
-        useExplorerUserTransactions([
-          "0x6669727374000000000000000000000000000000",
-          "0x7365636f6e640000000000000000000000000000",
-        ]),
+        useExplorerUserTransactions([firstAddress, "0x7365636f6e640000000000000000000000000000"]),
       { wrapper: createQueryClientWrapper() },
     );
 
@@ -1306,6 +1449,72 @@ describe("explorer hooks", () => {
     expect(result.current.pagination.hasPreviousPage).toBe(true);
   });
 
+  it("deduplicates archive user activity by unit position and merges roles across addresses", async () => {
+    publicClient.chain = { id: "dango-testnet-1" };
+    const firstAddress = "0x6669727374000000000000000000000000000000";
+    const secondAddress = "0x7365636f6e640000000000000000000000000000";
+    const repeatedHash = "ABCD";
+    const sharedTransaction = {
+      blockHeight: 5,
+      idx: 0,
+      kind: "transaction",
+      hash: repeatedHash,
+      sender: firstAddress,
+      success: true,
+      timestamp: "2026-01-03T00:00:00.000Z",
+      tx: { sender: firstAddress, gas_limit: 1, msgs: [] },
+      outcome: { transaction: { gas_limit: 1, gas_used: 1, result: { ok: null }, events: [] } },
+    };
+    const repeatedSubmission = {
+      ...sharedTransaction,
+      blockHeight: 4,
+      timestamp: "2026-01-02T00:00:00.000Z",
+    };
+    const cron = {
+      blockHeight: 3,
+      idx: 0,
+      kind: "cron",
+      hash: null,
+      sender: null,
+      success: true,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      tx: null,
+      outcome: { cron: { result: { ok: null }, events: [] } },
+    };
+    const fetchMock = vi.fn((input: URL) => {
+      const items = input.pathname.endsWith(firstAddress)
+        ? [sharedTransaction, repeatedSubmission]
+        : [sharedTransaction, cron];
+      return Promise.resolve(
+        jsonResponse({ items, pageInfo: { hasNextPage: false, endCursor: null } }),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(
+      () => useExplorerUserTransactions([firstAddress, secondAddress]),
+      { wrapper: createQueryClientWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.allTransactions).toHaveLength(3));
+
+    expect(result.current.allTransactions.map((transaction) => transaction.hash)).toEqual([
+      repeatedHash,
+      repeatedHash,
+      "",
+    ]);
+    expect(result.current.allTransactions.map((transaction) => transaction.involvement)).toEqual([
+      ["sender", "participant"],
+      ["sender"],
+      ["participant"],
+    ]);
+    expect(
+      fetchMock.mock.calls.every(
+        ([url]) => !(url as URL).searchParams.has("role") && !(url as URL).searchParams.has("kind"),
+      ),
+    ).toBe(true);
+  });
+
   it("preserves zero-valued backend fields while aggregating user transactions", async () => {
     const firstAddress = "0x6669727374000000000000000000000000000000";
     const secondAddress = "0x7365636f6e640000000000000000000000000000";
@@ -1324,8 +1533,12 @@ describe("explorer hooks", () => {
       transactionType: "TX",
     };
     const laterTx = {
+      blockHeight: 1,
       hash: "0x6c617465722d7478000000000000000000000000000000000000000000000000",
       createdAt: "2026-01-02T00:00:00.000Z",
+      sender: secondAddress,
+      transactionIdx: 1,
+      transactionType: "TX",
     };
     publicClient.searchTxs.mockImplementation(({ senderAddress }: { senderAddress: string }) =>
       Promise.resolve({
@@ -1342,8 +1555,11 @@ describe("explorer hooks", () => {
 
     await waitFor(() => expect(result.current.allTransactions).toHaveLength(2));
 
-    expect(result.current.allTransactions).toEqual([laterTx, genesisTx]);
-    expect(result.current.data).toEqual([laterTx, genesisTx]);
+    expect(result.current.allTransactions).toEqual([
+      { ...laterTx, involvement: ["sender"] },
+      { ...genesisTx, involvement: ["sender"] },
+    ]);
+    expect(result.current.data).toEqual(result.current.allTransactions);
   });
 
   it("keeps user transaction history available when one account query fails", async () => {
@@ -1352,8 +1568,12 @@ describe("explorer hooks", () => {
         return Promise.resolve({
           nodes: [
             {
+              blockHeight: 1,
               hash: "first-account-tx",
               createdAt: "2026-01-01T00:00:00.000Z",
+              sender: "0x6669727374000000000000000000000000000000",
+              transactionIdx: 0,
+              transactionType: "TX",
             },
           ],
         });
@@ -1385,8 +1605,13 @@ describe("explorer hooks", () => {
     });
     expect(result.current.data).toEqual([
       {
+        blockHeight: 1,
         hash: "first-account-tx",
         createdAt: "2026-01-01T00:00:00.000Z",
+        involvement: ["sender"],
+        sender: "0x6669727374000000000000000000000000000000",
+        transactionIdx: 0,
+        transactionType: "TX",
       },
     ]);
     expect(result.current.pagination.hasNextPage).toBe(false);

--- a/ui/portal/web/tests/explorer-tables.test.tsx
+++ b/ui/portal/web/tests/explorer-tables.test.tsx
@@ -40,6 +40,8 @@ vi.mock("@left-curve/foundation", async (importOriginal) => ({
 }));
 
 vi.mock("@left-curve/store", () => ({
+  getExplorerTransactionKey: (transaction: IndexedTransaction) =>
+    `${transaction.blockHeight}:${transaction.transactionType}:${transaction.transactionIdx}`,
   useAccount: () => ({
     accounts: [],
     username: undefined,
@@ -276,6 +278,66 @@ describe("explorer tables", () => {
     fireEvent.click(within(row).getByRole("link", { name: "0" }));
 
     expect(explorerTableMocks.navigate).toHaveBeenCalledWith({ to: "/block/0" });
+  });
+
+  it("shows contextual roles and renders cron units without transaction links", async () => {
+    const sender = "0x73656e6465720000000000000000000000000000";
+    explorerTableMocks.getAccountInfo.mockResolvedValue({ index: 1, username: "alice" });
+    const transaction = {
+      blockHeight: 80,
+      createdAt: "2026-06-08T12:01:00.000Z",
+      errorMessage: "",
+      gasUsed: 1,
+      gasWanted: 1,
+      hash: "0x7478000000000000000000000000000000000000000000000000000000000000",
+      hasSucceeded: true,
+      involvement: ["sender", "participant"] as ("sender" | "participant")[],
+      messages: [createIndexedMessage("execute")],
+      nestedEvents: "[]",
+      sender,
+      transactionIdx: 0,
+      transactionType: "TX" as const,
+    };
+    const cron = {
+      blockHeight: 79,
+      createdAt: "2026-06-08T12:00:00.000Z",
+      errorMessage: "",
+      gasUsed: 1,
+      gasWanted: 0,
+      hash: "",
+      hasSucceeded: true,
+      involvement: ["participant"] as ("sender" | "participant")[],
+      messages: [],
+      nestedEvents: "[]",
+      sender: "" as const,
+      transactionIdx: 1,
+      transactionType: "CRON" as const,
+    };
+
+    renderWithQueryClient(<TransactionsTable transactions={[transaction, cron]} />);
+
+    expect(getHeaderLabels()).toEqual([
+      "Hash",
+      "Block",
+      "Age",
+      "Sender",
+      m["explorer.txs.role"](),
+      "Actions",
+      "Result",
+    ]);
+    expect(screen.getAllByText(m["explorer.txs.roles.sender"]())).toHaveLength(2);
+    expect(screen.getAllByText(m["explorer.txs.roles.participant"]())).toHaveLength(2);
+    await waitFor(() => expect(screen.getByText("alice #1")).toBeInTheDocument());
+
+    const [, cronRow] = getBodyRows();
+    const cronCells = rowCells(cronRow);
+    expect(cronCells[0]).toBe("—");
+    expect(cronCells[3]).toBe("—");
+    expect(cronCells[4]).toBe(m["explorer.txs.roles.participant"]());
+    expect(cronCells[5]).toBe("—");
+    expect(cronRow.querySelector('a[href="/tx/"]')).toBeNull();
+    expect(explorerTableMocks.getAccountInfo).not.toHaveBeenCalledWith({ address: "" });
+    expect(explorerTableMocks.getContractInfo).not.toHaveBeenCalledWith({ address: "" });
   });
 
   it("falls back to the raw 0x sender when backend lookups cannot identify it", async () => {

--- a/ui/store/src/archive/api.ts
+++ b/ui/store/src/archive/api.ts
@@ -29,6 +29,7 @@ type ArchiveApi = {
 type ArchiveSearchTxsParameters = {
   hash?: string;
   senderAddress?: string;
+  involvedAddress?: string;
   first?: number;
   after?: string;
   sortBy?: string;
@@ -125,12 +126,14 @@ async function searchTxs(
     return toGraphqlResult((items ?? []).map(normalizeTransaction));
   }
 
-  if (parameters.senderAddress) {
+  const address = parameters.involvedAddress ?? parameters.senderAddress;
+
+  if (address) {
     const page = await archiveFetch<ArchivePage<ArchiveTransaction>>(
       archiveUrl,
-      `/transactions/involving/${encodeURIComponent(parameters.senderAddress)}`,
+      `/transactions/involving/${encodeURIComponent(address)}`,
       {
-        role: "sender",
+        role: parameters.involvedAddress ? undefined : "sender",
         first: String(parameters.first ?? 10),
         after: parameters.after,
       },

--- a/ui/store/src/hooks/explorer/transactionInvolvement.ts
+++ b/ui/store/src/hooks/explorer/transactionInvolvement.ts
@@ -1,0 +1,69 @@
+import type { Address, GraphqlQueryResult, IndexedTransaction } from "@left-curve/types";
+
+export type ExplorerTransactionRole = "sender" | "participant";
+
+export type ExplorerTransaction = IndexedTransaction & {
+  involvement: ExplorerTransactionRole[];
+};
+
+const ROLE_ORDER: ExplorerTransactionRole[] = ["sender", "participant"];
+
+export function getExplorerTransactionKey(transaction: IndexedTransaction): string {
+  return [transaction.blockHeight, transaction.transactionType, transaction.transactionIdx].join(
+    ":",
+  );
+}
+
+export function addTransactionInvolvement(
+  transaction: IndexedTransaction,
+  address: Address,
+  supportsParticipants: boolean,
+): ExplorerTransaction {
+  const isSender =
+    !supportsParticipants || transaction.sender?.toLowerCase() === address.toLowerCase();
+
+  return {
+    ...transaction,
+    involvement: [supportsParticipants && !isSender ? "participant" : "sender"],
+  };
+}
+
+export function addResultInvolvement(
+  result: GraphqlQueryResult<IndexedTransaction>,
+  address: Address,
+  supportsParticipants: boolean,
+): GraphqlQueryResult<ExplorerTransaction> {
+  return {
+    ...result,
+    nodes: result.nodes.map((transaction) =>
+      addTransactionInvolvement(transaction, address, supportsParticipants),
+    ),
+    edge: (result.edge ?? []).map((edge) => ({
+      ...edge,
+      node: addTransactionInvolvement(edge.node, address, supportsParticipants),
+    })),
+  };
+}
+
+export function mergeExplorerTransactions(
+  transactions: ExplorerTransaction[],
+): ExplorerTransaction[] {
+  const transactionsByKey = new Map<string, ExplorerTransaction>();
+
+  for (const transaction of transactions) {
+    const key = getExplorerTransactionKey(transaction);
+    const existing = transactionsByKey.get(key);
+
+    if (!existing) {
+      transactionsByKey.set(key, transaction);
+      continue;
+    }
+
+    const involvement = ROLE_ORDER.filter(
+      (role) => existing.involvement.includes(role) || transaction.involvement.includes(role),
+    );
+    transactionsByKey.set(key, { ...existing, involvement });
+  }
+
+  return [...transactionsByKey.values()];
+}

--- a/ui/store/src/hooks/explorer/useExplorerTransactionsByAddress.ts
+++ b/ui/store/src/hooks/explorer/useExplorerTransactionsByAddress.ts
@@ -1,0 +1,92 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { getArchiveApi } from "../../archive/api.js";
+import { usePublicClient } from "../usePublicClient.js";
+import { useQueryWithPagination } from "../useQueryWithPagination.js";
+import { addResultInvolvement } from "./transactionInvolvement.js";
+
+import type { Address } from "@left-curve/types";
+
+const PAGE_SIZE = 10;
+
+type ArchivePaginationState = {
+  address: Address;
+  after?: string;
+  previousAfters: (string | undefined)[];
+};
+
+export function useExplorerTransactionsByAddress(address: Address, enabled = true) {
+  const client = usePublicClient();
+  const archive = getArchiveApi(client.chain);
+  const [archivePagination, setArchivePagination] = useState<ArchivePaginationState>({
+    address,
+    after: undefined,
+    previousAfters: [],
+  });
+
+  const archiveState =
+    archivePagination.address === address
+      ? archivePagination
+      : { address, after: undefined, previousAfters: [] };
+
+  const archiveQuery = useQuery({
+    enabled: Boolean(archive && enabled && address),
+    queryKey: ["explorer_transactions", address, "involved", "archive", archiveState.after],
+    queryFn: async () => {
+      const result = await archive!.searchTxs({
+        involvedAddress: address,
+        first: PAGE_SIZE,
+        after: archiveState.after,
+      });
+      return addResultInvolvement(result, address, true);
+    },
+    placeholderData: keepPreviousData,
+  });
+
+  const publicQuery = useQueryWithPagination({
+    enabled: !archive && enabled && !!address,
+    queryKey: ["explorer_transactions", address, "involved"],
+    queryFn: async ({ pageParam }) => {
+      const result = await client.searchTxs({ senderAddress: address, ...pageParam });
+      return addResultInvolvement(result, address, false);
+    },
+  });
+
+  if (archive) {
+    const hasPreviousPage = archiveState.previousAfters.length > 0;
+
+    return {
+      ...archiveQuery,
+      pagination: {
+        goNext: () => {
+          const nextAfter = archiveQuery.data?.pageInfo.endCursor ?? undefined;
+          if (!archiveQuery.data?.pageInfo.hasNextPage || !nextAfter) return;
+          setArchivePagination((state) => ({
+            address,
+            after: nextAfter,
+            previousAfters:
+              state.address === address
+                ? [...state.previousAfters, archiveState.after]
+                : [undefined],
+          }));
+        },
+        goPrev: () => {
+          if (!hasPreviousPage) return;
+          setArchivePagination((state) => {
+            const previousAfters = state.address === address ? state.previousAfters : [];
+            const nextPreviousAfters = previousAfters.slice(0, -1);
+            return {
+              address,
+              after: previousAfters.at(-1),
+              previousAfters: nextPreviousAfters,
+            };
+          });
+        },
+        hasNextPage: archiveQuery.data?.pageInfo.hasNextPage ?? false,
+        hasPreviousPage,
+      },
+    };
+  }
+
+  return publicQuery;
+}

--- a/ui/store/src/hooks/explorer/useExplorerUserTransactions.ts
+++ b/ui/store/src/hooks/explorer/useExplorerUserTransactions.ts
@@ -2,8 +2,13 @@ import { useQueries } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { getArchiveApi } from "../../archive/api.js";
 import { usePublicClient } from "../usePublicClient.js";
+import {
+  addTransactionInvolvement,
+  mergeExplorerTransactions,
+  type ExplorerTransaction,
+} from "./transactionInvolvement.js";
 
-import type { Address, IndexedTransaction } from "@left-curve/types";
+import type { Address } from "@left-curve/types";
 
 const PAGE_SIZE = 10;
 
@@ -16,12 +21,16 @@ export function useExplorerUserTransactions(addresses: Address[]) {
     queries: addresses.map((address) => ({
       queryKey: ["explorer_user_transactions", address, archive ? "archive" : "public"],
       queryFn: async () => {
-        const result = await (archive ?? client).searchTxs({
-          senderAddress: address,
-          first: 50,
-          sortBy: "BLOCK_HEIGHT_DESC",
-        });
-        return result.nodes;
+        const result = archive
+          ? await archive.searchTxs({ involvedAddress: address, first: 50 })
+          : await client.searchTxs({
+              senderAddress: address,
+              first: 50,
+              sortBy: "BLOCK_HEIGHT_DESC",
+            });
+        return result.nodes.map((transaction) =>
+          addTransactionInvolvement(transaction, address, Boolean(archive)),
+        );
       },
       enabled: addresses.length > 0,
     })),
@@ -30,11 +39,13 @@ export function useExplorerUserTransactions(addresses: Address[]) {
   const isLoading = transactionQueries.some((q) => q.isLoading);
 
   const allTransactions = useMemo(() => {
-    const txs = transactionQueries
+    const transactions = transactionQueries
       .filter((q) => q.data)
-      .flatMap((q) => q.data as IndexedTransaction[]);
+      .flatMap((q) => q.data as ExplorerTransaction[]);
 
-    return txs.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return mergeExplorerTransactions(transactions).sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
   }, [transactionQueries]);
 
   const totalPages = Math.ceil(allTransactions.length / PAGE_SIZE);

--- a/ui/store/src/index.ts
+++ b/ui/store/src/index.ts
@@ -150,7 +150,13 @@ export {
   useExplorerContract,
   type ExplorerContract,
 } from "./hooks/explorer/useExplorerContract.js";
+export { useExplorerTransactionsByAddress } from "./hooks/explorer/useExplorerTransactionsByAddress.js";
 export { useExplorerTransactionsBySender } from "./hooks/explorer/useExplorerTransactionsBySender.js";
+export {
+  getExplorerTransactionKey,
+  type ExplorerTransaction,
+  type ExplorerTransactionRole,
+} from "./hooks/explorer/transactionInvolvement.js";
 export {
   useExplorerUser,
   type AccountWithDetails,


### PR DESCRIPTION
## Summary

- Show archive transactions where an address is the sender or a participant, with role tags.
- Render cronjobs safely when no transaction hash exists.

## Validation

### Completed

- [x] `pnpm exec vitest run tests/explorer*.test.tsx`
- [x] `pnpm exec vitest run tests/explorer-hooks.test.tsx`
- [x] `pnpm --filter @left-curve/portal-web... build`
- [x] Biome checks for touched files

### Remaining

- [ ] Full portal-app typecheck (blocked by existing unrelated module/type errors)

## Manual QA

None.