### PR TITLE
feat(perps): wind down the exchange at the next chain upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4670,8 +4670,18 @@ dependencies = [
 name = "dango-upgrade"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "dango-app",
+ "dango-bank",
+ "dango-math",
+ "dango-order-book",
+ "dango-perps",
  "dango-primitives",
+ "dango-storage",
+ "dango-types",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/book/perps/8-api.md
+++ b/book/perps/8-api.md
@@ -793,6 +793,7 @@ The response objects of the perps [read shortcuts](#32-typed-read-shortcuts) mir
 | `funding_period` | `Duration` | Interval between funding collections |
 | `vault_cooldown_period` | `Duration` | Vault-withdrawal cooldown |
 | `vault_deposit_cap` | `UsdValue \| null` | Max total vault margin (`null` = uncapped) |
+| `trading_enabled` | `bool` | When `false`, order placement, margin deposits, and vault deposits are rejected; withdrawals, cancellations, and liquidations still work |
 | `referral_active` | `bool` | Whether referral commissions are active |
 
 Plus `max_unlocks`, `liquidation_buffer_ratio`, `vault_total_weight`, `min_referrer_volume`, and `referrer_commission_rates` — see the source.

--- a/dango/exchange/perps/src/lib.rs
+++ b/dango/exchange/perps/src/lib.rs
@@ -33,12 +33,12 @@ use {
 /// Virtual shares added to total supply in share price calculations.
 /// Prevents the first-depositor attack (ERC-4626 inflation attack) by
 /// ensuring the share price cannot be trivially inflated.
-const VIRTUAL_SHARES: Uint128 = Uint128::new(1_000_000);
+pub const VIRTUAL_SHARES: Uint128 = Uint128::new(1_000_000);
 
 /// Virtual assets added to vault equity in share price calculations.
 /// Works in tandem with `VIRTUAL_SHARES` to set the initial share price
 /// and prevent share inflation attacks.
-const VIRTUAL_ASSETS: UsdValue = UsdValue::new_int(1);
+pub const VIRTUAL_ASSETS: UsdValue = UsdValue::new_int(1);
 
 /// Lookback window for volume-tiered fee rate resolution.
 const VOLUME_LOOKBACK: Duration = Duration::from_days(14);

--- a/dango/exchange/perps/src/maintain/configure.rs
+++ b/dango/exchange/perps/src/maintain/configure.rs
@@ -465,6 +465,7 @@ mod tests {
             referrer_commission_rates: RateSchedule::default(),
             vault_deposit_cap: None,
             max_action_batch_size: 5,
+            trading_enabled: true,
         }
     }
 

--- a/dango/exchange/perps/src/trade.rs
+++ b/dango/exchange/perps/src/trade.rs
@@ -14,9 +14,25 @@ pub use {
 
 use {
     crate::USER_STATES,
+    anyhow::ensure,
     dango_primitives::{Addr, StdResult, Storage},
-    dango_types::perps::UserState,
+    dango_types::perps::{Param, UserState},
 };
+
+/// Trading must be enabled.
+///
+/// Guards the actions that would open new risk on the exchange: placing an
+/// order, moving funds from a spot account into margin, and moving margin into
+/// the counterparty vault. Actions that reduce risk or return funds to the
+/// user are deliberately not guarded.
+pub fn ensure_trading_enabled(param: &Param) -> anyhow::Result<()> {
+    ensure!(
+        param.trading_enabled,
+        "trading is disabled; the exchange has been wound down"
+    );
+
+    Ok(())
+}
 
 /// 1. Load the user's state.
 /// 2. Perform a mutable action on the user state. The action may have side

--- a/dango/exchange/perps/src/trade/batch_update_orders.rs
+++ b/dango/exchange/perps/src/trade/batch_update_orders.rs
@@ -3,7 +3,7 @@ use {
         state::PARAM,
         trade::{
             _cancel_all_orders, _cancel_one_order, _cancel_one_order_by_client_order_id,
-            _submit_order,
+            _submit_order, ensure_trading_enabled,
         },
     },
     anyhow::ensure,
@@ -27,6 +27,10 @@ pub fn batch_update_orders(
     reqs: NonEmpty<Vec<SubmitOrCancelOrderRequest>>,
 ) -> anyhow::Result<Response> {
     let param = PARAM.load(ctx.storage)?;
+
+    // Gate the whole batch rather than only its submit actions: a batch that
+    // mixes cancels with submits must fail as a unit, not partially apply.
+    ensure_trading_enabled(&param)?;
 
     // Enforce the governance-tunable upper bound on batch size.
     ensure!(

--- a/dango/exchange/perps/src/trade/deposit.rs
+++ b/dango/exchange/perps/src/trade/deposit.rs
@@ -1,5 +1,5 @@
 use {
-    crate::USER_STATES,
+    crate::{USER_STATES, state::PARAM, trade::ensure_trading_enabled},
     anyhow::ensure,
     dango_math::IsZero,
     dango_order_book::Quantity,
@@ -12,6 +12,8 @@ use {
 /// The deposited tokens are converted to USD at a fixed 1:1 rate and credited
 /// to `user_state.margin`. Tokens stay in the perps contract's bank balance.
 pub fn deposit(mut ctx: MutableCtx, to: Option<Addr>) -> anyhow::Result<Response> {
+    ensure_trading_enabled(&PARAM.load(ctx.storage)?)?;
+
     // ----------------------- 1. Extract deposit amount -----------------------
 
     let deposit_amount = ctx.funds.take(settlement_currency::DENOM.clone()).amount;
@@ -65,6 +67,7 @@ mod tests {
         dango_math::Uint128,
         dango_order_book::UsdValue,
         dango_primitives::{Addr, Coins, MockContext, ResultExt},
+        dango_types::perps::Param,
     };
 
     const SENDER: Addr = Addr::mock(1);
@@ -84,6 +87,9 @@ mod tests {
         let mut ctx = MockContext::new()
             .with_sender(SENDER)
             .with_funds(usdc_coins(1_000));
+
+        // Deposits are gated on `trading_enabled`, so the param must exist.
+        PARAM.save(&mut ctx.storage, &Param::default()).unwrap();
 
         deposit(ctx.as_mutable(), Some(RECIPIENT)).should_succeed();
 

--- a/dango/exchange/perps/src/trade/submit_conditional_order.rs
+++ b/dango/exchange/perps/src/trade/submit_conditional_order.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{PAIR_PARAMS, USER_STATES},
+    crate::{PAIR_PARAMS, USER_STATES, state::PARAM, trade::ensure_trading_enabled},
     anyhow::{anyhow, ensure},
     dango_math::NumberConst,
     dango_order_book::{
@@ -17,6 +17,8 @@ pub fn submit_conditional_order(
     trigger_direction: TriggerDirection,
     max_slippage: Dimensionless,
 ) -> anyhow::Result<Response> {
+    ensure_trading_enabled(&PARAM.load(ctx.storage)?)?;
+
     let mut user_state = USER_STATES.load(ctx.storage, ctx.sender)?;
     let pair_param = PAIR_PARAMS.load(ctx.storage, &pair_id)?;
 

--- a/dango/exchange/perps/src/trade/submit_order.rs
+++ b/dango/exchange/perps/src/trade/submit_order.rs
@@ -12,7 +12,7 @@ use {
         query::query_volume,
         referral::{FeeCommissionsOutcome, apply_fee_commissions},
         state::{FEE_RATE_OVERRIDES, PAIR_PARAMS, PAIR_STATES, PARAM, STATE, USER_STATES},
-        trade::resize_reduce_only_orders,
+        trade::{ensure_trading_enabled, resize_reduce_only_orders},
     },
     anyhow::{bail, ensure},
     dango_math::{MathResult, Number, NumberConst},
@@ -42,6 +42,8 @@ pub fn submit_order(
     tp: Option<ChildOrder>,
     sl: Option<ChildOrder>,
 ) -> anyhow::Result<Response> {
+    ensure_trading_enabled(&PARAM.load(ctx.storage)?)?;
+
     let mut events = EventBuilder::new();
 
     _submit_order(

--- a/dango/exchange/perps/src/vault/add_liquidity.rs
+++ b/dango/exchange/perps/src/vault/add_liquidity.rs
@@ -4,6 +4,7 @@ use {
         core::{compute_available_margin, compute_user_equity},
         querier::NoCachePerpQuerier,
         state::{PARAM, STATE, USER_STATES},
+        trade::ensure_trading_enabled,
     },
     anyhow::ensure,
     dango_math::{IsZero, MultiplyRatio, Number as _, Signed, Uint128},
@@ -27,6 +28,8 @@ pub fn add_liquidity(
     ensure!(ctx.funds.is_empty(), "no funds expected");
 
     let param = PARAM.load(ctx.storage)?;
+
+    ensure_trading_enabled(&param)?;
 
     let mut state = STATE.load(ctx.storage)?;
 

--- a/dango/exchange/proposal-preparer/src/pyth_handler.rs
+++ b/dango/exchange/proposal-preparer/src/pyth_handler.rs
@@ -228,6 +228,22 @@ where
             txs.insert(0, oracle_tx.to_json_vec()?.into());
         }
 
+        // Once the exchange is wound down there are no positions to mark and
+        // no vault margin to quote with, so stop injecting the two perps
+        // maintenance transactions. The oracle price feed above keeps running,
+        // since other contracts still consume it.
+        let trading_enabled = querier
+            .query_wasm_smart(cfg.addresses.perps, perps::QueryParamRequest {})?
+            .trading_enabled;
+
+        if !trading_enabled {
+            #[cfg(feature = "metrics")]
+            histogram!("proposal_preparer.prepare_proposal.duration",)
+                .record(start.elapsed().as_secs_f64());
+
+            return Ok(txs);
+        }
+
         // Insert perps index-price refresh transaction.
         {
             let index_tx = Tx {

--- a/dango/exchange/types/src/perps.rs
+++ b/dango/exchange/types/src/perps.rs
@@ -110,7 +110,6 @@ impl RateSchedule {
 
 /// Global parameters that concerns the counterparty vault and all trading pairs.
 #[dango_primitives::derive(Serde, Borsh)]
-#[derive(Default)]
 pub struct Param {
     /// Maximum number of unlock requests a single user may have.
     ///
@@ -220,6 +219,43 @@ pub struct Param {
     /// Bounds: `>= 1`. Governance-tunable via `Configure`; no hard
     /// upper bound is enforced.
     pub max_action_batch_size: usize,
+
+    /// Whether traders may open new risk.
+    ///
+    /// When false, order placement (including conditional orders), deposits
+    /// from a spot account into margin, and deposits from margin into the
+    /// counterparty vault are all rejected. Everything that reduces risk or
+    /// returns funds to the user — withdrawals, cancellations, vault
+    /// withdrawals, liquidations — remains available.
+    ///
+    /// Set to false by the wind-down chain upgrade.
+    pub trading_enabled: bool,
+}
+
+impl Default for Param {
+    /// Trading is enabled by default. Only the wind-down upgrade turns it
+    /// off, so a freshly constructed `Param` must never accidentally halt a
+    /// live exchange.
+    fn default() -> Self {
+        Self {
+            max_unlocks: usize::default(),
+            max_open_orders: usize::default(),
+            maker_fee_rates: RateSchedule::default(),
+            taker_fee_rates: RateSchedule::default(),
+            protocol_fee_rate: Dimensionless::default(),
+            liquidation_fee_rate: Dimensionless::default(),
+            liquidation_buffer_ratio: Dimensionless::default(),
+            funding_period: Duration::default(),
+            vault_total_weight: Dimensionless::default(),
+            vault_cooldown_period: Duration::default(),
+            referral_active: bool::default(),
+            min_referrer_volume: UsdValue::default(),
+            referrer_commission_rates: RateSchedule::default(),
+            vault_deposit_cap: None,
+            max_action_batch_size: usize::default(),
+            trading_enabled: true,
+        }
+    }
 }
 
 /// Global state that concerns the counterparty vault and all trading pairs.

--- a/dango/exchange/upgrade/Cargo.toml
+++ b/dango/exchange/upgrade/Cargo.toml
@@ -9,6 +9,19 @@ repository    = { workspace = true }
 rust-version  = { workspace = true }
 
 [dependencies]
+anyhow           = { workspace = true }
 dango-app        = { workspace = true }
+dango-bank       = { workspace = true }
+dango-math       = { workspace = true }
+dango-order-book = { workspace = true }
+dango-perps      = { workspace = true }
 dango-primitives = { workspace = true }
+dango-storage    = { workspace = true }
+dango-types      = { workspace = true }
 tracing          = { workspace = true }
+
+[dev-dependencies]
+anyhow     = { workspace = true }
+reqwest    = { workspace = true }
+serde_json = { workspace = true }
+tokio      = { workspace = true }

--- a/dango/exchange/upgrade/examples/dump_perps_state.rs
+++ b/dango/exchange/upgrade/examples/dump_perps_state.rs
@@ -1,0 +1,266 @@
+//! Dump a live chain's perps state into a fixture for the wind-down tests.
+//!
+//! ```sh
+//! cargo run -p dango-upgrade --example dump_perps_state -- mainnet
+//! cargo run -p dango-upgrade --example dump_perps_state -- testnet
+//! ```
+//!
+//! Writes `testdata/<chain>_snapshot.json`, which `src/perps.rs`'s `#[ignore]`
+//! tests load. `testdata/` is gitignored — the dump is large and goes stale as
+//! the chain advances, so it is never committed.
+//!
+//! Everything is fetched in a single `multi` query, so the whole snapshot comes
+//! from one block. That matters: paginating would straddle blocks and produce
+//! an internally inconsistent snapshot, and the node only ever serves the
+//! latest finalized block, so a dump cannot be pinned to a chosen height.
+//!
+//! Only the storage the wind-down actually touches is scanned. An unbounded
+//! scan of the whole contract also works on mainnet, but it drags in the
+//! referral and per-user volume history — an order of magnitude more entries
+//! than the rest combined — and on testnet that exceeds the node's query gas
+//! limit outright.
+
+use {
+    serde_json::{Map, Value, json},
+    std::{env, fs, path::PathBuf},
+};
+
+const MAINNET_URL: &str = "https://api-mainnet.dango.zone";
+const MAINNET_PERPS: &str = "0x90bc84df68d1aa59a857e04ed529e9a26edbea4f";
+
+const TESTNET_URL: &str = "https://api-testnet.dango.zone";
+const TESTNET_PERPS: &str = "0xf6344c5e2792e8f9202c58a2d88fbbde4cd3142f";
+
+const USDC_DENOM: &str = "bridge/usdc";
+
+/// `wasm_scan` defaults to a 30-entry page, so an explicit limit is required.
+/// The largest namespace here holds a few thousand entries.
+const SCAN_LIMIT: u64 = 1_000_000;
+
+/// `Item`s, whose raw key is the bare name with no length prefix.
+const ITEMS: &[&str] = &[
+    "param",
+    "state",
+    "pair_ids",
+    "next_order_id",
+    "next_fill_id",
+];
+
+/// `Map`/`Set`/`IndexedMap` namespaces, including the secondary indexes, which
+/// live in the same keyspace and must be restored for the map to be coherent.
+const NAMESPACES: &[&str] = &[
+    "pair_param",
+    "pair_state",
+    "us",
+    "us__unlock",
+    "us__cond",
+    "long",
+    "short",
+    "bid",
+    "bid__id",
+    "bid__user",
+    "bid__cid",
+    "ask",
+    "ask__id",
+    "ask__user",
+    "ask__cid",
+    "depth",
+];
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let chain = env::args().nth(1).unwrap_or_else(|| "mainnet".to_string());
+
+    let (url, perps) = match chain.as_str() {
+        "mainnet" => (MAINNET_URL, MAINNET_PERPS),
+        "testnet" => (TESTNET_URL, TESTNET_PERPS),
+        _ => anyhow::bail!("unknown chain `{chain}`; expected `mainnet` or `testnet`"),
+    };
+
+    println!("Fetching perps state from {url}...");
+
+    // One request, so every sub-query is answered at the same block.
+    let mut queries = Vec::new();
+
+    for item in ITEMS {
+        queries.push(json!({
+            "wasm_raw": { "contract": perps, "key": encode(item.as_bytes()) },
+        }));
+    }
+
+    for namespace in NAMESPACES {
+        let (min, max) = namespace_bounds(namespace);
+
+        queries.push(json!({
+            "wasm_scan": {
+                "contract": perps,
+                "min": encode(&min),
+                "max": encode(&max),
+                "limit": SCAN_LIMIT,
+            },
+        }));
+    }
+
+    queries.push(json!({
+        "balance": { "address": perps, "denom": USDC_DENOM },
+    }));
+
+    let response: Value = reqwest::Client::new()
+        .post(format!("{url}/query"))
+        .json(&json!({ "multi": queries }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let results = response
+        .get("multi")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("malformed response: {response}"))?;
+
+    anyhow::ensure!(
+        results.len() == queries.len(),
+        "expected {} sub-results, got {}",
+        queries.len(),
+        results.len()
+    );
+
+    let mut storage = Map::new();
+    let mut cursor = 0;
+
+    // `Item`s come back as a bare value, or null when unset.
+    for item in ITEMS {
+        let value = unwrap_ok(&results[cursor])?
+            .get("wasm_raw")
+            .ok_or_else(|| anyhow::anyhow!("missing wasm_raw for `{item}`"))?;
+
+        if let Some(value) = value.as_str() {
+            storage.insert(encode(item.as_bytes()), json!(value));
+        }
+
+        cursor += 1;
+    }
+
+    for namespace in NAMESPACES {
+        let scanned = unwrap_ok(&results[cursor])?
+            .get("wasm_scan")
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow::anyhow!("missing wasm_scan for `{namespace}`"))?;
+
+        anyhow::ensure!(
+            scanned.len() < SCAN_LIMIT as usize,
+            "namespace `{namespace}` hit the scan limit; the snapshot would be truncated"
+        );
+
+        for (key, value) in scanned {
+            storage.insert(key.clone(), value.clone());
+        }
+
+        println!("  {namespace}: {} entries", scanned.len());
+
+        cursor += 1;
+    }
+
+    let balance = unwrap_ok(&results[cursor])?
+        .pointer("/balance/amount")
+        .ok_or_else(|| anyhow::anyhow!("missing balance in response"))?
+        .clone();
+
+    let entry_count = storage.len();
+
+    let snapshot = json!({
+        "perps_address": perps,
+        "storage": storage,
+        "balance": balance,
+    });
+
+    let out_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata")
+        .join(format!("{chain}_snapshot.json"));
+
+    fs::create_dir_all(out_path.parent().unwrap())?;
+    fs::write(&out_path, serde_json::to_vec(&snapshot)?)?;
+
+    println!(
+        "Saved {entry_count} entries and a USDC balance of {balance} to {}",
+        out_path.display()
+    );
+
+    Ok(())
+}
+
+/// Half-open key range covering one storage namespace.
+///
+/// A `Map` key is `len(ns)` as two big-endian bytes, then `ns`, then the key
+/// itself; so every entry in the namespace sorts within `[prefix, prefix+1)`.
+fn namespace_bounds(namespace: &str) -> (Vec<u8>, Vec<u8>) {
+    let mut min = Vec::with_capacity(namespace.len() + 2);
+    min.extend_from_slice(&(namespace.len() as u16).to_be_bytes());
+    min.extend_from_slice(namespace.as_bytes());
+
+    let mut max = min.clone();
+
+    // `max` is exclusive, so increment the last byte to take in the whole
+    // prefix. Namespaces are ASCII, so this never overflows.
+    *max.last_mut().unwrap() += 1;
+
+    (min, max)
+}
+
+/// Binary is base64 on the wire.
+fn encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    let mut out = String::new();
+
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            chunk.get(1).copied().unwrap_or(0),
+            chunk.get(2).copied().unwrap_or(0),
+        ];
+        let n = u32::from_be_bytes([0, b[0], b[1], b[2]]);
+
+        for i in 0..4 {
+            if i <= chunk.len() {
+                let _ = write!(
+                    out,
+                    "{}",
+                    ALPHABET[(n >> (18 - 6 * i)) as usize & 0x3f] as char
+                );
+            } else {
+                out.push('=');
+            }
+        }
+    }
+
+    out
+}
+
+fn unwrap_ok(result: &Value) -> anyhow::Result<&Value> {
+    if let Some(err) = result.get("Err") {
+        let message = err.get("error").unwrap_or(err).to_string();
+
+        // Gas is metered across the whole `multi`, so a chain with a large
+        // enough user set cannot be captured in one request. Paginating would
+        // spread the snapshot over several blocks and so could catch a
+        // position mid-close, which is exactly what a wind-down fixture must
+        // not do — so fail rather than silently produce a torn snapshot.
+        if message.contains("out of gas") {
+            anyhow::bail!(
+                "the node ran out of query gas part-way through the snapshot: {message}\n\nThis \
+                 chain holds more state than a single consistent query can return. Only chains \
+                 that fit in one request can be snapshotted."
+            );
+        }
+
+        anyhow::bail!("query failed: {message}");
+    }
+
+    result
+        .get("Ok")
+        .ok_or_else(|| anyhow::anyhow!("malformed sub-result: {result}"))
+}

--- a/dango/exchange/upgrade/src/lib.rs
+++ b/dango/exchange/upgrade/src/lib.rs
@@ -5,10 +5,8 @@ use {
     dango_primitives::{BlockInfo, Storage},
 };
 
-pub fn do_upgrade<VM>(_storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
-    // Call relevant upgrade functions here.
-
-    tracing::info!("Nothing to do for this upgrade");
+pub fn do_upgrade<VM>(storage: Box<dyn Storage>, _vm: VM, _block: BlockInfo) -> AppResult<()> {
+    perps::do_perps_upgrades(storage)?;
 
     Ok(())
 }

--- a/dango/exchange/upgrade/src/perps.rs
+++ b/dango/exchange/upgrade/src/perps.rs
@@ -1,9 +1,43 @@
-// This file contains only the boilerplate.
-#![allow(dead_code)]
+//! Wind-down of the perps exchange.
+//!
+//! Dango is being shut down. This one-time state transition unwinds the
+//! exchange in a single block, so that afterwards no user has any exposure and
+//! every dollar the contract held has been returned to its owner:
+//!
+//! 1. **Close every position** at the pair's mark price, realizing PnL and
+//!    settling accrued funding into the user's margin.
+//! 2. **Release the counterparty vault**, paying each liquidity provider their
+//!    pro-rata share of vault equity into their margin, and releasing unlocks
+//!    that were still in cooldown.
+//! 3. **Refund every margin balance** to the user's spot account as USDC.
+//! 4. **Sweep the remainder** — treasury, insurance fund, and rounding dust —
+//!    to the chain owner.
+//!
+//! It also flips `Param.trading_enabled` to false, which is what stops the
+//! exchange from being used again after the fork.
+//!
+//! The mark (`PairState.index_price`) is used as the settlement price because
+//! it is what `compute_user_equity` and the UI already report, so each user is
+//! refunded exactly the equity they last saw. Position PnL is zero-sum across
+//! all accounts at any single price — every fill creates a long and a short at
+//! the same entry — so the settlement neither creates nor destroys value.
 
 use {
-    dango_app::{AppResult, CHAIN_ID, CONTRACT_NAMESPACE, StorageProvider},
-    dango_primitives::{Addr, Storage, addr},
+    dango_app::{AppResult, CHAIN_ID, CONFIG, CONTRACT_NAMESPACE, StorageProvider},
+    dango_bank::BALANCES,
+    dango_math::{Dec128_6, Int128, IsZero, MultiplyRatio, Number, NumberConst, Uint128},
+    dango_order_book::{ASKS, BIDS, DEPTHS, PairId, Quantity, UsdValue},
+    dango_perps::{
+        VIRTUAL_ASSETS, VIRTUAL_SHARES,
+        core::execute_fill,
+        state::{LONGS, PAIR_STATES, PARAM, SHORTS, STATE, USER_STATES},
+    },
+    dango_primitives::{
+        Addr, Denom, Inner, Order as IterationOrder, StdError, StdResult, Storage, addr,
+    },
+    dango_storage::Item,
+    dango_types::perps::{Param, SETTLEMENT_CURRENCY_PRICE, UserState, settlement_currency},
+    std::collections::BTreeMap,
 };
 
 const MAINNET_CHAIN_ID: &str = "dango-1";
@@ -14,8 +48,51 @@ const TESTNET_PERPS_ADDRESS: Addr = addr!("f6344c5e2792e8f9202c58a2d88fbbde4cd31
 
 /// Pre-migration perps storage shapes.
 mod legacy_perps {
-    // Add content here.
+    use {
+        dango_order_book::{Dimensionless, UsdValue},
+        dango_primitives::Duration,
+        dango_types::perps::RateSchedule,
+    };
+
+    /// `Param` as stored before the `trading_enabled` field was appended.
+    /// Field order and types must match the old on-disk Borsh layout exactly.
+    #[dango_primitives::derive(Serde, Borsh)]
+    #[derive(Default)]
+    pub struct Param {
+        pub max_unlocks: usize,
+
+        pub max_open_orders: usize,
+
+        pub maker_fee_rates: RateSchedule,
+
+        pub taker_fee_rates: RateSchedule,
+
+        pub protocol_fee_rate: Dimensionless,
+
+        pub liquidation_fee_rate: Dimensionless,
+
+        pub liquidation_buffer_ratio: Dimensionless,
+
+        pub funding_period: Duration,
+
+        pub vault_total_weight: Dimensionless,
+
+        pub vault_cooldown_period: Duration,
+
+        pub referral_active: bool,
+
+        pub min_referrer_volume: UsdValue,
+
+        pub referrer_commission_rates: RateSchedule,
+
+        pub vault_deposit_cap: Option<UsdValue>,
+
+        pub max_action_batch_size: usize,
+    }
 }
+
+/// Reads the pre-upgrade `Param`, keyed identically to the live item.
+const LEGACY_PARAM: Item<legacy_perps::Param> = Item::new("param");
 
 pub fn do_perps_upgrades(storage: Box<dyn Storage>) -> AppResult<()> {
     let perps_address = {
@@ -27,9 +104,443 @@ pub fn do_perps_upgrades(storage: Box<dyn Storage>) -> AppResult<()> {
         }
     };
 
-    let mut _perps_storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &perps_address]);
+    let cfg = CONFIG.load(&storage)?;
 
-    // Add migration logic here.
+    // Two storage handles over the same (Arc-backed) buffer: one scoped to the
+    // perps contract, one to the bank, since refunding margins moves tokens
+    // between accounts in bank storage.
+    let mut perps_storage =
+        StorageProvider::new(storage.clone(), &[CONTRACT_NAMESPACE, &perps_address]);
+    let mut bank_storage = StorageProvider::new(storage, &[CONTRACT_NAMESPACE, &cfg.bank]);
+
+    wind_down(&mut perps_storage, &mut bank_storage, perps_address, cfg.owner)
+        // `?` converts `StdError` into `AppError`; there is no
+        // `From<anyhow::Error>`, so bridge through `StdError::host`.
+        .map_err(|err| StdError::host(err.to_string()))?;
+
+    Ok(())
+}
+
+/// What the wind-down moved, for logging and for tests to reconcile against.
+#[derive(Debug)]
+struct Summary {
+    user_count: usize,
+    position_count: usize,
+    /// USDC base units refunded to users' spot accounts.
+    total_refund: Uint128,
+    /// USDC base units handed to the chain owner.
+    swept: Uint128,
+    /// Equity that users were short by, and so could not be refunded.
+    bad_debt: UsdValue,
+    /// Vault equity handed to liquidity providers.
+    vault_distributed: UsdValue,
+    /// Vault equity left behind by floor rounding and the virtual shares'
+    /// pro-rata claim. Swept to the owner along with the treasury.
+    vault_residue: UsdValue,
+    /// Cooldown withdrawals released straight into margin.
+    unlocks_released: UsdValue,
+}
+
+/// Unwind the exchange. See the module-level documentation for the phases.
+///
+/// Returns an error — which halts the chain — if the perps contract does not
+/// hold enough USDC to cover what it owes its users. Nothing is written in
+/// that case: every balance change is computed up front and applied only once
+/// solvency has been confirmed.
+fn wind_down(
+    perps_storage: &mut dyn Storage,
+    bank_storage: &mut dyn Storage,
+    perps_address: Addr,
+    owner: Addr,
+) -> anyhow::Result<Summary> {
+    let usdc = settlement_currency::DENOM.clone();
+
+    disable_trading(perps_storage)?;
+
+    // ---------------- Phase 1. Close positions, release vault ----------------
+
+    // Collect before mutating: saving a user state while ranging over the map
+    // would invalidate the iterator.
+    let mut user_states = USER_STATES
+        .range(perps_storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    // Held in memory so open-interest decrements accumulate across all users
+    // before being written back once.
+    let mut pair_states = PAIR_STATES
+        .range(perps_storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<BTreeMap<_, _>>>()?;
+
+    let mut state = STATE.load(perps_storage)?;
+
+    let position_count = close_all_positions(&mut user_states, &mut pair_states)?;
+
+    let (vault_distributed, vault_residue, unlocks_released) =
+        release_vault(&mut user_states, &mut state, perps_address)?;
+
+    // ------------------- Phase 2. Compute the refund set ---------------------
+
+    let perps_balance = may_load_balance(bank_storage, perps_address, &usdc)?;
+
+    let mut refunds = Vec::with_capacity(user_states.len());
+    let mut total_refund = Uint128::ZERO;
+    let mut bad_debt = UsdValue::ZERO;
+
+    for (addr, user_state) in &user_states {
+        // The vault is not a real user: whatever is left in its margin after
+        // the pro-rata distribution is unallocated dust, and is swept to the
+        // owner along with the treasury.
+        if *addr == perps_address {
+            continue;
+        }
+
+        // A user can end up below zero if they were liquidatable but had not
+        // yet been liquidated. There is nothing to claw back, so the shortfall
+        // is absorbed out of what would otherwise go to the owner.
+        if user_state.margin.is_negative() {
+            bad_debt.checked_sub_assign(user_state.margin)?;
+            continue;
+        }
+
+        let refund = user_state
+            .margin
+            .checked_div(SETTLEMENT_CURRENCY_PRICE)?
+            .into_base_floor(settlement_currency::DECIMAL)?;
+
+        if refund.is_zero() {
+            continue;
+        }
+
+        total_refund.checked_add_assign(refund)?;
+        refunds.push((*addr, refund));
+    }
+
+    // Solvency gate. Checked before any write, so a failure halts the chain
+    // with the pre-upgrade state intact rather than half-applied.
+    if perps_balance < total_refund {
+        return Err(anyhow::anyhow!(
+            "perps exchange is insolvent! usdc balance: {perps_balance}, owed to users: \
+             {total_refund}"
+        ));
+    }
+
+    // ------------------------- Phase 3. Apply writes -------------------------
+
+    for (addr, refund) in &refunds {
+        let balance = may_load_balance(bank_storage, *addr, &usdc)?;
+        BALANCES.save(bank_storage, (addr, &usdc), &balance.checked_add(*refund)?)?;
+    }
+
+    // Everything the contract still holds after refunds — treasury, insurance
+    // fund, vault dust, and the rounding residue of months of operation — goes
+    // to the chain owner.
+    let swept = perps_balance.checked_sub(total_refund)?;
+
+    if swept.is_non_zero() {
+        let balance = may_load_balance(bank_storage, owner, &usdc)?;
+        BALANCES.save(bank_storage, (&owner, &usdc), &balance.checked_add(swept)?)?;
+    }
+
+    BALANCES.remove(bank_storage, (&perps_address, &usdc));
+
+    // Every user state is now fully zeroed, so all of them are pruned.
+    for (addr, _) in &user_states {
+        USER_STATES.remove(perps_storage, *addr)?;
+    }
+
+    for (pair_id, pair_state) in &pair_states {
+        PAIR_STATES.save(perps_storage, pair_id, pair_state)?;
+    }
+
+    state.treasury = UsdValue::ZERO;
+    state.insurance_fund = UsdValue::ZERO;
+    state.vault_share_supply = Uint128::ZERO;
+    STATE.save(perps_storage, &state)?;
+
+    // ------------------- Phase 4. Clear the order book -----------------------
+
+    BIDS.clear_all(perps_storage);
+    ASKS.clear_all(perps_storage);
+    LONGS.clear(perps_storage, None, None);
+    SHORTS.clear(perps_storage, None, None);
+    DEPTHS.clear(perps_storage, None, None);
+
+    let summary = Summary {
+        user_count: user_states.len(),
+        position_count,
+        total_refund,
+        swept,
+        bad_debt,
+        vault_distributed,
+        vault_residue,
+        unlocks_released,
+    };
+
+    tracing::info!(
+        refunded_users = refunds.len(),
+        pair_count = pair_states.len(),
+        user_count = summary.user_count,
+        position_count = summary.position_count,
+        total_refund = %summary.total_refund,
+        swept = %summary.swept,
+        bad_debt = %summary.bad_debt,
+        vault_distributed = %summary.vault_distributed,
+        vault_residue = %summary.vault_residue,
+        unlocks_released = %summary.unlocks_released,
+        "Wound down the perps exchange"
+    );
+
+    assert_invariants(perps_storage, bank_storage, perps_address, &usdc)?;
+
+    Ok(summary)
+}
+
+/// Rewrite `Param` in its new shape, with trading switched off.
+///
+/// `Param` gained the `trading_enabled` field in this release, so the stored
+/// value must be read through the pre-upgrade shape before it can be written
+/// back through the live one.
+fn disable_trading(perps_storage: &mut dyn Storage) -> StdResult<()> {
+    let legacy = LEGACY_PARAM.load(perps_storage)?;
+
+    PARAM.save(
+        perps_storage,
+        &Param {
+            max_unlocks: legacy.max_unlocks,
+            max_open_orders: legacy.max_open_orders,
+            maker_fee_rates: legacy.maker_fee_rates,
+            taker_fee_rates: legacy.taker_fee_rates,
+            protocol_fee_rate: legacy.protocol_fee_rate,
+            liquidation_fee_rate: legacy.liquidation_fee_rate,
+            liquidation_buffer_ratio: legacy.liquidation_buffer_ratio,
+            funding_period: legacy.funding_period,
+            vault_total_weight: legacy.vault_total_weight,
+            vault_cooldown_period: legacy.vault_cooldown_period,
+            referral_active: legacy.referral_active,
+            min_referrer_volume: legacy.min_referrer_volume,
+            referrer_commission_rates: legacy.referrer_commission_rates,
+            vault_deposit_cap: legacy.vault_deposit_cap,
+            max_action_batch_size: legacy.max_action_batch_size,
+            trading_enabled: false,
+        },
+    )
+}
+
+/// Close every open position at its pair's mark price, crediting the realized
+/// PnL and settled funding to the user's margin. Returns the number of
+/// positions closed.
+///
+/// Reuses the exchange's own fill primitive, so the accounting is identical to
+/// a trade that closes the position — including funding settlement, open
+/// interest, and the weighted-average entry price bookkeeping — except that no
+/// fee is charged, since this is a forced closure rather than a trade.
+fn close_all_positions(
+    user_states: &mut [(Addr, UserState)],
+    pair_states: &mut BTreeMap<PairId, dango_types::perps::PairState>,
+) -> anyhow::Result<usize> {
+    let mut position_count = 0;
+
+    for (_addr, user_state) in user_states.iter_mut() {
+        // Collect the pair ids first: `execute_fill` removes the position from
+        // the map once it is fully closed.
+        let pair_ids = user_state.positions.keys().cloned().collect::<Vec<_>>();
+
+        for pair_id in pair_ids {
+            let pair_state = pair_states
+                .get_mut(&pair_id)
+                .ok_or_else(|| anyhow::anyhow!("no pair state for {pair_id}"))?;
+
+            let size = user_state.positions[&pair_id].size;
+
+            let pnl = execute_fill(
+                &pair_id,
+                pair_state,
+                user_state,
+                pair_state.index_price,
+                // Closing the whole position means filling the opposite side
+                // for the full size, and opening nothing.
+                size.checked_neg()?,
+                Quantity::ZERO,
+            )?;
+
+            user_state.margin.checked_add_assign(pnl.total()?)?;
+
+            position_count += 1;
+        }
+
+        // Every resting order is cancelled by clearing the book, so nothing is
+        // reserved against them any more.
+        user_state.reserved_margin = UsdValue::ZERO;
+        user_state.open_order_count = 0;
+    }
+
+    Ok(position_count)
+}
+
+/// Pay out the counterparty vault and release unlocks still in cooldown.
+///
+/// Returns `(vault_distributed, vault_residue, unlocks_released)`.
+///
+/// Must run after [`close_all_positions`], which leaves the vault holding no
+/// positions, so its equity is simply its margin.
+fn release_vault(
+    user_states: &mut [(Addr, UserState)],
+    state: &mut dango_types::perps::State,
+    perps_address: Addr,
+) -> anyhow::Result<(UsdValue, UsdValue, UsdValue)> {
+    let vault_equity = user_states
+        .iter()
+        .find(|(addr, _)| *addr == perps_address)
+        .map_or(UsdValue::ZERO, |(_, user_state)| user_state.margin);
+
+    // Mirror the share maths of a regular vault withdrawal, virtual shares and
+    // all, so each provider is paid exactly what withdrawing would have paid.
+    let effective_supply = state.vault_share_supply.checked_add(VIRTUAL_SHARES)?;
+    let effective_equity = vault_equity.checked_add(VIRTUAL_ASSETS)?;
+
+    if !effective_equity.is_positive() {
+        tracing::error!(
+            %vault_equity,
+            "counterparty vault has non-positive equity; liquidity providers receive nothing"
+        );
+    }
+
+    let mut vault_distributed = UsdValue::ZERO;
+    let mut unlocks_released = UsdValue::ZERO;
+
+    for (addr, user_state) in user_states.iter_mut() {
+        // Unlocks were already debited from the vault's margin when the
+        // withdrawal was requested, so releasing them is independent of the
+        // share distribution below.
+        for unlock in std::mem::take(&mut user_state.unlocks) {
+            user_state
+                .margin
+                .checked_add_assign(unlock.amount_to_release)?;
+            unlocks_released.checked_add_assign(unlock.amount_to_release)?;
+        }
+
+        // A vault whose equity has gone non-positive has nothing to pay out;
+        // distributing on a negative ratio would claw margin *away* from the
+        // providers. The regular withdrawal path refuses in the same state.
+        if *addr == perps_address
+            || user_state.vault_shares.is_zero()
+            || !effective_equity.is_positive()
+        {
+            continue;
+        }
+
+        // Multiply before dividing to avoid intermediate precision loss, and
+        // round down so the vault can never pay out more than it holds.
+        let amount = {
+            let raw = effective_equity
+                .into_inner()
+                .0
+                .checked_multiply_ratio_floor(
+                    Int128::new(i128::try_from(user_state.vault_shares.into_inner())?),
+                    Int128::new(i128::try_from(effective_supply.into_inner())?),
+                )?;
+            UsdValue::new(Dec128_6::raw(raw))
+        };
+
+        user_state.margin.checked_add_assign(amount)?;
+        user_state.vault_shares = Uint128::ZERO;
+        vault_distributed.checked_add_assign(amount)?;
+    }
+
+    // Debit the distributed total from the vault in one go. What is left is the
+    // virtual shares' pro-rata claim (net of the virtual asset) plus floor
+    // rounding — the same residue an ordinary withdrawal leaves behind.
+    let vault_residue = vault_equity.checked_sub(vault_distributed)?;
+
+    if let Some((_, vault_state)) = user_states
+        .iter_mut()
+        .find(|(addr, _)| *addr == perps_address)
+    {
+        vault_state.margin.checked_sub_assign(vault_distributed)?;
+    }
+
+    state.vault_share_supply = Uint128::ZERO;
+
+    Ok((vault_distributed, vault_residue, unlocks_released))
+}
+
+fn may_load_balance(storage: &dyn Storage, address: Addr, denom: &Denom) -> StdResult<Uint128> {
+    Ok(BALANCES
+        .may_load(storage, (&address, denom))?
+        .unwrap_or(Uint128::ZERO))
+}
+
+/// Verify the exchange has been fully unwound. A violation means the migration
+/// itself is wrong, so it panics rather than returning — the chain must not
+/// continue on corrupt state.
+fn assert_invariants(
+    perps_storage: &dyn Storage,
+    bank_storage: &dyn Storage,
+    perps_address: Addr,
+    usdc: &Denom,
+) -> StdResult<()> {
+    // No user may retain any position, margin, vault share, or unlock. Since
+    // every field is zeroed, every entry is pruned and the map is empty.
+    let remaining = USER_STATES
+        .range(perps_storage, None, None, IterationOrder::Ascending)
+        .collect::<StdResult<Vec<_>>>()?;
+
+    assert!(
+        remaining.is_empty(),
+        "{} user states survived the wind-down",
+        remaining.len()
+    );
+
+    // The order book and its indexes must be gone.
+    assert!(BIDS.is_empty(perps_storage), "BIDS isn't empty!");
+    assert!(ASKS.is_empty(perps_storage), "ASKS isn't empty!");
+    assert!(LONGS.is_empty(perps_storage), "LONGS isn't empty!");
+    assert!(SHORTS.is_empty(perps_storage), "SHORTS isn't empty!");
+    assert!(DEPTHS.is_empty(perps_storage), "DEPTHS isn't empty!");
+
+    // Closing every position must have driven open interest to zero on both
+    // sides of every pair.
+    for entry in PAIR_STATES.range(perps_storage, None, None, IterationOrder::Ascending) {
+        let (pair_id, pair_state) = entry?;
+        assert!(
+            pair_state.long_oi.is_zero() && pair_state.short_oi.is_zero(),
+            "pair {pair_id} still has open interest: long={}, short={}",
+            pair_state.long_oi,
+            pair_state.short_oi,
+        );
+    }
+
+    let state = STATE.load(perps_storage)?;
+    assert!(
+        state.treasury.is_zero(),
+        "treasury not zero: {}",
+        state.treasury
+    );
+    assert!(
+        state.insurance_fund.is_zero(),
+        "insurance fund not zero: {}",
+        state.insurance_fund
+    );
+    assert!(
+        state.vault_share_supply.is_zero(),
+        "vault share supply not zero: {}",
+        state.vault_share_supply
+    );
+
+    // The contract must have paid out every token it held.
+    let balance = may_load_balance(bank_storage, perps_address, usdc)?;
+    assert!(
+        balance.is_zero(),
+        "perps contract still holds {balance} USDC"
+    );
+
+    // Trading must be off, or the exchange could be used again after the fork.
+    assert!(
+        !PARAM.load(perps_storage)?.trading_enabled,
+        "trading is still enabled!"
+    );
+
+    tracing::info!("All wind-down invariants passed");
 
     Ok(())
 }
@@ -38,5 +549,610 @@ pub fn do_perps_upgrades(storage: Box<dyn Storage>) -> AppResult<()> {
 
 #[cfg(test)]
 mod tests {
-    // Add tests here.
+    use {
+        super::*,
+        dango_order_book::{FundingPerUnit, UsdPrice},
+        dango_perps::{core::compute_user_equity, querier::NoCachePerpQuerier},
+        dango_primitives::{Binary, MockStorage, Shared, Timestamp},
+        dango_types::perps::{PairState, Position, State, Unlock},
+        std::{collections::VecDeque, fs, path::PathBuf},
+    };
+
+    const PERPS: Addr = Addr::mock(1);
+    const OWNER: Addr = Addr::mock(2);
+    const ALICE: Addr = Addr::mock(3);
+    const BOB: Addr = Addr::mock(4);
+    const BANK: Addr = Addr::mock(9);
+
+    /// 1 USD in USDC base units (6 decimals).
+    const ONE_USDC: u128 = 1_000_000;
+
+    fn pair_id() -> PairId {
+        "perp/btcusd".parse().unwrap()
+    }
+
+    fn usdc() -> Denom {
+        settlement_currency::DENOM.clone()
+    }
+
+    /// A `Param` in the pre-upgrade shape, which is what the migration reads.
+    fn legacy_param() -> legacy_perps::Param {
+        legacy_perps::Param {
+            max_unlocks: 10,
+            max_open_orders: 100,
+            ..Default::default()
+        }
+    }
+
+    fn position(size: i128, entry_price: i128) -> Position {
+        Position {
+            size: Quantity::new_int(size),
+            entry_price: UsdPrice::new_int(entry_price),
+            entry_funding_per_unit: FundingPerUnit::ZERO,
+            conditional_order_above: None,
+            conditional_order_below: None,
+        }
+    }
+
+    /// Perps and bank storage handles over one shared in-memory store.
+    struct Fixture {
+        base: Shared<MockStorage>,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let fixture = Self {
+                base: Shared::new(MockStorage::new()),
+            };
+
+            LEGACY_PARAM
+                .save(&mut fixture.perps(), &legacy_param())
+                .unwrap();
+
+            fixture
+        }
+
+        fn perps(&self) -> StorageProvider {
+            StorageProvider::new(Box::new(self.base.clone()), &[CONTRACT_NAMESPACE, &PERPS])
+        }
+
+        fn bank(&self) -> StorageProvider {
+            StorageProvider::new(Box::new(self.base.clone()), &[CONTRACT_NAMESPACE, &BANK])
+        }
+
+        fn with_state(self, state: State) -> Self {
+            STATE.save(&mut self.perps(), &state).unwrap();
+            self
+        }
+
+        fn with_pair(self, index_price: i128, funding_per_unit: i128) -> Self {
+            PAIR_STATES
+                .save(
+                    &mut self.perps(),
+                    &pair_id(),
+                    &PairState {
+                        index_price: UsdPrice::new_int(index_price),
+                        oracle_price: UsdPrice::new_int(index_price),
+                        funding_per_unit: FundingPerUnit::new_int(funding_per_unit),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            self
+        }
+
+        /// Seed a user, adjusting the pair's open interest to match the
+        /// position so the fixture starts from a self-consistent state.
+        fn with_user(self, addr: Addr, user_state: UserState) -> Self {
+            let mut perps = self.perps();
+
+            if let Some(pos) = user_state.positions.get(&pair_id()) {
+                let mut pair_state = PAIR_STATES.load(&perps, &pair_id()).unwrap();
+
+                if pos.size.is_positive() {
+                    pair_state.long_oi.checked_add_assign(pos.size).unwrap();
+                } else {
+                    pair_state
+                        .short_oi
+                        .checked_add_assign(pos.size.checked_abs().unwrap())
+                        .unwrap();
+                }
+
+                PAIR_STATES
+                    .save(&mut perps, &pair_id(), &pair_state)
+                    .unwrap();
+            }
+
+            USER_STATES.save(&mut perps, addr, &user_state).unwrap();
+            self
+        }
+
+        /// Fund the perps contract with USDC, as the bank sees it.
+        fn with_balance(self, usd: u128) -> Self {
+            BALANCES
+                .save(
+                    &mut self.bank(),
+                    (&PERPS, &usdc()),
+                    &Uint128::new(usd * ONE_USDC),
+                )
+                .unwrap();
+            self
+        }
+
+        fn run(&self) -> anyhow::Result<Summary> {
+            wind_down(&mut self.perps(), &mut self.bank(), PERPS, OWNER)
+        }
+
+        fn balance_of(&self, addr: Addr) -> Uint128 {
+            may_load_balance(&self.bank(), addr, &usdc()).unwrap()
+        }
+    }
+
+    // -------------------------- position settlement --------------------------
+
+    /// A long closed above its entry price realizes a gain: 10 units bought at
+    /// $100 and marked at $110 is $100 of profit on top of $1,000 of margin.
+    #[test]
+    fn closes_long_at_profit() {
+        let fixture = Fixture::new()
+            .with_state(State::default())
+            .with_pair(110, 0)
+            .with_user(
+                ALICE,
+                UserState {
+                    margin: UsdValue::new_int(1_000),
+                    positions: [(pair_id(), position(10, 100))].into(),
+                    ..Default::default()
+                },
+            )
+            .with_balance(1_100);
+
+        fixture.run().unwrap();
+
+        assert_eq!(fixture.balance_of(ALICE), Uint128::new(1_100 * ONE_USDC));
+        assert_eq!(fixture.balance_of(PERPS), Uint128::ZERO);
+    }
+
+    /// A short is the mirror image: 10 units sold at $100 and marked at $110
+    /// loses $100.
+    #[test]
+    fn closes_short_at_loss() {
+        let fixture = Fixture::new()
+            .with_state(State::default())
+            .with_pair(110, 0)
+            .with_user(
+                ALICE,
+                UserState {
+                    margin: UsdValue::new_int(1_000),
+                    positions: [(pair_id(), position(-10, 100))].into(),
+                    ..Default::default()
+                },
+            )
+            .with_balance(900);
+
+        fixture.run().unwrap();
+
+        assert_eq!(fixture.balance_of(ALICE), Uint128::new(900 * ONE_USDC));
+    }
+
+    /// Funding accrued since the position was last touched is settled as part
+    /// of the closure: a 10-unit long facing $5/unit of accumulated funding
+    /// owes $50.
+    #[test]
+    fn settles_funding_on_close() {
+        let fixture = Fixture::new()
+            .with_state(State::default())
+            .with_pair(100, 5)
+            .with_user(
+                ALICE,
+                UserState {
+                    margin: UsdValue::new_int(1_000),
+                    positions: [(pair_id(), position(10, 100))].into(),
+                    ..Default::default()
+                },
+            )
+            .with_balance(950);
+
+        fixture.run().unwrap();
+
+        assert_eq!(fixture.balance_of(ALICE), Uint128::new(950 * ONE_USDC));
+    }
+
+    // ----------------------------- vault release -----------------------------
+
+    /// Liquidity providers are paid their pro-rata share of vault equity, which
+    /// is what withdrawing normally would have paid them.
+    #[test]
+    fn distributes_vault_pro_rata() {
+        let fixture = Fixture::new()
+            .with_state(State {
+                vault_share_supply: Uint128::new(400_000_000),
+                ..Default::default()
+            })
+            .with_pair(100, 0)
+            // The vault holds the providers' deposited margin.
+            .with_user(PERPS, UserState {
+                margin: UsdValue::new_int(400),
+                ..Default::default()
+            })
+            .with_user(ALICE, UserState {
+                vault_shares: Uint128::new(300_000_000),
+                ..Default::default()
+            })
+            .with_user(BOB, UserState {
+                vault_shares: Uint128::new(100_000_000),
+                ..Default::default()
+            })
+            .with_balance(400);
+
+        fixture.run().unwrap();
+
+        // A 3:1 split of the vault's $400.
+        assert_eq!(fixture.balance_of(ALICE), Uint128::new(300 * ONE_USDC));
+        assert_eq!(fixture.balance_of(BOB), Uint128::new(100 * ONE_USDC));
+        assert_eq!(fixture.balance_of(PERPS), Uint128::ZERO);
+    }
+
+    /// A withdrawal still in its cooldown window is released immediately —
+    /// otherwise those funds would be stranded by the shutdown.
+    #[test]
+    fn releases_pending_unlocks() {
+        let fixture = Fixture::new()
+            .with_state(State::default())
+            .with_pair(100, 0)
+            .with_user(
+                ALICE,
+                UserState {
+                    margin: UsdValue::new_int(50),
+                    unlocks: VecDeque::from(vec![Unlock {
+                        end_time: Timestamp::from_seconds(9_999_999_999),
+                        amount_to_release: UsdValue::new_int(250),
+                    }]),
+                    ..Default::default()
+                },
+            )
+            .with_balance(300);
+
+        fixture.run().unwrap();
+
+        assert_eq!(fixture.balance_of(ALICE), Uint128::new(300 * ONE_USDC));
+    }
+
+    // -------------------------------- payouts --------------------------------
+
+    /// Treasury, insurance fund, and any rounding residue end up with the chain
+    /// owner, not with users.
+    #[test]
+    fn sweeps_residual_to_owner() {
+        let fixture = Fixture::new()
+            .with_state(State {
+                treasury: UsdValue::new_int(70),
+                insurance_fund: UsdValue::new_int(30),
+                ..Default::default()
+            })
+            .with_pair(100, 0)
+            .with_user(
+                ALICE,
+                UserState {
+                    margin: UsdValue::new_int(500),
+                    ..Default::default()
+                },
+            )
+            .with_balance(600);
+
+        fixture.run().unwrap();
+
+        assert_eq!(fixture.balance_of(ALICE), Uint128::new(500 * ONE_USDC));
+        assert_eq!(fixture.balance_of(OWNER), Uint128::new(100 * ONE_USDC));
+        assert_eq!(fixture.balance_of(PERPS), Uint128::ZERO);
+    }
+
+    /// A user who was liquidatable but not yet liquidated ends below zero.
+    /// There is nothing to claw back, so they are refunded nothing and the
+    /// shortfall comes out of what the owner would otherwise have swept.
+    #[test]
+    fn clamps_negative_margin_to_zero() {
+        let fixture = Fixture::new()
+            .with_state(State::default())
+            .with_pair(50, 0)
+            .with_user(
+                ALICE,
+                UserState {
+                    margin: UsdValue::new_int(100),
+                    // Marked down from $100 to $50: a $500 loss against $100 of
+                    // margin.
+                    positions: [(pair_id(), position(10, 100))].into(),
+                    ..Default::default()
+                },
+            )
+            .with_user(
+                BOB,
+                UserState {
+                    margin: UsdValue::new_int(700),
+                    positions: [(pair_id(), position(-10, 100))].into(),
+                    ..Default::default()
+                },
+            )
+            .with_balance(1_200);
+
+        fixture.run().unwrap();
+
+        // Alice's equity is -$400; she is credited nothing rather than a
+        // negative amount.
+        assert_eq!(fixture.balance_of(ALICE), Uint128::ZERO);
+        // Bob gained $500 on his short, on top of $700 of margin.
+        assert_eq!(fixture.balance_of(BOB), Uint128::new(1_200 * ONE_USDC));
+        // Bob's payout absorbed the whole balance, so there is nothing to
+        // sweep — Alice's bad debt came out of the owner's share.
+        assert_eq!(fixture.balance_of(OWNER), Uint128::ZERO);
+    }
+
+    /// If the contract cannot cover what it owes, the upgrade must fail so the
+    /// chain halts with its pre-upgrade state intact, rather than paying out an
+    /// arbitrary partial haircut.
+    #[test]
+    fn halts_when_insolvent() {
+        let fixture = Fixture::new()
+            .with_state(State::default())
+            .with_pair(100, 0)
+            .with_user(
+                ALICE,
+                UserState {
+                    margin: UsdValue::new_int(1_000),
+                    ..Default::default()
+                },
+            )
+            .with_balance(999);
+
+        let err = fixture.run().unwrap_err();
+
+        assert!(
+            err.to_string().contains("insolvent"),
+            "unexpected error: {err}"
+        );
+
+        // Nothing was paid out, and the user still holds their margin.
+        assert_eq!(fixture.balance_of(ALICE), Uint128::ZERO);
+        assert_eq!(fixture.balance_of(PERPS), Uint128::new(999 * ONE_USDC));
+        assert_eq!(
+            USER_STATES.load(&fixture.perps(), ALICE).unwrap().margin,
+            UsdValue::new_int(1_000)
+        );
+    }
+
+    /// Trading is switched off, which is what stops the exchange being used
+    /// again after the fork. Unrelated parameters survive the reshape.
+    #[test]
+    fn disables_trading() {
+        let fixture = Fixture::new()
+            .with_state(State::default())
+            .with_pair(100, 0)
+            .with_balance(0);
+
+        fixture.run().unwrap();
+
+        let param = PARAM.load(&fixture.perps()).unwrap();
+
+        assert!(!param.trading_enabled);
+        assert_eq!(param.max_unlocks, 10);
+        assert_eq!(param.max_open_orders, 100);
+    }
+
+    // ---------------------------- real-data tests ----------------------------
+    //
+    // These run against a snapshot of a live chain's perps state, pulled into
+    // `testdata/` (gitignored — the dump is large and goes stale as the chain
+    // advances). Ignored by default; produce a fixture and run them with:
+    //
+    //   cargo run -p dango-upgrade --example dump_perps_state -- mainnet
+    //   cargo test -p dango-upgrade -- --ignored
+
+    fn snapshot_path(chain: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join(format!("{chain}_snapshot.json"))
+    }
+
+    /// Rebuild a chain's perps and bank storage in memory from a snapshot.
+    fn reconstruct(chain: &str) -> (Shared<MockStorage>, Addr, Uint128) {
+        let path = snapshot_path(chain);
+
+        let snapshot: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+
+        let perps_address: Addr =
+            serde_json::from_value(snapshot["perps_address"].clone()).unwrap();
+        let balance: Uint128 = serde_json::from_value(snapshot["balance"].clone()).unwrap();
+
+        let base = Shared::new(MockStorage::new());
+
+        // Scanned keys are already relative to the contract's own storage, so
+        // they are written back through an identically scoped provider.
+        let storage: BTreeMap<Binary, Binary> =
+            serde_json::from_value(snapshot["storage"].clone()).unwrap();
+
+        let mut perps = StorageProvider::new(
+            Box::new(base.clone()),
+            &[CONTRACT_NAMESPACE, &perps_address],
+        );
+
+        for (key, value) in &storage {
+            perps.write(key.as_ref(), value.as_ref());
+        }
+
+        let mut bank = StorageProvider::new(Box::new(base.clone()), &[CONTRACT_NAMESPACE, &BANK]);
+
+        BALANCES
+            .save(&mut bank, (&perps_address, &usdc()), &balance)
+            .unwrap();
+
+        (base, perps_address, balance)
+    }
+
+    /// Wind down a real chain snapshot, then verify that not a cent was created
+    /// or destroyed and that the exchange is left fully unwound.
+    fn wind_down_real(chain: &str) {
+        // Snapshots are produced on demand and never committed, so a missing
+        // one means "not fetched", not "broken".
+        if !snapshot_path(chain).exists() {
+            println!(
+                "skipping {chain}: no snapshot; run `cargo run -p dango-upgrade --example \
+                 dump_perps_state -- {chain}`"
+            );
+
+            return;
+        }
+
+        let (base, perps_address, balance) = reconstruct(chain);
+
+        let perps_storage = || {
+            StorageProvider::new(
+                Box::new(base.clone()),
+                &[CONTRACT_NAMESPACE, &perps_address],
+            )
+        };
+        let bank_storage =
+            || StorageProvider::new(Box::new(base.clone()), &[CONTRACT_NAMESPACE, &BANK]);
+
+        // What the exchange owed before the wind-down: every account's equity
+        // at the mark, plus withdrawals still in cooldown. This includes the
+        // vault, whose equity is redistributed to providers rather than paid
+        // out to itself, so the total is unchanged by the distribution.
+        let (total_equity, total_unlocks, user_count, position_count) = {
+            let storage = perps_storage();
+            let querier = NoCachePerpQuerier::new_local(&storage);
+
+            let mut total_equity = UsdValue::ZERO;
+            let mut total_unlocks = UsdValue::ZERO;
+            let mut user_count = 0;
+            let mut position_count = 0;
+
+            for entry in USER_STATES.range(&storage, None, None, IterationOrder::Ascending) {
+                let (_addr, user_state) = entry.unwrap();
+
+                total_equity
+                    .checked_add_assign(compute_user_equity(&querier, &user_state).unwrap())
+                    .unwrap();
+
+                for unlock in &user_state.unlocks {
+                    total_unlocks
+                        .checked_add_assign(unlock.amount_to_release)
+                        .unwrap();
+                }
+
+                user_count += 1;
+                position_count += user_state.positions.len();
+            }
+
+            (total_equity, total_unlocks, user_count, position_count)
+        };
+
+        let summary = wind_down(
+            &mut perps_storage(),
+            &mut bank_storage(),
+            perps_address,
+            OWNER,
+        )
+        .unwrap();
+
+        // `assert_invariants` has already checked the structural
+        // post-conditions. What remains is to account for the money.
+        let bank = bank_storage();
+
+        let mut total_credited = Uint128::ZERO;
+        let mut credited_accounts = 0;
+
+        for entry in BALANCES.range(&bank, None, None, IterationOrder::Ascending) {
+            let ((_addr, denom), amount) = entry.unwrap();
+
+            if denom == usdc() {
+                total_credited.checked_add_assign(amount).unwrap();
+                credited_accounts += 1;
+            }
+        }
+
+        let swept = may_load_balance(&bank, OWNER, &usdc()).unwrap();
+
+        println!(
+            "{chain}: {user_count} users, {position_count} positions; equity {total_equity}, \
+             unlocks {total_unlocks}; credited {total_credited} across {credited_accounts} \
+             accounts, of which {swept} swept to the owner\n  {summary:?}"
+        );
+
+        // The snapshot must agree with what the migration walked over.
+        assert_eq!(summary.user_count, user_count);
+        assert_eq!(summary.position_count, position_count);
+
+        // Conservation: the contract's entire balance was paid out, no more and
+        // no less. This rules out both minting USDC and stranding user funds.
+        assert_eq!(
+            total_credited, balance,
+            "USDC was created or destroyed: credited {total_credited} against a starting balance \
+             of {balance}"
+        );
+        assert_eq!(
+            summary.total_refund.checked_add(summary.swept).unwrap(),
+            balance
+        );
+
+        // Closing positions at a single price is zero-sum, so the equity the
+        // exchange owed before the fork must reappear afterwards, split three
+        // ways and with nothing unaccounted for:
+        //
+        //   owed = refunded + bad debt + vault residue
+        //
+        // Bad debt is equity users were short by and so could not be paid; the
+        // vault residue is the virtual shares' claim. Both are absorbed out of
+        // the owner's sweep.
+        let owed = total_equity.checked_add(total_unlocks).unwrap();
+
+        let accounted = usd_to_base(owed)
+            .checked_sub(usd_to_base(summary.bad_debt))
+            .unwrap()
+            .checked_sub(usd_to_base(summary.vault_residue))
+            .unwrap();
+
+        // The two sides are algebraically equal but not bit-identical: equity
+        // computes `size * (mark - entry)` in one multiplication, whereas
+        // closing the position computes `|size| * mark - |size| * entry`. Each
+        // multiplication truncates to six decimals, so a position contributes
+        // up to a few units of the last place. The fill path is the
+        // authoritative one — it is what ordinary trading uses.
+        let tolerance = Uint128::new(4 * position_count as u128 + 1);
+        let drift = if summary.total_refund > accounted {
+            summary.total_refund.checked_sub(accounted).unwrap()
+        } else {
+            accounted.checked_sub(summary.total_refund).unwrap()
+        };
+
+        assert!(
+            drift <= tolerance,
+            "unaccounted equity: refunded {} against {accounted} owed net of bad debt {} and \
+             vault residue {}; drift of {drift} exceeds the {tolerance} rounding allowance for \
+             {position_count} positions",
+            summary.total_refund,
+            summary.bad_debt,
+            summary.vault_residue,
+        );
+    }
+
+    fn usd_to_base(value: UsdValue) -> Uint128 {
+        value
+            .checked_div(SETTLEMENT_CURRENCY_PRICE)
+            .unwrap()
+            .into_base_floor(settlement_currency::DECIMAL)
+            .unwrap()
+    }
+
+    #[test]
+    #[ignore = "requires gitignored testdata/mainnet_snapshot.json"]
+    fn wind_down_mainnet() {
+        wind_down_real("mainnet");
+    }
+
+    #[test]
+    #[ignore = "requires gitignored testdata/testnet_snapshot.json"]
+    fn wind_down_testnet() {
+        wind_down_real("testnet");
+    }
 }

--- a/dango/exchange/upgrade/src/perps.rs
+++ b/dango/exchange/upgrade/src/perps.rs
@@ -60,33 +60,19 @@ mod legacy_perps {
     #[derive(Default)]
     pub struct Param {
         pub max_unlocks: usize,
-
         pub max_open_orders: usize,
-
         pub maker_fee_rates: RateSchedule,
-
         pub taker_fee_rates: RateSchedule,
-
         pub protocol_fee_rate: Dimensionless,
-
         pub liquidation_fee_rate: Dimensionless,
-
         pub liquidation_buffer_ratio: Dimensionless,
-
         pub funding_period: Duration,
-
         pub vault_total_weight: Dimensionless,
-
         pub vault_cooldown_period: Duration,
-
         pub referral_active: bool,
-
         pub min_referrer_volume: UsdValue,
-
         pub referrer_commission_rates: RateSchedule,
-
         pub vault_deposit_cap: Option<UsdValue>,
-
         pub max_action_batch_size: usize,
     }
 }

--- a/dango/testing/tests/perps/main.rs
+++ b/dango/testing/tests/perps/main.rs
@@ -23,6 +23,7 @@ mod trading;
 mod vault;
 mod vault_snapshots;
 mod vault_withdrawal_health;
+mod wind_down;
 
 /// Return the genesis-default global params (mirrors `PerpsOption::preset_test()`).
 pub fn default_param() -> Param {

--- a/dango/testing/tests/perps/wind_down.rs
+++ b/dango/testing/tests/perps/wind_down.rs
@@ -1,0 +1,247 @@
+use {
+    crate::{default_pair_param, default_param, register_oracle_prices},
+    dango_math::Uint128,
+    dango_order_book::{OrderKind, Quantity, UsdPrice, UsdValue},
+    dango_primitives::{Addressable, Coins, NonEmpty, QuerierExt, ResultExt, btree_map},
+    dango_testing::{TestOption, pair_id, setup_test_naive},
+    dango_types::{
+        constants::usdc,
+        perps::{self, Param, SubmitOrCancelOrderRequest, SubmitOrderRequest},
+    },
+};
+
+/// The error every gated handler must reject with once the exchange has been
+/// wound down.
+const DISABLED: &str = "trading is disabled";
+
+/// Turning `trading_enabled` off must stop every way of taking on new risk,
+/// while leaving every way of getting funds *out* untouched. This is the
+/// contract-side half of the wind-down: the chain upgrade flips the flag, and
+/// these are the behaviors that flip with it.
+#[tokio::test]
+async fn disabling_trading_blocks_new_risk_but_not_exits() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let pair = pair_id();
+
+    // ---------------------- Set up while trading is open ---------------------
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    // A resting order, so there is something to cancel afterwards.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(1),
+                kind: OrderKind::Limit {
+                    limit_price: UsdPrice::new_int(1_900),
+                    time_in_force: dango_order_book::TimeInForce::GoodTilCanceled,
+                    client_order_id: None,
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // --------------------------- Wind trading down ---------------------------
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: Param {
+                    trading_enabled: false,
+                    ..default_param()
+                },
+                pair_params: btree_map! { pair.clone() => default_pair_param() },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // ------------------------- New risk is rejected --------------------------
+
+    // 1. Placing an order.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitOrder(SubmitOrderRequest {
+                pair_id: pair.clone(),
+                size: Quantity::new_int(1),
+                kind: OrderKind::Market {
+                    max_slippage: dango_order_book::Dimensionless::new_permille(100),
+                },
+                reduce_only: false,
+                tp: None,
+                sl: None,
+            })),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error(DISABLED);
+
+    // 2. Placing orders in a batch.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::BatchUpdateOrders(
+                NonEmpty::new_unchecked(vec![SubmitOrCancelOrderRequest::Submit(
+                    SubmitOrderRequest {
+                        pair_id: pair.clone(),
+                        size: Quantity::new_int(1),
+                        kind: OrderKind::Limit {
+                            limit_price: UsdPrice::new_int(1_900),
+                            time_in_force: dango_order_book::TimeInForce::GoodTilCanceled,
+                            client_order_id: None,
+                        },
+                        reduce_only: false,
+                        tp: None,
+                        sl: None,
+                    },
+                )]),
+            )),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error(DISABLED);
+
+    // 3. Moving USDC from a spot account into margin.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(1_000_000)).unwrap(),
+        )
+        .await
+        .should_fail_with_error(DISABLED);
+
+    // 4. Moving margin into the counterparty vault.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Vault(perps::VaultMsg::AddLiquidity {
+                amount: UsdValue::new_int(100),
+                min_shares_to_mint: None,
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error(DISABLED);
+
+    // ------------------------ Getting out still works ------------------------
+
+    // Cancelling a resting order.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::CancelOrder(
+                perps::CancelOrderRequest::All,
+            )),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    // Withdrawing margin back to the spot account.
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Withdraw {
+                amount: UsdValue::new_int(1_000),
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    let user_state = suite
+        .query_wasm_smart(
+            contracts.perps,
+            perps::QueryUserStateRequest {
+                user: accounts.user1.address(),
+            },
+        )
+        .should_succeed()
+        .unwrap();
+
+    assert_eq!(user_state.margin, UsdValue::new_int(9_000));
+    assert_eq!(user_state.open_order_count, 0);
+}
+
+/// A conditional order is still an order, and it goes through its own handler
+/// rather than the one `submit_order` uses, so it needs its own gate.
+#[tokio::test]
+async fn disabling_trading_blocks_conditional_orders() {
+    let (mut suite, mut accounts, _, contracts, _) = setup_test_naive(TestOption::default());
+
+    register_oracle_prices(&mut suite, &mut accounts, 2_000).await;
+
+    let pair = pair_id();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::Deposit { to: None }),
+            Coins::one(usdc::DENOM.clone(), Uint128::new(10_000_000_000)).unwrap(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.owner,
+            contracts.perps,
+            &perps::ExecuteMsg::Maintain(perps::MaintainerMsg::Configure {
+                param: Param {
+                    trading_enabled: false,
+                    ..default_param()
+                },
+                pair_params: btree_map! { pair.clone() => default_pair_param() },
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_succeed();
+
+    suite
+        .execute(
+            &mut accounts.user1,
+            contracts.perps,
+            &perps::ExecuteMsg::Trade(perps::TraderMsg::SubmitConditionalOrder {
+                pair_id: pair,
+                size: None,
+                trigger_price: UsdPrice::new_int(1_800),
+                trigger_direction: dango_order_book::TriggerDirection::Below,
+                max_slippage: dango_order_book::Dimensionless::new_permille(100),
+            }),
+            Coins::new(),
+        )
+        .await
+        .should_fail_with_error(DISABLED);
+}

--- a/deploy/roles/full-app/templates/config/cometbft/genesis.json
+++ b/deploy/roles/full-app/templates/config/cometbft/genesis.json
@@ -805,6 +805,7 @@
                 "base": "0.001",
                 "tiers": {}
               },
+              "trading_enabled": true,
               "vault_cooldown_period": "86400",
               "vault_deposit_cap": null,
               "vault_total_weight": "7"

--- a/docker/ci-stack/configs/cometbft/config/genesis.json
+++ b/docker/ci-stack/configs/cometbft/config/genesis.json
@@ -772,6 +772,7 @@
                 "base": "0.001",
                 "tiers": {}
               },
+              "trading_enabled": true,
               "vault_cooldown_period": "86400",
               "vault_deposit_cap": null,
               "vault_total_weight": "3"

--- a/sdk/python/dango/utils/types.py
+++ b/sdk/python/dango/utils/types.py
@@ -499,6 +499,7 @@ class Param(TypedDict):
     referrer_commission_rates: RateSchedule
     vault_deposit_cap: UsdValue | None
     max_action_batch_size: int
+    trading_enabled: bool
 
 
 class State(TypedDict):

--- a/sdk/python/tests/test_info_perps_queries.py
+++ b/sdk/python/tests/test_info_perps_queries.py
@@ -107,6 +107,7 @@ class TestGlobalQueries:
             "referrer_commission_rates": {"base": "0.000000", "tiers": {}},
             "vault_deposit_cap": None,
             "max_action_batch_size": 5,
+            "trading_enabled": True,
         }
         captured = _capture_request(
             httpserver, {"data": {"queryApp": {"wasm_smart": param_payload}}}

--- a/sdk/typescript/types/src/perps.ts
+++ b/sdk/typescript/types/src/perps.ts
@@ -131,6 +131,7 @@ export type PerpsParam = {
   minReferrerVolume: string;
   referrerCommissionRates: RateSchedule;
   vaultDepositCap: string | null;
+  tradingEnabled: boolean;
 };
 
 export type PerpsState = {


### PR DESCRIPTION
Add a one-time state transition to `dango-upgrade` that closes every
position at the mark, releases the counterparty vault to its liquidity
providers, refunds all margins to users' spot accounts as USDC, and
sweeps the remainder — treasury, insurance fund, and rounding dust — to
the chain owner. Withdrawals still in cooldown are released too, so
those funds are not stranded by the shutdown.

Add `Param.trading_enabled`, which the migration sets to false. While
disabled, order placement (including conditional orders and batches),
spot-to-margin deposits, and margin-to-vault deposits are rejected.
Withdrawals, cancellations, vault withdrawals, and liquidations stay
open, so users can always get funds out. The proposal preparer stops
injecting the two perps maintenance transactions once trading is off.

Positions settle at `PairState.index_price` — the same mark that
`compute_user_equity` and the UI already report — so each user is
refunded the equity they last saw. Settling every position at one price
is zero-sum across accounts, so the transition neither creates nor
destroys value. The handler computes the whole refund set before
writing anything and returns an error, halting the chain, if the
contract cannot cover what it owes.

Verified against a snapshot of live mainnet state, pulled by the new
`dump_perps_state` example in a single `multi` query so the whole
snapshot comes from one block. The test asserts that the contract's
entire USDC balance is accounted for, and that the equity owed before
the fork reappears afterwards as refunds, bad debt, and vault residue.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PRGWFeamVzcuNUahoqpNPk