### PR TITLE
feat(portal): disable exchange applets

### DIFF
--- a/ui/foundation/messages/en.json
+++ b/ui/foundation/messages/en.json
@@ -644,9 +644,9 @@
     "description": "We are currently undergoing maintenance. We apologize for any inconvenience this may cause and appreciate your patience."
   },
   "announcement": {
-    "title": "Dango is shutting down",
-    "windingDown": "Dango exchange is going to be wound down. We encourage you to close your positions and withdraw funds at your earliest convenience. For a detailed winding down timeline:",
-    "readMore": "Read more"
+    "title": "Dango exchange has been shut down.",
+    "windingDown": "Funds have been returned to your deposit addresses on Ethereum. See the relevant",
+    "readMore": "announcement"
   },
   "geoblock": {
     "bannerLead": "Your IP address indicates that you are in a country or region outside of Dango's service zone. We do not provide services to your location.",

--- a/ui/portal/web/constants.config.ts
+++ b/ui/portal/web/constants.config.ts
@@ -21,6 +21,16 @@ export const PERPS_DEFAULT_SLIPPAGE = "0.005";
 /** 14-day lookback window (in seconds), matching the backend VOLUME_LOOKBACK. */
 export const FEE_VOLUME_LOOKBACK_SECONDS = 14 * 24 * 60 * 60;
 
+export const EXCHANGE_SHUTDOWN_NOTICE = "exchange-shutdown" as const;
+
+export const EXCHANGE_SHUTDOWN_REDIRECT = {
+  replace: true,
+  search: { notice: EXCHANGE_SHUTDOWN_NOTICE },
+  to: "/",
+} as const;
+
+const DISABLED_APPLET_IDS = new Set(["earn", "trade"]);
+
 const translations = m as unknown as Record<string, () => string>;
 export const APPLETS: Record<string, AppletMetadata> = Object.keys(translations)
   .filter((k) => /^applets\..*\.id$/.test(k))
@@ -33,6 +43,7 @@ export const APPLETS: Record<string, AppletMetadata> = Object.keys(translations)
       img: translations[`applets.${id}.img`](),
       keywords: translations[`applets.${id}.keywords`]().split(","),
       path: translations[`applets.${id}.path`](),
+      isDisabled: DISABLED_APPLET_IDS.has(id),
     };
     return acc;
   }, Object.create({}));

--- a/ui/portal/web/src/components/foundation/SearchItem.tsx
+++ b/ui/portal/web/src/components/foundation/SearchItem.tsx
@@ -1,4 +1,9 @@
-import { AddressVisualizer, StarToggleButton, useMediaQuery } from "@left-curve/applets-kit";
+import {
+  AddressVisualizer,
+  StarToggleButton,
+  twMerge,
+  useMediaQuery,
+} from "@left-curve/applets-kit";
 import { useFavApplets } from "@left-curve/store";
 
 import { TruncateText } from "@left-curve/applets-kit";
@@ -21,27 +26,49 @@ const Root: React.FC<PropsWithChildren> = ({ children }) => {
 type SearchAppletItemProps = AppletMetadata;
 
 const AppletItem: React.FC<SearchAppletItemProps> = (applet) => {
-  const { id, title, description, img } = applet;
+  const { id, title, description, img, isDisabled } = applet;
   const { favApplets, addFavApplet, removeFavApplet } = useFavApplets();
   const isFav = favApplets.includes(id);
 
   return (
     <motion.div
-      className="w-full p-2 flex items-center justify-between hover:bg-surface-tertiary-rice rounded-xs group-data-[selected=true]:bg-surface-tertiary-rice cursor-pointer"
+      aria-disabled={isDisabled || undefined}
+      className={twMerge(
+        "w-full p-2 flex items-center justify-between rounded-xs",
+        isDisabled
+          ? "cursor-not-allowed text-fg-disabled"
+          : "cursor-pointer hover:bg-surface-tertiary-rice group-data-[selected=true]:bg-surface-tertiary-rice",
+      )}
       variants={childVariants}
       key={title}
     >
       <div className="flex items-center gap-4">
-        <div className="p-1 bg-surface-primary-red rounded-xxs border border-surface-secondary-red">
-          <Image src={img} alt={title} className="w-12 h-12" />
+        <div
+          className={twMerge(
+            "rounded-xxs border p-1",
+            isDisabled
+              ? "border-outline-secondary-gray bg-surface-disabled-gray"
+              : "border-surface-secondary-red bg-surface-primary-red",
+          )}
+        >
+          <Image
+            src={img}
+            alt={title}
+            className={twMerge("h-12 w-12", isDisabled && "grayscale opacity-50")}
+          />
         </div>
         <div>
-          <p className="diatype-lg-medium text-ink-secondary-700">{title}</p>
-          <p className="diatype-m-regular text-ink-tertiary-500">{description}</p>
+          <p className={twMerge("diatype-lg-medium", !isDisabled && "text-ink-secondary-700")}>
+            {title}
+          </p>
+          <p className={twMerge("diatype-m-regular", !isDisabled && "text-ink-tertiary-500")}>
+            {description}
+          </p>
         </div>
       </div>
       <StarToggleButton
         isActive={isFav}
+        isDisabled={isDisabled}
         onToggle={() => (isFav ? removeFavApplet(applet) : addFavApplet(applet))}
         className="w-6 h-6 text-primitives-rice-light-500"
       />

--- a/ui/portal/web/src/components/foundation/SearchMenu.tsx
+++ b/ui/portal/web/src/components/foundation/SearchMenu.tsx
@@ -255,7 +255,12 @@ const Body: React.FC<SearchMenuBodyProps> = ({
                         key={applet.title}
                         value={applet.title}
                         className="group"
-                        onSelect={() => [navigate({ to: applet.path }), hideMenu()]}
+                        disabled={applet.isDisabled}
+                        onSelect={
+                          applet.isDisabled
+                            ? undefined
+                            : () => [navigate({ to: applet.path }), hideMenu()]
+                        }
                       >
                         <SearchItem.Applet key={applet.title} {...applet} />
                       </Command.Item>
@@ -269,7 +274,12 @@ const Body: React.FC<SearchMenuBodyProps> = ({
                         key={applet.title}
                         value={applet.title}
                         className="group"
-                        onSelect={() => [navigate({ to: applet.path }), hideMenu()]}
+                        disabled={applet.isDisabled}
+                        onSelect={
+                          applet.isDisabled
+                            ? undefined
+                            : () => [navigate({ to: applet.path }), hideMenu()]
+                        }
                       >
                         <SearchItem.Applet key={applet.title} {...applet} />
                       </Command.Item>

--- a/ui/portal/web/src/components/landing/AppletsSection.tsx
+++ b/ui/portal/web/src/components/landing/AppletsSection.tsx
@@ -2,7 +2,7 @@ import { useFavApplets } from "@left-curve/store";
 
 import { APPLETS } from "~/constants";
 
-import { IconAddCross, useApp } from "@left-curve/applets-kit";
+import { IconAddCross, twMerge, useApp } from "@left-curve/applets-kit";
 import { Link } from "@tanstack/react-router";
 import { Image } from "~/components/foundation/Image";
 
@@ -21,14 +21,32 @@ export function AppletsSection() {
             key={`applets.section.${applet.title}}`}
           >
             <div className="flex flex-col items-center gap-2">
-              <Link
-                to={applet.path}
-                className="h-16 w-16 md:h-20 md:w-20 shadow-account-card bg-surface-primary-red hover:bg-surface-secondary-red transition-all rounded-xl p-[10px]"
-              >
-                <Image src={applet.img} alt={applet.title} className="w-full h-full" />
-              </Link>
+              {applet.isDisabled ? (
+                <button
+                  type="button"
+                  aria-label={applet.title}
+                  disabled
+                  className="h-16 w-16 cursor-not-allowed rounded-xl bg-surface-disabled-gray p-[10px] shadow-account-card md:h-20 md:w-20"
+                >
+                  <Image src={applet.img} alt="" className="h-full w-full grayscale opacity-50" />
+                </button>
+              ) : (
+                <Link
+                  to={applet.path}
+                  className="h-16 w-16 md:h-20 md:w-20 shadow-account-card bg-surface-primary-red hover:bg-surface-secondary-red transition-all rounded-xl p-[10px]"
+                >
+                  <Image src={applet.img} alt={applet.title} className="w-full h-full" />
+                </Link>
+              )}
               <div className="md:w-[5rem] h-[36.41px] relative">
-                <p className="text-sm font-bold text-center">{applet.title}</p>
+                <p
+                  className={twMerge(
+                    "text-center text-sm font-bold",
+                    applet.isDisabled && "text-fg-disabled",
+                  )}
+                >
+                  {applet.title}
+                </p>
               </div>
             </div>
           </div>

--- a/ui/portal/web/src/pages/(app)/_app.earn.index.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.earn.index.tsx
@@ -1,12 +1,16 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { m } from "@left-curve/foundation/paraglide/messages.js";
+import { EXCHANGE_SHUTDOWN_REDIRECT } from "~/constants";
 
 export const Route = createFileRoute("/(app)/_app/earn/")({
   head: () => ({
     meta: [{ title: `Dango | ${m["vaultLiquidity.title"]()}` }],
   }),
+  beforeLoad: async () => {
+    throw redirect(EXCHANGE_SHUTDOWN_REDIRECT);
+  },
   validateSearch: z.object({
     action: z.enum(["deposit", "withdraw"]).catch("deposit"),
   }),

--- a/ui/portal/web/src/pages/(app)/_app.trade.$ticker.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.$ticker.tsx
@@ -1,32 +1,15 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { MarketPair } from "@left-curve/foundation/market-pair";
 
 import { z } from "zod";
 import { m } from "@left-curve/foundation/paraglide/messages.js";
+import { EXCHANGE_SHUTDOWN_REDIRECT } from "~/constants";
 
 export const Route = createFileRoute("/(app)/_app/trade/$ticker")({
   head: () => ({
     meta: [{ title: `Dango | ${m["applets.trade.title"]()}` }],
   }),
-  beforeLoad: async ({ context, params }) => {
-    const { client } = context;
-    const { ticker } = params;
-    const fallback = {
-      to: "/trade/$ticker",
-      params: { ticker: MarketPair.default.ticker },
-    } as const;
-
-    const pair = MarketPair.tryFromTicker(ticker);
-    if (!pair) throw redirect(fallback);
-
-    if (pair.ticker !== ticker) {
-      throw redirect({ ...fallback, params: { ticker: pair.ticker } });
-    }
-
-    if (pair === MarketPair.default) return;
-
-    const pairParam = await client.getPerpsPairParam({ pairId: pair.id }).catch(() => null);
-    if (!pairParam) throw redirect(fallback);
+  beforeLoad: async () => {
+    throw redirect(EXCHANGE_SHUTDOWN_REDIRECT);
   },
   validateSearch: z.object({
     order_type: z.enum(["limit", "market"]).default("market"),

--- a/ui/portal/web/src/pages/(app)/_app.trade.index.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.trade.index.tsx
@@ -1,11 +1,8 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { MarketPair } from "@left-curve/foundation/market-pair";
+import { EXCHANGE_SHUTDOWN_REDIRECT } from "~/constants";
 
 export const Route = createFileRoute("/(app)/_app/trade/")({
   beforeLoad: async () => {
-    throw redirect({
-      to: "/trade/$ticker",
-      params: { ticker: MarketPair.default.ticker },
-    });
+    throw redirect(EXCHANGE_SHUTDOWN_REDIRECT);
   },
 });

--- a/ui/portal/web/src/pages/(app)/_app.tsx
+++ b/ui/portal/web/src/pages/(app)/_app.tsx
@@ -15,9 +15,11 @@ import { TestnetBanner } from "~/components/foundation/TestnetBanner";
 
 import { z } from "zod";
 import { Image } from "~/components/foundation/Image";
+import { EXCHANGE_SHUTDOWN_NOTICE } from "~/constants";
 
 export const Route = createFileRoute("/(app)/_app")({
   validateSearch: z.object({
+    notice: z.literal(EXCHANGE_SHUTDOWN_NOTICE).optional(),
     socketId: z.string().optional(),
   }),
   component: LayoutApp,
@@ -63,9 +65,15 @@ function LayoutApp() {
     return router.state.location.pathname.includes("trade");
   }, [router.state.location.pathname]);
 
-  const { socketId } = useSearch({ strict: false });
+  const { notice, socketId } = useSearch({ strict: false });
+  const isExchangeShutdownNotice = notice === EXCHANGE_SHUTDOWN_NOTICE;
 
   useEffect(() => {
+    if (isExchangeShutdownNotice) showModal(Modals.WindingDown);
+  }, [isExchangeShutdownNotice, showModal]);
+
+  useEffect(() => {
+    if (isExchangeShutdownNotice) return;
     if (!isConnected) modalShowed.current = false;
     if (!isConnected || modalShowed.current) return;
 
@@ -78,7 +86,7 @@ function LayoutApp() {
       modalShowed.current = true;
       showModal(Modals.ActivateAccount);
     }
-  }, [isConnected, userStatus, balances, chain.id]);
+  }, [isConnected, userStatus, balances, chain.id, isExchangeShutdownNotice, showModal]);
 
   useEffect(() => {
     if (socketId) showModal(Modals.SignWithDesktopFromNativeCamera, { socketId });

--- a/ui/portal/web/tests/app-layout-route.test.tsx
+++ b/ui/portal/web/tests/app-layout-route.test.tsx
@@ -35,7 +35,7 @@ const layoutRouteMocks = vi.hoisted(() => ({
     modal: null as string | null,
   },
   pathname: "/",
-  search: {} as { socketId?: string },
+  search: {} as { notice?: "exchange-shutdown"; socketId?: string },
   showModal: vi.fn(),
   theme: "light" as "dark" | "light",
   useBalances: vi.fn(),
@@ -113,7 +113,7 @@ type LayoutRoute = {
   options: {
     component: React.ComponentType;
     validateSearch: {
-      parse: (value: unknown) => { socketId?: string };
+      parse: (value: unknown) => { notice?: "exchange-shutdown"; socketId?: string };
     };
   };
 };
@@ -175,14 +175,32 @@ describe("app layout route", () => {
     vi.clearAllMocks();
   });
 
-  it("validates native-camera socket ids from route search state", () => {
+  it("validates supported route search state", () => {
     const route = Route as unknown as LayoutRoute;
 
     expect(route.options.validateSearch.parse({})).toEqual({});
+    expect(route.options.validateSearch.parse({ notice: "exchange-shutdown" })).toEqual({
+      notice: "exchange-shutdown",
+    });
     expect(route.options.validateSearch.parse({ socketId: "native-camera-socket" })).toEqual({
       socketId: "native-camera-socket",
     });
+    expect(() => route.options.validateSearch.parse({ notice: "maintenance" })).toThrow();
     expect(() => route.options.validateSearch.parse({ socketId: 123 })).toThrow();
+  });
+
+  it("opens the winding-down modal from shutdown route state", async () => {
+    layoutRouteMocks.search = {
+      notice: "exchange-shutdown",
+    };
+    const Component = LayoutComponent();
+
+    render(<Component />);
+
+    await waitFor(() => {
+      expect(layoutRouteMocks.showModal).toHaveBeenCalledWith(Modals.WindingDown);
+    });
+    expect(layoutRouteMocks.showModal).toHaveBeenCalledTimes(1);
   });
 
   it("shows account activation on mainnet when the connected user is not active", async () => {

--- a/ui/portal/web/tests/applet-routes.test.tsx
+++ b/ui/portal/web/tests/applet-routes.test.tsx
@@ -7,6 +7,10 @@ const appletRouteMocks = vi.hoisted(() => ({
   isConnected: true,
   navigate: vi.fn(),
   params: {} as Record<string, unknown>,
+  redirect: vi.fn((options: unknown) => ({
+    options,
+    type: "redirect",
+  })),
   search: {} as Record<string, unknown>,
 }));
 
@@ -23,6 +27,7 @@ function createInspectableRoute(routePath: string) {
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: createInspectableRoute,
   createLazyFileRoute: createInspectableRoute,
+  redirect: appletRouteMocks.redirect,
   useNavigate: () => appletRouteMocks.navigate,
 }));
 
@@ -349,6 +354,12 @@ type RouteWithComponent = {
   };
 };
 
+type RouteWithBeforeLoad = {
+  options: {
+    beforeLoad: () => Promise<void>;
+  };
+};
+
 function setSearch(search: Record<string, unknown>) {
   appletRouteMocks.search = search;
 }
@@ -371,7 +382,9 @@ async function loadBridgeLazyRoute() {
 
 async function loadEarnRoute() {
   return import("../src/pages/(app)/_app.earn.index").then(
-    ({ Route }) => Route as unknown as RouteWithValidate<{ action: "deposit" | "withdraw" }>,
+    ({ Route }) =>
+      Route as unknown as RouteWithValidate<{ action: "deposit" | "withdraw" }> &
+        RouteWithBeforeLoad,
   );
 }
 
@@ -506,6 +519,21 @@ describe("applet routes", () => {
       action: "deposit",
     });
   }, 10_000);
+
+  it("redirects the earn route to the exchange shutdown notice", async () => {
+    const EarnRoute = await loadEarnRoute();
+
+    await expect(EarnRoute.options.beforeLoad()).rejects.toMatchObject({
+      type: "redirect",
+    });
+    expect(appletRouteMocks.redirect).toHaveBeenLastCalledWith({
+      replace: true,
+      search: {
+        notice: "exchange-shutdown",
+      },
+      to: "/",
+    });
+  });
 
   it("defaults transfer search params to sends", async () => {
     const Route = await loadTransferRoute();

--- a/ui/portal/web/tests/applets-section.test.tsx
+++ b/ui/portal/web/tests/applets-section.test.tsx
@@ -9,7 +9,7 @@ import { APPLETS } from "../constants.config";
 import { AppletsSection } from "../src/components/landing/AppletsSection";
 
 const appletsSectionMocks = vi.hoisted(() => ({
-  favApplets: ["trade", "missing-applet", "transfer"] as string[],
+  favApplets: ["trade", "earn", "missing-applet", "transfer"] as string[],
   setSearchBarVisibility: vi.fn(),
 }));
 
@@ -41,7 +41,7 @@ vi.mock("@left-curve/store", () => ({
 describe("applets section", () => {
   beforeEach(() => {
     resetAppletsKitMocks();
-    appletsSectionMocks.favApplets = ["trade", "missing-applet", "transfer"];
+    appletsSectionMocks.favApplets = ["trade", "earn", "missing-applet", "transfer"];
     setAppletsKitUseApp({
       setSearchBarVisibility: appletsSectionMocks.setSearchBarVisibility,
     });
@@ -52,14 +52,23 @@ describe("applets section", () => {
     vi.clearAllMocks();
   });
 
-  it("renders known favorite applets from metadata and ignores stale favorite ids", () => {
+  it("disables shutdown applets while keeping other favorite applets navigable", () => {
     render(<AppletsSection />);
 
     const trade = APPLETS.trade;
+    const earn = APPLETS.earn;
     const transfer = APPLETS.transfer;
 
-    expect(screen.getByRole("link", { name: trade.title })).toHaveAttribute("href", trade.path);
-    expect(screen.getByAltText(trade.title)).toHaveAttribute("src", trade.img);
+    expect(trade.isDisabled).toBe(true);
+    expect(earn.isDisabled).toBe(true);
+    expect(transfer.isDisabled).toBe(false);
+    expect(screen.getByRole("button", { name: trade.title })).toBeDisabled();
+    expect(screen.getByRole("button", { name: earn.title })).toBeDisabled();
+    expect(screen.queryByRole("link", { name: trade.title })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: earn.title })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: trade.title }).querySelector("img")).toHaveClass(
+      "grayscale",
+    );
     expect(screen.getByText(trade.title)).toBeInTheDocument();
 
     expect(screen.getByRole("link", { name: transfer.title })).toHaveAttribute(
@@ -74,7 +83,11 @@ describe("applets section", () => {
   it("opens the search bar from the add applet tile", () => {
     render(<AppletsSection />);
 
-    const addButton = screen.getByRole("button");
+    const addButton = screen
+      .getAllByRole("button")
+      .find((button) => !button.hasAttribute("disabled"));
+    expect(addButton).toBeDefined();
+    if (!addButton) throw new Error("Expected an enabled add applet button");
     fireEvent.click(addButton);
 
     expect(appletsSectionMocks.setSearchBarVisibility).toHaveBeenCalledWith(true);

--- a/ui/portal/web/tests/search-menu-body.test.tsx
+++ b/ui/portal/web/tests/search-menu-body.test.tsx
@@ -28,6 +28,7 @@ type AppletFixture = {
   description: string;
   id: string;
   img: string;
+  isDisabled?: boolean;
   path: string;
   title: string;
 };
@@ -85,13 +86,20 @@ vi.mock("cmdk", () => ({
     ),
     Item: ({
       children,
+      disabled,
       onSelect,
       value,
     }: React.PropsWithChildren<{
+      disabled?: boolean;
       onSelect?: () => void;
       value?: string;
     }>) => (
-      <div data-command-item="true" data-value={value} onClick={onSelect}>
+      <div
+        aria-disabled={disabled || undefined}
+        data-command-item="true"
+        data-value={value}
+        onClick={disabled ? undefined : onSelect}
+      >
         {children}
       </div>
     ),
@@ -339,7 +347,7 @@ describe("search menu body", () => {
         address: accountAddress,
         index: 0,
         owner: 3,
-        username: undefined,
+        username: "",
       },
     });
 
@@ -371,6 +379,31 @@ describe("search menu body", () => {
 
     fireEvent.click(screen.getByRole("button", { name: m["common.starToggle.add"]() }));
     expect(searchMenuMocks.addFavApplet).toHaveBeenCalledWith(bridgeApplet);
+  });
+
+  it("keeps disabled applets visible without allowing selection or favorite changes", () => {
+    const disabledTradeApplet = {
+      ...tradeApplet,
+      isDisabled: true,
+    };
+
+    renderBody({
+      allApplets: [],
+      searchResult: emptySearchResult({
+        applets: [disabledTradeApplet as never],
+      }),
+    });
+
+    const row = screen.getByText("Trade perpetuals").closest('[data-command-item="true"]');
+    expect(row).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByAltText("Trade")).toHaveClass("grayscale");
+    expect(screen.getByRole("button", { name: m["common.starToggle.remove"]() })).toBeDisabled();
+
+    clickResult("Trade");
+
+    expect(searchMenuMocks.navigate).not.toHaveBeenCalled();
+    expect(searchMenuMocks.hideMenu).not.toHaveBeenCalled();
+    expect(searchMenuMocks.removeFavApplet).not.toHaveBeenCalled();
   });
 
   it("renders loading and empty states with localized copy", () => {

--- a/ui/portal/web/tests/trade-route.test.tsx
+++ b/ui/portal/web/tests/trade-route.test.tsx
@@ -112,21 +112,7 @@ vi.mock("~/components/dex/components/ProTrade", () => {
 
 type TradeRoute = {
   options: {
-    beforeLoad: (args: {
-      context: {
-        client: {
-          getPerpsPairParam: ReturnType<typeof vi.fn>;
-        };
-        config: {
-          chain: {
-            name: string;
-          };
-        };
-      };
-      params: {
-        ticker: string;
-      };
-    }) => Promise<void>;
+    beforeLoad: () => Promise<void>;
     validateSearch: {
       parse: (search: unknown) => {
         action: "buy" | "sell";
@@ -138,15 +124,7 @@ type TradeRoute = {
 
 type TradeIndexRoute = {
   options: {
-    beforeLoad: (args: {
-      context: {
-        config: {
-          chain: {
-            name: string;
-          };
-        };
-      };
-    }) => Promise<void>;
+    beforeLoad: () => Promise<void>;
   };
 };
 
@@ -187,23 +165,6 @@ async function loadTradeIndexRoute() {
   return tradeIndexRoutePromise;
 }
 
-function createRouteContext({
-  getPerpsPairParam = vi.fn().mockResolvedValue({ pairId: "perp/btcusd" }),
-}: {
-  getPerpsPairParam?: ReturnType<typeof vi.fn>;
-} = {}) {
-  return {
-    client: {
-      getPerpsPairParam,
-    },
-    config: {
-      chain: {
-        name: "Mainnet",
-      },
-    },
-  };
-}
-
 function setLazyRouteState({
   ticker = "ETHUSD",
   search = {},
@@ -240,88 +201,17 @@ describe("trade routes", () => {
     setLazyRouteState();
   });
 
-  it("keeps a backend-confirmed normalized pair on the trade pair route", async () => {
+  it("redirects the trade pair route to the exchange shutdown notice", async () => {
     const Route = await loadTradeRoute();
-    const getPerpsPairParam = vi.fn().mockResolvedValue({ pairId: "perp/ethusd" });
 
-    await expect(
-      Route.options.beforeLoad({
-        context: createRouteContext({ getPerpsPairParam }),
-        params: {
-          ticker: "ETHUSD",
-        },
-      }),
-    ).resolves.toBeUndefined();
-
-    expect(getPerpsPairParam).toHaveBeenCalledWith({
-      pairId: "perp/ethusd",
-    });
-    expect(routeMocks.redirect).not.toHaveBeenCalled();
-  });
-
-  it("normalizes cataloged pair ticker casing before asking the backend for pair params", async () => {
-    const Route = await loadTradeRoute();
-    const getPerpsPairParam = vi.fn();
-
-    const redirect = await expectRedirect(
-      Route.options.beforeLoad({
-        context: createRouteContext({ getPerpsPairParam }),
-        params: {
-          ticker: "ethusd",
-        },
-      }),
-    );
+    const redirect = await expectRedirect(Route.options.beforeLoad());
 
     expect(redirect.options).toEqual({
-      params: {
-        ticker: "ETHUSD",
+      replace: true,
+      search: {
+        notice: "exchange-shutdown",
       },
-      to: "/trade/$ticker",
-    });
-    expect(getPerpsPairParam).not.toHaveBeenCalled();
-  });
-
-  it("falls back to the route default when the pair route is malformed", async () => {
-    const Route = await loadTradeRoute();
-    const getPerpsPairParam = vi.fn();
-
-    const redirect = await expectRedirect(
-      Route.options.beforeLoad({
-        context: createRouteContext({ getPerpsPairParam }),
-        params: {
-          ticker: "ETHUSD-EXTRA",
-        },
-      }),
-    );
-
-    expect(redirect.options).toEqual({
-      params: {
-        ticker: "BTCUSD",
-      },
-      to: "/trade/$ticker",
-    });
-    expect(getPerpsPairParam).not.toHaveBeenCalled();
-  });
-
-  it("falls back to the route default without querying the backend when the ticker is uncataloged", async () => {
-    const Route = await loadTradeRoute();
-    const getPerpsPairParam = vi.fn();
-
-    const redirect = await expectRedirect(
-      Route.options.beforeLoad({
-        context: createRouteContext({ getPerpsPairParam }),
-        params: {
-          ticker: "DOGE-USD",
-        },
-      }),
-    );
-
-    expect(getPerpsPairParam).not.toHaveBeenCalled();
-    expect(redirect.options).toEqual({
-      params: {
-        ticker: "BTCUSD",
-      },
-      to: "/trade/$ticker",
+      to: "/",
     });
   });
 
@@ -344,26 +234,17 @@ describe("trade routes", () => {
     expect(() => Route.options.validateSearch.parse({ action: "close" })).toThrow();
   });
 
-  it("redirects the trade index route to the route default pair", async () => {
+  it("redirects the trade index route to the exchange shutdown notice", async () => {
     const Route = await loadTradeIndexRoute();
 
-    const redirect = await expectRedirect(
-      Route.options.beforeLoad({
-        context: {
-          config: {
-            chain: {
-              name: "Devnet",
-            },
-          },
-        },
-      }),
-    );
+    const redirect = await expectRedirect(Route.options.beforeLoad());
 
     expect(redirect.options).toEqual({
-      params: {
-        ticker: "BTCUSD",
+      replace: true,
+      search: {
+        notice: "exchange-shutdown",
       },
-      to: "/trade/$ticker",
+      to: "/",
     });
   });
 

--- a/ui/portal/web/tests/winding-down-modal.test.tsx
+++ b/ui/portal/web/tests/winding-down-modal.test.tsx
@@ -21,11 +21,15 @@ describe("WindingDown", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the winding-down notice and timeline link", () => {
+  it("renders the shutdown notice and announcement link", () => {
     render(<WindingDown />);
 
-    expect(screen.getByRole("heading", { name: m["announcement.title"]() })).toBeInTheDocument();
-    expect(screen.getByText(m["announcement.windingDown"](), { exact: false })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: m["announcement.title"]() })).toHaveTextContent(
+      m["announcement.title"](),
+    );
+    expect(screen.getByText(m["announcement.windingDown"](), { exact: false })).toHaveTextContent(
+      `${m["announcement.windingDown"]()} ${m["announcement.readMore"]()}.`,
+    );
     expect(screen.getByRole("link", { name: m["announcement.readMore"]() })).toHaveAttribute(
       "href",
       announcementUrl,

--- a/ui/store/src/types/applets.ts
+++ b/ui/store/src/types/applets.ts
@@ -5,4 +5,5 @@ export type AppletMetadata = {
   keywords: string[];
   description: string;
   path: string;
+  isDisabled?: boolean;
 };


### PR DESCRIPTION
## Summary

- disable the Earn and Trade applets, rendering their launchers grey and non-interactive
- redirect direct Earn and Trade routes to the exchange shutdown notice
- update the notice to confirm the shutdown and returned Ethereum funds, linking the existing announcement

## Verification

- Portal test suite: 151 files, 2,244 tests passed
- Biome checks passed
- GitHub commit signature verified